### PR TITLE
Restrict posting actions to email threads

### DIFF
--- a/.surface
+++ b/.surface
@@ -146,6 +146,7 @@ hey habit edit --name
 hey habit uncomplete
 hey habit uncomplete --date
 hey ignore
+hey ignore --kind
 hey journal
 hey journal list
 hey journal list --all
@@ -178,6 +179,7 @@ hey login --no-browser
 hey login --token
 hey logout
 hey move
+hey move --kind
 hey move --to
 hey recordings
 hey recordings --all
@@ -275,6 +277,7 @@ hey todo list --all
 hey todo list --limit
 hey todo uncomplete
 hey trash
+hey trash --kind
 hey tui
 hey tui --instance
 hey tui --remote

--- a/README.md
+++ b/README.md
@@ -400,11 +400,11 @@ hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org 
 hey drafts                         # list drafts
 hey seen 12345                     # mark a thread as seen
 hey unseen 12345 67890             # mark threads as unseen
-hey move 12345 --to feed           # move a thread to another box
-hey move 12345 67890 --to "paper trail"  # move multiple threads
-hey trash 12345                    # move a thread to Trash
+hey move 12345 --to feed --kind topic  # move an email thread to another box
+hey move 12345 67890 --to "paper trail" --kind topic  # move multiple email threads
+hey trash 12345 --kind topic       # move an email thread to Trash
 hey spam 12345                     # mark a thread as spam
-hey ignore 12345                   # ignore future activity on a thread
+hey ignore 12345 --kind topic      # ignore future activity on an email thread
 hey stop-ignoring 12345            # resume attention for a thread
 ```
 
@@ -424,7 +424,7 @@ The Screener is where first-time senders wait. `hey screener list` returns clear
 
 `--attach` is repeatable on `hey compose`, `hey reply`, and `hey bulk-reply send`, and attachment-only messages are supported. The CLI validates and uploads every file before sending the email. `hey attachments <topic_id>` returns stable message-and-position IDs such as `456:1`; pass an ID to `hey attachments save`. Saving uses the original filename by default, accepts `--output` for a file or directory, and preserves existing files unless `--force` is set.
 
-Organization actions take the `id` values returned by `hey box view --json`, `hey label view --json`, or `hey search --json`. Reading, replying to, and forwarding a thread take its `topic_id` instead, which `hey box view --json`, `hey label view --json`, `hey collection view --json` and `hey search --json` all carry alongside `id`. `hey box view` also returns `next_page` and accepts `--page <next_page>` to continue a box listing; it keeps `next_history_url` for the sync clients that read it, and `--page` accepts that URL as readily as the cursor inside it. Label IDs come from `hey label list`; `hey label view` returns `next_page` and `total_count`, accepts `--page <next_page>` for continuation, and supports `--all` for complete traversal. HEY creates a label while adding it to at least one thread, so `hey label create` requires thread item IDs.
+Organization actions take the `id` values returned by `hey box view --json`, `hey label view --json`, or `hey search --json`. For box and label results, select a record whose `kind` is exactly `topic`; search returns only email threads and does not include a `kind` field. `move`, `trash`, and `ignore` only manage email threads and require the exact flag `--kind topic`; missing and non-email kinds are rejected before setup or any request. The CLI does not manage HEY World posts. Reading, replying to, and forwarding a thread take its `topic_id` instead, which `hey box view --json`, `hey label view --json`, `hey collection view --json` and `hey search --json` all carry alongside `id`. `hey box view` also returns `next_page` and accepts `--page <next_page>` to continue a box listing; it keeps `next_history_url` for the sync clients that read it, and `--page` accepts that URL as readily as the cursor inside it. Label IDs come from `hey label list`; `hey label view` returns `next_page` and `total_count`, accepts `--page <next_page>` for continuation, and supports `--all` for complete traversal. HEY creates a label while adding it to at least one thread, so `hey label create` requires thread item IDs.
 
 Collection IDs come from `hey collection list`. `hey collection view` returns both each posting `id` and its `topic_id`, plus `next_page` and `total_count`. Collection membership commands take `topic_id`; posting organization commands continue to take `id`. Creating a collection returns a confirmed mutation, and `hey collection list` provides its ID for subsequent commands. Collection updates accept a non-empty name, summary, or both.
 

--- a/internal/cmd/box.go
+++ b/internal/cmd/box.go
@@ -40,7 +40,7 @@ var boxListing = postingsListing{
 	},
 	breadcrumbs: []output.Breadcrumb{
 		{Action: "read", Command: "hey threads <topic-id>", Description: "Read an email thread"},
-		{Action: "move", Command: "hey move <id> --to <box>", Description: "Move an email thread to another box"},
+		{Action: "move", Command: "hey move <id> --to <box> --kind topic", Description: "Move an email thread to another box"},
 		{Action: "compose", Command: "hey compose --to <email> --subject <subject>", Description: "Compose a new message"},
 	},
 }

--- a/internal/cmd/box_test.go
+++ b/internal/cmd/box_test.go
@@ -59,6 +59,18 @@ func TestValidateBoxArgs(t *testing.T) {
 	}
 }
 
+func TestBoxListingMoveBreadcrumbIncludesEmailKind(t *testing.T) {
+	for _, breadcrumb := range boxListing.breadcrumbs {
+		if breadcrumb.Action == "move" {
+			if breadcrumb.Command != "hey move <id> --to <box> --kind topic" {
+				t.Fatalf("move breadcrumb = %q", breadcrumb.Command)
+			}
+			return
+		}
+	}
+	t.Fatal("move breadcrumb not found")
+}
+
 func TestBoxCommandNamedRoutes(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -55,6 +55,35 @@ func TestEmailCommandHelpKeepsPostingAsAnInternalTerm(t *testing.T) {
 	}
 }
 
+func TestEmailActionAgentNotesUseBoxItemIDs(t *testing.T) {
+	root := newRootCmd()
+	for _, name := range []string{"move", "trash", "ignore"} {
+		t.Run(name, func(t *testing.T) {
+			command, _, err := root.Find([]string{name})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			notes := command.Annotations["agent_notes"]
+			for _, want := range []string{
+				"box item IDs (id)",
+				"hey box view <box> --json",
+				"hey label view <label> --json",
+				"kind=topic",
+				"hey search --json returns email threads",
+				"--kind topic",
+			} {
+				if !strings.Contains(notes, want) {
+					t.Errorf("%s agent notes missing %q: %s", name, want, notes)
+				}
+			}
+			if strings.Contains(notes, "topic IDs") {
+				t.Errorf("%s agent notes confuse topic_id with id: %s", name, notes)
+			}
+		})
+	}
+}
+
 func TestContactCommandHelpUsesHEYTerminology(t *testing.T) {
 	root := newRootCmd()
 	contacts, _, err := root.Find([]string{"contacts"})

--- a/internal/cmd/ignore.go
+++ b/internal/cmd/ignore.go
@@ -9,7 +9,8 @@ import (
 )
 
 type ignoreCommand struct {
-	cmd *cobra.Command
+	cmd  *cobra.Command
+	kind string
 }
 
 func newIgnoreCommand() *ignoreCommand {
@@ -18,14 +19,15 @@ func newIgnoreCommand() *ignoreCommand {
 		Use:   "ignore <id>...",
 		Short: "Ignore email threads",
 		Long:  "Ignore one or more email threads so new replies do not bring them back to your attention.",
-		Example: `  hey ignore 12345
-  hey ignore 12345 67890`,
+		Example: `  hey ignore 12345 --kind topic
+  hey ignore 12345 67890 --kind topic`,
 		Annotations: map[string]string{
-			"agent_notes": "Accepts one or more box item IDs from hey box view output. Ignored threads remain in their box and can be restored with hey stop-ignoring.",
+			"agent_notes": "Accepts one or more box item IDs (id). In hey box view <box> --json or hey label view <label> --json, select records with kind=topic. hey search --json returns email threads; pass each result's id. Always pass --kind topic. Ignored threads remain in their box and can be restored with hey stop-ignoring.",
 		},
 		RunE: ignoreCommand.run,
-		Args: usageMinOneArg(),
+		Args: emailPostingArgs(&ignoreCommand.kind, usageMinOneArg()),
 	}
+	ignoreCommand.cmd.Flags().StringVar(&ignoreCommand.kind, "kind", "", "Email thread kind; must be topic (required)")
 
 	return ignoreCommand
 }

--- a/internal/cmd/ignore_test.go
+++ b/internal/cmd/ignore_test.go
@@ -87,12 +87,13 @@ func TestIgnoreAndStopIgnoring(t *testing.T) {
 		command string
 		method  string
 		args    []string
+		wantIDs []int64
 		summary string
 	}{
-		{"ignore one", "ignore", http.MethodPost, []string{"12345"}, "1 thread ignored"},
-		{"ignore multiple", "ignore", http.MethodPost, []string{"12345", "67890"}, "2 threads ignored"},
-		{"stop ignoring one", "stop-ignoring", http.MethodDelete, []string{"12345"}, "Stopped ignoring 1 thread"},
-		{"stop ignoring multiple", "stop-ignoring", http.MethodDelete, []string{"12345", "67890"}, "Stopped ignoring 2 threads"},
+		{"ignore one", "ignore", http.MethodPost, []string{"12345", "--kind", "topic"}, []int64{12345}, "1 thread ignored"},
+		{"ignore multiple", "ignore", http.MethodPost, []string{"12345", "67890", "--kind", "topic"}, []int64{12345, 67890}, "2 threads ignored"},
+		{"stop ignoring one", "stop-ignoring", http.MethodDelete, []string{"12345"}, []int64{12345}, "Stopped ignoring 1 thread"},
+		{"stop ignoring multiple", "stop-ignoring", http.MethodDelete, []string{"12345", "67890"}, []int64{12345, 67890}, "Stopped ignoring 2 threads"},
 	}
 
 	for _, tt := range tests {
@@ -105,10 +106,10 @@ func TestIgnoreAndStopIgnoring(t *testing.T) {
 			if recorded.method != tt.method || recorded.path != "/postings/mutings.json" {
 				t.Errorf("request = %s %s, want %s /postings/mutings.json", recorded.method, recorded.path, tt.method)
 			}
-			if len(recorded.postingIDs) != len(tt.args) {
-				t.Fatalf("posting_ids = %v, want %d IDs", recorded.postingIDs, len(tt.args))
+			if len(recorded.postingIDs) != len(tt.wantIDs) {
+				t.Fatalf("posting_ids = %v, want %d IDs", recorded.postingIDs, len(tt.wantIDs))
 			}
-			for i, want := range []int64{12345, 67890}[:len(tt.args)] {
+			for i, want := range tt.wantIDs {
 				if recorded.postingIDs[i] != want {
 					t.Errorf("posting_ids[%d] = %d, want %d", i, recorded.postingIDs[i], want)
 				}
@@ -139,7 +140,11 @@ func TestIgnoreAndStopIgnoringRejectInvalidIDsBeforeRequest(t *testing.T) {
 	for _, command := range []string{"ignore", "stop-ignoring"} {
 		t.Run(command, func(t *testing.T) {
 			server, recorded := ignoringServer(t)
-			_, err := runIgnoring(t, server, command, "not-an-id")
+			args := []string{"not-an-id"}
+			if command == "ignore" {
+				args = append(args, "--kind", "topic")
+			}
+			_, err := runIgnoring(t, server, command, args...)
 			var cliErr *apierr.Error
 			if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
 				t.Fatalf("invalid ID should produce a usage error, got %v", err)
@@ -156,7 +161,11 @@ func TestIgnoreAndStopIgnoringReportServerFailures(t *testing.T) {
 		t.Run(command, func(t *testing.T) {
 			server, recorded := ignoringServer(t)
 			recorded.status = http.StatusUnprocessableEntity
-			if _, err := runIgnoring(t, server, command, "12345"); err == nil {
+			args := []string{"12345"}
+			if command == "ignore" {
+				args = append(args, "--kind", "topic")
+			}
+			if _, err := runIgnoring(t, server, command, args...); err == nil {
 				t.Fatal("server failure should be reported")
 			}
 		})

--- a/internal/cmd/move.go
+++ b/internal/cmd/move.go
@@ -16,8 +16,9 @@ import (
 )
 
 type moveCommand struct {
-	cmd *cobra.Command
-	to  string
+	cmd  *cobra.Command
+	to   string
+	kind string
 }
 
 func newMoveCommand() *moveCommand {
@@ -26,17 +27,18 @@ func newMoveCommand() *moveCommand {
 		Use:   "move <id>...",
 		Short: "Move email threads to another box",
 		Long:  "Move one or more email threads to Imbox, The Feed, Set Aside, Reply Later, or Paper Trail.",
-		Example: `  hey move 12345 --to feed
-  hey move 12345 67890 --to "paper trail"
-  hey move 12345 --to 987`,
+		Example: `  hey move 12345 --to feed --kind topic
+  hey move 12345 67890 --to "paper trail" --kind topic
+  hey move 12345 --to 987 --kind topic`,
 		Annotations: map[string]string{
-			"agent_notes": "Accepts box item IDs from hey box view output. --to accepts a box name, kind, or ID. Use HEY's scheduled Bubble Up flow for Bubble Up.",
+			"agent_notes": "Accepts one or more box item IDs (id). In hey box view <box> --json or hey label view <label> --json, select records with kind=topic. hey search --json returns email threads; pass each result's id. Always pass --kind topic. --to accepts a box name, kind, or ID. Use HEY's scheduled Bubble Up flow for Bubble Up.",
 		},
 		RunE: moveCommand.run,
-		Args: usageMinOneArg(),
+		Args: emailPostingArgs(&moveCommand.kind, usageMinOneArg()),
 	}
 
 	moveCommand.cmd.Flags().StringVar(&moveCommand.to, "to", "", "Destination box name, kind, or ID (required)")
+	moveCommand.cmd.Flags().StringVar(&moveCommand.kind, "kind", "", "Email thread kind; must be topic (required)")
 
 	return moveCommand
 }

--- a/internal/cmd/move_test.go
+++ b/internal/cmd/move_test.go
@@ -80,7 +80,7 @@ func runMove(t *testing.T, server *httptest.Server, args ...string) (output.Resp
 func TestMovePostingsToNamedBox(t *testing.T) {
 	server, recorded := moveServer(t)
 
-	resp, err := runMove(t, server, "12345", "67890", "--to", "paper-trail")
+	resp, err := runMove(t, server, "12345", "67890", "--to", "paper-trail", "--kind", "topic")
 	if err != nil {
 		t.Fatalf("move failed: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestMoveDestinationAliases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.to, func(t *testing.T) {
 			server, recorded := moveServer(t)
-			if _, err := runMove(t, server, "12345", "--to", tt.to); err != nil {
+			if _, err := runMove(t, server, "12345", "--to", tt.to, "--kind", "topic"); err != nil {
 				t.Fatalf("move failed: %v", err)
 			}
 			if recorded.boxID != tt.boxID {
@@ -132,7 +132,7 @@ func TestMoveRejectsBubbleUp(t *testing.T) {
 	for _, to := range []string{"bubble", "Bubble Up", "bubblebox", "6"} {
 		t.Run(to, func(t *testing.T) {
 			server, recorded := moveServer(t)
-			_, err := runMove(t, server, "12345", "--to", to)
+			_, err := runMove(t, server, "12345", "--to", to, "--kind", "topic")
 			var cliErr *apierr.Error
 			if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
 				t.Fatalf("Bubble Up should produce a usage error, got %v", err)
@@ -147,7 +147,7 @@ func TestMoveRejectsBubbleUp(t *testing.T) {
 func TestMoveRequiresDestination(t *testing.T) {
 	server, recorded := moveServer(t)
 
-	_, err := runMove(t, server, "12345")
+	_, err := runMove(t, server, "12345", "--kind", "topic")
 	var cliErr *apierr.Error
 	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
 		t.Fatalf("missing destination should produce a usage error, got %v", err)
@@ -160,7 +160,7 @@ func TestMoveRequiresDestination(t *testing.T) {
 func TestMoveRejectsInvalidPostingIDBeforeRequests(t *testing.T) {
 	server, recorded := moveServer(t)
 
-	_, err := runMove(t, server, "not-an-id", "--to", "feed")
+	_, err := runMove(t, server, "not-an-id", "--to", "feed", "--kind", "topic")
 	var cliErr *apierr.Error
 	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
 		t.Fatalf("invalid posting should produce a usage error, got %v", err)
@@ -173,7 +173,7 @@ func TestMoveRejectsInvalidPostingIDBeforeRequests(t *testing.T) {
 func TestMoveRejectsUnknownDestination(t *testing.T) {
 	server, recorded := moveServer(t)
 
-	_, err := runMove(t, server, "12345", "--to", "archive")
+	_, err := runMove(t, server, "12345", "--to", "archive", "--kind", "topic")
 	var cliErr *apierr.Error
 	if !errors.As(err, &cliErr) || cliErr.Code != "not_found" {
 		t.Fatalf("unknown destination should produce a not-found error, got %v", err)
@@ -187,7 +187,7 @@ func TestMoveReportsServerFailure(t *testing.T) {
 	server, recorded := moveServer(t)
 	recorded.moveStatus = http.StatusUnprocessableEntity
 
-	_, err := runMove(t, server, "12345", "--to", "feed")
+	_, err := runMove(t, server, "12345", "--to", "feed", "--kind", "topic")
 	if err == nil {
 		t.Fatal("move should report the server failure")
 	}

--- a/internal/cmd/posting_kind.go
+++ b/internal/cmd/posting_kind.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+)
+
+func emailPostingArgs(kind *string, positional cobra.PositionalArgs) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := positional(cmd, args); err != nil {
+			return err
+		}
+
+		switch *kind {
+		case "":
+			return apierr.ErrUsageHint(
+				"--kind is required for email thread actions",
+				"Use a kind=topic record from `hey box view <box> --json` or `hey label view <label> --json`, or an email result from `hey search --json`; pass `--kind topic`.",
+			)
+		case "topic":
+			return nil
+		case "world/post":
+			return apierr.ErrUsageHint(
+				fmt.Sprintf("hey %s does not manage HEY World posts", cmd.Name()),
+				"hey-cli only manages email threads. Pass `--kind topic` for an email thread.",
+			)
+		default:
+			return apierr.ErrUsageHint(
+				fmt.Sprintf("hey %s only manages email threads; unsupported kind %q", cmd.Name(), *kind),
+				"Use a kind=topic record from `hey box view <box> --json` or `hey label view <label> --json`, or an email result from `hey search --json`; pass `--kind topic`.",
+			)
+		}
+	}
+}

--- a/internal/cmd/posting_kind_test.go
+++ b/internal/cmd/posting_kind_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEmailPostingActionsRejectNonEmailKindsBeforeSetup(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "move missing kind", args: []string{"move", "12345", "--to", "feed"}, want: "--kind is required"},
+		{name: "move World post", args: []string{"move", "12345", "--to", "feed", "--kind", "world/post"}, want: "HEY World"},
+		{name: "trash other kind", args: []string{"trash", "12345", "--kind", "calendar/event"}, want: "only manages email threads"},
+		{name: "ignore World post", args: []string{"ignore", "12345", "--kind", "world/post"}, want: "HEY World"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HEY_TOKEN", "test-token")
+			t.Setenv("HEY_NO_KEYRING", "1")
+			t.Setenv("HEY_BASE_URL", "")
+			tmpDir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+			configDir := filepath.Join(tmpDir, "hey-cli")
+			if err := os.MkdirAll(configDir, 0700); err != nil {
+				t.Fatalf("create config directory: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte("{"), 0600); err != nil {
+				t.Fatalf("write invalid config: %v", err)
+			}
+
+			root := newRootCmd()
+			root.SetArgs(tt.args)
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("expected email kind validation error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %q, want %q", err, tt.want)
+			}
+			if strings.Contains(err.Error(), "parse config") {
+				t.Errorf("kind validation ran after root setup: %v", err)
+			}
+		})
+	}
+}

--- a/internal/cmd/trash.go
+++ b/internal/cmd/trash.go
@@ -9,7 +9,8 @@ import (
 )
 
 type trashCommand struct {
-	cmd *cobra.Command
+	cmd  *cobra.Command
+	kind string
 }
 
 func newTrashCommand() *trashCommand {
@@ -18,14 +19,15 @@ func newTrashCommand() *trashCommand {
 		Use:   "trash <id>...",
 		Short: "Move email threads to Trash",
 		Long:  "Move one or more email threads to Trash. For a shared thread, HEY removes your access instead of deleting it for everyone.",
-		Example: `  hey trash 12345
-  hey trash 12345 67890`,
+		Example: `  hey trash 12345 --kind topic
+  hey trash 12345 67890 --kind topic`,
 		Annotations: map[string]string{
-			"agent_notes": "Accepts one or more box item IDs from hey box view output. Shared threads lose your access rather than being deleted for everyone.",
+			"agent_notes": "Accepts one or more box item IDs (id). In hey box view <box> --json or hey label view <label> --json, select records with kind=topic. hey search --json returns email threads; pass each result's id. Always pass --kind topic. Shared threads lose your access rather than being deleted for everyone.",
 		},
 		RunE: trashCommand.run,
-		Args: usageMinOneArg(),
+		Args: emailPostingArgs(&trashCommand.kind, usageMinOneArg()),
 	}
+	trashCommand.cmd.Flags().StringVar(&trashCommand.kind, "kind", "", "Email thread kind; must be topic (required)")
 
 	return trashCommand
 }

--- a/internal/cmd/trash_test.go
+++ b/internal/cmd/trash_test.go
@@ -74,13 +74,14 @@ func TestTrashAndSpam(t *testing.T) {
 		name    string
 		command string
 		args    []string
+		wantIDs []int64
 		path    string
 		summary string
 	}{
-		{"trash one", "trash", []string{"12345"}, "/postings/trash.json", "1 thread moved to Trash"},
-		{"trash multiple", "trash", []string{"12345", "67890"}, "/postings/trash.json", "2 threads moved to Trash"},
-		{"spam one", "spam", []string{"12345"}, "/postings/spam.json", "1 thread marked as spam"},
-		{"spam multiple", "spam", []string{"12345", "67890"}, "/postings/spam.json", "2 threads marked as spam"},
+		{"trash one", "trash", []string{"12345", "--kind", "topic"}, []int64{12345}, "/postings/trash.json", "1 thread moved to Trash"},
+		{"trash multiple", "trash", []string{"12345", "67890", "--kind", "topic"}, []int64{12345, 67890}, "/postings/trash.json", "2 threads moved to Trash"},
+		{"spam one", "spam", []string{"12345"}, []int64{12345}, "/postings/spam.json", "1 thread marked as spam"},
+		{"spam multiple", "spam", []string{"12345", "67890"}, []int64{12345, 67890}, "/postings/spam.json", "2 threads marked as spam"},
 	}
 
 	for _, tt := range tests {
@@ -93,10 +94,10 @@ func TestTrashAndSpam(t *testing.T) {
 			if recorded.method != http.MethodPost || recorded.path != tt.path {
 				t.Errorf("request = %s %s, want POST %s", recorded.method, recorded.path, tt.path)
 			}
-			if len(recorded.postingIDs) != len(tt.args) {
-				t.Fatalf("posting_ids = %v, want %d IDs", recorded.postingIDs, len(tt.args))
+			if len(recorded.postingIDs) != len(tt.wantIDs) {
+				t.Fatalf("posting_ids = %v, want %d IDs", recorded.postingIDs, len(tt.wantIDs))
 			}
-			for i, want := range []int64{12345, 67890}[:len(tt.args)] {
+			for i, want := range tt.wantIDs {
 				if recorded.postingIDs[i] != want {
 					t.Errorf("posting_ids[%d] = %d, want %d", i, recorded.postingIDs[i], want)
 				}
@@ -127,7 +128,11 @@ func TestTrashAndSpamRejectInvalidIDsBeforeRequest(t *testing.T) {
 	for _, command := range []string{"trash", "spam"} {
 		t.Run(command, func(t *testing.T) {
 			server, recorded := removalServer(t)
-			_, err := runRemoval(t, server, command, "not-an-id")
+			args := []string{"not-an-id"}
+			if command == "trash" {
+				args = append(args, "--kind", "topic")
+			}
+			_, err := runRemoval(t, server, command, args...)
 			var cliErr *apierr.Error
 			if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
 				t.Fatalf("invalid ID should produce a usage error, got %v", err)
@@ -144,7 +149,11 @@ func TestTrashAndSpamReportServerFailures(t *testing.T) {
 		t.Run(command, func(t *testing.T) {
 			server, recorded := removalServer(t)
 			recorded.status = http.StatusUnprocessableEntity
-			if _, err := runRemoval(t, server, command, "12345"); err == nil {
+			args := []string{"12345"}
+			if command == "trash" {
+				args = append(args, "--kind", "topic")
+			}
+			if _, err := runRemoval(t, server, command, args...); err == nil {
 				t.Fatal("server failure should be reported")
 			}
 		})

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -205,10 +205,10 @@ notice on stderr. Both need list data, so they work on `hey box list`, `hey box 
 | Follow every change | `hey watch` |
 | Mark as seen | `hey seen 12345` |
 | Mark as unseen | `hey unseen 12345` |
-| Move email threads | `hey move 12345 --to feed` |
-| Move email threads to Trash | `hey trash 12345` |
+| Move email threads | `hey move 12345 --to feed --kind topic` |
+| Move email threads to Trash | `hey trash 12345 --kind topic` |
 | Mark email threads as spam | `hey spam 12345` |
-| Ignore email threads | `hey ignore 12345` |
+| Ignore email threads | `hey ignore 12345 --kind topic` |
 | Stop ignoring email threads | `hey stop-ignoring 12345` |
 | Create habit | `hey habit create "Morning strength training"` |
 | Edit habit | `hey habit edit 123 --days mon,wed,fri` |
@@ -250,10 +250,10 @@ Want to read email?
 ├── Turn off the sharing link? → hey unshare <thread_id>
 ├── Mark as seen? → hey seen <id>
 ├── Mark as unseen? → hey unseen <id>
-├── Move to another box? → hey move <id> --to <box>
-├── Move to Trash? → hey trash <id>
+├── Move to another box? → select a kind=topic item, then hey move <id> --to <box> --kind topic
+├── Move to Trash? → select a kind=topic item, then hey trash <id> --kind topic
 ├── Mark as spam? → hey spam <id>
-├── Ignore future activity? → hey ignore <id>
+├── Ignore future activity? → select a kind=topic item, then hey ignore <id> --kind topic
 ├── Stop ignoring? → hey stop-ignoring <id>
 ├── Who is waiting to be screened? → hey screener list --json
 ├── Screen a sender in or out? → hey screener approve|deny <clearance_id>
@@ -305,7 +305,7 @@ hey box view imbox --page next-cursor --json # Continue from an earlier listing
 
 Box names: `imbox`, `feedbox`, `trailbox`, `asidebox`, `laterbox`, `bubblebox`
 
-**Response format:** `hey box view --json` returns the box itself — `id`, `kind`, `name`, `app_url`, `next_history_url`, `next_page` — with a `postings` array of the email threads in it. Each posting has: `id` (box item ID), `topic_id` (thread ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`, `visible_entry_count`. Use `id` for `hey seen`, `hey unseen`, `hey move`, `hey label add`, `hey label remove`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring`, and `topic_id` for `hey threads`, `hey reply`, `hey forward`, `hey share` and `hey attachments`. A box item `id` passed to `hey threads` answers `not_found`, and so does a `topic_id` passed to `hey move`.
+**Response format:** `hey box view --json` returns the box itself — `id`, `kind`, `name`, `app_url`, `next_history_url`, `next_page` — with a `postings` array of the email threads in it. Each posting has: `id` (box item ID), `topic_id` (thread ID), `kind`, `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`, `visible_entry_count`. Use `id` for `hey seen`, `hey unseen`, `hey move`, `hey label add`, `hey label remove`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring`, and `topic_id` for `hey threads`, `hey reply`, `hey forward`, `hey share` and `hey attachments`. Before `move`, `trash`, or `ignore`, select a record whose `kind` is exactly `topic` and pass `--kind topic`; the CLI does not manage HEY World posts. A box item `id` passed to `hey threads` answers `not_found`, and so does a `topic_id` passed to `hey move`.
 
 `next_page` is the cursor `--page` takes, and it is the cursor inside `next_history_url` — `--page` accepts either. `--all` reads to the end instead.
 
@@ -482,33 +482,33 @@ Takes box item IDs (the `id` field from `hey box view` output).
 ### Email - Moving Threads
 
 ```bash
-hey move 12345 --to imbox                     # Move one thread
-hey move 12345 67890 --to "paper trail"       # Move multiple threads
+hey move 12345 --to imbox --kind topic                     # Move one email thread
+hey move 12345 67890 --to "paper trail" --kind topic       # Move multiple email threads
 ```
 
-Takes box item IDs (the `id` field from `hey box view --json`). `--to` accepts a box name, kind, or ID. Supported destinations are Imbox, The Feed, Set Aside, Reply Later, and Paper Trail. Bubble Up requires a scheduled date and is not supported by this command.
+Takes box item IDs. For `hey box view --json` and `hey label view --json`, select a record whose `kind` is exactly `topic` and use its `id`. `hey search --json` returns only email threads and has no `kind` field, so use the result's `id`. Pass `--kind topic`; missing and non-email kinds are rejected before setup. `--to` accepts a box name, kind, or ID. Supported destinations are Imbox, The Feed, Set Aside, Reply Later, and Paper Trail. Bubble Up requires a scheduled date and is not supported by this command.
 
 ### Email - Trash and Spam
 
 ```bash
-hey trash 12345                               # Move one thread to Trash
-hey trash 12345 67890                         # Move multiple threads to Trash
+hey trash 12345 --kind topic                  # Move one email thread to Trash
+hey trash 12345 67890 --kind topic            # Move multiple email threads to Trash
 hey spam 12345                                # Mark one thread as spam
 hey spam 12345 67890                          # Mark multiple threads as spam
 ```
 
-Takes box item IDs (the `id` field from `hey box view --json`). Trashing a shared thread removes your access instead of deleting it for everyone. Marking a thread as spam moves it to Spam and trains HEY's filters.
+Takes box item IDs. For box and label JSON results, select a record whose `kind` is exactly `topic` and use its `id`; search results are already email threads, so use their `id`. `trash` requires `--kind topic` and rejects every other kind; `spam` is unchanged. Trashing a shared thread removes your access instead of deleting it for everyone. Marking a thread as spam moves it to Spam and trains HEY's filters.
 
 ### Email - Ignoring Threads
 
 ```bash
-hey ignore 12345                              # Ignore one thread
-hey ignore 12345 67890                        # Ignore multiple threads
+hey ignore 12345 --kind topic                 # Ignore one email thread
+hey ignore 12345 67890 --kind topic           # Ignore multiple email threads
 hey stop-ignoring 12345                       # Stop ignoring one thread
 hey stop-ignoring 12345 67890                 # Stop ignoring multiple threads
 ```
 
-Takes box item IDs (the `id` field from `hey box view --json`). Ignored threads remain in their box; new replies do not bring them back to your attention. `hey stop-ignoring` reverses the action.
+Takes box item IDs. For box and label JSON results, select a record whose `kind` is exactly `topic` and use its `id`; search results are already email threads, so use their `id`. `ignore` requires `--kind topic` and rejects every other kind; `stop-ignoring` is unchanged. Ignored threads remain in their box; new replies do not bring them back to your attention. `hey stop-ignoring` reverses the action.
 
 ### Email - Watching for changes
 


### PR DESCRIPTION
## Summary

`hey move`, `hey trash`, and `hey ignore` now require the exact flag `--kind topic`. Missing and non-email kinds fail before config, authentication, or any SDK request, while existing bulk-ID behavior stays unchanged.

Fresh `main` already contains the posting actions from #173, #175, and #176. This rebase drops PR #152's superseded command implementations and applies only the email-thread safety guard to the current commands. The CLI does not manage HEY World posts.

## Validation

- `make fmt-check`
- `make vet`
- `go test ./internal/...`
- `make tidy-check`
- `make check-surface`
- `go test -race -count=1 ./internal/...`
- `make build`
- A malformed-config regression proves kind validation runs before root setup
- Compound Engineering review completed; its `id` versus `topic_id` wording finding was fixed and regression-tested

## Risk

`--kind` is a caller-supplied safety assertion, not an authorization boundary. The server remains responsible for rejecting an ID that is invalid for an action.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts `move`, `trash`, and `ignore` to email threads and fails fast on non-email kinds. Previously these commands ran with any box item ID; now they require `--kind topic` and reject `world/post` and other kinds before config, auth, or any request.

- Callers must pass `--kind topic` with box item IDs (`id`) for `hey move`, `hey trash`, and `hey ignore`. `spam` and `stop-ignoring` are unchanged.
- Adds `emailPostingArgs` to validate the kind early and return clearer errors, including a specific message for HEY World posts.
- Updates CLI help, README, `.surface`, breadcrumbs, and examples to show `--kind topic`; help notes clarify using `id` vs `topic_id` and how to source `id` from box/label/search JSON.
- Adds unit tests verifying early kind validation (even with malformed config) and updated help content.

<sup>Written for commit 22a946a1605706b61d94d5b0fa5b6e7c4f6d9100. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

