### PR TITLE
Add embedded agent skill with hey skill install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ hey journal read                   # read today's entry (or pass YYYY-MM-DD)
 hey journal write --content "..."  # write today's entry (or omit --content for $EDITOR)
 ```
 
+## Agent Skill
+
+hey-cli ships with an embedded agent skill so your agent can interact with HEY on your behalf.
+
+```bash
+hey skill install   # install the skill globally for your agent
+```
+
 ## Development
 
 ```bash

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -85,6 +85,7 @@ func Execute() {
 	rootCmd.AddCommand(newTimetrackCommand().cmd)
 	rootCmd.AddCommand(newJournalCommand().cmd)
 	rootCmd.AddCommand(newTuiCommand().cmd)
+	rootCmd.AddCommand(newSkillCommand().cmd)
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/internal/cmd/skill.go
+++ b/internal/cmd/skill.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"hey-cli/skills"
+)
+
+type skillCommand struct {
+	cmd *cobra.Command
+}
+
+func newSkillCommand() *skillCommand {
+	sc := &skillCommand{}
+	sc.cmd = &cobra.Command{
+		Use:   "skill",
+		Short: "Manage the embedded agent skill",
+		Long:  "Print or install the SKILL.md embedded in this binary.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := skills.FS.ReadFile("hey/SKILL.md")
+			if err != nil {
+				return fmt.Errorf("reading embedded skill: %w", err)
+			}
+			_, err = fmt.Fprint(cmd.OutOrStdout(), string(data))
+			return err
+		},
+	}
+	sc.cmd.AddCommand(newSkillInstallCommand())
+	return sc
+}

--- a/internal/cmd/skill_install.go
+++ b/internal/cmd/skill_install.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"hey-cli/skills"
+)
+
+func newSkillInstallCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "install",
+		Short: "Install the hey skill globally for Claude",
+		Long:  "Copies the embedded SKILL.md to ~/.agents/skills/hey/ and creates a symlink in ~/.claude/skills/hey.",
+		RunE:  runSkillInstall,
+	}
+}
+
+func runSkillInstall(cmd *cobra.Command, args []string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("getting home directory: %w", err)
+	}
+
+	skillDir := filepath.Join(home, ".agents", "skills", "hey")
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	symlinkDir := filepath.Join(home, ".claude", "skills")
+	symlinkPath := filepath.Join(symlinkDir, "hey")
+
+	// Read embedded SKILL.md
+	data, err := skills.FS.ReadFile("hey/SKILL.md")
+	if err != nil {
+		return fmt.Errorf("reading embedded skill: %w", err)
+	}
+
+	// Create skill directory and write file
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return fmt.Errorf("creating skill directory: %w", err)
+	}
+	if err := os.WriteFile(skillFile, data, 0o644); err != nil {
+		return fmt.Errorf("writing skill file: %w", err)
+	}
+
+	// Create symlink directory and symlink
+	if err := os.MkdirAll(symlinkDir, 0o755); err != nil {
+		return fmt.Errorf("creating symlink directory: %w", err)
+	}
+	// Remove existing symlink/file if present
+	os.Remove(symlinkPath)
+	if err := os.Symlink(filepath.Join("..", "..", ".agents", "skills", "hey"), symlinkPath); err != nil {
+		return fmt.Errorf("creating symlink: %w", err)
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Installed hey skill to ~/.agents/skills/hey/SKILL.md")
+	fmt.Fprintln(cmd.OutOrStdout(), "Symlinked ~/.claude/skills/hey → ../../.agents/skills/hey")
+	return nil
+}

--- a/skills/embed.go
+++ b/skills/embed.go
@@ -1,0 +1,7 @@
+// Package skills embeds the skill files in the binary.
+package skills
+
+import "embed"
+
+//go:embed hey
+var FS embed.FS

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: hey
+description: |
+  Interact with HEY email via the HEY CLI. Read and send emails, manage boxes,
+  calendars, todos, habits, time tracking, and journal entries. Use for ANY
+  HEY-related question or action.
+triggers:
+  # Direct invocations
+  - hey
+  - /hey
+  # Email actions
+  - hey boxes
+  - hey box
+  - hey topic
+  - hey reply
+  - hey compose
+  - hey drafts
+  # Calendar actions
+  - hey calendars
+  - hey recordings
+  # Todos
+  - hey todo
+  # Habits
+  - hey habit
+  # Time tracking
+  - hey timetrack
+  # Journal
+  - hey journal
+  # Auth
+  - hey auth
+  # Common actions
+  - check my email
+  - read email
+  - send email
+  - reply to email
+  - compose email
+  - list mailboxes
+  - check calendar
+  - add todo
+  - complete todo
+  - track time
+  - write journal
+  # Questions
+  - can I hey
+  - how do I hey
+  - what's in hey
+  - what hey
+  - does hey
+  # My work
+  - my emails
+  - my inbox
+  - my imbox
+  - my todos
+  - my calendar
+  - my journal
+  # URLs
+  - hey.com
+invocable: true
+argument-hint: "[command] [args...]"
+---
+
+# /hey - HEY Email Workflow Command
+
+CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos, habits, time tracking, and journal entries.
+
+## Agent Invariants
+
+**MUST follow these rules:**
+
+1. **Always use `--json`** for structured, predictable output
+2. **Authentication required** for all data commands — run `hey auth login` first
+3. **HTML output** is available via `--html` for commands that return HTML content
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| List mailboxes | `hey boxes --json` |
+| List emails in a box | `hey box imbox --json` |
+| Read email thread | `hey topic 123 --json` |
+| Reply to email | `hey reply 123 -m "Thanks!"` |
+| Compose email | `hey compose --to user@example.com --subject "Hello"` |
+| List drafts | `hey drafts --json` |
+| List calendars | `hey calendars --json` |
+| List calendar events | `hey recordings 123 --json` |
+| List todos | `hey todo list --json` |
+| Add todo | `hey todo add "Buy milk"` |
+| Complete todo | `hey todo complete 123` |
+| Uncomplete todo | `hey todo uncomplete 123` |
+| Delete todo | `hey todo delete 123` |
+| Complete habit | `hey habit complete` |
+| Uncomplete habit | `hey habit uncomplete` |
+| Start time tracking | `hey timetrack start` |
+| Stop time tracking | `hey timetrack stop` |
+| Current timer | `hey timetrack current --json` |
+| List time entries | `hey timetrack list --json` |
+| List journal entries | `hey journal list --json` |
+| Read journal entry | `hey journal read 2024-03-15 --json` |
+| Write journal entry | `hey journal write -m "Today was great"` |
+| Check auth status | `hey auth status` |
+| Print access token | `hey auth token` |
+| Launch TUI | `hey` |
+
+## Decision Trees
+
+### Reading Email
+
+```
+Want to read email?
+├── Which mailbox? → hey boxes --json
+├── List emails in box? → hey box <name|id> --json
+├── Read full thread? → hey topic <id> --json
+└── Launch interactive UI? → hey (no args, launches TUI)
+```
+
+### Sending Email
+
+```
+Want to send email?
+├── Reply to thread? → hey reply <topic_id> -m "message"
+│   └── Open editor? → hey reply <topic_id> (omit -m to open $EDITOR)
+├── Compose new? → hey compose --to <email> --subject "Subject"
+│   └── With body? → hey compose --to <email> --subject "Subject" -m "Body"
+└── Check drafts? → hey drafts --json
+```
+
+### Managing Todos
+
+```
+Want to manage todos?
+├── List todos? → hey todo list --json
+├── Add todo? → hey todo add "Task description"
+├── Complete? → hey todo complete <id>
+├── Uncomplete? → hey todo uncomplete <id>
+└── Delete? → hey todo delete <id>
+```
+
+## Resource Reference
+
+### Email - Boxes
+
+```bash
+hey boxes --json                              # List all mailboxes
+hey box imbox --json                          # List emails in Imbox (by name)
+hey box 123 --json                            # List emails in box (by ID)
+```
+
+Box names: `imbox`, `the_feed`, `paper_trail`, `set_aside`, `reply_later`, `screened_out`
+
+**Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. Each posting has: `id`, `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`.
+
+### Email - Topics
+
+```bash
+hey topic 123 --json                          # Read full email thread
+hey topic 123 --html                          # Read with raw HTML content
+```
+
+### Email - Reply & Compose
+
+```bash
+hey reply 123 -m "Thanks!"                   # Reply with inline message
+hey reply 123                                 # Reply via $EDITOR
+hey compose --to user@example.com --subject "Hello"         # Compose new
+hey compose --to user@example.com --subject "Hi" -m "Body"  # With body
+```
+
+### Drafts
+
+```bash
+hey drafts --json                             # List drafts
+```
+
+### Calendars
+
+```bash
+hey calendars --json                          # List calendars (returns array of {id, name, kind})
+hey recordings 123 --json                     # List events in calendar
+```
+
+**Response format:** `hey recordings` returns `{"Calendar::Event": [...]}`. Each event has: `id`, `title`, `starts_at`, `ends_at`, `all_day`, `recurring`, `starts_at_time_zone`. Access events via `.["Calendar::Event"]` in jq.
+
+### Todos
+
+```bash
+hey todo list --json                          # List all todos
+hey todo add "Task description"               # Add a todo
+hey todo complete 123                         # Mark complete
+hey todo uncomplete 123                       # Mark incomplete
+hey todo delete 123                           # Delete a todo
+```
+
+### Habits
+
+```bash
+hey habit complete                            # Mark habit complete for today
+hey habit uncomplete                          # Unmark habit for today
+```
+
+### Time Tracking
+
+```bash
+hey timetrack start                           # Start timer
+hey timetrack stop                            # Stop timer
+hey timetrack current --json                  # Show current timer
+hey timetrack list --json                     # List time entries
+```
+
+### Journal
+
+```bash
+hey journal list --json                       # List journal entries
+hey journal read 2024-03-15 --json            # Read entry by date
+hey journal write -m "Today's entry"          # Write entry inline
+hey journal write                             # Write entry via $EDITOR
+```
+
+### Authentication
+
+```bash
+hey auth login                                # Log in (browser-based OAuth)
+hey auth status                               # Check if authenticated
+hey auth logout                               # Log out
+```
+
+If a command fails with an auth error, run `hey auth status` to check, then `hey auth login` to re-authenticate.


### PR DESCRIPTION
## Summary
- Embeds a SKILL.md agent skill definition into the binary via Go's `embed` package
- Adds `hey skill` to print the embedded skill and `hey skill install` to install it
  globally at `~/.agents/skills/hey/` with a symlink into `~/.claude/skills/hey`
- Documents the new feature in the README

<img width="1708" height="1716" alt="image" src="https://github.com/user-attachments/assets/3be24013-df09-4d9c-9b93-379cf3ae742e" />
