### PR TITLE
fix(skill): document bundle postings and topic ID resolution

### DIFF
--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -161,7 +161,12 @@ hey box 123 --json                            # List emails in box (by ID)
 
 Box names: `imbox`, `feedbox`, `trailbox`, `asidebox`, `laterbox`, `bubblebox`
 
-**Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. Each posting has an `id` (posting ID), plus fields such as `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, and `app_url`. It does not currently guarantee a `topic_id`.
+**Response format:** `hey box --json` returns `{"ok": true, "data": {...box fields..., "postings": [...]}}`. Each posting has an `id` (posting ID), plus fields such as `kind`, `name` (subject), `created_at`, `contacts`, `summary`, `app_url`, and — on bundles — `app_bundle_url`. No posting carries a `topic_id`; see the ID note under Threads for resolving one.
+
+Postings come in two kinds:
+
+- `kind: "topic"` — a single message. `app_url` is `/topics/<id>`.
+- `kind: "bundle"` — HEY's per-contact digest, wrapping one or more messages from one sender. `app_url` is `/contacts/<id>`, and `name` is a `•`-joined concatenation of the bundled subjects rather than one email's subject.
 
 ### Email - Threads
 
@@ -170,7 +175,12 @@ hey threads <topic_id> --json                 # Read full email thread
 hey threads <topic_id> --html                 # Read with raw HTML content
 ```
 
-**ID note:** `hey threads` and `hey reply` expect a **topic ID**, not a posting ID. When a posting's `app_url` contains `/topics/<id>`, use that ID. If it does not, do not substitute the posting ID: the current CLI has no supported lookup from posting ID to topic ID, so ask the user to open the thread in HEY instead. See issue #156.
+**ID note:** `hey threads` and `hey reply` expect a **topic ID**, not a posting ID. Resolve one from the first `/topics/<id>` URL the posting offers:
+
+1. `app_url` — present on every `kind: "topic"` posting.
+2. `app_bundle_url` — a `kind: "bundle"` posting has a contact-shaped `app_url`, but a bundle wrapping a single message still points at that one topic here.
+
+If neither is topic-shaped, the posting is a bundle of several messages: it names a contact, not a thread, so no topic ID exists for it. Do not substitute the posting ID — `hey threads <posting-id>` requests `/topics/<posting-id>/entries` and returns not-found. The CLI has no command to list the topics inside a bundle, so ask the user to open it in HEY instead. See issue #156.
 
 ### Email - Reply & Compose
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -161,7 +161,7 @@ hey box 123 --json                            # List emails in box (by ID)
 
 Box names: `imbox`, `feedbox`, `trailbox`, `asidebox`, `laterbox`, `bubblebox`
 
-**Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. Each posting has: `id` (posting ID), `topic_id` (topic ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`. Use `topic_id` for `hey threads` and `hey reply`.
+**Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. Each posting has an `id` (posting ID), plus fields such as `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, and `app_url`. It does not currently guarantee a `topic_id`.
 
 ### Email - Threads
 
@@ -170,7 +170,7 @@ hey threads <topic_id> --json                 # Read full email thread
 hey threads <topic_id> --html                 # Read with raw HTML content
 ```
 
-**ID note:** `hey box` returns postings with an `id` (posting ID) and a `topic_id` (topic ID). `hey threads` and `hey reply` expect the **topic ID** — use `topic_id` directly. The `app_url` field also contains the topic ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
+**ID note:** `hey threads` and `hey reply` expect a **topic ID**, not a posting ID. When a posting's `app_url` contains `/topics/<id>`, use that ID. If it does not, do not substitute the posting ID: the current CLI has no supported lookup from posting ID to topic ID, so ask the user to open the thread in HEY instead. See issue #156.
 
 ### Email - Reply & Compose
 


### PR DESCRIPTION
The embedded skill documented a `topic_id` on every `hey box` posting. No live posting carries that field, so the documented `box` → `threads` workflow fails.

This corrects the guidance to describe what postings actually carry. Agents resolve a topic ID from the first `/topics/<id>` URL a posting offers — `app_url` on a `kind: "topic"` posting, or `app_bundle_url` on a `kind: "bundle"` posting wrapping a single message. A bundle wrapping several messages names a contact rather than a thread, so no topic ID exists for it; agents are told to direct the user to HEY rather than substituting the posting ID, which 404s as `/topics/<posting-id>/entries`.

Measured on a 500-posting Imbox: 262 topic postings, 70 single-entry bundles resolvable via `app_bundle_url`, 168 multi-message bundles unresolvable. Reading `app_url` alone would give up on all 238 bundles.

Also corrects the documented response envelope (`{ok, data:{...}}`, not `{box, postings}`) and notes that a bundle's `name` concatenates several subjects.

This is a docs-only change to bundled agent guidance; it does not make unreachable bodies readable. Bundle expansion is tracked in #156.

Validation: `GOCACHE=/private/tmp/hey-cli-go-build make test`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required; this only corrects bundled agent guidance and has no runtime service behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies ID handling in the HEY skill so `hey threads`/`hey reply` always use a topic ID and never a posting ID. Updates `hey box --json` docs with the correct `{"ok": true, "data": {...}}` envelope, defines `kind: "topic"` and `kind: "bundle"`, states postings don’t include `topic_id`, and explains resolving topic IDs from `app_url` or `app_bundle_url` (single-message bundles); multi-message bundles have no topic ID and should be opened in HEY.

<sup>Written for commit 90be0bb9b5cbdd784dfa5dc8c05c26571916056d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


