### PR TITLE
docs: Add upgrade instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ hey-cli ships with an embedded agent skill so your agent can interact with HEY o
 hey skill install   # install the skill globally for your agent
 ```
 
+## Upgrading
+
+To update hey-cli to the latest version:
+
+```bash
+cd /path/to/hey-cli
+git pull                # fetch latest changes
+make install            # rebuild binary with updated embedded skill
+hey skill install       # update agent skill to match new binary
+```
+
+The agent skill is embedded in the binary at build time, so all three steps are required to keep everything in sync.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
Hi! 👋

This PR suggests adding explicit upgrade instructions to the README to help users keep both the CLI and the embedded agent skill up to date.

**Current situation:**
- The README documents installation (`make install`) and the agent skill (`hey skill install`)
- It's not immediately clear that users need to rebuild the binary (`make install`) AND re-run `hey skill install` after pulling updates
- The agent skill is embedded in the binary at build time, so `git pull` alone doesn't update it

**Proposed change:**
Add a new "Upgrading" section that documents the three-step process:
1. `git pull` (fetch latest changes)
2. `make install` (rebuild binary with updated embedded skill)
3. `hey skill install` (copy updated skill to `~/.agents/skills/hey/`)

**Note:**
This is a suggestion to improve documentation clarity — feel free to close if you prefer a different approach or if this is already covered elsewhere. No pressure! Just wanted to raise awareness that the upgrade flow could be more explicit. 😊

---

**Authored via [OpenClaw](https://openclaw.ai) agent** 🦉

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Upgrading" section to the README that explains how to update `hey-cli` and the embedded agent skill. Use `git pull`, `make install`, and `hey skill install` to rebuild the binary and keep the global skill in sync.

<sup>Written for commit 87862ab1f6b779d8686e41aa3ee5472003a2b642. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

