### PR TITLE
Populate sender email and recipients in threads output

### DIFF
--- a/internal/htmlutil/entries.go
+++ b/internal/htmlutil/entries.go
@@ -12,6 +12,7 @@ import (
 var (
 	entryBlockRe     = regexp.MustCompile(`(?s)data-entry-id="(\d+)"`)
 	senderRe         = regexp.MustCompile(`id="sender_entry_(\d+)"[^>]*>\s*([^<]+?)\s*<`)
+	senderEmailRe    = regexp.MustCompile(`(?s)sender_entry_(\d+).*?entry__sender-email[^>]*><span[^>]*>[^<]*</span>([^<]+)<`)
 	timeRe           = regexp.MustCompile(`<time[^>]*datetime="([^"]+)"`)
 	srcdocRe         = regexp.MustCompile(`(?s)srcdoc="([^"]*trix-content[^"]*)"`)
 	fullRecipientsRe = regexp.MustCompile(`(?s)entry__full-recipients[^>]*>(.*?)</span>`)
@@ -86,6 +87,12 @@ func ParseTopicEntriesHTML(html string) []models.Entry {
 			senders[m[1]] = m[2]
 		}
 	}
+	senderEmails := map[string]string{}
+	for _, m := range senderEmailRe.FindAllStringSubmatch(html, -1) {
+		if _, exists := senderEmails[m[1]]; !exists {
+			senderEmails[m[1]] = strings.TrimSpace(m[2])
+		}
+	}
 
 	// Associate times with entries by finding the first <time> after each entry anchor
 	entryTimes := map[string]string{}
@@ -97,6 +104,35 @@ func ParseTopicEntriesHTML(html string) []models.Entry {
 		}
 		if m := timeRe.FindStringSubmatch(html[idx:]); m != nil {
 			entryTimes[eid] = m[1]
+		}
+	}
+
+	// Associate recipients with entries by slicing between entry anchors.
+	entryRecipients := map[string][]models.Contact{}
+	for i, eid := range entryIDs {
+		anchor := fmt.Sprintf(`id="entry_%s"`, eid)
+		start := strings.Index(html, anchor)
+		if start < 0 {
+			continue
+		}
+		end := len(html)
+		if i+1 < len(entryIDs) {
+			nextAnchor := fmt.Sprintf(`id="entry_%s"`, entryIDs[i+1])
+			if n := strings.Index(html[start:], nextAnchor); n > 0 {
+				end = start + n
+			}
+		}
+		m := fullRecipientsRe.FindStringSubmatch(html[start:end])
+		if m == nil {
+			continue
+		}
+		seen := map[string]bool{}
+		for _, addr := range extractEmails(m[1]) {
+			if seen[addr] {
+				continue
+			}
+			seen[addr] = true
+			entryRecipients[eid] = append(entryRecipients[eid], models.Contact{EmailAddress: addr})
 		}
 	}
 
@@ -122,7 +158,10 @@ func ParseTopicEntriesHTML(html string) []models.Entry {
 			CreatedAt: entryTimes[eid],
 		}
 		if name, ok := senders[eid]; ok {
-			e.Creator = models.Contact{Name: name}
+			e.Creator = models.Contact{Name: name, EmailAddress: senderEmails[eid]}
+		}
+		if recips, ok := entryRecipients[eid]; ok {
+			e.Recipients = recips
 		}
 		if i < len(bodies) {
 			e.Body = bodies[i].text


### PR DESCRIPTION
## Summary

- `hey threads <id> --json` was returning empty `creator.email_address` and an empty `recipients` array for every entry. The HTML parser only captured the sender's display name and discarded the rest of the sender link.
- Scrape the sender email from the `<span class="entry__sender-email">` element inside the sender anchor.
- Extract per-entry recipients by slicing HTML between entry anchors and reusing the existing `fullRecipientsRe` + `extractEmails` helpers. Dedupe recipients by email so a repeat in the HTML does not produce duplicate contacts.
- Additive only — existing callers of `ParseTopicEntriesHTML` keep working; empty fields become populated.

Why it matters: the empty recipients list makes any "reply all" flow downstream impossible without re-fetching and re-parsing the topic page, because there is no way to know who else was addressed on the entry.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/htmlutil/... ./internal/cmd/...`
- [x] `hey threads <real-thread-id> --json` — verified `creator.email_address` and `recipients[].email_address` are populated on all entries (previously empty)
- [x] `hey threads <real-thread-id>` (styled) — output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populates `creator.email_address` and per-entry `recipients` in `hey threads <id> --json` so reply-all flows have the data they need. No changes to styled output; existing callers keep working.

- **Bug Fixes**
  - Scrapes sender email from `<span class="entry__sender-email">` inside the sender anchor and maps it by entry id.
  - Extracts per-entry recipients by slicing between entry anchors and using `fullRecipientsRe` + `extractEmails`; dedupes by email.
  - Keeps `ParseTopicEntriesHTML` signature and behavior additive; previously empty fields are now populated.

<sup>Written for commit eeb083d3479806c53e0b5525f5dbbf64adb093e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

