### PR TITLE
Reject non-positive posting IDs and drop duplicates

### DIFF
--- a/internal/cmd/args_test.go
+++ b/internal/cmd/args_test.go
@@ -62,8 +62,19 @@ func TestParseIntArgsRejectsNonPositive(t *testing.T) {
 }
 
 func TestParseIntArgsRejectsNonNumeric(t *testing.T) {
-	if _, err := parseIntArgs([]string{"abc"}); err == nil {
-		t.Error("parseIntArgs(\"abc\"): expected an error, got nil")
+	for _, tc := range []struct{ arg, want string }{
+		{"abc", "invalid posting ID: abc"},
+		{"", "invalid posting ID: "},
+		{"1.5", "invalid posting ID: 1.5"},
+	} {
+		_, err := parseIntArgs([]string{tc.arg})
+		if err == nil {
+			t.Errorf("parseIntArgs(%q): expected an error, got nil", tc.arg)
+			continue
+		}
+		if err.Error() != tc.want {
+			t.Errorf("parseIntArgs(%q) = %q, want %q", tc.arg, err.Error(), tc.want)
+		}
 	}
 }
 

--- a/internal/cmd/args_test.go
+++ b/internal/cmd/args_test.go
@@ -43,9 +43,20 @@ func TestCleanUseLineStripsFlagsSuffix(t *testing.T) {
 }
 
 func TestParseIntArgsRejectsNonPositive(t *testing.T) {
-	for _, arg := range []string{"0", "-1", "-99999"} {
-		if _, err := parseIntArgs([]string{arg}); err == nil {
-			t.Errorf("parseIntArgs(%q): expected an error, got nil", arg)
+	for _, tc := range []struct{ arg, want string }{
+		{"0", "invalid posting ID: 0 (must be positive)"},
+		{"-1", "invalid posting ID: -1 (must be positive)"},
+		{"-99999", "invalid posting ID: -99999 (must be positive)"},
+	} {
+		_, err := parseIntArgs([]string{tc.arg})
+		if err == nil {
+			t.Errorf("parseIntArgs(%q): expected an error, got nil", tc.arg)
+			continue
+		}
+		// The clearer message is the point of the change, so assert it rather
+		// than just the presence of an error.
+		if err.Error() != tc.want {
+			t.Errorf("parseIntArgs(%q) = %q, want %q", tc.arg, err.Error(), tc.want)
 		}
 	}
 }

--- a/internal/cmd/args_test.go
+++ b/internal/cmd/args_test.go
@@ -41,3 +41,43 @@ func TestCleanUseLineStripsFlagsSuffix(t *testing.T) {
 		t.Fatalf("cleanUseLine() = %q", line)
 	}
 }
+
+func TestParseIntArgsRejectsNonPositive(t *testing.T) {
+	for _, arg := range []string{"0", "-1", "-99999"} {
+		if _, err := parseIntArgs([]string{arg}); err == nil {
+			t.Errorf("parseIntArgs(%q): expected an error, got nil", arg)
+		}
+	}
+}
+
+func TestParseIntArgsRejectsNonNumeric(t *testing.T) {
+	if _, err := parseIntArgs([]string{"abc"}); err == nil {
+		t.Error("parseIntArgs(\"abc\"): expected an error, got nil")
+	}
+}
+
+func TestParseIntArgsDeduplicatesPreservingOrder(t *testing.T) {
+	got, err := parseIntArgs([]string{"3", "1", "3", "2", "1"})
+	if err != nil {
+		t.Fatalf("parseIntArgs: %v", err)
+	}
+	want := []int64{3, 1, 2}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v (first occurrence order preserved)", got, want)
+		}
+	}
+}
+
+func TestParseIntArgsAcceptsValidIDs(t *testing.T) {
+	got, err := parseIntArgs([]string{"12345", "67890"})
+	if err != nil {
+		t.Fatalf("parseIntArgs: %v", err)
+	}
+	if len(got) != 2 || got[0] != 12345 || got[1] != 67890 {
+		t.Errorf("got %v, want [12345 67890]", got)
+	}
+}

--- a/internal/cmd/seen.go
+++ b/internal/cmd/seen.go
@@ -102,11 +102,13 @@ func (c *unseenCommand) run(cmd *cobra.Command, args []string) error {
 }
 
 // parseIntArgs parses posting IDs, rejecting non-positive values and dropping
-// duplicates. Zero and negatives are not valid posting IDs, and passing one
-// through produces a request against a nonsense path (/postings/0/...) that the
-// server can only reject. Duplicates cost a round trip and, for commands where
-// the operation is not idempotent, can turn a request the caller got right into
-// a reported failure.
+// duplicates. Zero and negatives are not valid posting IDs, so including one in
+// the posting_ids payload asks the server to act on something the client already
+// knows is invalid; rejecting locally gives a clearer message than whatever
+// comes back. Duplicates are dropped, first occurrence wins — for the bulk
+// seen/unseen calls that only trims the payload, but it matters more for any
+// caller that issues one request per ID, where a repeat can come back as a
+// failure.
 func parseIntArgs(args []string) ([]int64, error) {
 	ids := make([]int64, 0, len(args))
 	seen := make(map[int64]bool, len(args))

--- a/internal/cmd/seen.go
+++ b/internal/cmd/seen.go
@@ -101,14 +101,30 @@ func (c *unseenCommand) run(cmd *cobra.Command, args []string) error {
 	return writeOK(nil, output.WithSummary(summary))
 }
 
+// parseIntArgs parses posting IDs, rejecting non-positive values and dropping
+// duplicates. Zero and negatives are not valid posting IDs, and passing one
+// through produces a request against a nonsense path (/postings/0/...) that the
+// server can only reject. Duplicates cost a round trip and, for commands where
+// the operation is not idempotent, can turn a request the caller got right into
+// a reported failure.
 func parseIntArgs(args []string) ([]int64, error) {
 	ids := make([]int64, 0, len(args))
+	seen := make(map[int64]bool, len(args))
+
 	for _, arg := range args {
 		id, err := strconv.ParseInt(arg, 10, 64)
 		if err != nil {
 			return nil, output.ErrUsage(fmt.Sprintf("invalid posting ID: %s", arg))
 		}
+		if id <= 0 {
+			return nil, output.ErrUsage(fmt.Sprintf("invalid posting ID: %d (must be positive)", id))
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
 		ids = append(ids, id)
 	}
+
 	return ids, nil
 }


### PR DESCRIPTION
`parseIntArgs` is shared by `seen` and `unseen`, and accepts anything that parses as an `int64`. So `hey seen 0` and `hey seen -- -5` are accepted locally and go into the `posting_ids` payload of the bulk request:

```
POST /postings/seen.json    {"posting_ids": [0]}
```

Zero and negatives are not valid posting IDs, so this asks the server to act on something the client already knows is invalid. Rejecting locally gives a clearer message than whatever comes back:

```
invalid posting ID: 0 (must be positive)
```

Duplicates are also dropped, first occurrence wins. For the bulk `seen`/`unseen` calls that only trims the payload. It matters more for any caller that issues one request per ID, where a repeat can come back as a failure and turn a request the caller got right into a reported error.

Both are behaviour changes, but only for input that could not have succeeded, or that asked for the same thing twice.

Four tests added in `args_test.go`, asserting the messages rather than just the presence of an error. Existing `seen`/`unseen` tests unchanged and passing. `make check` passes.

---

I found this while adding a `hey move` command locally — moves are one request per ID rather than one bulk call, which made both gaps visible. That's coming as a separate PR; this one stands on its own and touches only the shared helper.

Built with Claude Code, which is also how I ran into it. The design calls and the review are mine.
