### PR TITLE
Sync Dependabot action pin comments via reusable workflow

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -33,7 +33,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')
-    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@95a9f7a2bd69c73cd2839eb4a27616e1651497e2
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@9ca40e3b2d6be769b370b7cee86e8448267c95d8
     with:
       ci-workflow-name: Test
       branch: ${{ inputs.branch || '' }}

--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -8,8 +8,9 @@ name: Sync Dependabot action pin comments
 
 on:
   workflow_run: # zizmor: ignore[dangerous-triggers] -- only the SHA-pinned reusable workflow (reviewed default-branch code) executes; the Dependabot head branch is fetched as data, never executed
-    workflows: [CI]
+    workflows: [Test]
     types: [completed]
+    branches: ["dependabot/github_actions/**"]
   workflow_dispatch:
     inputs:
       branch:
@@ -26,14 +27,15 @@ permissions: {}
 
 jobs:
   sync:
-    # Cheap prefilter to avoid a skipped-run entry on every CI completion;
-    # the reusable workflow re-checks this and everything else.
+    # Defense-in-depth behind the trigger-level branches filter (which stops
+    # runs from being created for other branches at all); the reusable
+    # workflow re-checks this and everything else.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')
     uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@95a9f7a2bd69c73cd2839eb4a27616e1651497e2
     with:
-      ci-workflow-name: CI
+      ci-workflow-name: Test
       branch: ${{ inputs.branch || '' }}
       e2e: ${{ inputs.e2e || false }}
     permissions:

--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -1,0 +1,46 @@
+name: Sync Dependabot action pin comments
+
+# Thin caller: all logic lives in basecamp/.github's reusable workflow —
+# trusted default-branch code that fetches the Dependabot head branch as data
+# only, rewrites stale `# vX.Y.Z` pin comments, and pushes back behind a
+# compare-and-swap lease using the write deploy key scoped to this repo's
+# dependabot-sync environment.
+
+on:
+  workflow_run: # zizmor: ignore[dangerous-triggers] -- only the SHA-pinned reusable workflow (reviewed default-branch code) executes; the Dependabot head branch is fetched as data, never executed
+    workflows: [CI]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Dependabot branch to sync (dependabot/github_actions/...)
+        required: true
+        type: string
+      e2e:
+        description: "E2E proof mode: expect a draft PR authored by the dispatcher on a dependabot/github_actions/e2e-proof-* branch"
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  sync:
+    # Cheap prefilter to avoid a skipped-run entry on every CI completion;
+    # the reusable workflow re-checks this and everything else.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@95a9f7a2bd69c73cd2839eb4a27616e1651497e2
+    with:
+      ci-workflow-name: CI
+      branch: ${{ inputs.branch || '' }}
+      e2e: ${{ inputs.e2e || false }}
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+    # The deploy key is scoped to this repo's dependabot-sync environment
+    # (deployment branches: default branch only); environment secrets cannot
+    # be forwarded explicitly to a reusable workflow, so inherit is required.
+    secrets: inherit # zizmor: ignore[secrets-inherit] -- see above; the called workflow is SHA-pinned and reads only SYNC_ACTIONS_DEPLOY_KEY, gated by the dependabot-sync environment

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,7 @@
 name: Security
 
 on:
+  workflow_dispatch:
   workflow_call:
   push:
     branches: [main]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/hey-cli
 
-go 1.26.2
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/hey-cli
 
-go 1.26.1
+go 1.26.2
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
Thin caller for the `dependabot-sync-actions-comments` reusable workflow (basecamp/.github#8 + #10, pinned at 9ca40e3b). After CI completes on a Dependabot `github_actions` branch, trusted default-branch code fixes any stale `# vX.Y.Z` pin comments — including compound ones with trailing `# zizmor: ignore[...]` annotations that Dependabot can't rewrite — and pushes back behind a compare-and-swap lease using the write deploy key scoped to this repo's `dependabot-sync` environment (deployment branches: main only). Validated end-to-end today on a live Dependabot PR in basecamp-cli (basecamp/basecamp-cli#566).

Also in this PR:

- **workflow_dispatch** added to test.yml and security.yml (the other repos already had it).
- **test.yml renamed `CI` → `Test`** — ci.yml and test.yml both being named `CI` made the `workflow_run` anchor fire twice per head and the detection name ambiguous. Required status checks are job-name contexts (`test`, `lint`, `security`, `race-check`), so the `main-gate` ruleset is unaffected. Consolidating the ci.yml/test.yml overlap is left as follow-up.
- **Require Go 1.26.5** — the required `security` check (govulncheck) was failing on stdlib vulnerabilities in go1.26.1; fixes span 1.26.3–1.26.5 (GO-2026-5856 et al.), so this jumps to the newest patch release. Workflows resolve the toolchain from go.mod.

Sibling callers (all merged): basecamp-sdk#459, basecamp-cli#572/#573, fizzy-cli#189/#190, cli#51/#52.