### PR TITLE
Bare pin comments: let Dependabot maintain action version comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Run actionlint
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:
           advanced-security: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,8 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
Dependabot rewrites *bare* `# vX.Y.Z` comments on pinned `uses:` lines natively but cannot touch compound ones carrying a trailing `# zizmor: ignore[...]`. Moving each ignore to its own line directly below the pin (reason text kept, association verified under zizmor 1.28) makes Dependabot itself the comment maintainer — no push automation required on its PRs. Same restructure basecamp-sdk shipped in basecamp-sdk#458. Part of the post-merge redesign of the comment-sync program (see basecamp/.github#10 for why in-PR pushing is unsafe: a deploy-key push flips the run actor off dependabot[bot] and lifts the Dependabot sandbox for the unreviewed bumped actions).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let Dependabot maintain action version comments by moving `# zizmor: ignore[...]` to its own line below each pinned `uses:` entry. Also update `zizmorcore/zizmor-action` to v0.6.0 to correctly associate standalone ignores.

- **Refactors**
  - Move trailing `# zizmor: ignore[...]` into a standalone line directly under each `uses: … # vX.Y.Z`.
  - Keeps ignore reasons and avoids push automation on Dependabot PRs.

- **Dependencies**
  - Bump `zizmorcore/zizmor-action` to v0.6.0.

<sup>Written for commit 33c9e08b1ba3b5398058b3fa4285cbe302c9db9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

