### PR TITLE
Fix `make tools` installing golangci-lint v1 against a v2 config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ clean-pgo:
 
 # Install dev tools
 tools:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	go install golang.org/x/vuln/cmd/govulncheck@latest
 	@echo "For gitleaks, install via: brew install gitleaks (or see https://github.com/gitleaks/gitleaks)"
 	@echo "For benchstat: go install golang.org/x/perf/cmd/benchstat@latest"


### PR DESCRIPTION
`make tools` installs golangci-lint from the v1 module path, but `.golangci.yml` is `version: "2"`. So a clean setup following `CONTRIBUTING.md` breaks at the first lint:

```
$ make tools
$ make lint
golangci-lint run ./...
Error: you are using a configuration file for golangci-lint v2 with golangci-lint v1: please use golangci-lint v2
make: *** [lint] Error 3
```

That also takes out `make check`, which `CONTRIBUTING.md` asks contributors to run before opening a PR.

The fix is the `/v2/` module path — v1 and v2 are separate modules, so `@latest` on the old path keeps resolving to the last v1 release:

```diff
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
```

CI never hits this because it doesn't use `make tools` — `ci.yml` and `test.yml` both install through `golangci-lint-action` pinned to `v2.10.1`, and `.mise.toml` pins only Go. So the break is invisible to the project and only lands on someone setting up locally for the first time.

Verified on macOS: before the change `make lint` fails as above; after it, `make check` passes clean.

One thing you may want on top, which I've deliberately left alone: CI pins `v2.10.1` while this line is `@latest`, currently resolving to `2.12.2`. Local lint can therefore be stricter than CI. Happy to pin the Makefile to match instead — I kept `@latest` to stay consistent with the other installs in the target.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `make tools` to install `github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`, aligning with `.golangci.yml` v2. This fixes clean setups where `make lint` failed with a v1 binary and restores `make check`.

<sup>Written for commit 317c4c6579e37bc5d09719b7e05af69758e411f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

