### PR TITLE
Add draft pagination and draft workflow commands via web forms

### DIFF
--- a/.surface
+++ b/.surface
@@ -40,6 +40,21 @@ hey config
 hey config set
 hey config show
 hey doctor
+hey draft
+hey draft create
+hey draft create --bcc
+hey draft create --cc
+hey draft create --message
+hey draft create --subject
+hey draft create --thread-id
+hey draft create --to
+hey draft delete
+hey draft update
+hey draft update --bcc
+hey draft update --cc
+hey draft update --message
+hey draft update --subject
+hey draft update --to
 hey drafts
 hey drafts --all
 hey drafts --limit

--- a/.surface
+++ b/.surface
@@ -32,6 +32,7 @@ hey completion
 hey compose
 hey compose --bcc
 hey compose --cc
+hey compose --draft
 hey compose --message
 hey compose --subject
 hey compose --thread-id
@@ -76,6 +77,7 @@ hey recordings --ends-on
 hey recordings --limit
 hey recordings --starts-on
 hey reply
+hey reply --draft
 hey reply --message
 hey seen
 hey setup

--- a/DRAFT_SUPPORT_NOTE.md
+++ b/DRAFT_SUPPORT_NOTE.md
@@ -2,7 +2,7 @@
 
 ## Authorship
 
-Authored by Mike Gyi with Codex, based on GPT-5.
+Authored by Mike Gyi with Codex 5.5.
 
 ## Intent
 

--- a/DRAFT_SUPPORT_NOTE.md
+++ b/DRAFT_SUPPORT_NOTE.md
@@ -1,0 +1,30 @@
+# Draft Support Implementation Note
+
+## Authorship
+
+Authored by Mike Gyi with Codex, based on GPT-5.
+
+## Intent
+
+The goal of this work is to make HEY draft workflows scriptable from the CLI while keeping Basecamp's CLI taste as the reference point.
+
+The public Basecamp CLI treats drafts as part of the normal creation flow, for example with a `--draft` option on a create command. This HEY CLI change follows that shape by adding draft mode to the existing mail commands:
+
+```sh
+hey compose --draft --to person@example.com --subject "Hello" -m "Draft body"
+hey reply 123 --draft -m "Thanks!"
+```
+
+Explicit draft commands are still included because they are useful for agent and scripting workflows:
+
+```sh
+hey draft create --to person@example.com --subject "Hello" -m "Draft body"
+hey draft update 123 --subject "Updated subject" -m "Updated body"
+hey draft delete 123
+```
+
+## Implementation Constraint
+
+The current HEY SDK surface does not expose first-class draft create/update/delete methods. The implementation therefore uses the authenticated HEY web form flow for draft mutations, with CSRF parsing and fail-closed form validation around the fields needed by the CLI.
+
+If HEY later exposes official draft endpoints in the SDK, the CLI command surface should stay the same and only the internal draft implementation should move to the official API.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ hey threads 123                    # read a full email thread
 hey reply 123 -m "Thanks!"        # reply to a thread (or omit -m to open $EDITOR)
 hey compose --to user@example.com --subject "Hello"  # compose a new message
 hey compose --to user@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello"  # with CC/BCC
+hey draft create --to user@example.com --subject "Hello" -m "Draft body"  # save without sending
+hey draft create --thread-id 123 -m "Thanks!"  # save a reply draft without sending
+hey draft update 456 --to user@example.com --subject "Hello" -m "Updated body"
+hey draft delete 456
 hey drafts                         # list drafts
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ hey boxes                          # list mailboxes
 hey box imbox                      # list postings in a box (by name or ID)
 hey threads 123                    # read a full email thread
 hey reply 123 -m "Thanks!"        # reply to a thread (or omit -m to open $EDITOR)
+hey reply 123 --draft -m "Thanks!" # save a reply draft without sending
 hey compose --to user@example.com --subject "Hello"  # compose a new message
+hey compose --draft --to user@example.com --subject "Hello" -m "Draft body"  # save without sending
 hey compose --to user@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello"  # with CC/BCC
 hey draft create --to user@example.com --subject "Hello" -m "Draft body"  # save without sending
 hey draft create --thread-id 123 -m "Thanks!"  # save a reply draft without sending

--- a/internal/cmd/box.go
+++ b/internal/cmd/box.go
@@ -224,7 +224,10 @@ func validateSameOrigin(baseURL, targetURL string) error {
 	if err != nil {
 		return fmt.Errorf("invalid pagination URL: %w", err)
 	}
-	if base.Scheme != target.Scheme || base.Host != target.Host {
+	if target.Scheme == "" && target.Host != "" {
+		target.Scheme = base.Scheme
+	}
+	if !strings.EqualFold(base.Scheme, target.Scheme) || base.Host != target.Host {
 		return fmt.Errorf("pagination URL origin %s://%s does not match base %s://%s",
 			target.Scheme, target.Host, base.Scheme, base.Host)
 	}

--- a/internal/cmd/box.go
+++ b/internal/cmd/box.go
@@ -227,7 +227,7 @@ func validateSameOrigin(baseURL, targetURL string) error {
 	if target.Scheme == "" && target.Host != "" {
 		target.Scheme = base.Scheme
 	}
-	if !strings.EqualFold(base.Scheme, target.Scheme) || base.Host != target.Host {
+	if !strings.EqualFold(base.Scheme, target.Scheme) || !strings.EqualFold(base.Host, target.Host) {
 		return fmt.Errorf("pagination URL origin %s://%s does not match base %s://%s",
 			target.Scheme, target.Host, base.Scheme, base.Host)
 	}

--- a/internal/cmd/box_test.go
+++ b/internal/cmd/box_test.go
@@ -219,6 +219,8 @@ func TestValidateSameOrigin(t *testing.T) {
 		{"same origin", "https://app.hey.com", "https://app.hey.com/page2", false},
 		{"different host", "https://app.hey.com", "https://evil.com/page2", true},
 		{"different scheme", "https://app.hey.com", "http://app.hey.com/page2", true},
+		{"scheme relative same host", "https://app.hey.com", "//app.hey.com/page2", false},
+		{"mixed case scheme", "https://app.hey.com", "HTTPS://app.hey.com/page2", false},
 		{"with port match", "https://app.hey.com:443", "https://app.hey.com:443/page2", false},
 		{"port mismatch", "https://app.hey.com:443", "https://app.hey.com:8080/page2", true},
 	}

--- a/internal/cmd/box_test.go
+++ b/internal/cmd/box_test.go
@@ -221,6 +221,7 @@ func TestValidateSameOrigin(t *testing.T) {
 		{"different scheme", "https://app.hey.com", "http://app.hey.com/page2", true},
 		{"scheme relative same host", "https://app.hey.com", "//app.hey.com/page2", false},
 		{"mixed case scheme", "https://app.hey.com", "HTTPS://app.hey.com/page2", false},
+		{"mixed case host", "https://app.hey.com", "https://APP.HEY.COM/page2", false},
 		{"with port match", "https://app.hey.com:443", "https://app.hey.com:443/page2", false},
 		{"port mismatch", "https://app.hey.com:443", "https://app.hey.com:8080/page2", true},
 	}

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -19,6 +19,7 @@ type composeCommand struct {
 	subject  string
 	message  string
 	threadID string
+	draft    bool
 }
 
 func newComposeCommand() *composeCommand {
@@ -27,9 +28,10 @@ func newComposeCommand() *composeCommand {
 		Use:   "compose",
 		Short: "Compose a new message",
 		Annotations: map[string]string{
-			"agent_notes": "Creates a new email. Requires --subject. Use --to (optionally with --cc/--bcc) for new threads or --thread-id for existing ones.",
+			"agent_notes": "Creates and sends a new email unless --draft is set. Requires --subject. Use --to (optionally with --cc/--bcc) for new threads or --thread-id for existing ones.",
 		},
 		Example: `  hey compose --to alice@example.com --subject "Hello" -m "Hi there"
+  hey compose --draft --to alice@example.com --subject "Hello" -m "Draft body"
   hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello" -m "Hi"
   hey compose --subject "Update" --thread-id 12345 -m "Thread reply"
   echo "Long message" | hey compose --to bob@example.com --subject "Report"`,
@@ -42,6 +44,7 @@ func newComposeCommand() *composeCommand {
 	composeCommand.cmd.Flags().StringVar(&composeCommand.subject, "subject", "", "Message subject (required)")
 	composeCommand.cmd.Flags().StringVarP(&composeCommand.message, "message", "m", "", "Message body (or opens $EDITOR)")
 	composeCommand.cmd.Flags().StringVar(&composeCommand.threadID, "thread-id", "", "Thread ID to post message to")
+	composeCommand.cmd.Flags().BoolVar(&composeCommand.draft, "draft", false, "Save as draft instead of sending")
 
 	return composeCommand
 }
@@ -85,6 +88,12 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return output.ErrUsage(fmt.Sprintf("invalid thread ID: %s", c.threadID))
 		}
+		if c.draft {
+			return createReplyDraft(ctx, cmd.OutOrStdout(), topicID, draftFormRequest{
+				Subject: c.subject,
+				Content: message,
+			})
+		}
 		if err := sdk.Messages().CreateTopicMessage(ctx, topicID, message); err != nil {
 			return convertSDKError(err)
 		}
@@ -92,6 +101,15 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		to := parseAddresses(c.to)
 		cc := parseAddresses(c.cc)
 		bcc := parseAddresses(c.bcc)
+		if c.draft {
+			return createMessageDraft(ctx, cmd.OutOrStdout(), draftFormRequest{
+				Subject: c.subject,
+				Content: message,
+				To:      to,
+				CC:      cc,
+				BCC:     bcc,
+			})
+		}
 		if err := sdk.Messages().Create(ctx, c.subject, message, to, cc, bcc); err != nil {
 			return convertSDKError(err)
 		}

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/basecamp/hey-cli/internal/editor"
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
@@ -58,27 +57,9 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		return output.ErrUsageHint("--subject is required", "hey compose --to <email> --subject <subject> -m <message>")
 	}
 
-	message := c.message
-	if message == "" {
-		if !stdinIsTerminal() {
-			var err error
-			message, err = readStdin()
-			if err != nil {
-				return err
-			}
-			if message == "" {
-				return output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
-			}
-		} else {
-			var err error
-			message, err = editor.Open("")
-			if err != nil {
-				return output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
-			}
-			if message == "" {
-				return output.ErrUsage("empty message, aborting")
-			}
-		}
+	message, err := draftMessageWithInitial(c.message, "", c.draft && cmd.Flags().Changed("message"))
+	if err != nil {
+		return err
 	}
 
 	ctx := cmd.Context()

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -144,7 +144,7 @@ func (c *draftUpdateCommand) run(cmd *cobra.Command, args []string) error {
 		return output.ErrUsage(fmt.Sprintf("invalid draft ID: %s", args[0]))
 	}
 	flags := cmd.Flags()
-	if !draftUpdateHasChanges(flags.Changed("subject"), flags.Changed("to"), flags.Changed("cc"), flags.Changed("bcc"), flags.Changed("message")) {
+	if !flags.Changed("subject") && !flags.Changed("to") && !flags.Changed("cc") && !flags.Changed("bcc") && !flags.Changed("message") {
 		return output.ErrUsageHint("No update fields specified", "hey draft update <draft-id> --subject <subject> -m <message>")
 	}
 
@@ -180,10 +180,6 @@ func (c *draftUpdateCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	return updateDraft(cmd.Context(), cmd.OutOrStdout(), draftID, draft, existing.CSRFToken)
-}
-
-func draftUpdateHasChanges(subjectChanged, toChanged, ccChanged, bccChanged, messageChanged bool) bool {
-	return subjectChanged || toChanged || ccChanged || bccChanged || messageChanged
 }
 
 type draftDeleteCommand struct{}
@@ -257,11 +253,6 @@ func createMessageDraft(ctx context.Context, w io.Writer, draft draftFormRequest
 }
 
 func createReplyDraft(ctx context.Context, w io.Writer, threadID int64, draft draftFormRequest) error {
-	senderID, err := sdk.DefaultSenderID(ctx)
-	if err != nil {
-		return convertSDKError(err)
-	}
-
 	topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", threadID))
 	if err != nil {
 		return convertSDKError(err)
@@ -278,17 +269,27 @@ func createReplyDraft(ctx context.Context, w io.Writer, threadID int64, draft dr
 	}
 
 	latestEntryID := entries[len(entries)-1].ID
+	if len(draft.To) == 0 && len(draft.CC) == 0 && len(draft.BCC) == 0 {
+		draft.To = addressed.To
+		draft.CC = addressed.CC
+		draft.BCC = addressed.BCC
+	}
+
+	return createReplyDraftForEntry(ctx, w, latestEntryID, draft)
+}
+
+func createReplyDraftForEntry(ctx context.Context, w io.Writer, latestEntryID int64, draft draftFormRequest) error {
+	senderID, err := sdk.DefaultSenderID(ctx)
+	if err != nil {
+		return convertSDKError(err)
+	}
+
 	replyForm, err := loadReplyDraftForm(ctx, latestEntryID)
 	if err != nil {
 		return err
 	}
 	if draft.Subject == "" {
 		draft.Subject = replyForm.Request.Subject
-	}
-	if len(draft.To) == 0 && len(draft.CC) == 0 && len(draft.BCC) == 0 {
-		draft.To = addressed.To
-		draft.CC = addressed.CC
-		draft.BCC = addressed.BCC
 	}
 
 	values := draftValues(senderID, draft)

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -1,0 +1,425 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/editor"
+	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type draftCommand struct {
+	cmd *cobra.Command
+}
+
+var (
+	messageSubjectInputRe = regexp.MustCompile(`(?s)<input[^>]+name="message\[subject\]"[^>]*>`)
+	valueAttrRe           = regexp.MustCompile(`\svalue="([^"]*)"`)
+)
+
+func newDraftCommand() *draftCommand {
+	draftCommand := &draftCommand{}
+	draftCommand.cmd = &cobra.Command{
+		Use:   "draft",
+		Short: "Create, update, or delete drafts",
+		Annotations: map[string]string{
+			"agent_notes": "Use draft create/update/delete for draft-safe email work. These commands save drafts and do not send.",
+		},
+	}
+
+	draftCommand.cmd.AddCommand(newDraftCreateCommand())
+	draftCommand.cmd.AddCommand(newDraftUpdateCommand())
+	draftCommand.cmd.AddCommand(newDraftDeleteCommand())
+
+	return draftCommand
+}
+
+type draftCreateCommand struct {
+	to       string
+	cc       string
+	bcc      string
+	subject  string
+	message  string
+	threadID string
+}
+
+func newDraftCreateCommand() *cobra.Command {
+	c := &draftCreateCommand{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a saved draft without sending",
+		Example: `  hey draft create --to alice@example.com --subject "Hello" -m "Hi there"
+  hey draft create --thread-id 12345 -m "Thanks, I'll take a look."`,
+		RunE: c.run,
+	}
+
+	cmd.Flags().StringVar(&c.to, "to", "", "Recipient email address(es)")
+	cmd.Flags().StringVar(&c.cc, "cc", "", "CC recipient email address(es)")
+	cmd.Flags().StringVar(&c.bcc, "bcc", "", "BCC recipient email address(es)")
+	cmd.Flags().StringVar(&c.subject, "subject", "", "Message subject")
+	cmd.Flags().StringVarP(&c.message, "message", "m", "", "Draft body (or opens $EDITOR)")
+	cmd.Flags().StringVar(&c.threadID, "thread-id", "", "Thread ID to draft a reply in")
+
+	return cmd
+}
+
+func (c *draftCreateCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	message, err := draftMessage(c.message)
+	if err != nil {
+		return err
+	}
+
+	req := draftFormRequest{
+		Subject: c.subject,
+		Content: message,
+		To:      parseAddresses(c.to),
+		CC:      parseAddresses(c.cc),
+		BCC:     parseAddresses(c.bcc),
+	}
+
+	if c.threadID != "" {
+		threadID, err := strconv.ParseInt(c.threadID, 10, 64)
+		if err != nil {
+			return output.ErrUsage(fmt.Sprintf("invalid thread ID: %s", c.threadID))
+		}
+		return createReplyDraft(cmd.Context(), cmd.OutOrStdout(), threadID, req)
+	}
+
+	if req.Subject == "" {
+		return output.ErrUsageHint("--subject is required for new drafts", "hey draft create --to <email> --subject <subject> -m <message>")
+	}
+
+	return createMessageDraft(cmd.Context(), cmd.OutOrStdout(), req)
+}
+
+type draftUpdateCommand struct {
+	to      string
+	cc      string
+	bcc     string
+	subject string
+	message string
+}
+
+func newDraftUpdateCommand() *cobra.Command {
+	c := &draftUpdateCommand{}
+	cmd := &cobra.Command{
+		Use:     "update <draft-id>",
+		Short:   "Replace a saved draft without sending",
+		Example: `  hey draft update 12345 --to alice@example.com --subject "Hello" -m "Updated body"`,
+		Args:    usageExactOneArg(),
+		RunE:    c.run,
+	}
+
+	cmd.Flags().StringVar(&c.to, "to", "", "Recipient email address(es)")
+	cmd.Flags().StringVar(&c.cc, "cc", "", "CC recipient email address(es)")
+	cmd.Flags().StringVar(&c.bcc, "bcc", "", "BCC recipient email address(es)")
+	cmd.Flags().StringVar(&c.subject, "subject", "", "Message subject (required)")
+	cmd.Flags().StringVarP(&c.message, "message", "m", "", "Draft body (or opens $EDITOR)")
+
+	return cmd
+}
+
+func (c *draftUpdateCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	draftID, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return output.ErrUsage(fmt.Sprintf("invalid draft ID: %s", args[0]))
+	}
+	if c.subject == "" {
+		return output.ErrUsageHint("--subject is required", "hey draft update <draft-id> --to <email> --subject <subject> -m <message>")
+	}
+
+	message, err := draftMessage(c.message)
+	if err != nil {
+		return err
+	}
+
+	return updateDraft(cmd.Context(), cmd.OutOrStdout(), draftID, draftFormRequest{
+		Subject: c.subject,
+		Content: message,
+		To:      parseAddresses(c.to),
+		CC:      parseAddresses(c.cc),
+		BCC:     parseAddresses(c.bcc),
+	})
+}
+
+type draftDeleteCommand struct{}
+
+func newDraftDeleteCommand() *cobra.Command {
+	c := &draftDeleteCommand{}
+	return &cobra.Command{
+		Use:     "delete <draft-id>",
+		Short:   "Delete a saved draft",
+		Example: `  hey draft delete 12345`,
+		Args:    usageExactOneArg(),
+		RunE:    c.run,
+	}
+}
+
+func (c *draftDeleteCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	draftID, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return output.ErrUsage(fmt.Sprintf("invalid draft ID: %s", args[0]))
+	}
+
+	return deleteDraft(cmd.Context(), cmd.OutOrStdout(), draftID)
+}
+
+type draftFormRequest struct {
+	Subject string
+	Content string
+	To      []string
+	CC      []string
+	BCC     []string
+}
+
+type draftResponse struct {
+	ID      int64  `json:"id"`
+	URL     string `json:"url"`
+	EditURL string `json:"edit_url"`
+	Subject string `json:"subject,omitempty"`
+}
+
+func createMessageDraft(ctx context.Context, w io.Writer, draft draftFormRequest) error {
+	senderID, err := sdk.DefaultSenderID(ctx)
+	if err != nil {
+		return convertSDKError(err)
+	}
+
+	values := draftValues(senderID, draft)
+	resp, err := submitDraftForm(ctx, "POST", "/messages", values)
+	if err != nil {
+		return err
+	}
+
+	return writeDraftSaved(w, resp, "Draft created")
+}
+
+func createReplyDraft(ctx context.Context, w io.Writer, threadID int64, draft draftFormRequest) error {
+	senderID, err := sdk.DefaultSenderID(ctx)
+	if err != nil {
+		return convertSDKError(err)
+	}
+
+	topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", threadID))
+	if err != nil {
+		return convertSDKError(err)
+	}
+	addressed := htmlutil.ParseTopicAddressed(string(topicResp.Data))
+
+	entriesResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d/entries", threadID))
+	if err != nil {
+		return convertSDKError(err)
+	}
+	entries := htmlutil.ParseTopicEntriesHTML(string(entriesResp.Data))
+	if len(entries) == 0 {
+		return output.ErrNotFound("entries for thread", fmt.Sprintf("%d", threadID))
+	}
+
+	latestEntryID := entries[len(entries)-1].ID
+	if draft.Subject == "" {
+		subject, err := defaultReplySubject(ctx, latestEntryID)
+		if err != nil {
+			return err
+		}
+		draft.Subject = subject
+	}
+	if len(draft.To) == 0 && len(draft.CC) == 0 && len(draft.BCC) == 0 {
+		draft.To = addressed.To
+		draft.CC = addressed.CC
+		draft.BCC = addressed.BCC
+	}
+
+	values := draftValues(senderID, draft)
+	resp, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/entries/%d/replies", latestEntryID), values)
+	if err != nil {
+		return err
+	}
+
+	return writeDraftSaved(w, resp, "Reply draft created")
+}
+
+func defaultReplySubject(ctx context.Context, entryID int64) (string, error) {
+	resp, err := sdk.GetHTML(ctx, fmt.Sprintf("/entries/%d/replies/new", entryID))
+	if err != nil {
+		return "", convertSDKError(err)
+	}
+	subject := parseMessageSubject(string(resp.Data))
+	if subject == "" {
+		return "", output.ErrAPI(0, "could not determine reply draft subject")
+	}
+	return subject, nil
+}
+
+func updateDraft(ctx context.Context, w io.Writer, draftID int64, draft draftFormRequest) error {
+	senderID, err := sdk.DefaultSenderID(ctx)
+	if err != nil {
+		return convertSDKError(err)
+	}
+
+	values := draftValues(senderID, draft)
+	values.Set("_method", "patch")
+
+	resp, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/messages/%d", draftID), values)
+	if err != nil {
+		return err
+	}
+	if resp.ID == 0 {
+		resp.ID = draftID
+		resp.URL = fmt.Sprintf("%s/messages/%d", strings.TrimRight(cfg.BaseURL, "/"), draftID)
+		resp.EditURL = resp.URL + "/edit"
+	}
+
+	return writeDraftSaved(w, resp, "Draft updated")
+}
+
+func deleteDraft(ctx context.Context, w io.Writer, draftID int64) error {
+	values := url.Values{}
+	values.Set("_method", "delete")
+	values.Set("status", "drafted")
+
+	if _, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/messages/%d", draftID), values); err != nil {
+		return err
+	}
+
+	if writer.IsStyled() {
+		fmt.Fprintf(w, "Draft %d deleted.\n", draftID)
+		return nil
+	}
+
+	return writeOK(map[string]int64{"id": draftID}, output.WithSummary("Draft deleted"))
+}
+
+func draftValues(senderID int64, draft draftFormRequest) url.Values {
+	values := url.Values{}
+	values.Set("acting_sender_id", fmt.Sprintf("%d", senderID))
+	values.Set("entry[status]", "drafted")
+	values.Set("message[subject]", draft.Subject)
+	values.Set("message[content]", draft.Content)
+	for _, to := range draft.To {
+		values.Add("entry[addressed][directly][]", to)
+	}
+	for _, cc := range draft.CC {
+		values.Add("entry[addressed][copied][]", cc)
+	}
+	for _, bcc := range draft.BCC {
+		values.Add("entry[addressed][blindcopied][]", bcc)
+	}
+	return values
+}
+
+func submitDraftForm(ctx context.Context, method, path string, values url.Values) (draftResponse, error) {
+	reqURL := strings.TrimRight(cfg.BaseURL, "/") + path
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, strings.NewReader(values.Encode()))
+	if err != nil {
+		return draftResponse{}, err
+	}
+	if err := authMgr.AuthenticateRequest(ctx, req); err != nil {
+		return draftResponse{}, output.ErrAuth(err.Error())
+	}
+	req.Header.Set("User-Agent", "hey-cli")
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return draftResponse{}, output.ErrNetwork(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return draftResponse{}, output.ErrAPI(resp.StatusCode, msg)
+	}
+
+	location := resp.Header.Get("Location")
+	return draftResponseFromLocation(location), nil
+}
+
+func draftResponseFromLocation(location string) draftResponse {
+	if location == "" {
+		return draftResponse{}
+	}
+	location = strings.TrimRight(location, "/")
+	id, _ := strconv.ParseInt(location[strings.LastIndex(location, "/")+1:], 10, 64)
+	return draftResponse{
+		ID:      id,
+		URL:     location,
+		EditURL: location + "/edit",
+	}
+}
+
+func parseMessageSubject(pageHTML string) string {
+	input := messageSubjectInputRe.FindString(pageHTML)
+	if input == "" {
+		return ""
+	}
+	match := valueAttrRe.FindStringSubmatch(input)
+	if match == nil {
+		return ""
+	}
+	return html.UnescapeString(match[1])
+}
+
+func writeDraftSaved(w io.Writer, resp draftResponse, summary string) error {
+	if writer.IsStyled() {
+		if resp.ID > 0 {
+			fmt.Fprintf(w, "%s: %d\n", summary, resp.ID)
+		} else {
+			fmt.Fprintln(w, summary+".")
+		}
+		return nil
+	}
+	return writeOK(resp, output.WithSummary(summary))
+}
+
+func draftMessage(inline string) (string, error) {
+	if inline != "" {
+		return inline, nil
+	}
+	if !stdinIsTerminal() {
+		message, err := readStdin()
+		if err != nil {
+			return "", err
+		}
+		if message == "" {
+			return "", output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
+		}
+		return message, nil
+	}
+
+	message, err := editor.Open("")
+	if err != nil {
+		return "", output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
+	}
+	if message == "" {
+		return "", output.ErrUsage("empty message, aborting")
+	}
+	return message, nil
+}

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -139,21 +139,25 @@ func newDraftUpdateCommand() *cobra.Command {
 }
 
 func (c *draftUpdateCommand) run(cmd *cobra.Command, args []string) error {
-	if err := requireAuth(); err != nil {
-		return err
-	}
-
 	draftID, err := strconv.ParseInt(args[0], 10, 64)
 	if err != nil {
 		return output.ErrUsage(fmt.Sprintf("invalid draft ID: %s", args[0]))
 	}
+	flags := cmd.Flags()
+	if !draftUpdateHasChanges(flags.Changed("subject"), flags.Changed("to"), flags.Changed("cc"), flags.Changed("bcc"), flags.Changed("message")) {
+		return output.ErrUsageHint("No update fields specified", "hey draft update <draft-id> --subject <subject> -m <message>")
+	}
+
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
 	existing, err := loadMessageDraft(cmd.Context(), draftID)
 	if err != nil {
 		return err
 	}
 	draft := existing.Request
 
-	flags := cmd.Flags()
 	if flags.Changed("subject") {
 		draft.Subject = c.subject
 	}
@@ -167,7 +171,7 @@ func (c *draftUpdateCommand) run(cmd *cobra.Command, args []string) error {
 		draft.BCC = parseAddresses(c.bcc)
 	}
 
-	if flags.Changed("message") || !stdinIsTerminal() {
+	if flags.Changed("message") {
 		message, err := draftMessageWithInitial(c.message, draft.Content, flags.Changed("message"))
 		if err != nil {
 			return err
@@ -176,6 +180,10 @@ func (c *draftUpdateCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	return updateDraft(cmd.Context(), cmd.OutOrStdout(), draftID, draft, existing.CSRFToken)
+}
+
+func draftUpdateHasChanges(subjectChanged, toChanged, ccChanged, bccChanged, messageChanged bool) bool {
+	return subjectChanged || toChanged || ccChanged || bccChanged || messageChanged
 }
 
 type draftDeleteCommand struct{}

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -322,6 +322,18 @@ func loadMessageDraft(ctx context.Context, draftID int64) (draftFormState, error
 	return state, nil
 }
 
+func loadMessageDraftCSRFToken(ctx context.Context, draftID int64) (string, error) {
+	resp, err := sdk.GetHTML(ctx, fmt.Sprintf("/messages/%d/edit", draftID))
+	if err != nil {
+		return "", convertSDKError(err)
+	}
+	token := parseCSRFToken(string(resp.Data))
+	if token == "" {
+		return "", output.ErrAPI(0, "could not determine draft authenticity token")
+	}
+	return token, nil
+}
+
 func loadCSRFToken(ctx context.Context, path string) (string, error) {
 	resp, err := sdk.GetHTML(ctx, path)
 	if err != nil {
@@ -357,7 +369,7 @@ func updateDraft(ctx context.Context, w io.Writer, draftID int64, draft draftFor
 }
 
 func deleteDraft(ctx context.Context, w io.Writer, draftID int64) error {
-	existing, err := loadMessageDraft(ctx, draftID)
+	csrfToken, err := loadMessageDraftCSRFToken(ctx, draftID)
 	if err != nil {
 		return err
 	}
@@ -365,7 +377,7 @@ func deleteDraft(ctx context.Context, w io.Writer, draftID int64) error {
 	values.Set("_method", "delete")
 	values.Set("status", "drafted")
 
-	if _, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/messages/%d", draftID), values, existing.CSRFToken); err != nil {
+	if _, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/messages/%d", draftID), values, csrfToken); err != nil {
 		return err
 	}
 
@@ -533,9 +545,10 @@ func parseSelectedAddressesField(pageHTML, fieldName string) ([]string, bool) {
 	var addresses []string
 	for _, option := range optionRe.FindAllString(match[1], -1) {
 		valueMatch := valueAttrRe.FindStringSubmatch(option)
-		if valueMatch != nil {
-			addresses = append(addresses, html.UnescapeString(valueMatch[1]))
+		if valueMatch == nil {
+			return nil, false
 		}
+		addresses = append(addresses, html.UnescapeString(valueMatch[1]))
 	}
 	return addresses, true
 }

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -24,7 +25,11 @@ type draftCommand struct {
 
 var (
 	messageSubjectInputRe = regexp.MustCompile(`(?s)<input[^>]+name="message\[subject\]"[^>]*>`)
+	messageContentInputRe = regexp.MustCompile(`(?s)<input[^>]+name="message\[content\]"[^>]*>`)
+	csrfMetaRe            = regexp.MustCompile(`(?s)<meta[^>]+name="csrf-token"[^>]*>`)
+	optionRe              = regexp.MustCompile(`(?s)<option[^>]*\bselected\b[^>]*>`)
 	valueAttrRe           = regexp.MustCompile(`\svalue="([^"]*)"`)
+	contentAttrRe         = regexp.MustCompile(`\scontent="([^"]*)"`)
 )
 
 func newDraftCommand() *draftCommand {
@@ -118,7 +123,7 @@ func newDraftUpdateCommand() *cobra.Command {
 	c := &draftUpdateCommand{}
 	cmd := &cobra.Command{
 		Use:     "update <draft-id>",
-		Short:   "Replace a saved draft without sending",
+		Short:   "Update a saved draft without sending",
 		Example: `  hey draft update 12345 --to alice@example.com --subject "Hello" -m "Updated body"`,
 		Args:    usageExactOneArg(),
 		RunE:    c.run,
@@ -127,7 +132,7 @@ func newDraftUpdateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&c.to, "to", "", "Recipient email address(es)")
 	cmd.Flags().StringVar(&c.cc, "cc", "", "CC recipient email address(es)")
 	cmd.Flags().StringVar(&c.bcc, "bcc", "", "BCC recipient email address(es)")
-	cmd.Flags().StringVar(&c.subject, "subject", "", "Message subject (required)")
+	cmd.Flags().StringVar(&c.subject, "subject", "", "Message subject")
 	cmd.Flags().StringVarP(&c.message, "message", "m", "", "Draft body (or opens $EDITOR)")
 
 	return cmd
@@ -142,22 +147,33 @@ func (c *draftUpdateCommand) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return output.ErrUsage(fmt.Sprintf("invalid draft ID: %s", args[0]))
 	}
-	if c.subject == "" {
-		return output.ErrUsageHint("--subject is required", "hey draft update <draft-id> --to <email> --subject <subject> -m <message>")
-	}
-
-	message, err := draftMessage(c.message)
+	existing, err := loadMessageDraft(cmd.Context(), draftID)
 	if err != nil {
 		return err
 	}
+	draft := existing.Request
 
-	return updateDraft(cmd.Context(), cmd.OutOrStdout(), draftID, draftFormRequest{
-		Subject: c.subject,
-		Content: message,
-		To:      parseAddresses(c.to),
-		CC:      parseAddresses(c.cc),
-		BCC:     parseAddresses(c.bcc),
-	})
+	flags := cmd.Flags()
+	if flags.Changed("subject") {
+		draft.Subject = c.subject
+	}
+	if flags.Changed("to") {
+		draft.To = parseAddresses(c.to)
+	}
+	if flags.Changed("cc") {
+		draft.CC = parseAddresses(c.cc)
+	}
+	if flags.Changed("bcc") {
+		draft.BCC = parseAddresses(c.bcc)
+	}
+
+	message, err := draftMessageWithInitial(c.message, draft.Content, flags.Changed("message"))
+	if err != nil {
+		return err
+	}
+	draft.Content = message
+
+	return updateDraft(cmd.Context(), cmd.OutOrStdout(), draftID, draft, existing.CSRFToken)
 }
 
 type draftDeleteCommand struct{}
@@ -201,14 +217,23 @@ type draftResponse struct {
 	Subject string `json:"subject,omitempty"`
 }
 
+type draftFormState struct {
+	Request   draftFormRequest
+	CSRFToken string
+}
+
 func createMessageDraft(ctx context.Context, w io.Writer, draft draftFormRequest) error {
 	senderID, err := sdk.DefaultSenderID(ctx)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	csrfToken, err := loadCSRFToken(ctx, "/messages/new")
+	if err != nil {
+		return err
+	}
 
 	values := draftValues(senderID, draft)
-	resp, err := submitDraftForm(ctx, "POST", "/messages", values)
+	resp, err := submitDraftForm(ctx, "POST", "/messages", values, csrfToken)
 	if err != nil {
 		return err
 	}
@@ -238,12 +263,12 @@ func createReplyDraft(ctx context.Context, w io.Writer, threadID int64, draft dr
 	}
 
 	latestEntryID := entries[len(entries)-1].ID
+	replyForm, err := loadReplyDraftForm(ctx, latestEntryID)
+	if err != nil {
+		return err
+	}
 	if draft.Subject == "" {
-		subject, err := defaultReplySubject(ctx, latestEntryID)
-		if err != nil {
-			return err
-		}
-		draft.Subject = subject
+		draft.Subject = replyForm.Request.Subject
 	}
 	if len(draft.To) == 0 && len(draft.CC) == 0 && len(draft.BCC) == 0 {
 		draft.To = addressed.To
@@ -252,7 +277,7 @@ func createReplyDraft(ctx context.Context, w io.Writer, threadID int64, draft dr
 	}
 
 	values := draftValues(senderID, draft)
-	resp, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/entries/%d/replies", latestEntryID), values)
+	resp, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/entries/%d/replies", latestEntryID), values, replyForm.CSRFToken)
 	if err != nil {
 		return err
 	}
@@ -260,19 +285,35 @@ func createReplyDraft(ctx context.Context, w io.Writer, threadID int64, draft dr
 	return writeDraftSaved(w, resp, "Reply draft created")
 }
 
-func defaultReplySubject(ctx context.Context, entryID int64) (string, error) {
+func loadReplyDraftForm(ctx context.Context, entryID int64) (draftFormState, error) {
 	resp, err := sdk.GetHTML(ctx, fmt.Sprintf("/entries/%d/replies/new", entryID))
+	if err != nil {
+		return draftFormState{}, convertSDKError(err)
+	}
+	state := parseDraftForm(string(resp.Data))
+	if state.Request.Subject == "" {
+		return draftFormState{}, output.ErrAPI(0, "could not determine reply draft subject")
+	}
+	return state, nil
+}
+
+func loadMessageDraft(ctx context.Context, draftID int64) (draftFormState, error) {
+	resp, err := sdk.GetHTML(ctx, fmt.Sprintf("/messages/%d/edit", draftID))
+	if err != nil {
+		return draftFormState{}, convertSDKError(err)
+	}
+	return parseDraftForm(string(resp.Data)), nil
+}
+
+func loadCSRFToken(ctx context.Context, path string) (string, error) {
+	resp, err := sdk.GetHTML(ctx, path)
 	if err != nil {
 		return "", convertSDKError(err)
 	}
-	subject := parseMessageSubject(string(resp.Data))
-	if subject == "" {
-		return "", output.ErrAPI(0, "could not determine reply draft subject")
-	}
-	return subject, nil
+	return parseCSRFToken(string(resp.Data)), nil
 }
 
-func updateDraft(ctx context.Context, w io.Writer, draftID int64, draft draftFormRequest) error {
+func updateDraft(ctx context.Context, w io.Writer, draftID int64, draft draftFormRequest, csrfToken string) error {
 	senderID, err := sdk.DefaultSenderID(ctx)
 	if err != nil {
 		return convertSDKError(err)
@@ -281,7 +322,7 @@ func updateDraft(ctx context.Context, w io.Writer, draftID int64, draft draftFor
 	values := draftValues(senderID, draft)
 	values.Set("_method", "patch")
 
-	resp, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/messages/%d", draftID), values)
+	resp, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/messages/%d", draftID), values, csrfToken)
 	if err != nil {
 		return err
 	}
@@ -295,11 +336,15 @@ func updateDraft(ctx context.Context, w io.Writer, draftID int64, draft draftFor
 }
 
 func deleteDraft(ctx context.Context, w io.Writer, draftID int64) error {
+	existing, err := loadMessageDraft(ctx, draftID)
+	if err != nil {
+		return err
+	}
 	values := url.Values{}
 	values.Set("_method", "delete")
 	values.Set("status", "drafted")
 
-	if _, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/messages/%d", draftID), values); err != nil {
+	if _, err := submitDraftForm(ctx, "POST", fmt.Sprintf("/messages/%d", draftID), values, existing.CSRFToken); err != nil {
 		return err
 	}
 
@@ -329,7 +374,10 @@ func draftValues(senderID int64, draft draftFormRequest) url.Values {
 	return values
 }
 
-func submitDraftForm(ctx context.Context, method, path string, values url.Values) (draftResponse, error) {
+func submitDraftForm(ctx context.Context, method, path string, values url.Values, csrfToken string) (draftResponse, error) {
+	if csrfToken != "" {
+		values.Set("authenticity_token", csrfToken)
+	}
 	reqURL := strings.TrimRight(cfg.BaseURL, "/") + path
 	req, err := http.NewRequestWithContext(ctx, method, reqURL, strings.NewReader(values.Encode()))
 	if err != nil {
@@ -342,8 +390,17 @@ func submitDraftForm(ctx context.Context, method, path string, values url.Values
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	if csrfToken != "" {
+		req.Header.Set("X-CSRF-Token", csrfToken)
+	}
 
-	resp, err := http.DefaultClient.Do(req)
+	client := httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	start := time.Now()
+	resp, err := client.Do(req)
+	trackDraftRequest(time.Since(start))
 	if err != nil {
 		return draftResponse{}, output.ErrNetwork(err)
 	}
@@ -360,6 +417,14 @@ func submitDraftForm(ctx context.Context, method, path string, values url.Values
 
 	location := resp.Header.Get("Location")
 	return draftResponseFromLocation(location), nil
+}
+
+func trackDraftRequest(duration time.Duration) {
+	if sdkStats == nil {
+		return
+	}
+	sdkStats.requestCount.Add(1)
+	sdkStats.totalLatency.Add(int64(duration))
 }
 
 func draftResponseFromLocation(location string) draftResponse {
@@ -387,6 +452,60 @@ func parseMessageSubject(pageHTML string) string {
 	return html.UnescapeString(match[1])
 }
 
+func parseDraftForm(pageHTML string) draftFormState {
+	return draftFormState{
+		Request: draftFormRequest{
+			Subject: parseMessageSubject(pageHTML),
+			Content: parseMessageContent(pageHTML),
+			To:      parseSelectedAddresses(pageHTML, "entry[addressed][directly][]"),
+			CC:      parseSelectedAddresses(pageHTML, "entry[addressed][copied][]"),
+			BCC:     parseSelectedAddresses(pageHTML, "entry[addressed][blindcopied][]"),
+		},
+		CSRFToken: parseCSRFToken(pageHTML),
+	}
+}
+
+func parseMessageContent(pageHTML string) string {
+	input := messageContentInputRe.FindString(pageHTML)
+	if input == "" {
+		return ""
+	}
+	match := valueAttrRe.FindStringSubmatch(input)
+	if match == nil {
+		return ""
+	}
+	return html.UnescapeString(match[1])
+}
+
+func parseSelectedAddresses(pageHTML, fieldName string) []string {
+	selectRe := regexp.MustCompile(`(?s)<select[^>]+name="` + regexp.QuoteMeta(fieldName) + `"[^>]*>(.*?)</select>`)
+	match := selectRe.FindStringSubmatch(pageHTML)
+	if match == nil {
+		return nil
+	}
+
+	var addresses []string
+	for _, option := range optionRe.FindAllString(match[1], -1) {
+		valueMatch := valueAttrRe.FindStringSubmatch(option)
+		if valueMatch != nil {
+			addresses = append(addresses, html.UnescapeString(valueMatch[1]))
+		}
+	}
+	return addresses
+}
+
+func parseCSRFToken(pageHTML string) string {
+	meta := csrfMetaRe.FindString(pageHTML)
+	if meta == "" {
+		return ""
+	}
+	match := contentAttrRe.FindStringSubmatch(meta)
+	if match == nil {
+		return ""
+	}
+	return html.UnescapeString(match[1])
+}
+
 func writeDraftSaved(w io.Writer, resp draftResponse, summary string) error {
 	if writer.IsStyled() {
 		if resp.ID > 0 {
@@ -400,8 +519,15 @@ func writeDraftSaved(w io.Writer, resp draftResponse, summary string) error {
 }
 
 func draftMessage(inline string) (string, error) {
+	return draftMessageWithInitial(inline, "", inline != "")
+}
+
+func draftMessageWithInitial(inline, initial string, inlineChanged bool) (string, error) {
 	if inline != "" {
 		return inline, nil
+	}
+	if inlineChanged {
+		return "", nil
 	}
 	if !stdinIsTerminal() {
 		message, err := readStdin()
@@ -409,12 +535,15 @@ func draftMessage(inline string) (string, error) {
 			return "", err
 		}
 		if message == "" {
+			if initial != "" {
+				return initial, nil
+			}
 			return "", output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
 		}
 		return message, nil
 	}
 
-	message, err := editor.Open("")
+	message, err := editor.Open(initial)
 	if err != nil {
 		return "", output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
 	}

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -414,9 +414,13 @@ func draftContentHTML(content string) string {
 	content = strings.ReplaceAll(content, "\r", "\n")
 	lines := strings.Split(content, "\n")
 	for i, line := range lines {
-		lines[i] = html.EscapeString(line)
+		if line == "" {
+			lines[i] = "<div><br></div>"
+			continue
+		}
+		lines[i] = "<div>" + html.EscapeString(line) + "</div>"
 	}
-	return "<div>" + strings.Join(lines, "<br>") + "</div>"
+	return strings.Join(lines, "")
 }
 
 func looksLikeDraftHTML(content string) bool {

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -167,11 +167,13 @@ func (c *draftUpdateCommand) run(cmd *cobra.Command, args []string) error {
 		draft.BCC = parseAddresses(c.bcc)
 	}
 
-	message, err := draftMessageWithInitial(c.message, draft.Content, flags.Changed("message"))
-	if err != nil {
-		return err
+	if flags.Changed("message") || !stdinIsTerminal() {
+		message, err := draftMessageWithInitial(c.message, draft.Content, flags.Changed("message"))
+		if err != nil {
+			return err
+		}
+		draft.Content = message
 	}
-	draft.Content = message
 
 	return updateDraft(cmd.Context(), cmd.OutOrStdout(), draftID, draft, existing.CSRFToken)
 }
@@ -218,8 +220,13 @@ type draftResponse struct {
 }
 
 type draftFormState struct {
-	Request   draftFormRequest
-	CSRFToken string
+	Request    draftFormRequest
+	CSRFToken  string
+	HasSubject bool
+	HasContent bool
+	HasTo      bool
+	HasCC      bool
+	HasBCC     bool
 }
 
 func createMessageDraft(ctx context.Context, w io.Writer, draft draftFormRequest) error {
@@ -291,8 +298,11 @@ func loadReplyDraftForm(ctx context.Context, entryID int64) (draftFormState, err
 		return draftFormState{}, convertSDKError(err)
 	}
 	state := parseDraftForm(string(resp.Data))
-	if state.Request.Subject == "" {
+	if !state.HasSubject || state.Request.Subject == "" {
 		return draftFormState{}, output.ErrAPI(0, "could not determine reply draft subject")
+	}
+	if state.CSRFToken == "" {
+		return draftFormState{}, output.ErrAPI(0, "could not determine reply draft authenticity token")
 	}
 	return state, nil
 }
@@ -302,7 +312,14 @@ func loadMessageDraft(ctx context.Context, draftID int64) (draftFormState, error
 	if err != nil {
 		return draftFormState{}, convertSDKError(err)
 	}
-	return parseDraftForm(string(resp.Data)), nil
+	state := parseDraftForm(string(resp.Data))
+	if !state.HasSubject || !state.HasContent || !state.HasTo || !state.HasCC || !state.HasBCC {
+		return draftFormState{}, output.ErrAPI(0, "could not parse draft edit form")
+	}
+	if state.CSRFToken == "" {
+		return draftFormState{}, output.ErrAPI(0, "could not determine draft authenticity token")
+	}
+	return state, nil
 }
 
 func loadCSRFToken(ctx context.Context, path string) (string, error) {
@@ -310,7 +327,11 @@ func loadCSRFToken(ctx context.Context, path string) (string, error) {
 	if err != nil {
 		return "", convertSDKError(err)
 	}
-	return parseCSRFToken(string(resp.Data)), nil
+	token := parseCSRFToken(string(resp.Data))
+	if token == "" {
+		return "", output.ErrAPI(0, "could not determine draft authenticity token")
+	}
+	return token, nil
 }
 
 func updateDraft(ctx context.Context, w io.Writer, draftID int64, draft draftFormRequest, csrfToken string) error {
@@ -441,47 +462,72 @@ func draftResponseFromLocation(location string) draftResponse {
 }
 
 func parseMessageSubject(pageHTML string) string {
+	subject, _ := parseMessageSubjectField(pageHTML)
+	return subject
+}
+
+func parseMessageSubjectField(pageHTML string) (string, bool) {
 	input := messageSubjectInputRe.FindString(pageHTML)
 	if input == "" {
-		return ""
+		return "", false
 	}
 	match := valueAttrRe.FindStringSubmatch(input)
 	if match == nil {
-		return ""
+		return "", false
 	}
-	return html.UnescapeString(match[1])
+	return html.UnescapeString(match[1]), true
 }
 
 func parseDraftForm(pageHTML string) draftFormState {
+	subject, hasSubject := parseMessageSubjectField(pageHTML)
+	content, hasContent := parseMessageContentField(pageHTML)
+	to, hasTo := parseSelectedAddressesField(pageHTML, "entry[addressed][directly][]")
+	cc, hasCC := parseSelectedAddressesField(pageHTML, "entry[addressed][copied][]")
+	bcc, hasBCC := parseSelectedAddressesField(pageHTML, "entry[addressed][blindcopied][]")
 	return draftFormState{
 		Request: draftFormRequest{
-			Subject: parseMessageSubject(pageHTML),
-			Content: parseMessageContent(pageHTML),
-			To:      parseSelectedAddresses(pageHTML, "entry[addressed][directly][]"),
-			CC:      parseSelectedAddresses(pageHTML, "entry[addressed][copied][]"),
-			BCC:     parseSelectedAddresses(pageHTML, "entry[addressed][blindcopied][]"),
+			Subject: subject,
+			Content: content,
+			To:      to,
+			CC:      cc,
+			BCC:     bcc,
 		},
-		CSRFToken: parseCSRFToken(pageHTML),
+		CSRFToken:  parseCSRFToken(pageHTML),
+		HasSubject: hasSubject,
+		HasContent: hasContent,
+		HasTo:      hasTo,
+		HasCC:      hasCC,
+		HasBCC:     hasBCC,
 	}
 }
 
 func parseMessageContent(pageHTML string) string {
+	content, _ := parseMessageContentField(pageHTML)
+	return content
+}
+
+func parseMessageContentField(pageHTML string) (string, bool) {
 	input := messageContentInputRe.FindString(pageHTML)
 	if input == "" {
-		return ""
+		return "", false
 	}
 	match := valueAttrRe.FindStringSubmatch(input)
 	if match == nil {
-		return ""
+		return "", false
 	}
-	return html.UnescapeString(match[1])
+	return html.UnescapeString(match[1]), true
 }
 
 func parseSelectedAddresses(pageHTML, fieldName string) []string {
+	addresses, _ := parseSelectedAddressesField(pageHTML, fieldName)
+	return addresses
+}
+
+func parseSelectedAddressesField(pageHTML, fieldName string) ([]string, bool) {
 	selectRe := regexp.MustCompile(`(?s)<select[^>]+name="` + regexp.QuoteMeta(fieldName) + `"[^>]*>(.*?)</select>`)
 	match := selectRe.FindStringSubmatch(pageHTML)
 	if match == nil {
-		return nil
+		return nil, false
 	}
 
 	var addresses []string
@@ -491,7 +537,7 @@ func parseSelectedAddresses(pageHTML, fieldName string) []string {
 			addresses = append(addresses, html.UnescapeString(valueMatch[1]))
 		}
 	}
-	return addresses
+	return addresses, true
 }
 
 func parseCSRFToken(pageHTML string) string {

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -322,18 +322,6 @@ func loadMessageDraft(ctx context.Context, draftID int64) (draftFormState, error
 	return state, nil
 }
 
-func loadMessageDraftCSRFToken(ctx context.Context, draftID int64) (string, error) {
-	resp, err := sdk.GetHTML(ctx, fmt.Sprintf("/messages/%d/edit", draftID))
-	if err != nil {
-		return "", convertSDKError(err)
-	}
-	token := parseCSRFToken(string(resp.Data))
-	if token == "" {
-		return "", output.ErrAPI(0, "could not determine draft authenticity token")
-	}
-	return token, nil
-}
-
 func loadCSRFToken(ctx context.Context, path string) (string, error) {
 	resp, err := sdk.GetHTML(ctx, path)
 	if err != nil {
@@ -369,7 +357,7 @@ func updateDraft(ctx context.Context, w io.Writer, draftID int64, draft draftFor
 }
 
 func deleteDraft(ctx context.Context, w io.Writer, draftID int64) error {
-	csrfToken, err := loadMessageDraftCSRFToken(ctx, draftID)
+	csrfToken, err := loadCSRFToken(ctx, fmt.Sprintf("/messages/%d/edit", draftID))
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -253,12 +253,6 @@ func createMessageDraft(ctx context.Context, w io.Writer, draft draftFormRequest
 }
 
 func createReplyDraft(ctx context.Context, w io.Writer, threadID int64, draft draftFormRequest) error {
-	topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", threadID))
-	if err != nil {
-		return convertSDKError(err)
-	}
-	addressed := htmlutil.ParseTopicAddressed(string(topicResp.Data))
-
 	entriesResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d/entries", threadID))
 	if err != nil {
 		return convertSDKError(err)
@@ -268,14 +262,7 @@ func createReplyDraft(ctx context.Context, w io.Writer, threadID int64, draft dr
 		return output.ErrNotFound("entries for thread", fmt.Sprintf("%d", threadID))
 	}
 
-	latestEntryID := entries[len(entries)-1].ID
-	if len(draft.To) == 0 && len(draft.CC) == 0 && len(draft.BCC) == 0 {
-		draft.To = addressed.To
-		draft.CC = addressed.CC
-		draft.BCC = addressed.BCC
-	}
-
-	return createReplyDraftForEntry(ctx, w, latestEntryID, draft)
+	return createReplyDraftForEntry(ctx, w, entries[len(entries)-1].ID, draft)
 }
 
 func createReplyDraftForEntry(ctx context.Context, w io.Writer, latestEntryID int64, draft draftFormRequest) error {
@@ -290,6 +277,10 @@ func createReplyDraftForEntry(ctx context.Context, w io.Writer, latestEntryID in
 	}
 	if draft.Subject == "" {
 		draft.Subject = replyForm.Request.Subject
+	}
+	draft = withReplyFormRecipients(draft, replyForm.Request)
+	if len(draft.To) == 0 && len(draft.CC) == 0 && len(draft.BCC) == 0 {
+		return output.ErrUsage("could not determine thread recipients")
 	}
 
 	values := draftValues(senderID, draft)
@@ -391,7 +382,7 @@ func draftValues(senderID int64, draft draftFormRequest) url.Values {
 	values.Set("acting_sender_id", fmt.Sprintf("%d", senderID))
 	values.Set("entry[status]", "drafted")
 	values.Set("message[subject]", draft.Subject)
-	values.Set("message[content]", draft.Content)
+	values.Set("message[content]", draftContentHTML(draft.Content))
 	for _, to := range draft.To {
 		values.Add("entry[addressed][directly][]", to)
 	}
@@ -402,6 +393,40 @@ func draftValues(senderID int64, draft draftFormRequest) url.Values {
 		values.Add("entry[addressed][blindcopied][]", bcc)
 	}
 	return values
+}
+
+func withReplyFormRecipients(draft, replyForm draftFormRequest) draftFormRequest {
+	if len(draft.To) > 0 || len(draft.CC) > 0 || len(draft.BCC) > 0 {
+		return draft
+	}
+	draft.To = replyForm.To
+	draft.CC = replyForm.CC
+	draft.BCC = replyForm.BCC
+	return draft
+}
+
+func draftContentHTML(content string) string {
+	if looksLikeDraftHTML(content) {
+		return content
+	}
+
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		lines[i] = html.EscapeString(line)
+	}
+	return "<div>" + strings.Join(lines, "<br>") + "</div>"
+}
+
+func looksLikeDraftHTML(content string) bool {
+	trimmed := strings.TrimSpace(strings.ToLower(content))
+	return strings.HasPrefix(trimmed, "<div") ||
+		strings.HasPrefix(trimmed, "<p") ||
+		strings.HasPrefix(trimmed, "<ul") ||
+		strings.HasPrefix(trimmed, "<ol") ||
+		strings.HasPrefix(trimmed, "<blockquote") ||
+		strings.Contains(trimmed, "<br")
 }
 
 func submitDraftForm(ctx context.Context, method, path string, values url.Values, csrfToken string) (draftResponse, error) {

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -464,14 +464,19 @@ func submitDraftForm(ctx context.Context, method, path string, values url.Values
 		return draftResponse{}, output.ErrNetwork(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		msg := strings.TrimSpace(string(body))
-		if msg == "" {
-			msg = resp.Status
+		msg := resp.Status
+		if readErr == nil {
+			if bodyText := strings.TrimSpace(string(body)); bodyText != "" {
+				msg = bodyText
+			}
 		}
 		return draftResponse{}, output.ErrAPI(resp.StatusCode, msg)
+	}
+	if readErr != nil {
+		return draftResponse{}, output.ErrNetwork(readErr)
 	}
 
 	location := resp.Header.Get("Location")
@@ -490,12 +495,23 @@ func draftResponseFromLocation(location string) draftResponse {
 	if location == "" {
 		return draftResponse{}
 	}
-	location = strings.TrimRight(location, "/")
-	id, _ := strconv.ParseInt(location[strings.LastIndex(location, "/")+1:], 10, 64)
+	locationURL := strings.TrimRight(location, "/")
+	if parsed, err := url.Parse(location); err == nil {
+		parsed.RawQuery = ""
+		parsed.Fragment = ""
+		parsed.Path = strings.TrimRight(parsed.Path, "/")
+		locationURL = parsed.String()
+	}
+
+	path := locationURL
+	if parsed, err := url.Parse(locationURL); err == nil && parsed.Path != "" {
+		path = parsed.Path
+	}
+	id, _ := strconv.ParseInt(path[strings.LastIndex(path, "/")+1:], 10, 64)
 	return draftResponse{
 		ID:      id,
-		URL:     location,
-		EditURL: location + "/edit",
+		URL:     locationURL,
+		EditURL: locationURL + "/edit",
 	}
 }
 

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -633,15 +633,11 @@ func writeDraftSaved(w io.Writer, resp draftResponse, summary string) error {
 	return writeOK(resp, output.WithSummary(summary))
 }
 
-func draftMessage(inline string) (string, error) {
-	return draftMessageWithInitial(inline, "", inline != "")
-}
-
-func draftMessageWithInitial(inline, initial string, inlineChanged bool) (string, error) {
+func draftMessageWithInitial(inline, initial string, messageFlagChanged bool) (string, error) {
 	if inline != "" {
 		return inline, nil
 	}
-	if inlineChanged {
+	if messageFlagChanged {
 		return "", nil
 	}
 	if !stdinIsTerminal() {

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -484,16 +484,17 @@ func submitDraftForm(ctx context.Context, method, path string, values url.Values
 }
 
 func responseBodyErrorMessage(body []byte) string {
-	const maxErrorBodyBytes = 500
+	const maxErrorBodyRunes = 500
 	bodyText := strings.TrimSpace(string(body))
 	if bodyText == "" {
 		return ""
 	}
 	bodyText = strings.Join(strings.Fields(bodyText), " ")
-	if len(bodyText) <= maxErrorBodyBytes {
+	runes := []rune(bodyText)
+	if len(runes) <= maxErrorBodyRunes {
 		return bodyText
 	}
-	return bodyText[:maxErrorBodyBytes] + "..."
+	return string(runes[:maxErrorBodyRunes]) + "..."
 }
 
 func trackDraftRequest(duration time.Duration) {

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -83,7 +83,7 @@ func (c *draftCreateCommand) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	message, err := draftMessage(c.message)
+	message, err := draftMessageWithInitial(c.message, "", cmd.Flags().Changed("message"))
 	if err != nil {
 		return err
 	}
@@ -469,7 +469,7 @@ func submitDraftForm(ctx context.Context, method, path string, values url.Values
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		msg := resp.Status
 		if readErr == nil {
-			if bodyText := strings.TrimSpace(string(body)); bodyText != "" {
+			if bodyText := responseBodyErrorMessage(body); bodyText != "" {
 				msg = bodyText
 			}
 		}
@@ -481,6 +481,19 @@ func submitDraftForm(ctx context.Context, method, path string, values url.Values
 
 	location := resp.Header.Get("Location")
 	return draftResponseFromLocation(location), nil
+}
+
+func responseBodyErrorMessage(body []byte) string {
+	const maxErrorBodyBytes = 500
+	bodyText := strings.TrimSpace(string(body))
+	if bodyText == "" {
+		return ""
+	}
+	bodyText = strings.Join(strings.Fields(bodyText), " ")
+	if len(bodyText) <= maxErrorBodyBytes {
+		return bodyText
+	}
+	return bodyText[:maxErrorBodyBytes] + "..."
 }
 
 func trackDraftRequest(duration time.Duration) {

--- a/internal/cmd/draft_command_test.go
+++ b/internal/cmd/draft_command_test.go
@@ -29,6 +29,15 @@ func TestComposeDraftNewMessageUsesDraftEndpoint(t *testing.T) {
 	recorder.assertHit(t, "POST /messages.json", 0)
 }
 
+func TestComposeDraftAllowsExplicitEmptyMessage(t *testing.T) {
+	recorder := newDraftEndpointRecorder(t)
+	cmd := newComposeCommand().cmd
+	runCommandWithServer(t, cmd, recorder.handler, "--draft", "--to", "alice@example.com", "--subject", "Hello", "--message", "")
+
+	recorder.assertHit(t, "POST /messages", 1)
+	recorder.assertFormValue(t, "POST /messages", "message[content]", "<div><br></div>")
+}
+
 func TestDraftCreateAllowsExplicitEmptyMessage(t *testing.T) {
 	recorder := newDraftEndpointRecorder(t)
 	cmd := newDraftCreateCommand()
@@ -36,6 +45,15 @@ func TestDraftCreateAllowsExplicitEmptyMessage(t *testing.T) {
 
 	recorder.assertHit(t, "POST /messages", 1)
 	recorder.assertFormValue(t, "POST /messages", "message[content]", "<div><br></div>")
+}
+
+func TestDraftUpdateAllowsExplicitEmptyMessage(t *testing.T) {
+	recorder := newDraftEndpointRecorder(t)
+	cmd := newDraftUpdateCommand()
+	runCommandWithServer(t, cmd, recorder.handler, "123", "--message", "")
+
+	recorder.assertHit(t, "POST /messages/123", 1)
+	recorder.assertFormValue(t, "POST /messages/123", "message[content]", "<div><br></div>")
 }
 
 func TestComposeSendsNewMessageWithoutDraft(t *testing.T) {
@@ -63,6 +81,15 @@ func TestReplyDraftUsesReplyDraftEndpoint(t *testing.T) {
 
 	recorder.assertHit(t, "POST /entries/456/replies", 1)
 	recorder.assertHit(t, "POST /entries/456/replies.json", 0)
+}
+
+func TestReplyDraftAllowsExplicitEmptyMessage(t *testing.T) {
+	recorder := newDraftEndpointRecorder(t)
+	cmd := newReplyCommand().cmd
+	runCommandWithServer(t, cmd, recorder.handler, "123", "--draft", "--message", "")
+
+	recorder.assertHit(t, "POST /entries/456/replies", 1)
+	recorder.assertFormValue(t, "POST /entries/456/replies", "message[content]", "<div><br></div>")
 }
 
 func TestReplySendsWithoutDraft(t *testing.T) {
@@ -102,7 +129,7 @@ func (r *draftEndpointRecorder) handler(w http.ResponseWriter, req *http.Request
 	case "GET /identity.json":
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(testIdentityJSON))
-	case "GET /messages/new", "GET /entries/456/replies/new":
+	case "GET /messages/new", "GET /messages/123/edit", "GET /entries/456/replies/new":
 		w.Header().Set("Content-Type", "text/html")
 		_, _ = w.Write([]byte(testDraftFormHTML()))
 	case "GET /topics/123/entries":
@@ -114,6 +141,9 @@ func (r *draftEndpointRecorder) handler(w http.ResponseWriter, req *http.Request
 	case "POST /entries/456/replies":
 		w.Header().Set("Location", "https://app.hey.test/messages/9002")
 		w.WriteHeader(http.StatusCreated)
+	case "POST /messages/123":
+		w.Header().Set("Location", "https://app.hey.test/messages/123")
+		w.WriteHeader(http.StatusOK)
 	case "POST /messages.json", "POST /topics/123/entries.json", "POST /entries/456/replies.json":
 		w.WriteHeader(http.StatusNoContent)
 	default:

--- a/internal/cmd/draft_command_test.go
+++ b/internal/cmd/draft_command_test.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/auth"
+	"github.com/basecamp/hey-cli/internal/config"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+const testIdentityJSON = `{"email_address":"user@hey.com","id":1,"senders":[{"id":42,"default":true}],"primary_contact":{"id":42}}`
+
+func TestComposeDraftNewMessageUsesDraftEndpoint(t *testing.T) {
+	recorder := newDraftEndpointRecorder(t)
+	cmd := newComposeCommand().cmd
+	runCommandWithServer(t, cmd, recorder.handler, "--draft", "--to", "alice@example.com", "--subject", "Hello", "-m", "Draft body")
+
+	recorder.assertHit(t, "POST /messages", 1)
+	recorder.assertHit(t, "POST /messages.json", 0)
+}
+
+func TestComposeSendsNewMessageWithoutDraft(t *testing.T) {
+	recorder := newDraftEndpointRecorder(t)
+	cmd := newComposeCommand().cmd
+	runCommandWithServer(t, cmd, recorder.handler, "--to", "alice@example.com", "--subject", "Hello", "-m", "Send body")
+
+	recorder.assertHit(t, "POST /messages.json", 1)
+	recorder.assertHit(t, "POST /messages", 0)
+}
+
+func TestComposeDraftThreadMessageUsesReplyDraftEndpoint(t *testing.T) {
+	recorder := newDraftEndpointRecorder(t)
+	cmd := newComposeCommand().cmd
+	runCommandWithServer(t, cmd, recorder.handler, "--draft", "--thread-id", "123", "--subject", "Re: Hello", "-m", "Draft body")
+
+	recorder.assertHit(t, "POST /entries/456/replies", 1)
+	recorder.assertHit(t, "POST /topics/123/entries.json", 0)
+}
+
+func TestReplyDraftUsesReplyDraftEndpoint(t *testing.T) {
+	recorder := newDraftEndpointRecorder(t)
+	cmd := newReplyCommand().cmd
+	runCommandWithServer(t, cmd, recorder.handler, "123", "--draft", "-m", "Draft reply")
+
+	recorder.assertHit(t, "POST /entries/456/replies", 1)
+	recorder.assertHit(t, "POST /entries/456/replies.json", 0)
+}
+
+func TestReplySendsWithoutDraft(t *testing.T) {
+	recorder := newDraftEndpointRecorder(t)
+	cmd := newReplyCommand().cmd
+	runCommandWithServer(t, cmd, recorder.handler, "123", "-m", "Send reply")
+
+	recorder.assertHit(t, "POST /entries/456/replies.json", 1)
+	recorder.assertHit(t, "POST /entries/456/replies", 0)
+}
+
+type draftEndpointRecorder struct {
+	mu   sync.Mutex
+	hits map[string]int
+}
+
+func newDraftEndpointRecorder(t *testing.T) *draftEndpointRecorder {
+	t.Helper()
+	return &draftEndpointRecorder{hits: map[string]int{}}
+}
+
+func (r *draftEndpointRecorder) handler(w http.ResponseWriter, req *http.Request) {
+	key := req.Method + " " + req.URL.Path
+	r.mu.Lock()
+	r.hits[key]++
+	r.mu.Unlock()
+
+	switch key {
+	case "GET /identity.json":
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testIdentityJSON))
+	case "GET /messages/new", "GET /entries/456/replies/new":
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(testDraftFormHTML()))
+	case "GET /topics/123/entries":
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<article id="entry_456" data-entry-id="456"></article>`))
+	case "POST /messages":
+		w.Header().Set("Location", "https://app.hey.test/messages/9001")
+		w.WriteHeader(http.StatusCreated)
+	case "POST /entries/456/replies":
+		w.Header().Set("Location", "https://app.hey.test/messages/9002")
+		w.WriteHeader(http.StatusCreated)
+	case "POST /messages.json", "POST /topics/123/entries.json", "POST /entries/456/replies.json":
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, fmt.Sprintf("unexpected request %s", key), http.StatusNotFound)
+	}
+}
+
+func (r *draftEndpointRecorder) assertHit(t *testing.T, key string, want int) {
+	t.Helper()
+	r.mu.Lock()
+	got := r.hits[key]
+	r.mu.Unlock()
+	if got != want {
+		t.Fatalf("%s hit %d times, want %d", key, got, want)
+	}
+}
+
+func runCommandWithServer(t *testing.T, cmd *cobra.Command, handler http.HandlerFunc, args ...string) string {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	oldCfg, oldAuthMgr, oldHTTPClient, oldSDK, oldWriter := cfg, authMgr, httpClient, sdk, writer
+	t.Cleanup(func() {
+		cfg, authMgr, httpClient, sdk, writer = oldCfg, oldAuthMgr, oldHTTPClient, oldSDK, oldWriter
+	})
+
+	t.Setenv("HEY_TOKEN", "test-token")
+	cfg = &config.Config{BaseURL: server.URL}
+	httpClient = server.Client()
+	authMgr = auth.NewManager(cfg.BaseURL, httpClient, t.TempDir())
+	sdk = hey.NewClient(
+		&hey.Config{BaseURL: server.URL, CacheEnabled: false},
+		nil,
+		hey.WithAuthStrategy(&cliAuthStrategy{mgr: authMgr}),
+		hey.WithHTTPClient(httpClient),
+	)
+
+	var buf bytes.Buffer
+	writer = output.New(output.Options{Format: output.FormatJSON, Stdout: &buf, Stderr: &buf})
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute %v: %v\n%s", args, err, buf.String())
+	}
+	return buf.String()
+}
+
+func testDraftFormHTML() string {
+	return `
+<meta name="csrf-token" content="csrf-123" />
+<input value="Re: Hello" name="message[subject]" />
+<input type="hidden" name="message[content]" value="Existing body" />
+<select name="entry[addressed][directly][]" hidden multiple>
+  <option value="alice@example.com" selected>Alice</option>
+</select>
+<select name="entry[addressed][copied][]" hidden multiple></select>
+<select name="entry[addressed][blindcopied][]" hidden multiple></select>`
+}

--- a/internal/cmd/draft_command_test.go
+++ b/internal/cmd/draft_command_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync"
 	"testing"
 
@@ -26,6 +27,15 @@ func TestComposeDraftNewMessageUsesDraftEndpoint(t *testing.T) {
 
 	recorder.assertHit(t, "POST /messages", 1)
 	recorder.assertHit(t, "POST /messages.json", 0)
+}
+
+func TestDraftCreateAllowsExplicitEmptyMessage(t *testing.T) {
+	recorder := newDraftEndpointRecorder(t)
+	cmd := newDraftCreateCommand()
+	runCommandWithServer(t, cmd, recorder.handler, "--to", "alice@example.com", "--subject", "Hello", "--message", "")
+
+	recorder.assertHit(t, "POST /messages", 1)
+	recorder.assertFormValue(t, "POST /messages", "message[content]", "<div><br></div>")
 }
 
 func TestComposeSendsNewMessageWithoutDraft(t *testing.T) {
@@ -67,17 +77,25 @@ func TestReplySendsWithoutDraft(t *testing.T) {
 type draftEndpointRecorder struct {
 	mu   sync.Mutex
 	hits map[string]int
+	form map[string]url.Values
 }
 
 func newDraftEndpointRecorder(t *testing.T) *draftEndpointRecorder {
 	t.Helper()
-	return &draftEndpointRecorder{hits: map[string]int{}}
+	return &draftEndpointRecorder{
+		hits: map[string]int{},
+		form: map[string]url.Values{},
+	}
 }
 
 func (r *draftEndpointRecorder) handler(w http.ResponseWriter, req *http.Request) {
 	key := req.Method + " " + req.URL.Path
+	_ = req.ParseForm()
 	r.mu.Lock()
 	r.hits[key]++
+	if len(req.PostForm) > 0 {
+		r.form[key] = req.PostForm
+	}
 	r.mu.Unlock()
 
 	switch key {
@@ -110,6 +128,16 @@ func (r *draftEndpointRecorder) assertHit(t *testing.T, key string, want int) {
 	r.mu.Unlock()
 	if got != want {
 		t.Fatalf("%s hit %d times, want %d", key, got, want)
+	}
+}
+
+func (r *draftEndpointRecorder) assertFormValue(t *testing.T, key, name, want string) {
+	t.Helper()
+	r.mu.Lock()
+	got := r.form[key].Get(name)
+	r.mu.Unlock()
+	if got != want {
+		t.Fatalf("%s form %s = %q, want %q", key, name, got, want)
 	}
 }
 

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestDraftValues(t *testing.T) {
 	values := draftValues(123, draftFormRequest{
@@ -46,5 +49,43 @@ func TestParseMessageSubject(t *testing.T) {
 
 	if got := parseMessageSubject(html); got != "Re: Research & Planning" {
 		t.Fatalf("subject = %q", got)
+	}
+}
+
+func TestParseDraftForm(t *testing.T) {
+	html := `
+<meta name="csrf-token" content="csrf-123" />
+<select name="entry[addressed][directly][]" hidden multiple>
+  <option value="alice@example.com" selected>Alice</option>
+  <option value="bob@example.com">Bob</option>
+</select>
+<select name="entry[addressed][copied][]" hidden multiple>
+  <option value="carol@example.com" selected>Carol</option>
+</select>
+<select name="entry[addressed][blindcopied][]" hidden multiple>
+  <option value="dave@example.com" selected>Dave</option>
+</select>
+<input value="Hello &amp; welcome" name="message[subject]" />
+<input type="hidden" name="message[content]" value="Body &amp; more" />`
+
+	state := parseDraftForm(html)
+
+	if state.CSRFToken != "csrf-123" {
+		t.Fatalf("csrf = %q", state.CSRFToken)
+	}
+	if state.Request.Subject != "Hello & welcome" {
+		t.Fatalf("subject = %q", state.Request.Subject)
+	}
+	if state.Request.Content != "Body & more" {
+		t.Fatalf("content = %q", state.Request.Content)
+	}
+	if !reflect.DeepEqual(state.Request.To, []string{"alice@example.com"}) {
+		t.Fatalf("to = %#v", state.Request.To)
+	}
+	if !reflect.DeepEqual(state.Request.CC, []string{"carol@example.com"}) {
+		t.Fatalf("cc = %#v", state.Request.CC)
+	}
+	if !reflect.DeepEqual(state.Request.BCC, []string{"dave@example.com"}) {
+		t.Fatalf("bcc = %#v", state.Request.BCC)
 	}
 }

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -37,6 +37,56 @@ func TestDraftValues(t *testing.T) {
 	}
 }
 
+func TestDraftValuesFormatsPlainTextContent(t *testing.T) {
+	values := draftValues(123, draftFormRequest{
+		Subject: "Hello",
+		Content: "Hi Chrissie,\n\nThanks & all the best.\n\nMike",
+		To:      []string{"chrissie@example.com"},
+	})
+
+	want := "<div>Hi Chrissie,<br><br>Thanks &amp; all the best.<br><br>Mike</div>"
+	if got := values.Get("message[content]"); got != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+}
+
+func TestWithReplyFormRecipientsUsesReplyFormDefaults(t *testing.T) {
+	got := withReplyFormRecipients(draftFormRequest{
+		Content: "Thanks",
+	}, draftFormRequest{
+		To:  []string{"chrissie@example.com"},
+		CC:  []string{"friend@example.com"},
+		BCC: nil,
+	})
+
+	want := draftFormRequest{
+		Content: "Thanks",
+		To:      []string{"chrissie@example.com"},
+		CC:      []string{"friend@example.com"},
+		BCC:     nil,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("draft = %#v, want %#v", got, want)
+	}
+}
+
+func TestWithReplyFormRecipientsKeepsExplicitRecipients(t *testing.T) {
+	got := withReplyFormRecipients(draftFormRequest{
+		Content: "Thanks",
+		To:      []string{"selected@example.com"},
+	}, draftFormRequest{
+		To:  []string{"form@example.com"},
+		BCC: []string{"hidden@example.com"},
+	})
+
+	if !reflect.DeepEqual(got.To, []string{"selected@example.com"}) {
+		t.Fatalf("to = %#v", got.To)
+	}
+	if len(got.BCC) != 0 {
+		t.Fatalf("bcc = %#v, want empty explicit recipient state to be preserved", got.BCC)
+	}
+}
+
 func TestDraftResponseFromLocation(t *testing.T) {
 	resp := draftResponseFromLocation("https://app.hey.com/messages/2159062391")
 

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -73,6 +73,9 @@ func TestParseDraftForm(t *testing.T) {
 	if state.CSRFToken != "csrf-123" {
 		t.Fatalf("csrf = %q", state.CSRFToken)
 	}
+	if !state.HasSubject || !state.HasContent || !state.HasTo || !state.HasCC || !state.HasBCC {
+		t.Fatalf("field presence = subject:%t content:%t to:%t cc:%t bcc:%t", state.HasSubject, state.HasContent, state.HasTo, state.HasCC, state.HasBCC)
+	}
 	if state.Request.Subject != "Hello & welcome" {
 		t.Fatalf("subject = %q", state.Request.Subject)
 	}
@@ -87,5 +90,16 @@ func TestParseDraftForm(t *testing.T) {
 	}
 	if !reflect.DeepEqual(state.Request.BCC, []string{"dave@example.com"}) {
 		t.Fatalf("bcc = %#v", state.Request.BCC)
+	}
+}
+
+func TestParseDraftFormMissingFields(t *testing.T) {
+	state := parseDraftForm(`<meta name="csrf-token" content="csrf-123" />`)
+
+	if state.CSRFToken != "csrf-123" {
+		t.Fatalf("csrf = %q", state.CSRFToken)
+	}
+	if state.HasSubject || state.HasContent || state.HasTo || state.HasCC || state.HasBCC {
+		t.Fatalf("unexpected field presence = subject:%t content:%t to:%t cc:%t bcc:%t", state.HasSubject, state.HasContent, state.HasTo, state.HasCC, state.HasBCC)
 	}
 }

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/basecamp/hey-cli/internal/output"
 )
 
 func TestDraftValues(t *testing.T) {
@@ -117,14 +121,23 @@ func TestParseSelectedAddressesFieldRejectsSelectedOptionWithoutValue(t *testing
 	}
 }
 
-func TestDraftUpdateHasChanges(t *testing.T) {
-	if draftUpdateHasChanges(false, false, false, false, false) {
-		t.Fatal("expected no changes when no flags are changed")
+func TestDraftUpdateWithoutFieldsFailsBeforeAuth(t *testing.T) {
+	cmd := newDraftUpdateCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"123"})
+
+	err := cmd.Execute()
+
+	var usageErr *output.Error
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("error = %T, want output.Error", err)
 	}
-	if !draftUpdateHasChanges(true, false, false, false, false) {
-		t.Fatal("expected subject flag change to count")
+	if usageErr.Code != "usage" {
+		t.Fatalf("code = %q, want usage", usageErr.Code)
 	}
-	if !draftUpdateHasChanges(false, false, false, false, true) {
-		t.Fatal("expected message flag change to count")
+	if usageErr.Message != "No update fields specified" {
+		t.Fatalf("message = %q", usageErr.Message)
 	}
 }

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -44,7 +44,7 @@ func TestDraftValuesFormatsPlainTextContent(t *testing.T) {
 		To:      []string{"chrissie@example.com"},
 	})
 
-	want := "<div>Hi Chrissie,<br><br>Thanks &amp; all the best.<br><br>Mike</div>"
+	want := "<div>Hi Chrissie,</div><div><br></div><div>Thanks &amp; all the best.</div><div><br></div><div>Mike</div>"
 	if got := values.Get("message[content]"); got != want {
 		t.Fatalf("content = %q, want %q", got, want)
 	}

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import "testing"
+
+func TestDraftValues(t *testing.T) {
+	values := draftValues(123, draftFormRequest{
+		Subject: "Hello",
+		Content: "<div>Hi there</div>",
+		To:      []string{"alice@example.com", "bob@example.org"},
+		CC:      []string{"carol@example.com"},
+		BCC:     []string{"dave@example.org"},
+	})
+
+	if got := values.Get("acting_sender_id"); got != "123" {
+		t.Fatalf("acting_sender_id = %q, want 123", got)
+	}
+	if got := values.Get("entry[status]"); got != "drafted" {
+		t.Fatalf("entry status = %q, want drafted", got)
+	}
+	if got := values.Get("message[subject]"); got != "Hello" {
+		t.Fatalf("subject = %q, want Hello", got)
+	}
+	if got := values.Get("message[content]"); got != "<div>Hi there</div>" {
+		t.Fatalf("content = %q", got)
+	}
+
+	to := values["entry[addressed][directly][]"]
+	if len(to) != 2 || to[0] != "alice@example.com" || to[1] != "bob@example.org" {
+		t.Fatalf("to = %#v", to)
+	}
+}
+
+func TestDraftResponseFromLocation(t *testing.T) {
+	resp := draftResponseFromLocation("https://app.hey.com/messages/2159062391")
+
+	if resp.ID != 2159062391 {
+		t.Fatalf("ID = %d, want 2159062391", resp.ID)
+	}
+	if resp.EditURL != "https://app.hey.com/messages/2159062391/edit" {
+		t.Fatalf("EditURL = %q", resp.EditURL)
+	}
+}
+
+func TestParseMessageSubject(t *testing.T) {
+	html := `<input class="input" value="Re: Research &amp; Planning" name="message[subject]" id="message_subject" />`
+
+	if got := parseMessageSubject(html); got != "Re: Research & Planning" {
+		t.Fatalf("subject = %q", got)
+	}
+}

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -116,3 +116,15 @@ func TestParseSelectedAddressesFieldRejectsSelectedOptionWithoutValue(t *testing
 		t.Fatalf("expected parser to reject selected option without value, got %#v", addresses)
 	}
 }
+
+func TestDraftUpdateHasChanges(t *testing.T) {
+	if draftUpdateHasChanges(false, false, false, false, false) {
+		t.Fatal("expected no changes when no flags are changed")
+	}
+	if !draftUpdateHasChanges(true, false, false, false, false) {
+		t.Fatal("expected subject flag change to count")
+	}
+	if !draftUpdateHasChanges(false, false, false, false, true) {
+		t.Fatal("expected message flag change to count")
+	}
+}

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -103,3 +103,16 @@ func TestParseDraftFormMissingFields(t *testing.T) {
 		t.Fatalf("unexpected field presence = subject:%t content:%t to:%t cc:%t bcc:%t", state.HasSubject, state.HasContent, state.HasTo, state.HasCC, state.HasBCC)
 	}
 }
+
+func TestParseSelectedAddressesFieldRejectsSelectedOptionWithoutValue(t *testing.T) {
+	html := `
+<select name="entry[addressed][directly][]" hidden multiple>
+  <option selected>Alice</option>
+</select>`
+
+	addresses, ok := parseSelectedAddressesField(html, "entry[addressed][directly][]")
+
+	if ok {
+		t.Fatalf("expected parser to reject selected option without value, got %#v", addresses)
+	}
+}

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -180,6 +180,18 @@ func TestResponseBodyErrorMessageCapsAndCollapsesWhitespace(t *testing.T) {
 	}
 }
 
+func TestResponseBodyErrorMessageCapsMultibyteText(t *testing.T) {
+	got := responseBodyErrorMessage([]byte(strings.Repeat("é", 600)))
+	prefix := strings.TrimSuffix(got, "...")
+
+	if len([]rune(prefix)) != 500 {
+		t.Fatalf("message prefix length = %d, want 500 runes", len([]rune(prefix)))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("message = %q, want ellipsis", got)
+	}
+}
+
 func TestParseMessageSubject(t *testing.T) {
 	html := `<input class="input" value="Re: Research &amp; Planning" name="message[subject]" id="message_subject" />`
 

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -2,10 +2,17 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"io"
+	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/basecamp/hey-cli/internal/auth"
+	"github.com/basecamp/hey-cli/internal/config"
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
@@ -98,12 +105,87 @@ func TestDraftResponseFromLocation(t *testing.T) {
 	}
 }
 
+func TestDraftResponseFromLocationWithQueryAndFragment(t *testing.T) {
+	resp := draftResponseFromLocation("https://app.hey.com/messages/2159062391?draft=1#top")
+
+	if resp.ID != 2159062391 {
+		t.Fatalf("ID = %d, want 2159062391", resp.ID)
+	}
+	if resp.URL != "https://app.hey.com/messages/2159062391" {
+		t.Fatalf("URL = %q", resp.URL)
+	}
+	if resp.EditURL != "https://app.hey.com/messages/2159062391/edit" {
+		t.Fatalf("EditURL = %q", resp.EditURL)
+	}
+}
+
+func TestDraftResponseFromRelativeLocation(t *testing.T) {
+	resp := draftResponseFromLocation("/messages/2159062391?draft=1")
+
+	if resp.ID != 2159062391 {
+		t.Fatalf("ID = %d, want 2159062391", resp.ID)
+	}
+	if resp.URL != "/messages/2159062391" {
+		t.Fatalf("URL = %q", resp.URL)
+	}
+	if resp.EditURL != "/messages/2159062391/edit" {
+		t.Fatalf("EditURL = %q", resp.EditURL)
+	}
+}
+
+func TestSubmitDraftFormFallsBackToStatusWhenErrorBodyReadFails(t *testing.T) {
+	oldCfg, oldAuthMgr, oldHTTPClient := cfg, authMgr, httpClient
+	t.Cleanup(func() {
+		cfg, authMgr, httpClient = oldCfg, oldAuthMgr, oldHTTPClient
+	})
+	t.Setenv("HEY_TOKEN", "test-token")
+	cfg = &config.Config{BaseURL: "https://app.hey.com"}
+	authMgr = auth.NewManager(cfg.BaseURL, nil, t.TempDir())
+	httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Status:     "502 Bad Gateway",
+			Body:       errorReadCloser{},
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	_, err := submitDraftForm(context.Background(), "POST", "/messages", url.Values{}, "csrf")
+
+	var apiErr *output.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T, want output.Error", err)
+	}
+	if apiErr.HTTPStatus != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", apiErr.HTTPStatus, http.StatusBadGateway)
+	}
+	if !strings.Contains(apiErr.Message, "502 Bad Gateway") {
+		t.Fatalf("message = %q, want status fallback", apiErr.Message)
+	}
+}
+
 func TestParseMessageSubject(t *testing.T) {
 	html := `<input class="input" value="Re: Research &amp; Planning" name="message[subject]" id="message_subject" />`
 
 	if got := parseMessageSubject(html); got != "Re: Research & Planning" {
 		t.Fatalf("subject = %q", got)
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errorReadCloser struct{}
+
+func (errorReadCloser) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
+
+func (errorReadCloser) Close() error {
+	return nil
 }
 
 func TestParseDraftForm(t *testing.T) {

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -169,8 +169,8 @@ func TestResponseBodyErrorMessageCapsAndCollapsesWhitespace(t *testing.T) {
 
 	got := responseBodyErrorMessage(body)
 
-	if len(got) != 503 {
-		t.Fatalf("length = %d, want capped message plus ellipsis", len(got))
+	if len([]rune(strings.TrimSuffix(got, "..."))) > 500 {
+		t.Fatalf("message prefix length = %d, want at most 500 runes", len([]rune(strings.TrimSuffix(got, "..."))))
 	}
 	if strings.Contains(got, "\n") || strings.Contains(got, "  ") {
 		t.Fatalf("message was not normalized: %q", got)

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -164,6 +164,22 @@ func TestSubmitDraftFormFallsBackToStatusWhenErrorBodyReadFails(t *testing.T) {
 	}
 }
 
+func TestResponseBodyErrorMessageCapsAndCollapsesWhitespace(t *testing.T) {
+	body := []byte("<html>\n" + strings.Repeat("long error body ", 80) + "</html>")
+
+	got := responseBodyErrorMessage(body)
+
+	if len(got) != 503 {
+		t.Fatalf("length = %d, want capped message plus ellipsis", len(got))
+	}
+	if strings.Contains(got, "\n") || strings.Contains(got, "  ") {
+		t.Fatalf("message was not normalized: %q", got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("message = %q, want ellipsis", got)
+	}
+}
+
 func TestParseMessageSubject(t *testing.T) {
 	html := `<input class="input" value="Re: Research &amp; Planning" name="message[subject]" id="message_subject" />`
 

--- a/internal/cmd/drafts.go
+++ b/internal/cmd/drafts.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -42,20 +45,11 @@ func (c *draftsCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := cmd.Context()
-	result, err := sdk.Entries().ListDrafts(ctx, nil)
+	drafts, total, hasMore, err := paginateDrafts(ctx, c.limit, c.all, fetchDraftsPage)
 	if err != nil {
-		return convertSDKError(err)
+		return err
 	}
-
-	var drafts []generated.DraftMessage
-	if result != nil {
-		drafts = *result
-	}
-	total := len(drafts)
-	if c.limit > 0 && !c.all && len(drafts) > c.limit {
-		drafts = drafts[:c.limit]
-	}
-	notice := output.TruncationNotice(len(drafts), total)
+	notice := draftsTruncationNotice(len(drafts), total, hasMore, c.all)
 
 	if writer.IsStyled() {
 		if len(drafts) == 0 {
@@ -79,4 +73,104 @@ func (c *draftsCommand) run(cmd *cobra.Command, args []string) error {
 		output.WithSummary(fmt.Sprintf("%d drafts", len(drafts))),
 		output.WithNotice(notice),
 	)
+}
+
+type draftPageFetcher func(ctx context.Context, pageURL string) ([]generated.DraftMessage, string, int, error)
+
+func fetchDraftsPage(ctx context.Context, pageURL string) ([]generated.DraftMessage, string, int, error) {
+	if strings.HasPrefix(pageURL, "http://") || strings.HasPrefix(pageURL, "https://") {
+		if err := validateSameOrigin(sdk.Config().BaseURL, pageURL); err != nil {
+			return nil, "", 0, err
+		}
+	}
+
+	resp, err := sdk.Get(ctx, pageURL)
+	if err != nil {
+		return nil, "", 0, convertSDKError(err)
+	}
+
+	var drafts []generated.DraftMessage
+	if err := resp.UnmarshalData(&drafts); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to parse drafts response: %w", err)
+	}
+
+	total := len(drafts)
+	if totalHeader := resp.Headers.Get("X-Total-Count"); totalHeader != "" {
+		if parsed, err := strconv.Atoi(totalHeader); err == nil {
+			total = parsed
+		}
+	}
+
+	return drafts, parseNextLinkHeader(resp.Headers.Get("Link")), total, nil
+}
+
+func paginateDrafts(ctx context.Context, limit int, all bool, fetch draftPageFetcher) ([]generated.DraftMessage, int, bool, error) {
+	if fetch == nil {
+		return nil, 0, false, fmt.Errorf("paginateDrafts: fetch function is nil")
+	}
+
+	pageDrafts, nextURL, total, err := fetch(ctx, "/entries/drafts.json")
+	if err != nil {
+		return nil, 0, false, err
+	}
+
+	drafts := append([]generated.DraftMessage(nil), pageDrafts...)
+	if total == 0 {
+		total = len(drafts)
+	}
+
+	needMore := all || (limit > 0 && len(drafts) < limit)
+	for page := 1; needMore && nextURL != "" && page <= maxAdditionalPages; page++ {
+		var pageTotal int
+		pageDrafts, nextURL, pageTotal, err = fetch(ctx, nextURL)
+		if err != nil {
+			return nil, 0, false, err
+		}
+		if pageTotal > total {
+			total = pageTotal
+		}
+		if len(pageDrafts) == 0 {
+			nextURL = ""
+			break
+		}
+
+		drafts = append(drafts, pageDrafts...)
+		needMore = all || (limit > 0 && len(drafts) < limit)
+	}
+
+	hasMore := nextURL != ""
+	if limit > 0 && !all && len(drafts) > limit {
+		drafts = drafts[:limit]
+		hasMore = true
+	}
+	if total < len(drafts) {
+		total = len(drafts)
+	}
+
+	return drafts, total, hasMore, nil
+}
+
+func draftsTruncationNotice(shown, total int, hasMore, all bool) string {
+	if hasMore && all {
+		return fmt.Sprintf("Showing %d of at least %d drafts. Pagination limit reached; not all drafts could be fetched.", shown, total)
+	}
+	if hasMore {
+		return fmt.Sprintf("Showing %d of %d drafts. Use --all to fetch all.", shown, total)
+	}
+	return output.TruncationNotice(shown, total)
+}
+
+func parseNextLinkHeader(linkHeader string) string {
+	for _, part := range strings.Split(linkHeader, ",") {
+		part = strings.TrimSpace(part)
+		if !strings.Contains(part, `rel="next"`) {
+			continue
+		}
+		start := strings.Index(part, "<")
+		end := strings.Index(part, ">")
+		if start >= 0 && end > start {
+			return part[start+1 : end]
+		}
+	}
+	return ""
 }

--- a/internal/cmd/drafts.go
+++ b/internal/cmd/drafts.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -78,13 +79,12 @@ func (c *draftsCommand) run(cmd *cobra.Command, args []string) error {
 type draftPageFetcher func(ctx context.Context, pageURL string) ([]generated.DraftMessage, string, int, error)
 
 func fetchDraftsPage(ctx context.Context, pageURL string) ([]generated.DraftMessage, string, int, error) {
-	if strings.HasPrefix(pageURL, "http://") || strings.HasPrefix(pageURL, "https://") {
-		if err := validateSameOrigin(sdk.Config().BaseURL, pageURL); err != nil {
-			return nil, "", 0, err
-		}
+	requestPath, err := normalizeDraftsPageURL(sdk.Config().BaseURL, pageURL)
+	if err != nil {
+		return nil, "", 0, err
 	}
 
-	resp, err := sdk.Get(ctx, pageURL)
+	resp, err := sdk.Get(ctx, requestPath)
 	if err != nil {
 		return nil, "", 0, convertSDKError(err)
 	}
@@ -102,6 +102,36 @@ func fetchDraftsPage(ctx context.Context, pageURL string) ([]generated.DraftMess
 	}
 
 	return drafts, parseNextLinkHeader(resp.Headers.Get("Link")), total, nil
+}
+
+func normalizeDraftsPageURL(baseURL, pageURL string) (string, error) {
+	parsed, err := url.Parse(pageURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid pagination URL: %w", err)
+	}
+	if parsed.Host == "" {
+		return pageURL, nil
+	}
+
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid base URL: %w", err)
+	}
+	if parsed.Scheme == "" {
+		parsed.Scheme = base.Scheme
+	}
+	if err := validateSameOrigin(baseURL, parsed.String()); err != nil {
+		return "", err
+	}
+
+	path := parsed.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	if parsed.RawQuery != "" {
+		path += "?" + parsed.RawQuery
+	}
+	return path, nil
 }
 
 func paginateDrafts(ctx context.Context, limit int, all bool, fetch draftPageFetcher) ([]generated.DraftMessage, int, bool, error) {

--- a/internal/cmd/drafts.go
+++ b/internal/cmd/drafts.go
@@ -110,6 +110,9 @@ func normalizeDraftsPageURL(baseURL, pageURL string) (string, error) {
 		return "", fmt.Errorf("invalid pagination URL: %w", err)
 	}
 	if parsed.Host == "" {
+		if parsed.Scheme != "" {
+			return "", fmt.Errorf("invalid pagination URL: absolute URL missing host")
+		}
 		return pageURL, nil
 	}
 

--- a/internal/cmd/drafts_test.go
+++ b/internal/cmd/drafts_test.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 )
 
 func TestPaginateDraftsAllFollowsNextLinks(t *testing.T) {
@@ -100,6 +102,63 @@ func TestParseNextLinkHeader(t *testing.T) {
 
 	if got != "https://app.hey.com/entries/drafts.json?page=next" {
 		t.Fatalf("next link = %q", got)
+	}
+}
+
+func TestFetchDraftsPageRejectsCrossOriginURL(t *testing.T) {
+	originalSDK := sdk
+	sdk = hey.NewClient(&hey.Config{BaseURL: "https://app.hey.com"}, nil)
+	t.Cleanup(func() { sdk = originalSDK })
+
+	_, _, _, err := fetchDraftsPage(context.Background(), "https://evil.example/entries/drafts.json")
+
+	if err == nil {
+		t.Fatal("expected cross-origin pagination URL to fail")
+	}
+	if !strings.Contains(err.Error(), "does not match base") {
+		t.Fatalf("error = %q, want origin mismatch", err.Error())
+	}
+}
+
+func TestDraftsTruncationNotice(t *testing.T) {
+	tests := []struct {
+		name    string
+		shown   int
+		total   int
+		hasMore bool
+		all     bool
+		want    string
+	}{
+		{
+			name:    "default page has more",
+			shown:   15,
+			total:   146,
+			hasMore: true,
+			want:    "Showing 15 of 146 drafts. Use --all to fetch all.",
+		},
+		{
+			name:    "all capped",
+			shown:   1500,
+			total:   1600,
+			hasMore: true,
+			all:     true,
+			want:    "Showing 1500 of at least 1600 drafts. Pagination limit reached; not all drafts could be fetched.",
+		},
+		{
+			name:  "complete result",
+			shown: 3,
+			total: 3,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := draftsTruncationNotice(tt.shown, tt.total, tt.hasMore, tt.all)
+			if got != tt.want {
+				t.Fatalf("notice = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/drafts_test.go
+++ b/internal/cmd/drafts_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+func TestPaginateDraftsAllFollowsNextLinks(t *testing.T) {
+	pages := map[string]struct {
+		drafts []generated.DraftMessage
+		next   string
+		total  int
+	}{
+		"/entries/drafts.json": {
+			drafts: []generated.DraftMessage{{Id: 1}, {Id: 2}},
+			next:   "https://app.hey.com/entries/drafts.json?page=2",
+			total:  3,
+		},
+		"https://app.hey.com/entries/drafts.json?page=2": {
+			drafts: []generated.DraftMessage{{Id: 3}},
+			total:  3,
+		},
+	}
+	var calls []string
+	fetch := func(_ context.Context, pageURL string) ([]generated.DraftMessage, string, int, error) {
+		calls = append(calls, pageURL)
+		page, ok := pages[pageURL]
+		if !ok {
+			t.Fatalf("unexpected page URL %q", pageURL)
+		}
+		return page.drafts, page.next, page.total, nil
+	}
+
+	drafts, total, hasMore, err := paginateDrafts(context.Background(), 0, true, fetch)
+	if err != nil {
+		t.Fatalf("paginateDrafts: %v", err)
+	}
+
+	if got := draftIDs(drafts); !reflect.DeepEqual(got, []int64{1, 2, 3}) {
+		t.Fatalf("draft ids = %#v", got)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	if hasMore {
+		t.Fatal("expected hasMore=false after final page")
+	}
+	if !reflect.DeepEqual(calls, []string{"/entries/drafts.json", "https://app.hey.com/entries/drafts.json?page=2"}) {
+		t.Fatalf("calls = %#v", calls)
+	}
+}
+
+func TestPaginateDraftsLimitStopsAfterEnoughResults(t *testing.T) {
+	pages := map[string]struct {
+		drafts []generated.DraftMessage
+		next   string
+		total  int
+	}{
+		"/entries/drafts.json": {
+			drafts: []generated.DraftMessage{{Id: 1}, {Id: 2}},
+			next:   "https://app.hey.com/entries/drafts.json?page=2",
+			total:  4,
+		},
+		"https://app.hey.com/entries/drafts.json?page=2": {
+			drafts: []generated.DraftMessage{{Id: 3}, {Id: 4}},
+			total:  4,
+		},
+	}
+	fetch := func(_ context.Context, pageURL string) ([]generated.DraftMessage, string, int, error) {
+		page, ok := pages[pageURL]
+		if !ok {
+			t.Fatalf("unexpected page URL %q", pageURL)
+		}
+		return page.drafts, page.next, page.total, nil
+	}
+
+	drafts, total, hasMore, err := paginateDrafts(context.Background(), 3, false, fetch)
+	if err != nil {
+		t.Fatalf("paginateDrafts: %v", err)
+	}
+
+	if got := draftIDs(drafts); !reflect.DeepEqual(got, []int64{1, 2, 3}) {
+		t.Fatalf("draft ids = %#v", got)
+	}
+	if total != 4 {
+		t.Fatalf("total = %d, want 4", total)
+	}
+	if !hasMore {
+		t.Fatal("expected hasMore=true when limit truncates fetched results")
+	}
+}
+
+func TestParseNextLinkHeader(t *testing.T) {
+	header := `<https://app.hey.com/entries/drafts.json?page=prev>; rel="prev", <https://app.hey.com/entries/drafts.json?page=next>; rel="next"`
+
+	got := parseNextLinkHeader(header)
+
+	if got != "https://app.hey.com/entries/drafts.json?page=next" {
+		t.Fatalf("next link = %q", got)
+	}
+}
+
+func draftIDs(drafts []generated.DraftMessage) []int64 {
+	ids := make([]int64, 0, len(drafts))
+	for _, draft := range drafts {
+		ids = append(ids, draft.Id)
+	}
+	return ids
+}

--- a/internal/cmd/drafts_test.go
+++ b/internal/cmd/drafts_test.go
@@ -120,6 +120,59 @@ func TestFetchDraftsPageRejectsCrossOriginURL(t *testing.T) {
 	}
 }
 
+func TestNormalizeDraftsPageURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    string
+		pageURL string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "relative path is unchanged",
+			base:    "https://app.hey.com",
+			pageURL: "/entries/drafts.json?page=2",
+			want:    "/entries/drafts.json?page=2",
+		},
+		{
+			name:    "same origin absolute URL becomes relative",
+			base:    "https://app.hey.com",
+			pageURL: "https://app.hey.com/entries/drafts.json?page=2",
+			want:    "/entries/drafts.json?page=2",
+		},
+		{
+			name:    "scheme-relative same host becomes relative",
+			base:    "https://app.hey.com",
+			pageURL: "//app.hey.com/entries/drafts.json?page=2",
+			want:    "/entries/drafts.json?page=2",
+		},
+		{
+			name:    "mixed-case same origin becomes relative",
+			base:    "https://app.hey.com",
+			pageURL: "HTTPS://app.hey.com/entries/drafts.json?page=2",
+			want:    "/entries/drafts.json?page=2",
+		},
+		{
+			name:    "cross origin is rejected",
+			base:    "https://app.hey.com",
+			pageURL: "//evil.example/entries/drafts.json?page=2",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeDraftsPageURL(tt.base, tt.pageURL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("normalizeDraftsPageURL error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("normalized URL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDraftsTruncationNotice(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cmd/drafts_test.go
+++ b/internal/cmd/drafts_test.go
@@ -158,6 +158,12 @@ func TestNormalizeDraftsPageURL(t *testing.T) {
 			pageURL: "//evil.example/entries/drafts.json?page=2",
 			wantErr: true,
 		},
+		{
+			name:    "scheme without host is rejected",
+			base:    "https://app.hey.com",
+			pageURL: "mailto:alice@example.com",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -17,7 +17,7 @@ var curatedCategories = []struct {
 }{
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "threads", "compose", "reply", "drafts", "seen", "unseen"},
+		names:   []string{"boxes", "box", "threads", "compose", "reply", "draft", "drafts", "seen", "unseen"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -14,6 +14,7 @@ import (
 type replyCommand struct {
 	cmd     *cobra.Command
 	message string
+	draft   bool
 }
 
 func newReplyCommand() *replyCommand {
@@ -22,15 +23,17 @@ func newReplyCommand() *replyCommand {
 		Use:   "reply <thread-id>",
 		Short: "Reply to a thread",
 		Annotations: map[string]string{
-			"agent_notes": "Replies to the latest entry in a thread. Accepts message via -m, stdin, or $EDITOR.",
+			"agent_notes": "Replies to the latest entry in a thread. Accepts message via -m, stdin, or $EDITOR. Use --draft to save without sending.",
 		},
 		Example: `  hey reply 12345 -m "Thanks!"
+  hey reply 12345 --draft -m "Draft reply"
   echo "Detailed reply" | hey reply 12345`,
 		RunE: replyCommand.run,
 		Args: usageExactOneArg(),
 	}
 
 	replyCommand.cmd.Flags().StringVarP(&replyCommand.message, "message", "m", "", "Reply message (or opens $EDITOR)")
+	replyCommand.cmd.Flags().BoolVar(&replyCommand.draft, "draft", false, "Save as draft instead of sending")
 
 	return replyCommand
 }
@@ -88,6 +91,15 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 				return output.ErrUsage("empty message, aborting")
 			}
 		}
+	}
+
+	if c.draft {
+		return createReplyDraft(ctx, cmd.OutOrStdout(), threadID, draftFormRequest{
+			Content: message,
+			To:      addressed.To,
+			CC:      addressed.CC,
+			BCC:     addressed.BCC,
+		})
 	}
 
 	if err = sdk.Entries().CreateReply(ctx, latestEntryID, message, addressed.To, addressed.CC, addressed.BCC); err != nil {

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -50,16 +50,6 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 
-	// Fetch topic page to extract recipients (To/CC/BCC).
-	topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", threadID))
-	if err != nil {
-		return convertSDKError(err)
-	}
-	addressed := htmlutil.ParseTopicAddressed(string(topicResp.Data))
-	if len(addressed.To) == 0 && len(addressed.CC) == 0 && len(addressed.BCC) == 0 {
-		return output.ErrUsage("could not determine thread recipients")
-	}
-
 	// Fetch entries to find the latest entry ID for the reply.
 	entriesResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d/entries", threadID))
 	if err != nil {
@@ -96,10 +86,16 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 	if c.draft {
 		return createReplyDraftForEntry(ctx, cmd.OutOrStdout(), latestEntryID, draftFormRequest{
 			Content: message,
-			To:      addressed.To,
-			CC:      addressed.CC,
-			BCC:     addressed.BCC,
 		})
+	}
+
+	replyForm, err := loadReplyDraftForm(ctx, latestEntryID)
+	if err != nil {
+		return err
+	}
+	addressed := replyForm.Request
+	if len(addressed.To) == 0 && len(addressed.CC) == 0 && len(addressed.BCC) == 0 {
+		return output.ErrUsage("could not determine thread recipients")
 	}
 
 	if err = sdk.Entries().CreateReply(ctx, latestEntryID, message, addressed.To, addressed.CC, addressed.BCC); err != nil {

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -94,7 +94,7 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if c.draft {
-		return createReplyDraft(ctx, cmd.OutOrStdout(), threadID, draftFormRequest{
+		return createReplyDraftForEntry(ctx, cmd.OutOrStdout(), latestEntryID, draftFormRequest{
 			Content: message,
 			To:      addressed.To,
 			CC:      addressed.CC,

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/basecamp/hey-cli/internal/editor"
 	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/output"
 )
@@ -62,25 +61,9 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 
 	latestEntryID := entries[len(entries)-1].ID
 
-	message := c.message
-	if message == "" {
-		if !stdinIsTerminal() {
-			message, err = readStdin()
-			if err != nil {
-				return err
-			}
-			if message == "" {
-				return output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
-			}
-		} else {
-			message, err = editor.Open("")
-			if err != nil {
-				return output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
-			}
-			if message == "" {
-				return output.ErrUsage("empty message, aborting")
-			}
-		}
+	message, err := draftMessageWithInitial(c.message, "", c.draft && cmd.Flags().Changed("message"))
+	if err != nil {
+		return err
 	}
 
 	if c.draft {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -33,6 +33,7 @@ var (
 	baseURL     string
 	cfg         *config.Config
 	authMgr     *auth.Manager
+	httpClient  *http.Client
 	writer      *output.Writer
 )
 
@@ -76,7 +77,7 @@ func newRootCmd() *cobra.Command {
 			}
 
 			configDir := config.ConfigDir()
-			httpClient := &http.Client{Timeout: 30 * time.Second}
+			httpClient = &http.Client{Timeout: 30 * time.Second}
 			authMgr = auth.NewManager(cfg.BaseURL, httpClient, configDir)
 			initSDK(authMgr, cfg.BaseURL)
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -122,6 +122,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newThreadsCommand().cmd)
 	root.AddCommand(newReplyCommand().cmd)
 	root.AddCommand(newComposeCommand().cmd)
+	root.AddCommand(newDraftCommand().cmd)
 	root.AddCommand(newDraftsCommand().cmd)
 	root.AddCommand(newCalendarsCommand().cmd)
 	root.AddCommand(newRecordingsCommand().cmd)

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -87,7 +87,9 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 | List emails in a box | `hey box imbox --json` |
 | Read email thread | `hey threads <topic_id> --json` |
 | Reply to email | `hey reply <topic_id> -m "Thanks!"` |
+| Save reply draft | `hey reply <topic_id> --draft -m "Thanks!"` |
 | Compose email | `hey compose --to user@example.com --subject "Hello"` |
+| Save compose draft | `hey compose --draft --to user@example.com --subject "Hello" -m "Draft body"` |
 | Compose with CC/BCC | `hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello"` |
 | Create draft | `hey draft create --to user@example.com --subject "Hello" -m "Draft body"` |
 | Create reply draft | `hey draft create --thread-id 12345 -m "Thanks!"` |
@@ -136,9 +138,11 @@ Want to read email?
 Want to send email?
 ├── Reply to thread? → hey reply <topic_id> -m "message"
 │   └── Open editor? → hey reply <topic_id> (omit -m to open $EDITOR)
+├── Save reply draft? → hey reply <topic_id> --draft -m "message"
 ├── Compose new? → hey compose --to <email> --subject "Subject"
 │   ├── With body? → hey compose --to <email> --subject "Subject" -m "Body"
 │   ├── With CC? → add --cc <email>
+│   ├── Save as draft? → add --draft
 │   └── With BCC? → add --bcc <email>
 ├── Save a draft instead? → hey draft create --to <email> --subject "Subject" -m "Body"
 ├── Save a reply draft? → hey draft create --thread-id <topic_id> -m "Body"
@@ -183,9 +187,11 @@ hey threads <topic_id> --html                 # Read with raw HTML content
 
 ```bash
 hey reply <topic_id> -m "Thanks!"             # Reply with inline message
+hey reply <topic_id> --draft -m "Thanks!"     # Save reply draft without sending
 hey reply <topic_id>                          # Reply via $EDITOR
 hey compose --to user@example.com --subject "Hello"         # Compose new (opens $EDITOR)
 hey compose --to user@example.com --subject "Hi" -m "Body"  # With inline body
+hey compose --draft --to user@example.com --subject "Hi" -m "Body"  # Save draft without sending
 hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Project update" -m "Body"  # With CC/BCC
 hey compose --subject "Update" --thread-id 12345 -m "msg"   # Post to existing thread
 ```
@@ -212,7 +218,7 @@ hey draft delete 67890                        # Delete draft
 ```
 
 Use `hey draft ...` when an agent must prepare mail without sending. `hey compose`
-and `hey reply` send immediately.
+and `hey reply` send immediately unless `--draft` is set.
 
 ### Calendars
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -14,6 +14,7 @@ triggers:
   - hey threads
   - hey reply
   - hey compose
+  - hey draft
   - hey drafts
   # Calendar actions
   - hey calendars
@@ -88,6 +89,10 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 | Reply to email | `hey reply <topic_id> -m "Thanks!"` |
 | Compose email | `hey compose --to user@example.com --subject "Hello"` |
 | Compose with CC/BCC | `hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello"` |
+| Create draft | `hey draft create --to user@example.com --subject "Hello" -m "Draft body"` |
+| Create reply draft | `hey draft create --thread-id 12345 -m "Thanks!"` |
+| Update draft | `hey draft update 12345 --to user@example.com --subject "Hello" -m "Updated body"` |
+| Delete draft | `hey draft delete 12345` |
 | List drafts | `hey drafts --json` |
 | List calendars | `hey calendars --json` |
 | List calendar events | `hey recordings 123 --json` |
@@ -135,6 +140,8 @@ Want to send email?
 │   ├── With body? → hey compose --to <email> --subject "Subject" -m "Body"
 │   ├── With CC? → add --cc <email>
 │   └── With BCC? → add --bcc <email>
+├── Save a draft instead? → hey draft create --to <email> --subject "Subject" -m "Body"
+├── Save a reply draft? → hey draft create --thread-id <topic_id> -m "Body"
 └── Check drafts? → hey drafts --json
 ```
 
@@ -198,7 +205,14 @@ Takes posting IDs (the `id` field from `hey box` output).
 
 ```bash
 hey drafts --json                             # List drafts
+hey draft create --to user@example.com --subject "Hello" -m "Body"  # Save new draft
+hey draft create --thread-id 12345 -m "Thanks!"       # Save reply draft
+hey draft update 67890 --to user@example.com --subject "Hello" -m "Updated body"
+hey draft delete 67890                        # Delete draft
 ```
+
+Use `hey draft ...` when an agent must prepare mail without sending. `hey compose`
+and `hey reply` send immediately.
 
 ### Calendars
 


### PR DESCRIPTION
## Summary

This adds fuller draft support to `hey-cli`.

The API-safe part is draft listing pagination:

- `hey drafts --all`
- `hey drafts --limit N`
- pagination via HEY’s `Link` header
- truncation notices when only part of the draft list is shown

It also adds an experimental draft workflow:

- `hey draft create`
- `hey draft update`
- `hey draft delete`
- `hey compose --draft`
- `hey reply --draft`

## API surface note

Draft listing uses HEY’s JSON endpoint.

Draft create/update/delete currently use HEY’s authenticated web form flow because the SDK does not expose first-class draft mutation methods yet. I kept that code isolated so it can be replaced with SDK/API calls if those endpoints become available.

This means the mutation commands are useful as a working implementation and command-shape proposal, but they are less stable than the listing/pagination work.

## Safety notes

- Draft form parsing fails closed if required form fields or CSRF tokens are missing.
- Draft updates preserve omitted existing fields instead of blanking them.
- Reply drafts use HEY’s reply form recipient state rather than broad topic-level recipients.
- Plain-text draft bodies are converted to escaped HTML with `<br>` line breaks so HEY preserves spacing.

## Authoring note

This was authored by Mike Gyi with Codex 5.5.

The intent was to explore a practical draft workflow for `hey-cli`, using Basecamp’s own CLI taste as the reference point: small commands, direct behavior, clear failure modes, and no hidden send action.

## Testing

- `go test ./internal/cmd -run 'TestDraftValues|TestWithReplyFormRecipients|TestParseDraftForm|TestReply|TestCreateReplyDraft'`
- `make build && make test`
- Manual smoke test for draft reply creation confirmed safe recipient state and preserved line breaks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full draft support to `hey-cli`: paginated drafts, `hey draft` commands, and `--draft` on `compose`/`reply`, with unified message input, safer pagination/recipients, and clearer draft error messages.
This lets you save, update, and delete drafts from the CLI without sending.

- **New Features**
  - Paginated `hey drafts` with `--all` and `--limit`; follows `Link` rel=next (absolute or scheme-relative), reads `X-Total-Count`, and caps traversal with a clear limit notice.
  - Draft workflow: `hey draft create|update|delete`, `hey draft create --thread-id` for reply drafts, plus `hey compose --draft` and `hey reply --draft`.

- **Bug Fixes**
  - Replies (send and draft) use reply-form recipients, avoiding unsafe topic-level defaults.
  - Draft updates preserve unspecified fields; reject no-op updates; CSRF and form parsing fail closed and server error messages are normalized and trimmed (500-rune, multibyte-safe).
  - Pagination URLs are normalized and must be same-origin (case-insensitive scheme/host); scheme-relative same-host links are allowed; absolute URLs without a host are rejected.
  - Unified message handling across compose/reply/draft; plain text becomes Trix blocks with preserved blank lines; explicit empty bodies are allowed and saved as a blank block when requested.

<sup>Written for commit d2222062a4697e11f8a85d25943c4b575d58a18f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Manual testing scope

I have started using the draft workflow against my own HEY account, but it has not had broad real-world testing yet.

So far the live testing covered two reply drafts. That surfaced two important bugs: reply drafts could inherit unsafe recipient state from a broader thread, and plain-text line breaks collapsed in HEY. Both are fixed in this PR.

I plan to keep using this workflow myself and will keep fixing issues as they come up.
