### PR TITLE
Add email search command

### DIFF
--- a/.surface
+++ b/.surface
@@ -62,6 +62,8 @@ hey recordings --limit
 hey recordings --starts-on
 hey reply
 hey reply --message
+hey search
+hey search --page
 hey seen
 hey setup
 hey skill

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -1,7 +1,7 @@
 # API Coverage
 
 Mapping of HEY API endpoints used by the CLI. Most endpoints use the HEY SDK (`hey-sdk/go`).
-The legacy `internal/client/` is used only for HTML-scraping gap operations marked below.
+HTML-only gaps use the SDK's generic `GetHTML` method and parsers in `internal/htmlutil`.
 
 | Endpoint | Method | Client | CLI Command | Status |
 |----------|--------|--------|-------------|--------|
@@ -13,9 +13,11 @@ The legacy `internal/client/` is used only for HTML-scraping gap operations mark
 | `/asidebox.json` | GET | SDK `Boxes().GetAsidebox` | `hey box asidebox` | covered |
 | `/laterbox.json` | GET | SDK `Boxes().GetLaterbox` | `hey box laterbox` | covered |
 | `/bubblebox.json` | GET | SDK `Boxes().GetBubblebox` | `hey box bubblebox` | covered |
+| `/search.json` | GET | SDK `Search().Search` | not exposed | stale: live service returns 406 |
+| `/advanced_search` | GET (HTML) | SDK `GetHTML` + `ParseSearchResultsHTML` | `hey search <query>` | covered |
 | `/calendars.json` | GET | SDK `Calendars().List` | `hey calendars` | covered |
 | `/calendars/{id}/recordings.json` | GET | SDK `Calendars().GetRecordings` | `hey recordings <calendar-id>`, `hey todo list`, `hey timetrack list`, `hey journal list` | covered |
-| `/topics/{id}/entries` | GET (HTML) | Legacy `GetTopicEntries` | `hey threads <id>` | gap: SDK Entry lacks body |
+| `/topics/{id}/entries` | GET (HTML) | SDK `GetHTML` + `ParseTopicEntriesHTML` | `hey threads <id>` | gap: SDK Entry lacks body |
 | `/entries/drafts.json` | GET | SDK `Entries().ListDrafts` | `hey drafts` | covered |
 | `/topics/messages` | POST | SDK `Messages().Create` | `hey compose` | covered |
 | `/topics/{id}/messages` | POST | SDK `Messages().CreateTopicMessage` | `hey compose --topic` | covered |
@@ -23,7 +25,7 @@ The legacy `internal/client/` is used only for HTML-scraping gap operations mark
 | `/calendar/days/{date}/habits/{id}/completions.json` | POST | SDK `Habits().Complete` | `hey habit complete <id>` | covered |
 | `/calendar/days/{date}/habits/{id}/completions.json` | DELETE | SDK `Habits().Uncomplete` | `hey habit uncomplete <id>` | covered |
 | `/calendar/days/{date}/journal_entry.json` | GET | SDK `Journal().Get` | `hey journal read [date]` | partial: falls back to legacy |
-| `/calendar/days/{date}/journal_entry/edit` | GET (HTML) | Legacy `GetJournalEntry` | `hey journal read [date]` | gap: fallback for 204 response |
+| `/calendar/days/{date}/journal_entry/edit` | GET (HTML) | SDK `GetHTML` | `hey journal read [date]` | gap: fallback for 204 response |
 | `/calendar/days/{date}/journal_entry.json` | PATCH | SDK `Journal().Update` | `hey journal write [date]` | covered |
 | `/calendar/ongoing_time_track.json` | GET | SDK `TimeTracks().GetOngoing` | `hey timetrack current` | covered |
 | `/calendar/ongoing_time_track.json` | POST | SDK `TimeTracks().Start` | `hey timetrack start` | covered |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ All commands support `--json` for raw JSON output and `--base-url` to override t
 ```bash
 hey boxes                          # list mailboxes
 hey box imbox                      # list postings in a box (by name or ID)
+hey search "quarterly planning"    # search email topics
 hey threads 123                    # read a full email thread
 hey reply 123 -m "Thanks!"        # reply to a thread (or omit -m to open $EDITOR)
 hey compose --to user@example.com --subject "Hello"  # compose a new message

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -17,7 +17,7 @@ var curatedCategories = []struct {
 }{
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "threads", "compose", "reply", "drafts", "seen", "unseen"},
+		names:   []string{"boxes", "box", "search", "threads", "compose", "reply", "drafts", "seen", "unseen"},
 	},
 	{
 		heading: "CALENDAR & TASKS",
@@ -123,6 +123,7 @@ func renderRootHelp(w io.Writer, cmd *cobra.Command) {
 	examples := []string{
 		"$ hey boxes",
 		"$ hey box imbox",
+		`$ hey search "quarterly planning"`,
 		"$ hey threads 123",
 		`$ hey compose --to "someone@hey.com" -m "Hello!"`,
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -119,6 +119,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newAuthCommand().cmd)
 	root.AddCommand(newBoxesCommand().cmd)
 	root.AddCommand(newBoxCommand().cmd)
+	root.AddCommand(newSearchCommand().cmd)
 	root.AddCommand(newThreadsCommand().cmd)
 	root.AddCommand(newReplyCommand().cmd)
 	root.AddCommand(newComposeCommand().cmd)

--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -19,9 +19,9 @@ type searchCommand struct {
 }
 
 func newSearchCommand() *searchCommand {
-	searchCommand := &searchCommand{}
-	searchCommand.cmd = &cobra.Command{
-		Use:   "search <query>",
+	command := &searchCommand{}
+	command.cmd = &cobra.Command{
+		Use:   "search <query...>",
 		Short: "Search email",
 		Long:  "Search email topics by keyword or phrase using HEY's advanced search.",
 		Annotations: map[string]string{
@@ -30,13 +30,13 @@ func newSearchCommand() *searchCommand {
 		Example: `  hey search "quarterly planning"
   hey search invoice --page 2
   hey search "project update" --json`,
-		RunE: searchCommand.run,
+		RunE: command.run,
 		Args: usageMinOneArg(),
 	}
 
-	searchCommand.cmd.Flags().IntVar(&searchCommand.page, "page", 1, "Result page (starting at 1)")
+	command.cmd.Flags().IntVar(&command.page, "page", 1, "Result page (starting at 1)")
 
-	return searchCommand
+	return command
 }
 
 func (c *searchCommand) run(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type searchCommand struct {
+	cmd  *cobra.Command
+	page int
+}
+
+func newSearchCommand() *searchCommand {
+	searchCommand := &searchCommand{}
+	searchCommand.cmd = &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search email",
+		Long:  "Search email topics by keyword or phrase using HEY's advanced search.",
+		Annotations: map[string]string{
+			"agent_notes": "Returns matching email topics. Use a result ID with hey threads to read the full conversation.",
+		},
+		Example: `  hey search "quarterly planning"
+  hey search invoice --page 2
+  hey search "project update" --json`,
+		RunE: searchCommand.run,
+		Args: usageMinOneArg(),
+	}
+
+	searchCommand.cmd.Flags().IntVar(&searchCommand.page, "page", 1, "Result page (starting at 1)")
+
+	return searchCommand
+}
+
+func (c *searchCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	query := strings.TrimSpace(strings.Join(args, " "))
+	if query == "" {
+		return output.ErrUsage("search query cannot be empty")
+	}
+	if c.page < 1 {
+		return output.ErrUsage("--page must be at least 1")
+	}
+
+	params := url.Values{"q": []string{query}}
+	if c.page > 1 {
+		params.Set("page", strconv.Itoa(c.page))
+	}
+
+	resp, err := sdk.GetHTML(cmd.Context(), "/advanced_search?"+params.Encode())
+	if err != nil {
+		return convertSDKError(err)
+	}
+	page := htmlutil.ParseSearchResultsHTML(string(resp.Data))
+	results := page.Results
+	notice := searchPageNotice(page.NextPage)
+
+	if writer.IsStyled() {
+		if len(results) == 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "No results for %q.\n", query)
+			return nil
+		}
+
+		table := newTable(cmd.OutOrStdout())
+		table.addRow([]string{"Thread", "Subject", "Summary", "Date"})
+		for _, result := range results {
+			table.addRow([]string{
+				fmt.Sprintf("%d", result.ID),
+				truncate(result.Subject, 48),
+				truncate(result.Summary, 60),
+				searchResultDate(result.ActiveAt),
+			})
+		}
+		table.print()
+		if notice != "" {
+			fmt.Fprintln(cmd.OutOrStdout(), notice)
+		}
+		return nil
+	}
+
+	return writeOK(results,
+		output.WithSummary(searchSummary(len(results), query)),
+		output.WithNotice(notice),
+		output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "read",
+			Command:     "hey threads <id>",
+			Description: "Read a matching email thread",
+		}),
+	)
+}
+
+func searchSummary(count int, query string) string {
+	noun := "results"
+	if count == 1 {
+		noun = "result"
+	}
+	return fmt.Sprintf("%d search %s for %q", count, noun, query)
+}
+
+func searchPageNotice(nextPage int) string {
+	if nextPage < 1 {
+		return ""
+	}
+	return fmt.Sprintf("More results available. Use --page %d.", nextPage)
+}
+
+func searchResultDate(value string) string {
+	if value == "" {
+		return ""
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return value
+	}
+	return formatDate(parsed)
+}

--- a/internal/cmd/search_test.go
+++ b/internal/cmd/search_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/models"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+func searchServer(t *testing.T, body string, checkRequest func(*http.Request)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/advanced_search" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if checkRequest != nil {
+			checkRequest(r)
+		}
+		if got := r.Header.Get("Accept"); got != "text/html" {
+			t.Errorf("Accept = %q, want text/html", got)
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+const searchResultsHTML = `<section class="search__results-group">
+<article class="search-result posting">
+  <time class="search-result__timestamp" datetime="2026-08-16T15:00:00Z">Today</time>
+  <a href="/topics/42">
+    <span class="search-topic__title">Quarterly planning notes</span>
+    <div class="search-result__summary">Amanda shared the latest plan.</div>
+  </a>
+</article>
+<a class="pagination-link" href="/advanced_search?q=quarterly+planning&amp;page=3">More</a>
+</section>`
+
+func runSearch(t *testing.T, server *httptest.Server, args ...string) (output.Response, string, error) {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(append([]string{"search", "--base-url", server.URL}, args...))
+
+	err := root.Execute()
+	var resp output.Response
+	if strings.Contains(strings.Join(args, " "), "--json") && buf.Len() > 0 {
+		_ = json.Unmarshal(buf.Bytes(), &resp)
+	}
+	return resp, buf.String(), err
+}
+
+func TestSearchReturnsTopicsAndForwardsQuery(t *testing.T) {
+	server := searchServer(t, searchResultsHTML, func(r *http.Request) {
+		if got := r.URL.Query().Get("q"); got != "quarterly planning" {
+			t.Errorf("q = %q, want %q", got, "quarterly planning")
+		}
+		if got := r.URL.Query().Get("page"); got != "2" {
+			t.Errorf("page = %q, want %q", got, "2")
+		}
+	})
+	defer server.Close()
+
+	resp, _, err := runSearch(t, server, "quarterly", "planning", "--page", "2", "--json")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !resp.OK {
+		t.Fatal("expected ok response")
+	}
+	if resp.Summary != `1 search result for "quarterly planning"` {
+		t.Errorf("summary = %q", resp.Summary)
+	}
+
+	topicsJSON, err := json.Marshal(resp.Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var topics []models.SearchResult
+	if err := json.Unmarshal(topicsJSON, &topics); err != nil {
+		t.Fatal(err)
+	}
+	if len(topics) != 1 || topics[0].ID != 42 {
+		t.Fatalf("topics = %#v, want one topic with ID 42", topics)
+	}
+	if resp.Notice != "More results available. Use --page 3." {
+		t.Errorf("notice = %q", resp.Notice)
+	}
+}
+
+func TestSearchStyledOutput(t *testing.T) {
+	server := searchServer(t, searchResultsHTML, nil)
+	defer server.Close()
+
+	_, stdout, err := runSearch(t, server, "quarterly", "planning", "--styled")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	for _, want := range []string{"42", "Quarterly planning notes", "Amanda shared the latest plan.", "2026-08-16", "Use --page 3"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestSearchEmptyResults(t *testing.T) {
+	server := searchServer(t, `<section class="search__results-group"></section>`, nil)
+	defer server.Close()
+
+	resp, _, err := runSearch(t, server, "missing phrase", "--json")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if resp.Summary != `0 search results for "missing phrase"` {
+		t.Errorf("summary = %q", resp.Summary)
+	}
+}
+
+func TestSearchRequiresQuery(t *testing.T) {
+	server := searchServer(t, "", nil)
+	defer server.Close()
+
+	_, _, err := runSearch(t, server, "--json")
+	if err == nil {
+		t.Fatal("expected missing query to fail")
+	}
+	if !strings.Contains(err.Error(), "Usage:") {
+		t.Errorf("error = %q, want usage error", err)
+	}
+}
+
+func TestSearchRejectsInvalidPage(t *testing.T) {
+	server := searchServer(t, "", nil)
+	defer server.Close()
+
+	_, _, err := runSearch(t, server, "quarterly planning", "--page", "0", "--json")
+	if err == nil {
+		t.Fatal("expected invalid page to fail")
+	}
+	if !strings.Contains(err.Error(), "--page must be at least 1") {
+		t.Errorf("error = %q", err)
+	}
+}

--- a/internal/htmlutil/search.go
+++ b/internal/htmlutil/search.go
@@ -1,0 +1,157 @@
+package htmlutil
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+
+	"github.com/basecamp/hey-cli/internal/models"
+)
+
+// SearchPage is a parsed page from HEY's HTML advanced-search view.
+type SearchPage struct {
+	Results  []models.SearchResult
+	NextPage int
+}
+
+// ParseSearchResultsHTML extracts topic results and pagination from
+// /advanced_search. HEY's former /search.json route returns HTTP 406 on the
+// live service, so search currently uses the HTML view.
+func ParseSearchResultsHTML(source string) SearchPage {
+	doc, err := html.Parse(strings.NewReader(source))
+	if err != nil {
+		return SearchPage{}
+	}
+
+	page := SearchPage{}
+	walkElements(doc, func(node *html.Node) {
+		switch {
+		case node.Data == "article" && hasClass(node, "search-result"):
+			if result, ok := parseSearchResult(node); ok {
+				page.Results = append(page.Results, result)
+			}
+		case node.Data == "a" && hasClass(node, "pagination-link"):
+			if next := pageNumber(getAttr(node, "href")); next > page.NextPage {
+				page.NextPage = next
+			}
+		}
+	})
+	return page
+}
+
+func parseSearchResult(article *html.Node) (models.SearchResult, bool) {
+	anchor := findElement(article, func(node *html.Node) bool {
+		return node.Data == "a" && topicID(getAttr(node, "href")) > 0
+	})
+	if anchor == nil {
+		return models.SearchResult{}, false
+	}
+
+	href := getAttr(anchor, "href")
+	result := models.SearchResult{
+		ID:     topicID(href),
+		AppURL: href,
+	}
+	if subject := findElement(anchor, func(node *html.Node) bool {
+		return hasClass(node, "search-topic__title")
+	}); subject != nil {
+		result.Subject = visibleText(subject)
+	}
+	if summary := findElement(article, func(node *html.Node) bool {
+		return hasClass(node, "search-result__summary")
+	}); summary != nil {
+		result.Summary = visibleText(summary)
+	}
+	if timestamp := findElement(article, func(node *html.Node) bool {
+		return node.Data == "time" && hasClass(node, "search-result__timestamp")
+	}); timestamp != nil {
+		result.ActiveAt = getAttr(timestamp, "datetime")
+	}
+
+	return result, true
+}
+
+func walkElements(node *html.Node, visit func(*html.Node)) {
+	if node.Type == html.ElementNode {
+		visit(node)
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		walkElements(child, visit)
+	}
+}
+
+func findElement(node *html.Node, match func(*html.Node) bool) *html.Node {
+	if node.Type == html.ElementNode && match(node) {
+		return node
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		if found := findElement(child, match); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func hasClass(node *html.Node, target string) bool {
+	for _, className := range strings.Fields(getAttr(node, "class")) {
+		if className == target {
+			return true
+		}
+	}
+	return false
+}
+
+func visibleText(node *html.Node) string {
+	var text strings.Builder
+	var walk func(*html.Node)
+	walk = func(current *html.Node) {
+		if current.Type == html.ElementNode {
+			if hasClass(current, "u-for-screen-reader") || current.Data == "script" || current.Data == "style" {
+				return
+			}
+		}
+		if current.Type == html.TextNode {
+			text.WriteString(current.Data)
+		}
+		for child := current.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(node)
+	return strings.Join(strings.Fields(text.String()), " ")
+}
+
+func topicID(rawURL string) int64 {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return 0
+	}
+	const marker = "/topics/"
+	index := strings.LastIndex(parsed.Path, marker)
+	if index < 0 {
+		return 0
+	}
+	segment := parsed.Path[index+len(marker):]
+	if slash := strings.IndexByte(segment, '/'); slash >= 0 {
+		segment = segment[:slash]
+	}
+	id, err := strconv.ParseInt(segment, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
+func pageNumber(rawURL string) int {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return 0
+	}
+	page, err := strconv.Atoi(parsed.Query().Get("page"))
+	if err != nil || page < 1 {
+		return 0
+	}
+	return page
+}

--- a/internal/htmlutil/search_test.go
+++ b/internal/htmlutil/search_test.go
@@ -1,0 +1,80 @@
+package htmlutil
+
+import "testing"
+
+func TestParseSearchResultsHTML(t *testing.T) {
+	source := `<!doctype html><html><body>
+<section class="search__results-group">
+  <article class="bulk-actions__container search-result posting">
+    <time class="posting__time search-result__timestamp" datetime="2026-08-16T15:00:00Z">Today</time>
+    <div class="search__content">
+      <a href="/topics/42">
+        <h3><span class="posting__title search-topic__title"><span class="u-for-screen-reader">Unread: </span>Quarterly planning<span class="u-for-screen-reader">, selected</span></span></h3>
+        <div class="search-result__summary"><span>Amanda wrote</span> <span class="posting__summary">Please review the <mark>plan</mark>.</span></div>
+      </a>
+    </div>
+  </article>
+  <article class="search-result posting">
+    <time class="search-result__timestamp" datetime="2026-08-15T14:30:00-05:00">Yesterday</time>
+    <a href="https://app.hey.com/topics/77?source=search">
+      <span class="search-topic__title">Project update</span>
+      <div class="search-result__summary">Latest status</div>
+    </a>
+  </article>
+  <article class="search-result"><a href="/contacts/12">Not a topic</a></article>
+</section>
+<a class="pagination-link" href="/advanced_search?q=planning&amp;page=2">More</a>
+</body></html>`
+
+	page := ParseSearchResultsHTML(source)
+	if len(page.Results) != 2 {
+		t.Fatalf("results = %#v, want 2", page.Results)
+	}
+	if page.NextPage != 2 {
+		t.Errorf("next page = %d, want 2", page.NextPage)
+	}
+
+	first := page.Results[0]
+	if first.ID != 42 {
+		t.Errorf("ID = %d, want 42", first.ID)
+	}
+	if first.Subject != "Quarterly planning" {
+		t.Errorf("subject = %q", first.Subject)
+	}
+	if first.Summary != "Amanda wrote Please review the plan." {
+		t.Errorf("summary = %q", first.Summary)
+	}
+	if first.ActiveAt != "2026-08-16T15:00:00Z" {
+		t.Errorf("active_at = %q", first.ActiveAt)
+	}
+	if first.AppURL != "/topics/42" {
+		t.Errorf("app_url = %q", first.AppURL)
+	}
+
+	second := page.Results[1]
+	if second.ID != 77 || second.Subject != "Project update" {
+		t.Errorf("second result = %#v", second)
+	}
+}
+
+func TestParseSearchResultsHTMLEmpty(t *testing.T) {
+	page := ParseSearchResultsHTML(`<div class="search__results-group">No results</div>`)
+	if len(page.Results) != 0 {
+		t.Fatalf("results = %#v, want empty", page.Results)
+	}
+	if page.NextPage != 0 {
+		t.Errorf("next page = %d, want 0", page.NextPage)
+	}
+}
+
+func TestParseSearchResultsHTMLRejectsInvalidTopicIDAndPage(t *testing.T) {
+	source := `<article class="search-result"><a href="/topics/not-a-number"><span class="search-topic__title">Bad</span></a></article>
+<a class="pagination-link" href="/advanced_search?page=next">More</a>`
+	page := ParseSearchResultsHTML(source)
+	if len(page.Results) != 0 {
+		t.Fatalf("results = %#v, want empty", page.Results)
+	}
+	if page.NextPage != 0 {
+		t.Errorf("next page = %d, want 0", page.NextPage)
+	}
+}

--- a/internal/models/search.go
+++ b/internal/models/search.go
@@ -1,0 +1,10 @@
+package models
+
+// SearchResult is a topic returned by HEY's HTML advanced-search view.
+type SearchResult struct {
+	ID       int64  `json:"id"`
+	Subject  string `json:"subject"`
+	Summary  string `json:"summary,omitempty"`
+	ActiveAt string `json:"active_at,omitempty"`
+	AppURL   string `json:"app_url"`
+}

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -11,6 +11,7 @@ triggers:
   # Email actions
   - hey boxes
   - hey box
+  - hey search
   - hey threads
   - hey reply
   - hey compose
@@ -84,6 +85,7 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 |------|---------|
 | List mailboxes | `hey boxes --json` |
 | List emails in a box | `hey box imbox --json` |
+| Search email | `hey search "quarterly planning" --json` |
 | Read email thread | `hey threads <topic_id> --json` |
 | Reply to email | `hey reply <topic_id> -m "Thanks!"` |
 | Compose email | `hey compose --to user@example.com --subject "Hello"` |
@@ -119,6 +121,7 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 Want to read email?
 ├── Which mailbox? → hey boxes --json
 ├── List emails in box? → hey box <name|id> --json
+├── Search email? → hey search "<query>" --json
 ├── Read full thread? → hey threads <topic_id> --json
 ├── Mark as seen? → hey seen <posting-id>
 ├── Mark as unseen? → hey unseen <posting-id>
@@ -162,6 +165,15 @@ hey box 123 --json                            # List emails in box (by ID)
 Box names: `imbox`, `feedbox`, `trailbox`, `asidebox`, `laterbox`, `bubblebox`
 
 **Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. Each posting has: `id` (posting ID), `topic_id` (topic ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`. Use `topic_id` for `hey threads` and `hey reply`.
+
+### Email - Search
+
+```bash
+hey search "quarterly planning" --json         # Search email topics
+hey search invoice --page 2 --json             # Read another result page
+```
+
+Search returns topics. Use a result's `id` with `hey threads`.
 
 ### Email - Threads
 

--- a/tests/smoke/search_test.go
+++ b/tests/smoke/search_test.go
@@ -1,0 +1,25 @@
+package smoke_test
+
+import "testing"
+
+type SearchTopic struct {
+	ID int64 `json:"id"`
+}
+
+func TestSearch(t *testing.T) {
+	resp := heyJSON(t, "search", "Basecamp")
+	topics := dataAs[[]SearchTopic](t, resp)
+	for _, topic := range topics {
+		if topic.ID <= 0 {
+			t.Errorf("expected positive topic ID, got %d", topic.ID)
+		}
+	}
+}
+
+func TestSearchPage(t *testing.T) {
+	_ = heyJSON(t, "search", "Basecamp", "--page", "2")
+}
+
+func TestSearchRequiresQuery(t *testing.T) {
+	heyFail(t, "search", "--json")
+}


### PR DESCRIPTION
## What changed

Adds `hey search <query>` for HEY's advanced search page. Results include the topic ID, subject, summary, timestamp, and HEY path. The command supports `--page` for pagination.

The SDK's `/search.json` route returns HTTP 406 against the live service. This command uses the SDK's authenticated `GetHTML` method for `/advanced_search` and parses the returned page in `internal/htmlutil`. It does not add another HTTP client or authentication path.

The command is included in root help, `.surface`, the README, API coverage, the bundled HEY skill, and smoke coverage.

Fixes #104

## Tests

- `GOWORK=off mise x -- make check`
- `GOWORK=off mise x -- make build`
- Live HEY: search returned the expected topics, and pagination advanced from page 1 to page 2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `hey search <query>` to find email topics via HEY’s advanced search. Previously no search existed; now it returns topic ID, subject, summary, timestamp, and app path, with `--page` for pagination.

- Fetches `/advanced_search` with SDK `GetHTML` and parses with `internal/htmlutil.ParseSearchResultsHTML`; avoids `'/search.json'` which returns 406 on the live service.
- Outputs a styled table or `--json` as `[]models.SearchResult`; shows a next-page hint when available; requires a query and enforces `--page >= 1`.
- Adds `search` to root help and `.surface`; updates README examples, `skills/hey/SKILL.md`, and API coverage (adds `/advanced_search`, marks `/search.json` as stale, and notes HTML routes now use SDK `GetHTML`).
- Tests include HTML parser unit tests, command tests for query forwarding, pagination, styled/JSON output, validation, and a smoke test.

<sup>Written for commit d1ce56cc4d1d909673d0238dcf18e61f48e70f5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

