### PR TITLE
Move onto SDK v0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,26 @@ Remember to update the examples in the README when you change, add or remove CLI
 
 ### HTML content
 
-Some HEY API endpoints return 204 or incomplete data via JSON, but the full HTML content is available by scraping the edit page (e.g., `/calendar/days/{date}/journal_entry/edit` contains the Trix editor hidden input with full HTML). When an API endpoint returns incomplete data, check the corresponding web page for the full content. The `internal/htmlutil` package provides `ToText` (HTML→plain text), `ExtractImageURLs`, and `ParseTopicEntriesHTML` shared by both CLI and TUI. HEY uses Trix editor with `<figure data-trix-attachment="{...}">` for attachments — image URLs in those attributes are relative paths requiring authentication via `sdk.Get`.
+**Scraping is being removed, not extended.** HEY grew JSON for the endpoints the CLI reads,
+the SDK dropped its scrapers in v0.4.0, and what is left here is on its way out. Do not
+answer "the JSON looks incomplete" by parsing a web page — check whether the SDK already
+has a typed operation, and if HEY does not serve JSON for what you need, add it there
+rather than working around it here.
+
+The journal used to be the example of this: a day with an entry answered 204, so the
+content was scraped from the Trix input on `/calendar/days/{date}/journal_entry/edit`.
+HEY answers the entry itself now, a 204 means the day is empty, and the scrape is gone.
+
+What still reads HTML, and only until the typed reads replace it: `hey reply`, `hey topic`
+and two TUI paths use `internal/htmlutil`'s `ParseTopicEntriesHTML` and
+`ParseTopicAddressed` to find a thread's entries and recipients. `Topics.Get` carries the
+topic's entries as of SDK v0.4.0, so this can go; `resolveThreadReply` in
+`internal/cmd/thread_reply.go` is the one place to change.
+
+`internal/htmlutil` also provides `ToText` (HTML→plain text) and `ExtractImageURLs`, which
+are presentation helpers rather than scrapers and are staying. HEY uses the Trix editor
+with `<figure data-trix-attachment="{...}">` for attachments — image URLs in those
+attributes are relative paths requiring authentication via `sdk.Get`.
 
 ### TUI structure
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.6
-	github.com/basecamp/hey-sdk/go v0.3.0
+	github.com/basecamp/hey-sdk/go v0.4.0
 	github.com/mattn/go-runewidth v0.0.27
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -28,11 +28,11 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
-	github.com/google/uuid v1.5.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.1 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/oapi-codegen/runtime v1.2.0 // indirect
+	github.com/oapi-codegen/runtime v1.6.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
-github.com/basecamp/hey-sdk/go v0.3.0 h1:NnXFYTYS5t5RBNJG/q0r5M8P3Gz4FQOBY+y59krbfyU=
-github.com/basecamp/hey-sdk/go v0.3.0/go.mod h1:Mo8DxZT7gmWHePXVDA1Cgy1xRMFDTpeyuKlprEE+srE=
 github.com/basecamp/hey-sdk/go v0.4.0 h1:5tngAdT7eucUp53wn9qXHY6Z3GJ1pKM7fQycaOnVvsM=
 github.com/basecamp/hey-sdk/go v0.4.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
@@ -44,8 +42,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
-github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
-github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -57,8 +53,8 @@ github.com/mattn/go-runewidth v0.0.27 h1:Feg/Oou5zI/wnpgDF6omIU0OokC9GxLC/WRknhV
 github.com/mattn/go-runewidth v0.0.27/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
-github.com/oapi-codegen/runtime v1.2.0 h1:RvKc1CVS1QeKSNzO97FBQbSMZyQ8s6rZd+LpmzwHMP4=
-github.com/oapi-codegen/runtime v1.2.0/go.mod h1:Y7ZhmmlE8ikZOmuHRRndiIm7nf3xcVv+YMweKgG1DT0=
+github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
+github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
 github.com/oapi-codegen/runtime v1.6.0 h1:7Xx+GlueD6nRuyKoCPzL434Jfi3BetbiJOrzCHp/VPU=
 github.com/oapi-codegen/runtime v1.6.0/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -83,9 +79,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 h1:985EYyeCOxTpcgOTJpflJUwOeEz0CQOdPt73OzpE9F8=
+golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
 golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/basecamp/hey-sdk/go v0.3.0 h1:NnXFYTYS5t5RBNJG/q0r5M8P3Gz4FQOBY+y59krbfyU=
 github.com/basecamp/hey-sdk/go v0.3.0/go.mod h1:Mo8DxZT7gmWHePXVDA1Cgy1xRMFDTpeyuKlprEE+srE=
+github.com/basecamp/hey-sdk/go v0.4.0 h1:5tngAdT7eucUp53wn9qXHY6Z3GJ1pKM7fQycaOnVvsM=
+github.com/basecamp/hey-sdk/go v0.4.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
@@ -44,6 +46,8 @@ github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
@@ -55,6 +59,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/oapi-codegen/runtime v1.2.0 h1:RvKc1CVS1QeKSNzO97FBQbSMZyQ8s6rZd+LpmzwHMP4=
 github.com/oapi-codegen/runtime v1.2.0/go.mod h1:Y7ZhmmlE8ikZOmuHRRndiIm7nf3xcVv+YMweKgG1DT0=
+github.com/oapi-codegen/runtime v1.6.0 h1:7Xx+GlueD6nRuyKoCPzL434Jfi3BetbiJOrzCHp/VPU=
+github.com/oapi-codegen/runtime v1.6.0/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
@@ -79,6 +85,7 @@ github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cma
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 h1:985EYyeCOxTpcgOTJpflJUwOeEz0CQOdPt73OzpE9F8=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
 golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -27,11 +27,11 @@ func newComposeCommand() *composeCommand {
 		Use:   "compose",
 		Short: "Compose a new message",
 		Annotations: map[string]string{
-			"agent_notes": "Creates a new email. Requires --subject. Use --to (optionally with --cc/--bcc) for new threads or --thread-id for existing ones.",
+			"agent_notes": "Starts a new thread with --to (optionally --cc/--bcc), which requires --subject, or replies to an existing one with --thread-id, which does not: a reply carries the thread's subject and goes to that thread's recipients.",
 		},
 		Example: `  hey compose --to alice@example.com --subject "Hello" -m "Hi there"
   hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello" -m "Hi"
-  hey compose --subject "Update" --thread-id 12345 -m "Thread reply"
+  hey compose --thread-id 12345 -m "Thread reply"
   echo "Long message" | hey compose --to bob@example.com --subject "Report"`,
 		RunE: composeCommand.run,
 	}

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -39,9 +39,9 @@ func newComposeCommand() *composeCommand {
 	composeCommand.cmd.Flags().StringVar(&composeCommand.to, "to", "", "Recipient email address(es)")
 	composeCommand.cmd.Flags().StringVar(&composeCommand.cc, "cc", "", "CC recipient email address(es)")
 	composeCommand.cmd.Flags().StringVar(&composeCommand.bcc, "bcc", "", "BCC recipient email address(es)")
-	composeCommand.cmd.Flags().StringVar(&composeCommand.subject, "subject", "", "Message subject (required)")
+	composeCommand.cmd.Flags().StringVar(&composeCommand.subject, "subject", "", "Message subject (required for a new message)")
 	composeCommand.cmd.Flags().StringVarP(&composeCommand.message, "message", "m", "", "Message body (or opens $EDITOR)")
-	composeCommand.cmd.Flags().StringVar(&composeCommand.threadID, "thread-id", "", "Thread ID to post message to")
+	composeCommand.cmd.Flags().StringVar(&composeCommand.threadID, "thread-id", "", "Reply to this thread instead of starting a new one")
 
 	return composeCommand
 }
@@ -51,7 +51,8 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if c.subject == "" {
+	// A reply carries the thread's subject, so only a new message needs one.
+	if c.subject == "" && c.threadID == "" {
 		return output.ErrUsageHint("--subject is required", "hey compose --to <email> --subject <subject> -m <message>")
 	}
 

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -85,7 +85,12 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return output.ErrUsage(fmt.Sprintf("invalid thread ID: %s", c.threadID))
 		}
-		if err := sdk.Messages().CreateTopicMessage(ctx, topicID, message); err != nil {
+		target, err := resolveThreadReply(ctx, topicID)
+		if err != nil {
+			return err
+		}
+		if err := sdk.Entries().CreateReply(ctx, target.EntryID, message,
+			target.Addressed.To, target.Addressed.CC, target.Addressed.BCC); err != nil {
 			return convertSDKError(err)
 		}
 	} else {

--- a/internal/cmd/compose_test.go
+++ b/internal/cmd/compose_test.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
 )
 
 func TestParseAddresses(t *testing.T) {
@@ -56,5 +61,32 @@ func TestParseAddresses(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// A reply carries the thread's subject with it, so --subject is only wanted when
+// starting a new thread. Requiring it either way made people pass one that HEY ignores.
+func TestComposeSubjectRequiredOnlyForANewMessage(t *testing.T) {
+	server := threadReplyServer(t, topicWithRecipients, topicEntries)
+	withSDKPointedAt(t, server)
+
+	newMessage := newComposeCommand()
+	newMessage.cmd.SetContext(context.Background())
+	newMessage.message = "body"
+	err := newMessage.run(newMessage.cmd, nil)
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+		t.Fatalf("a new message with no subject should be a usage error, got %v", err)
+	}
+
+	// The reply goes no further here — the stub server does not stand in for the whole
+	// send — but it has to get past the subject check, which is what changed.
+	reply := newComposeCommand()
+	reply.cmd.SetContext(context.Background())
+	reply.message = "body"
+	reply.threadID = "7"
+	err = reply.run(reply.cmd, nil)
+	if errors.As(err, &cliErr) && strings.Contains(cliErr.Message, "--subject") {
+		t.Errorf("a reply should not be asked for a subject, got %v", err)
 	}
 }

--- a/internal/cmd/compose_test.go
+++ b/internal/cmd/compose_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -67,26 +66,29 @@ func TestParseAddresses(t *testing.T) {
 // A reply carries the thread's subject with it, so --subject is only wanted when
 // starting a new thread. Requiring it either way made people pass one that HEY ignores.
 func TestComposeSubjectRequiredOnlyForANewMessage(t *testing.T) {
-	server := threadReplyServer(t, topicWithRecipients, topicEntries)
-	withSDKPointedAt(t, server)
+	server, sent := threadReplyServer(t, topicWithRecipients, topicEntries)
 
-	newMessage := newComposeCommand()
-	newMessage.cmd.SetContext(context.Background())
-	newMessage.message = "body"
-	err := newMessage.run(newMessage.cmd, nil)
+	err := runCLI(t, server, "compose", "-m", "body")
 	var cliErr *apierr.Error
 	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
 		t.Fatalf("a new message with no subject should be a usage error, got %v", err)
 	}
 
-	// The reply goes no further here — the stub server does not stand in for the whole
-	// send — but it has to get past the subject check, which is what changed.
-	reply := newComposeCommand()
-	reply.cmd.SetContext(context.Background())
-	reply.message = "body"
-	reply.threadID = "7"
-	err = reply.run(reply.cmd, nil)
-	if errors.As(err, &cliErr) && strings.Contains(cliErr.Message, "--subject") {
-		t.Errorf("a reply should not be asked for a subject, got %v", err)
+	// And the reply goes all the way out: --thread-id used to post a message to the
+	// topic, and now answers the thread's last entry with that entry's recipients.
+	if err := runCLI(t, server, "compose", "--thread-id", "7", "-m", "the reply body"); err != nil {
+		t.Fatalf("a reply should not need a subject, got %v", err)
+	}
+	if !strings.Contains(sent.Path, "/entries/12/replies") {
+		t.Errorf("expected the reply to answer the last entry, went to %q", sent.Path)
+	}
+	if !strings.Contains(sent.Content, "the reply body") {
+		t.Errorf("content = %q", sent.Content)
+	}
+	if len(sent.To) != 1 || sent.To[0] != "jane@example.com" {
+		t.Errorf("to = %v, want the thread's recipients", sent.To)
+	}
+	if len(sent.CC) != 1 || sent.CC[0] != "cc@example.com" {
+		t.Errorf("cc = %v", sent.CC)
 	}
 }

--- a/internal/cmd/journal.go
+++ b/internal/cmd/journal.go
@@ -257,7 +257,7 @@ func (c *journalWriteCommand) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := sdk.Journal().Update(ctx, date, content); err != nil {
+	if _, err := sdk.Journal().Update(ctx, date, content); err != nil {
 		return convertSDKError(err)
 	}
 

--- a/internal/cmd/journal_test.go
+++ b/internal/cmd/journal_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/basecamp/hey-cli/internal/output"
@@ -58,12 +59,12 @@ func journalServerWithReadBehavior(t *testing.T, readBehavior string) *httptest.
 
 // journalServerRecordingEditFetches answers 204 for the journal entry and notes whether
 // anything asked for the legacy edit page.
-func journalServerRecordingEditFetches(t *testing.T, editFetched *bool) *httptest.Server {
+func journalServerRecordingEditFetches(t *testing.T, editFetched *atomic.Bool) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/journal_entry/edit"):
-			*editFetched = true
+			editFetched.Store(true)
 			w.Header().Set("Content-Type", "text/html")
 			fmt.Fprint(w, `<html><body><input id="journal_trix_input" value="&lt;div&gt;Fallback content&lt;/div&gt;"></body></html>`)
 		case strings.Contains(r.URL.Path, "/journal_entry"):
@@ -229,7 +230,7 @@ func TestJournalReadReturns200WithContent(t *testing.T) {
 // now, so a 204 means what it says -- there is no entry that day -- and the edit page is
 // never fetched.
 func TestJournalReadReturns204MeansNoEntry(t *testing.T) {
-	var editFetched bool
+	var editFetched atomic.Bool
 	server := journalServerRecordingEditFetches(t, &editFetched)
 	defer server.Close()
 
@@ -244,7 +245,7 @@ func TestJournalReadReturns204MeansNoEntry(t *testing.T) {
 	if !strings.Contains(resp.Summary, "No journal entry") {
 		t.Errorf("summary = %q, want it to say there is no entry", resp.Summary)
 	}
-	if editFetched {
+	if editFetched.Load() {
 		t.Error("the edit page should not be fetched any more")
 	}
 }

--- a/internal/cmd/journal_test.go
+++ b/internal/cmd/journal_test.go
@@ -22,7 +22,6 @@ func journalServer(t *testing.T) *httptest.Server {
 //
 //	"200"               — returns a Recording with content
 //	"204"               — returns 204 No Content (SDK returns nil), no legacy fallback
-//	"204-with-fallback" — returns 204 on SDK path, serves HTML on legacy /edit path
 func journalServerWithReadBehavior(t *testing.T, readBehavior string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -30,17 +29,13 @@ func journalServerWithReadBehavior(t *testing.T, readBehavior string) *httptest.
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/calendar/days/") && strings.HasSuffix(r.URL.Path, "/journal_entry/edit"):
 			// Legacy HTML-scrape path
 			w.Header().Set("Content-Type", "text/html")
-			if readBehavior == "204-with-fallback" {
-				fmt.Fprint(w, `<html><body><input id="journal_trix_input" value="&lt;div&gt;Fallback content&lt;/div&gt;"></body></html>`)
-			} else {
-				fmt.Fprint(w, `<html><body></body></html>`)
-			}
+			fmt.Fprint(w, `<html><body></body></html>`)
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/calendar/days/") && (strings.HasSuffix(r.URL.Path, "/journal_entry") || strings.HasSuffix(r.URL.Path, "/journal_entry.json")):
 			path := r.URL.Path
 			path = strings.TrimPrefix(path, "/calendar/days/")
 			date := strings.TrimSuffix(strings.TrimSuffix(path, ".json"), "/journal_entry")
 			switch readBehavior {
-			case "204", "204-with-fallback":
+			case "204":
 				w.WriteHeader(204)
 			default:
 				resp := map[string]any{
@@ -54,6 +49,24 @@ func journalServerWithReadBehavior(t *testing.T, readBehavior string) *httptest.
 				json.NewEncoder(w).Encode(resp)
 			}
 		case r.Method == "PATCH" && strings.Contains(r.URL.Path, "/calendar/days/") && (strings.HasSuffix(r.URL.Path, "/journal_entry") || strings.HasSuffix(r.URL.Path, "/journal_entry.json")):
+			w.WriteHeader(204)
+		default:
+			w.WriteHeader(200)
+		}
+	}))
+}
+
+// journalServerRecordingEditFetches answers 204 for the journal entry and notes whether
+// anything asked for the legacy edit page.
+func journalServerRecordingEditFetches(t *testing.T, editFetched *bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/journal_entry/edit"):
+			*editFetched = true
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, `<html><body><input id="journal_trix_input" value="&lt;div&gt;Fallback content&lt;/div&gt;"></body></html>`)
+		case strings.Contains(r.URL.Path, "/journal_entry"):
 			w.WriteHeader(204)
 		default:
 			w.WriteHeader(200)
@@ -211,8 +224,13 @@ func TestJournalReadReturns200WithContent(t *testing.T) {
 	}
 }
 
-func TestJournalReadReturns204FallsBackToLegacyHTML(t *testing.T) {
-	server := journalServerWithReadBehavior(t, "204-with-fallback")
+// A 204 used to mean "ask the edit page instead": HEY answered 204 for a day that had an
+// entry, so the SDK scraped the Trix input for its content. HEY answers the entry itself
+// now, so a 204 means what it says -- there is no entry that day -- and the edit page is
+// never fetched.
+func TestJournalReadReturns204MeansNoEntry(t *testing.T) {
+	var editFetched bool
+	server := journalServerRecordingEditFetches(t, &editFetched)
 	defer server.Close()
 
 	resp, err := runJournalRead(t, server, "2024-01-15")
@@ -220,14 +238,14 @@ func TestJournalReadReturns204FallsBackToLegacyHTML(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 
-	// SDK returns nil (204), but the legacy HTML scrape at /edit should provide content.
-	data, ok := resp.Data.(map[string]any)
-	if !ok {
-		t.Fatalf("data type = %T, want map[string]any (fallback should have returned content)", resp.Data)
+	if resp.Data != nil {
+		t.Errorf("data = %v, want nil for a day with no entry", resp.Data)
 	}
-	content, _ := data["content"].(string)
-	if !strings.Contains(content, "Fallback content") {
-		t.Errorf("content = %q, want to contain %q", content, "Fallback content")
+	if !strings.Contains(resp.Summary, "No journal entry") {
+		t.Errorf("summary = %q, want it to say there is no entry", resp.Summary)
+	}
+	if editFetched {
+		t.Error("the edit page should not be fetched any more")
 	}
 }
 

--- a/internal/cmd/recordings.go
+++ b/internal/cmd/recordings.go
@@ -69,8 +69,8 @@ func (c *recordingsCommand) run(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 	resp, err := sdk.Calendars().GetRecordings(ctx, calendarID, &generated.GetCalendarRecordingsParams{
-		StartsOn: startsOn,
-		EndsOn:   endsOn,
+		StartsOn: &startsOn,
+		EndsOn:   &endsOn,
 	})
 	if err != nil {
 		return convertSDKError(err)

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/basecamp/hey-cli/internal/editor"
-	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
@@ -47,27 +46,10 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 
-	// Fetch topic page to extract recipients (To/CC/BCC).
-	topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", threadID))
+	target, err := resolveThreadReply(ctx, threadID)
 	if err != nil {
-		return convertSDKError(err)
+		return err
 	}
-	addressed := htmlutil.ParseTopicAddressed(string(topicResp.Data))
-	if len(addressed.To) == 0 && len(addressed.CC) == 0 && len(addressed.BCC) == 0 {
-		return output.ErrUsage("could not determine thread recipients")
-	}
-
-	// Fetch entries to find the latest entry ID for the reply.
-	entriesResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d/entries", threadID))
-	if err != nil {
-		return convertSDKError(err)
-	}
-	entries := htmlutil.ParseTopicEntriesHTML(string(entriesResp.Data))
-	if len(entries) == 0 {
-		return output.ErrNotFound("entries for thread", args[0])
-	}
-
-	latestEntryID := entries[len(entries)-1].ID
 
 	message := c.message
 	if message == "" {
@@ -90,7 +72,7 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err = sdk.Entries().CreateReply(ctx, latestEntryID, message, addressed.To, addressed.CC, addressed.BCC); err != nil {
+	if err = sdk.Entries().CreateReply(ctx, target.EntryID, message, target.Addressed.To, target.Addressed.CC, target.Addressed.BCC); err != nil {
 		return convertSDKError(err)
 	}
 

--- a/internal/cmd/sdk.go
+++ b/internal/cmd/sdk.go
@@ -190,8 +190,8 @@ func listPersonalRecordings(ctx context.Context) (*generated.CalendarRecordingsR
 	endsOn := now.AddDate(personalRecordingsLookaheadYears, 0, 0).Format("2006-01-02")
 
 	resp, err := sdk.Calendars().GetRecordings(ctx, calID, &generated.GetCalendarRecordingsParams{
-		StartsOn: startsOn,
-		EndsOn:   endsOn,
+		StartsOn: &startsOn,
+		EndsOn:   &endsOn,
 	})
 	if err != nil {
 		return nil, convertSDKError(err)

--- a/internal/cmd/thread_reply.go
+++ b/internal/cmd/thread_reply.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+// threadReplyTarget is what a reply to a thread needs: the entry it answers, and the
+// recipients that entry was addressed to. HEY saves an unaddressed reply as a draft, so
+// the recipients are not optional.
+type threadReplyTarget struct {
+	EntryID   int64
+	Addressed *htmlutil.TopicAddressed
+}
+
+// resolveThreadReply works out what replying to a thread means: the last entry on it, and
+// who that entry went to.
+//
+// It still reads the topic's HTML pages. The SDK gained typed reads for both in v0.4.0 —
+// Topics.Get carries the topic's entries — and this is the one place to change when the
+// CLI moves onto them.
+func resolveThreadReply(ctx context.Context, threadID int64) (*threadReplyTarget, error) {
+	topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", threadID))
+	if err != nil {
+		return nil, convertSDKError(err)
+	}
+	addressed := htmlutil.ParseTopicAddressed(string(topicResp.Data))
+	if len(addressed.To) == 0 && len(addressed.CC) == 0 && len(addressed.BCC) == 0 {
+		return nil, output.ErrUsage("could not determine thread recipients")
+	}
+
+	entriesResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d/entries", threadID))
+	if err != nil {
+		return nil, convertSDKError(err)
+	}
+	entries := htmlutil.ParseTopicEntriesHTML(string(entriesResp.Data))
+	if len(entries) == 0 {
+		return nil, output.ErrNotFound("entries for thread", fmt.Sprintf("%d", threadID))
+	}
+
+	return &threadReplyTarget{EntryID: entries[len(entries)-1].ID, Addressed: addressed}, nil
+}

--- a/internal/cmd/thread_reply_test.go
+++ b/internal/cmd/thread_reply_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+)
+
+const (
+	topicWithRecipients = `<span class="entry__full-recipients">
+		<a title="jane@example.com">Jane</a>
+		CC: <a title="cc@example.com">Cee</a>
+	</span>`
+	topicEntries = `<div data-entry-id="11"></div><div data-entry-id="12"></div>`
+)
+
+// threadReplyServer answers the two topic pages resolveThreadReply reads.
+func threadReplyServer(t *testing.T, topicHTML, entriesHTML string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		if strings.HasSuffix(r.URL.Path, "/entries") {
+			fmt.Fprint(w, entriesHTML)
+			return
+		}
+		fmt.Fprint(w, topicHTML)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// withSDKPointedAt builds the package-level client the commands use, aimed at a test
+// server, and puts the old one back afterwards.
+func withSDKPointedAt(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+
+	previous := sdk
+	t.Cleanup(func() { sdk = previous })
+	initSDK(nil, server.URL)
+}
+
+func TestResolveThreadReply(t *testing.T) {
+	withSDKPointedAt(t, threadReplyServer(t, topicWithRecipients, topicEntries))
+
+	target, err := resolveThreadReply(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// HEY replies to the last entry on the thread, not the first.
+	if target.EntryID != 12 {
+		t.Errorf("entry = %d, want the last one (12)", target.EntryID)
+	}
+	if len(target.Addressed.To) != 1 || target.Addressed.To[0] != "jane@example.com" {
+		t.Errorf("to = %v", target.Addressed.To)
+	}
+	if len(target.Addressed.CC) != 1 || target.Addressed.CC[0] != "cc@example.com" {
+		t.Errorf("cc = %v", target.Addressed.CC)
+	}
+}
+
+// An unaddressed reply is saved as a draft rather than sent, so a thread we cannot read
+// recipients from is refused before anything is written.
+func TestResolveThreadReplyWithoutRecipients(t *testing.T) {
+	withSDKPointedAt(t, threadReplyServer(t, `<html><body>no recipients here</body></html>`, topicEntries))
+
+	_, err := resolveThreadReply(context.Background(), 7)
+
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+		t.Fatalf("expected a usage error, got %v", err)
+	}
+}
+
+func TestResolveThreadReplyWithoutEntries(t *testing.T) {
+	withSDKPointedAt(t, threadReplyServer(t, topicWithRecipients, `<html><body></body></html>`))
+
+	_, err := resolveThreadReply(context.Background(), 7)
+
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "not_found" {
+		t.Fatalf("expected a not-found error, got %v", err)
+	}
+}

--- a/internal/cmd/thread_reply_test.go
+++ b/internal/cmd/thread_reply_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -20,19 +22,56 @@ const (
 	topicEntries = `<div data-entry-id="11"></div><div data-entry-id="12"></div>`
 )
 
-// threadReplyServer answers the two topic pages resolveThreadReply reads.
-func threadReplyServer(t *testing.T, topicHTML, entriesHTML string) *httptest.Server {
+// sentReply is what the server saw a reply arrive as.
+type sentReply struct {
+	Path    string
+	Content string
+	To      []string
+	CC      []string
+	BCC     []string
+}
+
+// threadReplyServer answers the two topic pages resolveThreadReply reads, the identity
+// the SDK needs for a sending operation, and the reply itself — recording it so a test
+// can say what actually went out.
+func threadReplyServer(t *testing.T, topicHTML, entriesHTML string) (*httptest.Server, *sentReply) {
 	t.Helper()
+	sent := &sentReply{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html")
-		if strings.HasSuffix(r.URL.Path, "/entries") {
+		switch {
+		case strings.Contains(r.URL.Path, "/replies"):
+			var body struct {
+				Message struct {
+					Content string `json:"content"`
+				} `json:"message"`
+				Entry struct {
+					Addressed struct {
+						Directly    []string `json:"directly"`
+						Copied      []string `json:"copied"`
+						Blindcopied []string `json:"blindcopied"`
+					} `json:"addressed"`
+				} `json:"entry"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			sent.Path = r.URL.Path
+			sent.Content = body.Message.Content
+			sent.To, sent.CC, sent.BCC = body.Entry.Addressed.Directly, body.Entry.Addressed.Copied, body.Entry.Addressed.Blindcopied
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		case strings.Contains(r.URL.Path, "identity"):
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"id":1,"senders":[{"id":42,"default":true}]}`)
+		case strings.HasSuffix(r.URL.Path, "/entries"):
+			w.Header().Set("Content-Type", "text/html")
 			fmt.Fprint(w, entriesHTML)
-			return
+		default:
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, topicHTML)
 		}
-		fmt.Fprint(w, topicHTML)
 	}))
 	t.Cleanup(server.Close)
-	return server
+	return server, sent
 }
 
 // withSDKPointedAt builds the package-level client the commands use, aimed at a test
@@ -48,7 +87,8 @@ func withSDKPointedAt(t *testing.T, server *httptest.Server) {
 }
 
 func TestResolveThreadReply(t *testing.T) {
-	withSDKPointedAt(t, threadReplyServer(t, topicWithRecipients, topicEntries))
+	server, _ := threadReplyServer(t, topicWithRecipients, topicEntries)
+	withSDKPointedAt(t, server)
 
 	target, err := resolveThreadReply(context.Background(), 7)
 	if err != nil {
@@ -70,7 +110,8 @@ func TestResolveThreadReply(t *testing.T) {
 // An unaddressed reply is saved as a draft rather than sent, so a thread we cannot read
 // recipients from is refused before anything is written.
 func TestResolveThreadReplyWithoutRecipients(t *testing.T) {
-	withSDKPointedAt(t, threadReplyServer(t, `<html><body>no recipients here</body></html>`, topicEntries))
+	server, _ := threadReplyServer(t, `<html><body>no recipients here</body></html>`, topicEntries)
+	withSDKPointedAt(t, server)
 
 	_, err := resolveThreadReply(context.Background(), 7)
 
@@ -81,7 +122,8 @@ func TestResolveThreadReplyWithoutRecipients(t *testing.T) {
 }
 
 func TestResolveThreadReplyWithoutEntries(t *testing.T) {
-	withSDKPointedAt(t, threadReplyServer(t, topicWithRecipients, `<html><body></body></html>`))
+	server, _ := threadReplyServer(t, topicWithRecipients, `<html><body></body></html>`)
+	withSDKPointedAt(t, server)
 
 	_, err := resolveThreadReply(context.Background(), 7)
 
@@ -89,4 +131,25 @@ func TestResolveThreadReplyWithoutEntries(t *testing.T) {
 	if !errors.As(err, &cliErr) || cliErr.Code != "not_found" {
 		t.Fatalf("expected a not-found error, got %v", err)
 	}
+}
+
+// runCLI drives a command the way the binary does — through the root command, so the
+// output writer and auth are set up — against a test server.
+func runCLI(t *testing.T, server *httptest.Server, args ...string) error {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(append([]string{"--json", "--base-url", server.URL}, args...))
+
+	return root.Execute()
 }

--- a/internal/cmd/timetrack.go
+++ b/internal/cmd/timetrack.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/basecamp/hey-sdk/go/pkg/generated"
-
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
@@ -57,7 +55,7 @@ func (c *timetrackStartCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := cmd.Context()
-	result, err := sdk.TimeTracks().Start(ctx, generated.StartTimeTrackJSONRequestBody{})
+	result, err := sdk.TimeTracks().Start(ctx)
 	if err != nil {
 		return convertSDKError(err)
 	}

--- a/internal/tui/calendar.go
+++ b/internal/tui/calendar.go
@@ -288,9 +288,10 @@ func (v *calendarView) fetchCalendars() tea.Cmd {
 func (v *calendarView) fetchRecordings(calID int64) tea.Cmd {
 	start, end := dateRangeForMode(v.viewMode, v.anchorDate, v.firstWeekDay)
 	return func() tea.Msg {
+		startsOn, endsOn := start.Format("2006-01-02"), end.Format("2006-01-02")
 		resp, err := v.vc.sdk.Calendars().GetRecordings(v.vc.ctx, calID, &generated.GetCalendarRecordingsParams{
-			StartsOn: start.Format("2006-01-02"),
-			EndsOn:   end.Format("2006-01-02"),
+			StartsOn: &startsOn,
+			EndsOn:   &endsOn,
 		})
 		if err != nil {
 			return errMsg{err}

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -200,7 +200,7 @@ func (v *mailView) HelpBindings() []helpBinding {
 		{"d", "feed"},
 		{"p", "paper trail"},
 		{"t", "trash"},
-		{"-", "ignore"},
+		{"-", "mute"},
 	}
 }
 
@@ -343,8 +343,8 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 			return v.vc.sdk.Postings().MoveToTrash(v.vc.ctx, p.ID)
 		})
 	case "-":
-		return v.doPostingAction("ignored", true, func() error {
-			return v.vc.sdk.Postings().Ignore(v.vc.ctx, p.ID)
+		return v.doPostingAction("muted", true, func() error {
+			return v.vc.sdk.Postings().Mute(v.vc.ctx, p.ID)
 		})
 	case "r":
 		topicID := p.ResolveTopicID()

--- a/internal/tui/translate_test.go
+++ b/internal/tui/translate_test.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+// These translators are the seam between the SDK's shapes and the TUI's own. A field
+// dropped or crossed here doesn't fail to compile — it renders blank, or renders someone
+// else's data — so they're worth pinning.
+
+func TestSDKPostingToModel(t *testing.T) {
+	created := time.Date(2026, 8, 18, 9, 30, 0, 0, time.UTC)
+	updated := time.Date(2026, 8, 18, 11, 0, 0, 0, time.UTC)
+
+	got := sdkPostingToModel(generated.Posting{
+		Id: 1233065884, CreatedAt: created, UpdatedAt: updated,
+		Kind: "topic", Name: "Life insurance", Seen: true, Bundled: true, Muted: true,
+		Summary: "the summary", EntryKind: "message", AppUrl: "https://app.hey.com/topics/21",
+		AlternativeSenderName: "Copilot", VisibleEntryCount: 3,
+		Extenzions: []generated.Extenzion{{Id: 7, Name: "receipts"}},
+		Creator:    generated.Contact{Id: 42, Name: "Jane Dawson", EmailAddress: "jane@example.com"},
+	})
+
+	if got.ID != 1233065884 || got.Name != "Life insurance" || got.Kind != "topic" {
+		t.Errorf("identity fields wrong: %+v", got)
+	}
+	if got.CreatedAt != "2026-08-18T09:30:00Z" || got.UpdatedAt != "2026-08-18T11:00:00Z" {
+		t.Errorf("timestamps = %q / %q", got.CreatedAt, got.UpdatedAt)
+	}
+	if !got.Seen || !got.Bundled || !got.Muted {
+		t.Errorf("flags should carry over: %+v", got)
+	}
+	if got.Summary != "the summary" || got.EntryKind != "message" || got.VisibleEntryCount != 3 {
+		t.Errorf("detail fields wrong: %+v", got)
+	}
+	if got.AppURL != "https://app.hey.com/topics/21" || got.AlternativeSenderName != "Copilot" {
+		t.Errorf("url or sender wrong: %+v", got)
+	}
+	if len(got.Extenzions) != 1 || got.Extenzions[0].Name != "receipts" {
+		t.Errorf("extenzions = %+v", got.Extenzions)
+	}
+	if got.Creator.ID != 42 || got.Creator.Name != "Jane Dawson" || got.Creator.EmailAddress != "jane@example.com" {
+		t.Errorf("creator = %+v", got.Creator)
+	}
+}
+
+func TestSDKPostingToModelLeavesMissingTimestampsEmpty(t *testing.T) {
+	got := sdkPostingToModel(generated.Posting{Id: 1})
+
+	if got.CreatedAt != "" || got.UpdatedAt != "" {
+		t.Errorf("a zero time should read as empty, got %q / %q", got.CreatedAt, got.UpdatedAt)
+	}
+	if got.Extenzions != nil {
+		t.Errorf("no extenzions should stay nil, got %+v", got.Extenzions)
+	}
+}
+
+func TestSDKBoxToModel(t *testing.T) {
+	got := sdkBoxToModel(generated.Box{Id: 24088, Kind: "imbox", Name: "Imbox"})
+
+	if got.ID != 24088 || got.Kind != "imbox" || got.Name != "Imbox" {
+		t.Errorf("box = %+v", got)
+	}
+}
+
+func TestSDKCalendarToModel(t *testing.T) {
+	got := sdkCalendarToModel(generated.Calendar{
+		Id: 4732, Name: "Rob Zolkos", Kind: "personal",
+		Owned: true, Personal: true, External: false,
+	})
+
+	if got.ID != 4732 || got.Name != "Rob Zolkos" || got.Kind != "personal" {
+		t.Errorf("calendar = %+v", got)
+	}
+	if !got.Owned || !got.Personal || got.External {
+		t.Errorf("flags = %+v", got)
+	}
+}
+
+func TestSDKRecordingToModel(t *testing.T) {
+	starts := time.Date(2026, 8, 18, 14, 0, 0, 0, time.UTC)
+	ends := time.Date(2026, 8, 18, 15, 0, 0, 0, time.UTC)
+	done := time.Date(2026, 8, 18, 16, 0, 0, 0, time.UTC)
+
+	got := sdkRecordingToModel(generated.Recording{
+		Id: 99, Title: "Standup", AllDay: false, Recurring: true,
+		StartsAt: starts, EndsAt: ends,
+		StartsAtTimeZone: "UTC", EndsAtTimeZone: "UTC",
+		Type: "Calendar::Event", Content: "notes", RemindersLabel: "10 minutes before",
+		CompletedAt: done, Label: "work",
+	})
+
+	if got.ID != 99 || got.Title != "Standup" || got.Type != "Calendar::Event" {
+		t.Errorf("recording = %+v", got)
+	}
+	if got.StartsAt != "2026-08-18T14:00:00Z" || got.EndsAt != "2026-08-18T15:00:00Z" {
+		t.Errorf("times = %q / %q", got.StartsAt, got.EndsAt)
+	}
+	if got.CompletedAt != "2026-08-18T16:00:00Z" {
+		t.Errorf("completed = %q", got.CompletedAt)
+	}
+	if !got.Recurring || got.AllDay {
+		t.Errorf("flags = %+v", got)
+	}
+	if got.Content != "notes" || got.RemindersLabel != "10 minutes before" || got.Label != "work" {
+		t.Errorf("detail = %+v", got)
+	}
+}
+
+// An incomplete recording is the common case — a todo has no end, an open one no
+// completion — and those have to read as empty rather than as a zero date.
+func TestSDKRecordingToModelLeavesMissingTimesEmpty(t *testing.T) {
+	got := sdkRecordingToModel(generated.Recording{Id: 5, Title: "Buy milk", Type: "Calendar::Todo"})
+
+	if got.StartsAt != "" || got.EndsAt != "" || got.CompletedAt != "" {
+		t.Errorf("zero times should read as empty: %+v", got)
+	}
+}

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -180,7 +180,7 @@ hey reply <topic_id>                          # Reply via $EDITOR
 hey compose --to user@example.com --subject "Hello"         # Compose new (opens $EDITOR)
 hey compose --to user@example.com --subject "Hi" -m "Body"  # With inline body
 hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Project update" -m "Body"  # With CC/BCC
-hey compose --subject "Update" --thread-id 12345 -m "msg"   # Post to existing thread
+hey compose --thread-id 12345 -m "msg"                       # Reply to an existing thread (no subject: it carries the thread's)
 ```
 
 ### Email - Seen/Unseen


### PR DESCRIPTION
Moves the CLI onto [hey-sdk v0.4.0](https://github.com/basecamp/hey-sdk/releases/tag/v0.4.0),
where the SDK stopped scraping HEY's HTML and started answering with the API's own shapes.
No new commands — the point is that everything does what it did before, on the new surface.

**What changed under us**

| | |
|---|---|
| `Postings.Ignore` → `Mute` | The key is still `-`, but the TUI said "ignore" where HEY says mute. Now it says mute. |
| `Messages.CreateTopicMessage` removed | A reply belongs to an entry, not a topic, and HEY saves an unaddressed reply as a draft — so `compose --thread-id` resolves the entry and its recipients, the way `hey reply` already did. That resolution now lives in one place instead of two. |
| `Journal.Update` returns the entry | |
| `TimeTracks.Start` takes no body | HEY ignored it. |
| `GetCalendarRecordingsParams` dates are pointers | They're optional in the spec. |
| The five `MoveTo*` calls are variadic | Source-compatible; they still read the same. |

**The journal's 204 fallback is gone, deliberately.** HEY used to answer 204 for a day that
*had* an entry, so the SDK scraped the edit page for its content. haystack#8624 fixed that,
and the SDK dropped the scrape — so a 204 now means what it says. The test asserts that
instead, and checks nothing asks for the edit page any more.

**Tests for the SDK → TUI translators.** `sdkPostingToModel`, `sdkBoxToModel`,
`sdkCalendarToModel`, `sdkRecordingToModel` and `sdkExtenzionsToModel` had no coverage,
and they're exactly where a signature change goes wrong quietly: a dropped or crossed
field still compiles, it just renders blank or renders the wrong thing. Six tests, including
the empty-timestamp cases a todo or an open time track hits.

**Verified**: `make lint` clean, the suite passes, and the smoke suite passes end to end
against a dev server running current haystack master. `hey journal read` and
`hey timetrack list` also check out against production.

One thing left where it is: `hey reply`, `hey topic` and two TUI paths still read topic
entries from HTML. v0.4.0 can answer that typed — `Topics.Get` carries the topic's entries
now — but swapping it is a behaviour change rather than a bump, so it belongs in its own
PR. `resolveThreadReply` is the one place that has to change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the CLI to `github.com/basecamp/hey-sdk/go` v0.4.0 and replaces HTML scrapes with typed API models. Behavior matches prior releases with two changes: journal reads now treat 204 as “no entry,” and `compose --thread-id` sends a reply without requiring `--subject` (subject and recipients come from the thread).

- Postings: `Postings.Ignore` → `Postings.Mute`; TUI label shows “mute.”
- Replies: removed `Messages.CreateTopicMessage`. Both `hey reply` and `compose --thread-id` resolve the latest entry and recipients via a new `resolveThreadReply`, then call `Entries.CreateReply`.
- Journal: `Journal.Update` now returns the entry; journal read no longer fetches the edit page on 204.
- Calendars/Time tracking: `GetCalendarRecordingsParams.StartsOn`/`EndsOn` are pointers; pass pointers. `TimeTracks.Start` takes no body.

**Review notes**

- Centralizes reply resolution in `internal/cmd/thread_reply.go`; this is the one remaining HTML read and will move to typed `Topics.Get` next.
- Updates help text and `skills/hey/SKILL.md` to reflect subjectless replies; examples show `compose --thread-id` without `--subject`.
- Adds tests for SDK→TUI translators and for reply resolution; new test proves `compose --thread-id` replies to the last entry with the thread’s recipients.
- Journal tests assert 204 means no entry and that the edit page is not fetched; `AGENTS.md` discourages adding scrapers.
- Removes `v0.3.0` sums from `go.sum`.

<sup>Written for commit 69c7007f650f83e7da41e29b59cc13eeecc3eb9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

