### PR TITLE
Add direct-push alerting and sensitive-change gate

### DIFF
--- a/.github/workflows/direct-push-alert.yml
+++ b/.github/workflows/direct-push-alert.yml
@@ -1,0 +1,16 @@
+name: Direct Push Alert
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  alert:
+    uses: basecamp/.github/.github/workflows/direct-push-alert.yml@a667bfaac8b33b9c8a6c61019664463a98055995
+    permissions:
+      contents: read
+      issues: write

--- a/.github/workflows/sensitive-change-gate.yml
+++ b/.github/workflows/sensitive-change-gate.yml
@@ -1,0 +1,20 @@
+name: Sensitive Change Gate
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gate:
+    uses: basecamp/.github/.github/workflows/sensitive-change-gate.yml@a667bfaac8b33b9c8a6c61019664463a98055995
+    with:
+      extra-patterns: |
+        scripts/publish-aur.sh
+        scripts/sync-skills.sh
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
## Summary
- **direct-push-alert**: Detects commits pushed directly to the default branch (bypassing PR flow) and creates/appends to a tracking issue.
- **sensitive-change-gate**: Detects PR changes to control-plane paths (workflows, CODEOWNERS, .goreleaser.yaml, release scripts). Runs in shadow mode — posts an informational comment but does not block.

Both are thin callers to reusable workflows in `basecamp/.github`, pinned to SHA `a667bfaa`.

## Test plan
- [ ] Open a PR touching `.github/workflows/` — verify shadow comment appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two GitHub Actions workflows to flag direct pushes to main and to surface sensitive PR changes. This helps enforce PR review flow and visibility without blocking merges.

- New Features
  - Direct Push Alert: Alerts on pushes to `main` and appends to a tracking issue. Uses reusable workflow in `basecamp/.github`. Minimal permissions (read contents, write issues).
  - Sensitive Change Gate: Comments on PRs that touch control-plane paths (e.g., `.github/workflows/**`, `CODEOWNERS`, `.goreleaser.yaml`, release scripts). Runs in shadow mode (informational only). Includes extra patterns `scripts/publish-aur.sh` and `scripts/sync-skills.sh`. Uses reusable workflow in `basecamp/.github` with read contents and write pull-requests permissions.

<sup>Written for commit 1fd21f9533ecf8bdd8aacb276b0424a56a07e2dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

