### PR TITLE
Make keyring availability checks read-only

### DIFF
--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,10 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
-const serviceName = "hey"
+const (
+	serviceName         = "hey"
+	keyringAvailability = "hey::availability"
+)
 
 type credentialKeyring struct {
 	set    func(service, user, password string) error
@@ -58,10 +62,8 @@ func (s *Store) ensureInit() {
 		if s.noKeyring {
 			return
 		}
-		testKey := "hey::test"
-		err := s.keyring.set(serviceName, testKey, "test")
-		if err == nil {
-			_ = s.keyring.delete(serviceName, testKey)
+		_, err := s.keyring.get(serviceName, keyringAvailability)
+		if err == nil || errors.Is(err, keyring.ErrNotFound) {
 			s.useKeyring = true
 			return
 		}

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -2,16 +2,37 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
 
-	"github.com/zalando/go-keyring"
+	keyringlib "github.com/zalando/go-keyring"
 )
 
 const serviceName = "hey"
+
+type credentialKeyring interface {
+	Get(service, user string) (string, error)
+	Set(service, user, password string) error
+	Delete(service, user string) error
+}
+
+type systemCredentialKeyring struct{}
+
+func (systemCredentialKeyring) Get(service, user string) (string, error) {
+	return keyringlib.Get(service, user)
+}
+
+func (systemCredentialKeyring) Set(service, user, password string) error {
+	return keyringlib.Set(service, user, password)
+}
+
+func (systemCredentialKeyring) Delete(service, user string) error {
+	return keyringlib.Delete(service, user)
+}
 
 // Credentials holds OAuth tokens and metadata.
 type Credentials struct {
@@ -29,6 +50,7 @@ type Store struct {
 	useKeyring  bool
 	noKeyring   bool
 	fallbackDir string
+	keyring     credentialKeyring
 }
 
 // NewStore creates a credential store. Keyring availability is probed lazily
@@ -37,6 +59,7 @@ func NewStore(fallbackDir string) *Store {
 	return &Store{
 		fallbackDir: fallbackDir,
 		noKeyring:   os.Getenv("HEY_NO_KEYRING") != "",
+		keyring:     systemCredentialKeyring{},
 	}
 }
 
@@ -45,10 +68,8 @@ func (s *Store) ensureInit() {
 		if s.noKeyring {
 			return
 		}
-		testKey := "hey::test"
-		err := keyring.Set(serviceName, testKey, "test")
-		if err == nil {
-			_ = keyring.Delete(serviceName, testKey)
+		_, err := s.keyring.Get(serviceName, "hey::availability")
+		if err == nil || errors.Is(err, keyringlib.ErrNotFound) {
 			s.useKeyring = true
 			return
 		}
@@ -83,13 +104,13 @@ func (s *Store) Save(origin string, creds *Credentials) error {
 func (s *Store) Delete(origin string) error {
 	s.ensureInit()
 	if s.useKeyring {
-		return keyring.Delete(serviceName, key(origin))
+		return s.keyring.Delete(serviceName, key(origin))
 	}
 	return s.deleteFile(origin)
 }
 
 func (s *Store) loadFromKeyring(origin string) (*Credentials, error) {
-	data, err := keyring.Get(serviceName, key(origin))
+	data, err := s.keyring.Get(serviceName, key(origin))
 	if err != nil {
 		return nil, fmt.Errorf("credentials not found: %w", err)
 	}
@@ -106,7 +127,7 @@ func (s *Store) saveToKeyring(origin string, creds *Credentials) error {
 	if err != nil {
 		return err
 	}
-	return keyring.Set(serviceName, key(origin), string(data))
+	return s.keyring.Set(serviceName, key(origin), string(data))
 }
 
 func (s *Store) credentialsPath() string {

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -6,7 +6,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+
+	keyringlib "github.com/zalando/go-keyring"
 )
 
 func testStore(t *testing.T) *Store {
@@ -16,12 +19,10 @@ func testStore(t *testing.T) *Store {
 }
 
 type fakeKeyring struct {
-	values         map[string]string
-	setErr         error
-	getErr         error
-	deleteErr      error
-	failAfterProbe bool
-	probeComplete  bool
+	values    map[string]string
+	setErr    error
+	getErr    error
+	deleteErr error
 }
 
 func newFakeKeyring() *fakeKeyring {
@@ -29,13 +30,10 @@ func newFakeKeyring() *fakeKeyring {
 }
 
 func (f *fakeKeyring) Set(service, user, password string) error {
-	if f.setErr != nil && (!f.failAfterProbe || f.probeComplete) {
+	if f.setErr != nil {
 		return f.setErr
 	}
 	f.values[service+"/"+user] = password
-	if user == "hey::test" {
-		f.probeComplete = true
-	}
 	return nil
 }
 
@@ -45,7 +43,7 @@ func (f *fakeKeyring) Get(service, user string) (string, error) {
 	}
 	value, ok := f.values[service+"/"+user]
 	if !ok {
-		return "", errors.New("not found")
+		return "", keyringlib.ErrNotFound
 	}
 	return value, nil
 }
@@ -98,15 +96,15 @@ func TestKeyringSaveLoadDelete(t *testing.T) {
 }
 
 func TestKeyringFailures(t *testing.T) {
-	t.Run("probe falls back to file", func(t *testing.T) {
+	t.Run("availability error falls back to file", func(t *testing.T) {
 		fake := newFakeKeyring()
-		fake.setErr = errors.New("keyring unavailable")
+		fake.getErr = errors.New("keyring unavailable")
 		store := keyringStore(t, fake)
 		if err := store.Save("https://app.hey.com", &Credentials{AccessToken: "file-token"}); err != nil {
 			t.Fatalf("Save fallback: %v", err)
 		}
 		if store.UsingKeyring() {
-			t.Fatal("UsingKeyring = true after failed probe")
+			t.Fatal("UsingKeyring = true after failed availability check")
 		}
 		if _, err := os.Stat(store.credentialsPath()); err != nil {
 			t.Fatalf("fallback credentials file: %v", err)
@@ -183,7 +181,6 @@ func TestMigrateToKeyring(t *testing.T) {
 func TestMigrationFailurePreservesFallbackFile(t *testing.T) {
 	fake := newFakeKeyring()
 	fake.setErr = errors.New("keyring write failed")
-	fake.failAfterProbe = true
 	store := keyringStore(t, fake)
 	if err := store.saveAllToFile(map[string]*Credentials{
 		"https://app.hey.com": {AccessToken: "production"},
@@ -245,6 +242,86 @@ func TestLoadNotFound(t *testing.T) {
 	_, err := s.Load("https://app.hey.com")
 	if err == nil {
 		t.Fatal("expected error for missing credentials")
+	}
+}
+
+func TestConcurrentKeyringAvailabilityChecksAreReadOnly(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "")
+
+	const storeCount = 16
+	var mu sync.Mutex
+	var getCalls, setCalls, deleteCalls, wrongLookups int
+	keyring := credentialKeyring{
+		get: func(service, user string) (string, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			getCalls++
+			if service != serviceName || user != keyringAvailability {
+				wrongLookups++
+			}
+			return "", keyringlib.ErrNotFound
+		},
+		set: func(_, _, _ string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			setCalls++
+			return nil
+		},
+		delete: func(_, _ string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			deleteCalls++
+			return nil
+		},
+	}
+
+	stores := make([]*Store, storeCount)
+	for i := range stores {
+		stores[i] = NewStore(t.TempDir())
+		stores[i].keyring = keyring
+	}
+
+	available := make(chan bool, storeCount)
+	var wg sync.WaitGroup
+	for _, store := range stores {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			available <- store.UsingKeyring()
+		}()
+	}
+	wg.Wait()
+	close(available)
+
+	for usingKeyring := range available {
+		if !usingKeyring {
+			t.Error("missing availability entry reported the keyring unavailable")
+		}
+	}
+	if getCalls != storeCount {
+		t.Errorf("availability Get calls = %d, want %d", getCalls, storeCount)
+	}
+	if wrongLookups != 0 {
+		t.Errorf("availability lookups with the wrong service or user = %d", wrongLookups)
+	}
+	if setCalls != 0 || deleteCalls != 0 {
+		t.Errorf("availability checks mutated the keyring: Set = %d, Delete = %d", setCalls, deleteCalls)
+	}
+}
+
+func TestKeyringAvailabilityErrorUsesFileStore(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "")
+	store := NewStore(t.TempDir())
+	store.keyring = credentialKeyring{
+		get: func(_, _ string) (string, error) {
+			return "", errors.New("keyring unavailable")
+		},
+		set:    func(_, _, _ string) error { return nil },
+		delete: func(_, _ string) error { return nil },
+	}
+
+	if store.UsingKeyring() {
+		t.Fatal("unavailable keyring reported as available")
 	}
 }
 

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -1,10 +1,35 @@
 package auth
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	keyringlib "github.com/zalando/go-keyring"
 )
+
+type recordingKeyring struct {
+	getCalls    int
+	setCalls    int
+	deleteCalls int
+	getErr      error
+}
+
+func (k *recordingKeyring) Get(_, _ string) (string, error) {
+	k.getCalls++
+	return "", k.getErr
+}
+
+func (k *recordingKeyring) Set(_, _, _ string) error {
+	k.setCalls++
+	return nil
+}
+
+func (k *recordingKeyring) Delete(_, _ string) error {
+	k.deleteCalls++
+	return nil
+}
 
 func testStore(t *testing.T) *Store {
 	t.Helper()
@@ -50,6 +75,34 @@ func TestLoadNotFound(t *testing.T) {
 	_, err := s.Load("https://app.hey.com")
 	if err == nil {
 		t.Fatal("expected error for missing credentials")
+	}
+}
+
+func TestKeyringAvailabilityCheckIsReadOnly(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "")
+	keyring := &recordingKeyring{getErr: keyringlib.ErrNotFound}
+	store := NewStore(t.TempDir())
+	store.keyring = keyring
+
+	if !store.UsingKeyring() {
+		t.Fatal("expected missing availability key to confirm keyring access")
+	}
+	if keyring.getCalls != 1 {
+		t.Errorf("Get calls = %d, want 1", keyring.getCalls)
+	}
+	if keyring.setCalls != 0 || keyring.deleteCalls != 0 {
+		t.Errorf("availability check mutated keyring: Set = %d, Delete = %d", keyring.setCalls, keyring.deleteCalls)
+	}
+}
+
+func TestKeyringAvailabilityErrorUsesFileStore(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "")
+	keyring := &recordingKeyring{getErr: errors.New("keyring unavailable")}
+	store := NewStore(t.TempDir())
+	store.keyring = keyring
+
+	if store.UsingKeyring() {
+		t.Fatal("expected unavailable keyring to use file store")
 	}
 }
 


### PR DESCRIPTION
## What changed

Credential-store initialization now checks Keychain availability with a read-only lookup. A missing availability entry means the keyring is working. Other errors keep the existing plaintext-file fallback.

The keyring interface lets the tests verify that initialization calls `Get` once and never calls `Set` or `Delete`.

## Why

Every CLI process previously wrote and deleted the same `hey::test` item before loading the real credential. Parallel processes could make that probe fail. The affected process then switched to an empty plaintext store and reported `not logged in`, even though valid credentials were still in Keychain.

I reproduced this with 60 read-only `hey auth status --json` calls at concurrency 6. Before the change, 25 printed the keyring warning and reported unauthenticated. After the change, all 60 completed without either failure.

## Checks

- `env GOWORK=off mise x golangci-lint@2.10.1 -- make check`
- `env GOWORK=off mise x -- go test -race -count=1 ./internal/auth`
- 60 concurrent installed CLI auth checks, with zero keyring warnings and zero false unauthenticated results

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes keyring availability checks read-only to remove concurrency races that caused false plaintext fallbacks. Previously the CLI wrote/deleted `hey::test`; now it does a single Get on `hey::availability`, where `ErrNotFound` means the keyring is available and only other errors fall back to the file store.

- Introduces a `credentialKeyring` interface with a default `systemCredentialKeyring` wrapper around `github.com/zalando/go-keyring`; `Store` now depends on this interface so tests assert exactly one `Get` and zero `Set`/`Delete` during init.
- Replaces direct calls to `github.com/zalando/go-keyring` with `s.keyring` across load/save/delete paths. External behavior is unchanged except fewer keyring warnings and no spurious unauthenticated states under concurrency.

<sup>Written for commit 4374b62859374387c84040152d7c250cfc85e1ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

