### PR TITLE
Test TUI posting actions end to end

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/net v0.58.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.45.0
 )
 
@@ -35,6 +36,5 @@ require (
 	github.com/oapi-codegen/runtime v1.6.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/internal/tui/compose.go
+++ b/internal/tui/compose.go
@@ -281,10 +281,9 @@ func (v *mailView) startCompose() tea.Cmd {
 // loadReplyContext fetches the thread's recipients and latest entry, the same
 // way `hey reply` does, then opens the reply form on replyContextLoadedMsg.
 func (v *mailView) loadReplyContext(topicID int64, topicName string) tea.Cmd {
-	ctx := v.vc.ctx
 	sdk := v.vc.sdk
 	boxID := v.currentBoxID()
-	requestID := v.beginRequest()
+	requestID, ctx := v.beginRequest(mailRequestReply)
 	return func() tea.Msg {
 		topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", topicID))
 		if err != nil {

--- a/internal/tui/compose.go
+++ b/internal/tui/compose.go
@@ -17,6 +17,7 @@ import (
 // replyContextLoadedMsg carries what a reply needs from the thread: the entry to
 // reply to and who the thread is addressed to.
 type replyContextLoadedMsg struct {
+	requestID uint64
 	boxID     int64
 	topicID   int64
 	topicName string
@@ -283,22 +284,28 @@ func (v *mailView) loadReplyContext(topicID int64, topicName string) tea.Cmd {
 	ctx := v.vc.ctx
 	sdk := v.vc.sdk
 	boxID := v.currentBoxID()
+	requestID := v.beginRequest()
 	return func() tea.Msg {
 		topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", topicID))
 		if err != nil {
-			return replyContextLoadedMsg{boxID: boxID, err: err}
+			return replyContextLoadedMsg{requestID: requestID, boxID: boxID, err: err}
 		}
 		addressed := htmlutil.ParseTopicAddressed(string(topicResp.Data))
 
 		entriesResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d/entries", topicID))
 		if err != nil {
-			return replyContextLoadedMsg{boxID: boxID, err: err}
+			return replyContextLoadedMsg{requestID: requestID, boxID: boxID, err: err}
 		}
 		entries := htmlutil.ParseTopicEntriesHTML(string(entriesResp.Data))
 		if len(entries) == 0 {
-			return replyContextLoadedMsg{boxID: boxID, err: fmt.Errorf("no entries found in thread %d", topicID)}
+			return replyContextLoadedMsg{
+				requestID: requestID,
+				boxID:     boxID,
+				err:       fmt.Errorf("no entries found in thread %d", topicID),
+			}
 		}
 		return replyContextLoadedMsg{
+			requestID: requestID,
 			boxID:     boxID,
 			topicID:   topicID,
 			topicName: topicName,

--- a/internal/tui/compose.go
+++ b/internal/tui/compose.go
@@ -17,6 +17,7 @@ import (
 // replyContextLoadedMsg carries what a reply needs from the thread: the entry to
 // reply to and who the thread is addressed to.
 type replyContextLoadedMsg struct {
+	boxID     int64
 	topicID   int64
 	topicName string
 	entryID   int64
@@ -281,22 +282,24 @@ func (v *mailView) startCompose() tea.Cmd {
 func (v *mailView) loadReplyContext(topicID int64, topicName string) tea.Cmd {
 	ctx := v.vc.ctx
 	sdk := v.vc.sdk
+	boxID := v.currentBoxID()
 	return func() tea.Msg {
 		topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", topicID))
 		if err != nil {
-			return replyContextLoadedMsg{err: err}
+			return replyContextLoadedMsg{boxID: boxID, err: err}
 		}
 		addressed := htmlutil.ParseTopicAddressed(string(topicResp.Data))
 
 		entriesResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d/entries", topicID))
 		if err != nil {
-			return replyContextLoadedMsg{err: err}
+			return replyContextLoadedMsg{boxID: boxID, err: err}
 		}
 		entries := htmlutil.ParseTopicEntriesHTML(string(entriesResp.Data))
 		if len(entries) == 0 {
-			return replyContextLoadedMsg{err: fmt.Errorf("no entries found in thread %d", topicID)}
+			return replyContextLoadedMsg{boxID: boxID, err: fmt.Errorf("no entries found in thread %d", topicID)}
 		}
 		return replyContextLoadedMsg{
+			boxID:     boxID,
 			topicID:   topicID,
 			topicName: topicName,
 			entryID:   entries[len(entries)-1].ID,

--- a/internal/tui/compose_test.go
+++ b/internal/tui/compose_test.go
@@ -63,7 +63,7 @@ func composeTestServer(t *testing.T) (*mailView, *struct {
 	vc.ctx = context.Background()
 	v := newMailView(vc)
 	v.boxes = orderBoxes(testBoxes())
-	v.Update(postingsLoadedMsg{postings: testPostings()})
+	v.Update(currentPostingsLoaded(v, testPostings()))
 	return v, rec
 }
 

--- a/internal/tui/compose_test.go
+++ b/internal/tui/compose_test.go
@@ -203,7 +203,7 @@ func TestReplyFormPrefillsAndSends(t *testing.T) {
 	v, rec := composeTestServer(t)
 	v.Resize(80, 30)
 	v.Update(replyContextLoadedMsg{
-		topicID: 7, topicName: "Kitchen", entryID: 99,
+		boxID: 1, topicID: 7, topicName: "Kitchen", entryID: 99,
 		to: []string{"jane@x.com"}, cc: []string{"bob@x.com"},
 	})
 	f := v.compose

--- a/internal/tui/journal.go
+++ b/internal/tui/journal.go
@@ -145,7 +145,7 @@ func (v *journalView) fetchJournalEntry(date string) tea.Cmd {
 		for _, imgURL := range extractImageURLs(content) {
 			var data []byte
 			if strings.HasPrefix(imgURL, "http://") || strings.HasPrefix(imgURL, "https://") {
-				data = fetchImageData(imgURL)
+				data = fetchImageData(v.vc.ctx, imgURL)
 			} else {
 				sdkResp, getErr := v.vc.sdk.Get(v.vc.ctx, imgURL)
 				if getErr == nil && sdkResp != nil {

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -16,6 +17,15 @@ import (
 // --- Mail messages ---
 
 const maxConcurrentMessageFetches = 6
+
+type mailRequestKind int
+
+const (
+	mailRequestNone mailRequestKind = iota
+	mailRequestPostings
+	mailRequestTopic
+	mailRequestReply
+)
 
 type boxesLoadedMsg []models.Box
 
@@ -60,9 +70,11 @@ type mailView struct {
 	inThread      bool
 	loading       bool
 
-	compose         *composeForm // non-nil while a new message or reply is being written
-	notice          string       // one-shot confirmation shown above the posting list
-	activeRequestID uint64       // identifies the only mail read allowed to update the view
+	compose           *composeForm // non-nil while a new message or reply is being written
+	notice            string       // one-shot confirmation shown above the posting list
+	activeRequestID   uint64       // identifies the only mail read allowed to update the view
+	activeRequestKind mailRequestKind
+	requestCancel     context.CancelFunc
 }
 
 func newMailView(vc *viewContext) *mailView {
@@ -98,7 +110,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		if msg.requestID != v.activeRequestID || msg.boxID != v.currentBoxID() {
 			return nil, true
 		}
-		v.loading = false
+		v.finishRequest(msg.requestID)
 		if msg.err != nil {
 			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
@@ -109,7 +121,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		if msg.requestID != v.activeRequestID || msg.boxID != v.currentBoxID() {
 			return nil, true
 		}
-		v.loading = false
+		v.finishRequest(msg.requestID)
 		if msg.err != nil {
 			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
@@ -137,7 +149,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		if msg.requestID != v.activeRequestID || msg.boxID != v.currentBoxID() {
 			return nil, true
 		}
-		v.loading = false
+		v.finishRequest(msg.requestID)
 		if msg.err != nil {
 			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
@@ -178,6 +190,9 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			v.postingList.ensureVisible()
 		} else if msg.action == "marked as seen" && idx >= 0 {
 			v.postingList.postings[idx].Seen = true
+		}
+		if v.activeRequestKind == mailRequestPostings {
+			return v.requestPostings(v.currentBoxID()), true
 		}
 		return nil, true
 	}
@@ -297,6 +312,15 @@ func (v *mailView) ExitThread() {
 	v.compose = nil
 	v.cancelRequest()
 }
+
+func (v *mailView) CancelPendingDetail() bool {
+	if v.activeRequestKind != mailRequestTopic && v.activeRequestKind != mailRequestReply {
+		return false
+	}
+	v.cancelRequest()
+	return true
+}
+
 func (v *mailView) Loading() bool { return v.loading }
 
 func (v *mailView) Resize(width, height int) {
@@ -330,19 +354,48 @@ func (v *mailView) currentBoxID() int64 {
 	return v.boxes[v.boxIndex].ID
 }
 
-func (v *mailView) beginRequest() uint64 {
+func (v *mailView) beginRequest(kind mailRequestKind) (uint64, context.Context) {
+	if v.requestCancel != nil {
+		v.requestCancel()
+	}
 	v.activeRequestID++
+	ctx, cancel := context.WithCancel(v.vc.ctx)
+	v.activeRequestKind = kind
+	v.requestCancel = cancel
 	v.loading = true
-	return v.activeRequestID
+	return v.activeRequestID, ctx
+}
+
+func (v *mailView) finishRequest(requestID uint64) {
+	if requestID != v.activeRequestID {
+		return
+	}
+	if v.requestCancel != nil {
+		v.requestCancel()
+	}
+	v.activeRequestKind = mailRequestNone
+	v.requestCancel = nil
+	v.loading = false
 }
 
 func (v *mailView) cancelRequest() {
+	if v.requestCancel != nil {
+		v.requestCancel()
+	}
 	v.activeRequestID++
+	v.activeRequestKind = mailRequestNone
+	v.requestCancel = nil
 	v.loading = false
 }
 
 func (v *mailView) requestPostings(boxID int64) tea.Cmd {
-	return v.fetchPostings(v.beginRequest(), boxID)
+	requestID, ctx := v.beginRequest(mailRequestPostings)
+	return v.fetchPostings(ctx, requestID, boxID)
+}
+
+func (v *mailView) requestTopic(boxID, topicID int64, title string) tea.Cmd {
+	requestID, ctx := v.beginRequest(mailRequestTopic)
+	return v.fetchTopic(ctx, requestID, boxID, topicID, title)
 }
 
 func (v *mailView) postingIndex(postingID int64) int {
@@ -363,7 +416,7 @@ func (v *mailView) openSelected() tea.Cmd {
 	if topicID == 0 {
 		topicID = p.ID
 	}
-	return v.fetchTopic(v.beginRequest(), v.currentBoxID(), topicID, p.Summary)
+	return v.requestTopic(v.currentBoxID(), topicID, p.Summary)
 }
 
 // --- Posting actions ---
@@ -416,7 +469,7 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 		if topicID == 0 {
 			topicID = p.ID
 		}
-		return v.fetchTopic(v.beginRequest(), v.currentBoxID(), topicID, p.Summary)
+		return v.requestTopic(v.currentBoxID(), topicID, p.Summary)
 	}
 	return nil
 }
@@ -535,9 +588,9 @@ func (v *mailView) fetchBoxes() tea.Cmd {
 	}
 }
 
-func (v *mailView) fetchPostings(requestID uint64, boxID int64) tea.Cmd {
+func (v *mailView) fetchPostings(ctx context.Context, requestID uint64, boxID int64) tea.Cmd {
 	return func() tea.Msg {
-		resp, err := v.vc.sdk.Boxes().Get(v.vc.ctx, boxID, nil)
+		resp, err := v.vc.sdk.Boxes().Get(ctx, boxID, nil)
 		if err != nil {
 			return postingsLoadedMsg{requestID: requestID, boxID: boxID, err: err}
 		}
@@ -549,9 +602,9 @@ func (v *mailView) fetchPostings(requestID uint64, boxID int64) tea.Cmd {
 	}
 }
 
-func (v *mailView) fetchTopic(requestID uint64, boxID, topicID int64, title string) tea.Cmd {
+func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topicID int64, title string) tea.Cmd {
 	return func() tea.Msg {
-		topic, err := v.vc.sdk.Topics().Get(v.vc.ctx, topicID)
+		topic, err := v.vc.sdk.Topics().Get(ctx, topicID)
 		if err != nil {
 			return topicLoadedMsg{requestID: requestID, boxID: boxID, topicID: topicID, title: title, err: err}
 		}
@@ -560,11 +613,11 @@ func (v *mailView) fetchTopic(requestID uint64, boxID, topicID int64, title stri
 		}
 
 		messages := make([]generated.Message, len(topic.Entries))
-		group, ctx := errgroup.WithContext(v.vc.ctx)
+		group, groupCtx := errgroup.WithContext(ctx)
 		group.SetLimit(maxConcurrentMessageFetches)
 		for i, entry := range topic.Entries {
 			group.Go(func() error {
-				message, getErr := v.vc.sdk.Messages().Get(ctx, entry.Id)
+				message, getErr := v.vc.sdk.Messages().Get(groupCtx, entry.Id)
 				if getErr != nil {
 					return fmt.Errorf("get message %d: %w", entry.Id, getErr)
 				}
@@ -595,9 +648,9 @@ func (v *mailView) fetchTopic(requestID uint64, boxID, topicID int64, title stri
 			for _, imgURL := range extractImageURLs(entry.Body) {
 				var data []byte
 				if strings.HasPrefix(imgURL, "http://") || strings.HasPrefix(imgURL, "https://") {
-					data = fetchImageData(imgURL)
+					data = fetchImageData(ctx, imgURL)
 				} else {
-					sdkResp, getErr := v.vc.sdk.Get(v.vc.ctx, imgURL)
+					sdkResp, getErr := v.vc.sdk.Get(ctx, imgURL)
 					if getErr == nil && sdkResp != nil {
 						data = sdkResp.Data
 					}

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 
-	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/models"
 )
 
@@ -22,9 +21,11 @@ type postingsLoadedMsg struct {
 }
 
 type topicLoadedMsg struct {
+	boxID   int64
 	title   string
 	entries []models.Entry
 	images  [][]byte
+	err     error
 }
 
 type postingActionDoneMsg struct {
@@ -92,7 +93,13 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case topicLoadedMsg:
+		if msg.boxID != v.currentBoxID() {
+			return nil, true
+		}
 		v.loading = false
+		if msg.err != nil {
+			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
 		v.inThread = true
 		v.topicContent = v.renderEntries(msg.entries)
 		v.topicViewport.SetContent(v.topicContent)
@@ -112,6 +119,9 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case replyContextLoadedMsg:
+		if msg.boxID != v.currentBoxID() {
+			return nil, true
+		}
 		v.loading = false
 		if msg.err != nil {
 			return func() tea.Msg { return errMsg{msg.err} }, true
@@ -134,11 +144,11 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case postingActionDoneMsg:
-		if msg.boxID != v.currentBoxID() {
-			return nil, true
-		}
 		if msg.err != nil {
 			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
+		if msg.boxID != v.currentBoxID() {
+			return nil, true
 		}
 		v.notice = msg.action
 		idx := v.postingIndex(msg.postingID)
@@ -150,6 +160,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			if v.postingList.cursor >= len(v.postingList.postings) && v.postingList.cursor > 0 {
 				v.postingList.cursor--
 			}
+			v.postingList.ensureVisible()
 		} else if msg.action == "marked as seen" && idx >= 0 {
 			v.postingList.postings[idx].Seen = true
 		}
@@ -337,7 +348,7 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 
 	switch key {
 	case "l":
-		return v.doPostingAction("moved to Reply Later", false, boxID, p.ID, func() error {
+		return v.doPostingAction("moved to Reply Later", true, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToReplyLater(v.vc.ctx, p.ID)
 		})
 	case "a":
@@ -440,6 +451,46 @@ func sdkExtenzionsToModel(exts []generated.Extenzion) []models.Extenzion {
 	return result
 }
 
+func sdkMessageToEntry(entry generated.Entry, message generated.Message) models.Entry {
+	creator := entry.Creator
+	if creator.Id == 0 {
+		creator = message.Creator
+	}
+	createdAt := entry.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = message.CreatedAt
+	}
+	updatedAt := entry.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = message.UpdatedAt
+	}
+	summary := entry.Summary
+	if summary == "" {
+		summary = message.Subject
+	}
+	appURL := entry.AppUrl
+	if appURL == "" {
+		appURL = message.Url
+	}
+
+	return models.Entry{
+		ID:                    entry.Id,
+		CreatedAt:             formatTimestamp(createdAt),
+		UpdatedAt:             formatTimestamp(updatedAt),
+		AlternativeSenderName: entry.AlternativeSenderName,
+		Summary:               summary,
+		Kind:                  entry.Kind,
+		AppURL:                appURL,
+		Body:                  message.Content,
+		BodyHTML:              message.Content,
+		Creator: models.Contact{
+			ID:           creator.Id,
+			Name:         creator.Name,
+			EmailAddress: creator.EmailAddress,
+		},
+	}
+}
+
 // --- Fetch commands ---
 
 func (v *mailView) fetchBoxes() tea.Cmd {
@@ -475,16 +526,31 @@ func (v *mailView) fetchPostings(boxID int64) tea.Cmd {
 }
 
 func (v *mailView) fetchTopic(topicID int64, title string) tea.Cmd {
+	boxID := v.currentBoxID()
 	return func() tea.Msg {
-		resp, err := v.vc.sdk.GetHTML(v.vc.ctx, fmt.Sprintf("/topics/%d/entries", topicID))
+		topic, err := v.vc.sdk.Topics().Get(v.vc.ctx, topicID)
 		if err != nil {
-			return errMsg{err}
+			return topicLoadedMsg{boxID: boxID, err: err}
 		}
-		entries := htmlutil.ParseTopicEntriesHTML(string(resp.Data))
+		if topic == nil {
+			return topicLoadedMsg{boxID: boxID, err: fmt.Errorf("topic %d returned no data", topicID)}
+		}
+
+		entries := make([]models.Entry, 0, len(topic.Entries))
+		for _, entry := range topic.Entries {
+			message, getErr := v.vc.sdk.Messages().Get(v.vc.ctx, entry.Id)
+			if getErr != nil {
+				return topicLoadedMsg{boxID: boxID, err: getErr}
+			}
+			if message == nil {
+				return topicLoadedMsg{boxID: boxID, err: fmt.Errorf("message %d returned no data", entry.Id)}
+			}
+			entries = append(entries, sdkMessageToEntry(entry, *message))
+		}
 
 		var images [][]byte
-		for _, e := range entries {
-			for _, imgURL := range extractImageURLs(e.Body) {
+		for _, entry := range entries {
+			for _, imgURL := range extractImageURLs(entry.Body) {
 				var data []byte
 				if strings.HasPrefix(imgURL, "http://") || strings.HasPrefix(imgURL, "https://") {
 					data = fetchImageData(imgURL)
@@ -500,7 +566,7 @@ func (v *mailView) fetchTopic(topicID int64, title string) tea.Cmd {
 			}
 		}
 
-		return topicLoadedMsg{title: title, entries: entries, images: images}
+		return topicLoadedMsg{boxID: boxID, title: title, entries: entries, images: images}
 	}
 }
 

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -17,15 +17,20 @@ import (
 type boxesLoadedMsg []models.Box
 
 type postingsLoadedMsg struct {
-	postings []models.Posting
+	requestID uint64
+	boxID     int64
+	postings  []models.Posting
+	err       error
 }
 
 type topicLoadedMsg struct {
-	boxID   int64
-	title   string
-	entries []models.Entry
-	images  [][]byte
-	err     error
+	requestID uint64
+	boxID     int64
+	topicID   int64
+	title     string
+	entries   []models.Entry
+	images    [][]byte
+	err       error
 }
 
 type postingActionDoneMsg struct {
@@ -52,8 +57,9 @@ type mailView struct {
 	inThread      bool
 	loading       bool
 
-	compose *composeForm // non-nil while a new message or reply is being written
-	notice  string       // one-shot confirmation shown above the posting list
+	compose         *composeForm // non-nil while a new message or reply is being written
+	notice          string       // one-shot confirmation shown above the posting list
+	activeRequestID uint64       // identifies the only mail read allowed to update the view
 }
 
 func newMailView(vc *viewContext) *mailView {
@@ -69,8 +75,7 @@ func (v *mailView) Init() tea.Cmd {
 		return v.fetchBoxes()
 	}
 	if v.boxIndex < len(v.boxes) {
-		v.loading = true
-		return v.fetchPostings(v.boxes[v.boxIndex].ID)
+		return v.requestPostings(v.boxes[v.boxIndex].ID)
 	}
 	return nil
 }
@@ -82,18 +87,23 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.loading = false
 		if len(v.boxes) > 0 {
 			v.boxIndex = 0
-			v.loading = true
-			return v.fetchPostings(v.boxes[0].ID), true
+			return v.requestPostings(v.boxes[0].ID), true
 		}
 		return nil, true
 
 	case postingsLoadedMsg:
+		if msg.requestID != v.activeRequestID || msg.boxID != v.currentBoxID() {
+			return nil, true
+		}
 		v.loading = false
+		if msg.err != nil {
+			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
 		v.postingList.setPostings(msg.postings)
 		return nil, true
 
 	case topicLoadedMsg:
-		if msg.boxID != v.currentBoxID() {
+		if msg.requestID != v.activeRequestID || msg.boxID != v.currentBoxID() {
 			return nil, true
 		}
 		v.loading = false
@@ -101,6 +111,8 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
 		v.inThread = true
+		v.topicID = msg.topicID
+		v.topicName = msg.title
 		v.topicContent = v.renderEntries(msg.entries)
 		v.topicViewport.SetContent(v.topicContent)
 		v.topicViewport.GotoTop()
@@ -119,7 +131,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case replyContextLoadedMsg:
-		if msg.boxID != v.currentBoxID() {
+		if msg.requestID != v.activeRequestID || msg.boxID != v.currentBoxID() {
 			return nil, true
 		}
 		v.loading = false
@@ -253,7 +265,6 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 
 	if v.inThread {
 		if msg.String() == "r" && v.topicID != 0 {
-			v.loading = true
 			return v.loadReplyContext(v.topicID, v.topicName)
 		}
 		var cmd tea.Cmd
@@ -278,8 +289,12 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 }
 
 func (v *mailView) InThread() bool { return v.inThread }
-func (v *mailView) ExitThread()    { v.inThread = false; v.compose = nil }
-func (v *mailView) Loading() bool  { return v.loading }
+func (v *mailView) ExitThread() {
+	v.inThread = false
+	v.compose = nil
+	v.cancelRequest()
+}
+func (v *mailView) Loading() bool { return v.loading }
 
 func (v *mailView) Resize(width, height int) {
 	if v.compose != nil {
@@ -302,8 +317,7 @@ func (v *mailView) switchBox(index int) tea.Cmd {
 	v.ExitThread()
 	v.notice = ""
 	v.boxIndex = index
-	v.loading = true
-	return v.fetchPostings(v.boxes[index].ID)
+	return v.requestPostings(v.boxes[index].ID)
 }
 
 func (v *mailView) currentBoxID() int64 {
@@ -311,6 +325,21 @@ func (v *mailView) currentBoxID() int64 {
 		return 0
 	}
 	return v.boxes[v.boxIndex].ID
+}
+
+func (v *mailView) beginRequest() uint64 {
+	v.activeRequestID++
+	v.loading = true
+	return v.activeRequestID
+}
+
+func (v *mailView) cancelRequest() {
+	v.activeRequestID++
+	v.loading = false
+}
+
+func (v *mailView) requestPostings(boxID int64) tea.Cmd {
+	return v.fetchPostings(v.beginRequest(), boxID)
 }
 
 func (v *mailView) postingIndex(postingID int64) int {
@@ -331,10 +360,7 @@ func (v *mailView) openSelected() tea.Cmd {
 	if topicID == 0 {
 		topicID = p.ID
 	}
-	v.topicID = topicID
-	v.topicName = p.Summary
-	v.loading = true
-	return v.fetchTopic(topicID, p.Summary)
+	return v.fetchTopic(v.beginRequest(), v.currentBoxID(), topicID, p.Summary)
 }
 
 // --- Posting actions ---
@@ -380,19 +406,13 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 		if topicID == 0 {
 			topicID = p.ID
 		}
-		v.topicID = topicID
-		v.topicName = p.Summary
-		v.loading = true
 		return v.loadReplyContext(topicID, p.Summary)
 	case "f":
 		topicID := p.ResolveTopicID()
 		if topicID == 0 {
 			topicID = p.ID
 		}
-		v.topicID = topicID
-		v.topicName = p.Summary
-		v.loading = true
-		return v.fetchTopic(topicID, p.Summary)
+		return v.fetchTopic(v.beginRequest(), v.currentBoxID(), topicID, p.Summary)
 	}
 	return nil
 }
@@ -511,39 +531,38 @@ func (v *mailView) fetchBoxes() tea.Cmd {
 	}
 }
 
-func (v *mailView) fetchPostings(boxID int64) tea.Cmd {
+func (v *mailView) fetchPostings(requestID uint64, boxID int64) tea.Cmd {
 	return func() tea.Msg {
 		resp, err := v.vc.sdk.Boxes().Get(v.vc.ctx, boxID, nil)
 		if err != nil {
-			return errMsg{err}
+			return postingsLoadedMsg{requestID: requestID, boxID: boxID, err: err}
 		}
 		postings := make([]models.Posting, 0, len(resp.Postings))
 		for _, p := range resp.Postings {
 			postings = append(postings, sdkPostingToModel(p))
 		}
-		return postingsLoadedMsg{postings: postings}
+		return postingsLoadedMsg{requestID: requestID, boxID: boxID, postings: postings}
 	}
 }
 
-func (v *mailView) fetchTopic(topicID int64, title string) tea.Cmd {
-	boxID := v.currentBoxID()
+func (v *mailView) fetchTopic(requestID uint64, boxID, topicID int64, title string) tea.Cmd {
 	return func() tea.Msg {
 		topic, err := v.vc.sdk.Topics().Get(v.vc.ctx, topicID)
 		if err != nil {
-			return topicLoadedMsg{boxID: boxID, err: err}
+			return topicLoadedMsg{requestID: requestID, boxID: boxID, topicID: topicID, title: title, err: err}
 		}
 		if topic == nil {
-			return topicLoadedMsg{boxID: boxID, err: fmt.Errorf("topic %d returned no data", topicID)}
+			return topicLoadedMsg{requestID: requestID, boxID: boxID, topicID: topicID, title: title, err: fmt.Errorf("topic %d returned no data", topicID)}
 		}
 
 		entries := make([]models.Entry, 0, len(topic.Entries))
 		for _, entry := range topic.Entries {
 			message, getErr := v.vc.sdk.Messages().Get(v.vc.ctx, entry.Id)
 			if getErr != nil {
-				return topicLoadedMsg{boxID: boxID, err: getErr}
+				return topicLoadedMsg{requestID: requestID, boxID: boxID, topicID: topicID, title: title, err: getErr}
 			}
 			if message == nil {
-				return topicLoadedMsg{boxID: boxID, err: fmt.Errorf("message %d returned no data", entry.Id)}
+				return topicLoadedMsg{requestID: requestID, boxID: boxID, topicID: topicID, title: title, err: fmt.Errorf("message %d returned no data", entry.Id)}
 			}
 			entries = append(entries, sdkMessageToEntry(entry, *message))
 		}
@@ -566,7 +585,14 @@ func (v *mailView) fetchTopic(topicID int64, title string) tea.Cmd {
 			}
 		}
 
-		return topicLoadedMsg{boxID: boxID, title: title, entries: entries, images: images}
+		return topicLoadedMsg{
+			requestID: requestID,
+			boxID:     boxID,
+			topicID:   topicID,
+			title:     title,
+			entries:   entries,
+			images:    images,
+		}
 	}
 }
 

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -343,6 +343,7 @@ func (v *mailView) switchBox(index int) tea.Cmd {
 	}
 	v.ExitThread()
 	v.notice = ""
+	v.postingList.setPostings(nil)
 	v.boxIndex = index
 	return v.requestPostings(v.boxes[index].ID)
 }

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -50,7 +50,7 @@ type mailView struct {
 	loading       bool
 
 	compose *composeForm // non-nil while a new message or reply is being written
-	notice  string       // one-shot confirmation shown above the list after a send
+	notice  string       // one-shot confirmation shown above the posting list
 }
 
 func newMailView(vc *viewContext) *mailView {
@@ -135,6 +135,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		if msg.err != nil {
 			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
+		v.notice = msg.action
 		if msg.removes {
 			if v.postingList.cursor < len(v.postingList.postings) {
 				idx := v.postingList.cursor
@@ -287,6 +288,7 @@ func (v *mailView) Resize(width, height int) {
 // handleBoxShortcut handles number-key shortcuts for switching boxes.
 func (v *mailView) handleBoxShortcut(key string) tea.Cmd {
 	if idx := boxForShortcut(key, v.boxes); idx >= 0 && idx != v.boxIndex {
+		v.notice = ""
 		v.boxIndex = idx
 		v.loading = true
 		return v.fetchPostings(v.boxes[idx].ID)

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/models"
 )
@@ -432,11 +433,11 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 
 	switch key {
 	case "l":
-		return v.doPostingAction("moved to Reply Later", true, boxID, p.ID, func() error {
+		return v.doPostingAction("moved to Reply Later", v.movesOutOfCurrentBox(hey.BoxKindLater), boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToReplyLater(v.vc.ctx, p.ID)
 		})
 	case "a":
-		return v.doPostingAction("moved to Set Aside", true, boxID, p.ID, func() error {
+		return v.doPostingAction("moved to Set Aside", v.movesOutOfCurrentBox(hey.BoxKindSetAside), boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToSetAside(v.vc.ctx, p.ID)
 		})
 	case "e":
@@ -444,11 +445,11 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 			return v.vc.sdk.Postings().MarkSeen(v.vc.ctx, []int64{p.ID})
 		})
 	case "d":
-		return v.doPostingAction("moved to The Feed", true, boxID, p.ID, func() error {
+		return v.doPostingAction("moved to The Feed", v.movesOutOfCurrentBox(hey.BoxKindFeed), boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToFeed(v.vc.ctx, p.ID)
 		})
 	case "p":
-		return v.doPostingAction("moved to Paper Trail", true, boxID, p.ID, func() error {
+		return v.doPostingAction("moved to Paper Trail", v.movesOutOfCurrentBox(hey.BoxKindTrail), boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToPaperTrail(v.vc.ctx, p.ID)
 		})
 	case "t":
@@ -473,6 +474,13 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 		return v.requestTopic(v.currentBoxID(), topicID, p.Summary)
 	}
 	return nil
+}
+
+func (v *mailView) movesOutOfCurrentBox(destinationKind string) bool {
+	if v.boxIndex < 0 || v.boxIndex >= len(v.boxes) {
+		return true
+	}
+	return !strings.EqualFold(v.boxes[v.boxIndex].Kind, destinationKind)
 }
 
 func (v *mailView) doPostingAction(label string, removes bool, boxID, postingID int64, fn func() error) tea.Cmd {

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 
@@ -13,6 +14,8 @@ import (
 )
 
 // --- Mail messages ---
+
+const maxConcurrentMessageFetches = 6
 
 type boxesLoadedMsg []models.Box
 
@@ -366,10 +369,11 @@ func (v *mailView) openSelected() tea.Cmd {
 // --- Posting actions ---
 
 func (v *mailView) handlePostingAction(key string) tea.Cmd {
-	p := v.postingList.selectedPosting()
-	if p == nil {
+	selected := v.postingList.selectedPosting()
+	if selected == nil {
 		return nil
 	}
+	p := *selected
 	boxID := v.currentBoxID()
 
 	switch key {
@@ -555,16 +559,35 @@ func (v *mailView) fetchTopic(requestID uint64, boxID, topicID int64, title stri
 			return topicLoadedMsg{requestID: requestID, boxID: boxID, topicID: topicID, title: title, err: fmt.Errorf("topic %d returned no data", topicID)}
 		}
 
-		entries := make([]models.Entry, 0, len(topic.Entries))
-		for _, entry := range topic.Entries {
-			message, getErr := v.vc.sdk.Messages().Get(v.vc.ctx, entry.Id)
-			if getErr != nil {
-				return topicLoadedMsg{requestID: requestID, boxID: boxID, topicID: topicID, title: title, err: getErr}
+		messages := make([]generated.Message, len(topic.Entries))
+		group, ctx := errgroup.WithContext(v.vc.ctx)
+		group.SetLimit(maxConcurrentMessageFetches)
+		for i, entry := range topic.Entries {
+			group.Go(func() error {
+				message, getErr := v.vc.sdk.Messages().Get(ctx, entry.Id)
+				if getErr != nil {
+					return fmt.Errorf("get message %d: %w", entry.Id, getErr)
+				}
+				if message == nil {
+					return fmt.Errorf("message %d returned no data", entry.Id)
+				}
+				messages[i] = *message
+				return nil
+			})
+		}
+		if getErr := group.Wait(); getErr != nil {
+			return topicLoadedMsg{
+				requestID: requestID,
+				boxID:     boxID,
+				topicID:   topicID,
+				title:     title,
+				err:       getErr,
 			}
-			if message == nil {
-				return topicLoadedMsg{requestID: requestID, boxID: boxID, topicID: topicID, title: title, err: fmt.Errorf("message %d returned no data", entry.Id)}
-			}
-			entries = append(entries, sdkMessageToEntry(entry, *message))
+		}
+
+		entries := make([]models.Entry, len(topic.Entries))
+		for i, entry := range topic.Entries {
+			entries[i] = sdkMessageToEntry(entry, messages[i])
 		}
 
 		var images [][]byte

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -28,9 +28,11 @@ type topicLoadedMsg struct {
 }
 
 type postingActionDoneMsg struct {
-	action  string
-	removes bool
-	err     error
+	action    string
+	boxID     int64
+	postingID int64
+	removes   bool
+	err       error
 }
 
 // --- Mail section view ---
@@ -132,22 +134,24 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case postingActionDoneMsg:
+		if msg.boxID != v.currentBoxID() {
+			return nil, true
+		}
 		if msg.err != nil {
 			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
 		v.notice = msg.action
-		if msg.removes {
-			if v.postingList.cursor < len(v.postingList.postings) {
-				idx := v.postingList.cursor
-				v.postingList.postings = append(v.postingList.postings[:idx], v.postingList.postings[idx+1:]...)
-				if v.postingList.cursor >= len(v.postingList.postings) && v.postingList.cursor > 0 {
-					v.postingList.cursor--
-				}
+		idx := v.postingIndex(msg.postingID)
+		if msg.removes && idx >= 0 {
+			v.postingList.postings = append(v.postingList.postings[:idx], v.postingList.postings[idx+1:]...)
+			if v.postingList.cursor > idx {
+				v.postingList.cursor--
 			}
-		} else if msg.action == "marked as seen" {
-			if v.postingList.cursor < len(v.postingList.postings) {
-				v.postingList.postings[v.postingList.cursor].Seen = true
+			if v.postingList.cursor >= len(v.postingList.postings) && v.postingList.cursor > 0 {
+				v.postingList.cursor--
 			}
+		} else if msg.action == "marked as seen" && idx >= 0 {
+			v.postingList.postings[idx].Seen = true
 		}
 		return nil, true
 	}
@@ -214,21 +218,11 @@ func (v *mailView) SubnavItems() ([]navItem, int, string, bool) {
 }
 
 func (v *mailView) SubnavLeft() tea.Cmd {
-	if v.boxIndex > 0 {
-		v.boxIndex--
-		v.loading = true
-		return v.fetchPostings(v.boxes[v.boxIndex].ID)
-	}
-	return nil
+	return v.switchBox(v.boxIndex - 1)
 }
 
 func (v *mailView) SubnavRight() tea.Cmd {
-	if v.boxIndex < len(v.boxes)-1 {
-		v.boxIndex++
-		v.loading = true
-		return v.fetchPostings(v.boxes[v.boxIndex].ID)
-	}
-	return nil
+	return v.switchBox(v.boxIndex + 1)
 }
 
 func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
@@ -287,13 +281,34 @@ func (v *mailView) Resize(width, height int) {
 
 // handleBoxShortcut handles number-key shortcuts for switching boxes.
 func (v *mailView) handleBoxShortcut(key string) tea.Cmd {
-	if idx := boxForShortcut(key, v.boxes); idx >= 0 && idx != v.boxIndex {
-		v.notice = ""
-		v.boxIndex = idx
-		v.loading = true
-		return v.fetchPostings(v.boxes[idx].ID)
+	return v.switchBox(boxForShortcut(key, v.boxes))
+}
+
+func (v *mailView) switchBox(index int) tea.Cmd {
+	if index < 0 || index >= len(v.boxes) || index == v.boxIndex {
+		return nil
 	}
-	return nil
+	v.ExitThread()
+	v.notice = ""
+	v.boxIndex = index
+	v.loading = true
+	return v.fetchPostings(v.boxes[index].ID)
+}
+
+func (v *mailView) currentBoxID() int64 {
+	if v.boxIndex < 0 || v.boxIndex >= len(v.boxes) {
+		return 0
+	}
+	return v.boxes[v.boxIndex].ID
+}
+
+func (v *mailView) postingIndex(postingID int64) int {
+	for i := range v.postingList.postings {
+		if v.postingList.postings[i].ID == postingID {
+			return i
+		}
+	}
+	return -1
 }
 
 func (v *mailView) openSelected() tea.Cmd {
@@ -318,34 +333,35 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 	if p == nil {
 		return nil
 	}
+	boxID := v.currentBoxID()
 
 	switch key {
 	case "l":
-		return v.doPostingAction("moved to Reply Later", false, func() error {
+		return v.doPostingAction("moved to Reply Later", false, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToReplyLater(v.vc.ctx, p.ID)
 		})
 	case "a":
-		return v.doPostingAction("moved to Set Aside", true, func() error {
+		return v.doPostingAction("moved to Set Aside", true, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToSetAside(v.vc.ctx, p.ID)
 		})
 	case "e":
-		return v.doPostingAction("marked as seen", false, func() error {
+		return v.doPostingAction("marked as seen", false, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MarkSeen(v.vc.ctx, []int64{p.ID})
 		})
 	case "d":
-		return v.doPostingAction("moved to The Feed", true, func() error {
+		return v.doPostingAction("moved to The Feed", true, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToFeed(v.vc.ctx, p.ID)
 		})
 	case "p":
-		return v.doPostingAction("moved to Paper Trail", true, func() error {
+		return v.doPostingAction("moved to Paper Trail", true, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToPaperTrail(v.vc.ctx, p.ID)
 		})
 	case "t":
-		return v.doPostingAction("moved to Trash", true, func() error {
+		return v.doPostingAction("moved to Trash", true, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToTrash(v.vc.ctx, p.ID)
 		})
 	case "-":
-		return v.doPostingAction("muted", true, func() error {
+		return v.doPostingAction("muted", true, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().Mute(v.vc.ctx, p.ID)
 		})
 	case "r":
@@ -370,10 +386,16 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 	return nil
 }
 
-func (v *mailView) doPostingAction(label string, removes bool, fn func() error) tea.Cmd {
+func (v *mailView) doPostingAction(label string, removes bool, boxID, postingID int64, fn func() error) tea.Cmd {
 	return func() tea.Msg {
 		err := fn()
-		return postingActionDoneMsg{action: label, removes: removes, err: err}
+		return postingActionDoneMsg{
+			action:    label,
+			boxID:     boxID,
+			postingID: postingID,
+			removes:   removes,
+			err:       err,
+		}
 	}
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -27,9 +27,10 @@ func mailWithPostings() *mailView {
 }
 
 type recordedMailRequest struct {
-	method string
-	path   string
-	body   struct {
+	method   string
+	path     string
+	requests []string
+	body     struct {
 		PostingIDs []int64 `json:"posting_ids"`
 		BoxID      int64   `json:"box_id"`
 	}
@@ -54,19 +55,17 @@ func mailWithTestServer(t *testing.T, status int) (*mailView, *recordedMailReque
 
 		recorded.method = r.Method
 		recorded.path = r.URL.Path
-		if r.URL.Path == "/topics/100/entries" {
-			w.Header().Set("Content-Type", "text/html")
+		recorded.requests = append(recorded.requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/topics/100.json":
+			_, _ = w.Write([]byte(`{"id":100,"name":"Hello world","entries":[{"id":501,"kind":"message","summary":"Hello world","created_at":"2026-08-19T09:00:00Z","creator":{"id":10,"name":"Alice"}}]}`))
+		case "/messages/501.json":
+			_, _ = w.Write([]byte(`{"id":501,"subject":"Hello world","content":"<p>Message body</p>","created_at":"2026-08-19T09:00:00Z","creator":{"id":10,"name":"Alice"}}`))
+		default:
+			_ = json.NewDecoder(r.Body).Decode(&recorded.body)
 			w.WriteHeader(status)
-			_, _ = w.Write([]byte(`<article id="entry_501" data-entry-id="501">
-				<span id="sender_entry_501">Alice</span>
-				<time datetime="2026-08-19T09:00:00Z"></time>
-				<iframe srcdoc="&lt;div class=&quot;trix-content&quot;&gt;Message body&lt;/div&gt;"></iframe>
-			</article>`))
-			return
 		}
-
-		_ = json.NewDecoder(r.Body).Decode(&recorded.body)
-		w.WriteHeader(status)
 	}))
 	t.Cleanup(server.Close)
 
@@ -146,6 +145,7 @@ func TestMailViewHandlesTopicLoaded(t *testing.T) {
 	v.loading = true
 
 	_, consumed := v.Update(topicLoadedMsg{
+		boxID:   1,
 		title:   "Test topic",
 		entries: []models.Entry{{Creator: models.Contact{Name: "Alice"}, Body: "hello"}},
 	})
@@ -180,7 +180,7 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 		notice  string
 		seen    bool
 	}{
-		{"reply later", "l", "/postings/moves.json", 4, false, "moved to Reply Later", false},
+		{"reply later", "l", "/postings/moves.json", 4, true, "moved to Reply Later", false},
 		{"set aside", "a", "/postings/moves.json", 3, true, "moved to Set Aside", false},
 		{"seen", "e", "/postings/seen.json", 0, false, "marked as seen", true},
 		{"feed", "d", "/postings/moves.json", 2, true, "moved to The Feed", false},
@@ -257,6 +257,7 @@ func TestMailViewPostingKeyFailureKeepsPosting(t *testing.T) {
 
 func TestMailViewPostingCompletionUpdatesOriginatingPosting(t *testing.T) {
 	v, _ := mailWithTestServer(t, http.StatusNoContent)
+	v.Resize(80, 2)
 
 	msg := runCmd(v.HandleContentKey(keyPress("t")))
 	done, ok := msg.(postingActionDoneMsg)
@@ -264,10 +265,16 @@ func TestMailViewPostingCompletionUpdatesOriginatingPosting(t *testing.T) {
 		t.Fatalf("posting command returned %T, want postingActionDoneMsg", msg)
 	}
 	v.postingList.moveDown()
+	if v.postingList.scrollOff != 1 {
+		t.Fatalf("scroll offset before completion = %d, want 1", v.postingList.scrollOff)
+	}
 	v.Update(done)
 
 	if len(v.postingList.postings) != 1 || v.postingList.postings[0].ID != 101 {
 		t.Errorf("postings after completion = %v, want only posting 101", v.postingList.postings)
+	}
+	if v.postingList.scrollOff != 0 || !strings.Contains(v.View(), "│") {
+		t.Errorf("selected posting is not visible: cursor=%d scroll=%d view=%q", v.postingList.cursor, v.postingList.scrollOff, v.View())
 	}
 }
 
@@ -288,6 +295,29 @@ func TestMailViewIgnoresPostingCompletionAfterBoxSwitch(t *testing.T) {
 	}
 	if v.notice != "" {
 		t.Errorf("stale completion notice = %q, want empty", v.notice)
+	}
+}
+
+func TestMailViewReportsPostingFailureAfterBoxSwitch(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusInternalServerError)
+
+	msg := runCmd(v.HandleContentKey(keyPress("t")))
+	done, ok := msg.(postingActionDoneMsg)
+	if !ok || done.err == nil {
+		t.Fatalf("posting command returned %#v, want an action error", msg)
+	}
+	v.SubnavRight()
+	v.Update(postingsLoadedMsg{postings: []models.Posting{{ID: 200, Summary: "Other box"}}})
+	errCmd, consumed := v.Update(done)
+
+	if !consumed || errCmd == nil {
+		t.Fatal("failed action should still return an error after a box switch")
+	}
+	if _, ok := runCmd(errCmd).(errMsg); !ok {
+		t.Error("failed action should produce errMsg")
+	}
+	if len(v.postingList.postings) != 1 || v.postingList.postings[0].ID != 200 {
+		t.Errorf("failed action changed the new box: %v", v.postingList.postings)
 	}
 }
 
@@ -343,14 +373,44 @@ func TestMailViewEnterOpensSelectedThread(t *testing.T) {
 	}
 	v.Update(loaded)
 
-	if recorded.method != http.MethodGet || recorded.path != "/topics/100/entries" {
-		t.Errorf("request = %s %s, want GET /topics/100/entries", recorded.method, recorded.path)
+	wantRequests := "GET /topics/100.json,GET /messages/501.json"
+	if got := strings.Join(recorded.requests, ","); got != wantRequests {
+		t.Errorf("requests = %q, want %q", got, wantRequests)
 	}
 	if !v.inThread || v.topicID != 100 || v.topicName != "Hello world" {
 		t.Errorf("thread state = open:%v id:%d name:%q", v.inThread, v.topicID, v.topicName)
 	}
 	if !strings.Contains(v.View(), "Alice") || !strings.Contains(v.View(), "Message body") {
 		t.Errorf("thread view does not contain the fetched entry: %q", v.View())
+	}
+}
+
+func TestMailViewIgnoresThreadLoadAfterBoxSwitch(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusOK)
+
+	loaded := runCmd(v.HandleContentKey(keyPress("enter")))
+	v.SubnavRight()
+	v.Update(loaded)
+
+	if v.inThread {
+		t.Error("stale thread load should not reopen a thread after switching boxes")
+	}
+}
+
+func TestMailViewIgnoresReplyLoadAfterBoxSwitch(t *testing.T) {
+	v := mailWithPostings()
+
+	v.SubnavRight()
+	cmd, consumed := v.Update(replyContextLoadedMsg{
+		boxID: 1, topicID: 100, topicName: "Hello world", entryID: 501,
+		to: []string{"jane@example.com"},
+	})
+
+	if !consumed {
+		t.Error("stale reply context should be consumed")
+	}
+	if cmd != nil || v.compose != nil {
+		t.Error("stale reply context should not open the reply form")
 	}
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -1,9 +1,15 @@
 package tui
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/models"
 )
@@ -18,6 +24,65 @@ func mailWithPostings() *mailView {
 	v.boxIndex = 0
 	v.Update(postingsLoadedMsg{postings: testPostings()})
 	return v
+}
+
+type recordedMailRequest struct {
+	method string
+	path   string
+	body   struct {
+		PostingIDs []int64 `json:"posting_ids"`
+		BoxID      int64   `json:"box_id"`
+	}
+}
+
+func mailWithTestServer(t *testing.T, status int) (*mailView, *recordedMailRequest) {
+	t.Helper()
+
+	recorded := &recordedMailRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/boxes.json" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[
+				{"id":1,"kind":"imbox","name":"Imbox"},
+				{"id":2,"kind":"feedbox","name":"The Feed"},
+				{"id":3,"kind":"asidebox","name":"Set Aside"},
+				{"id":4,"kind":"laterbox","name":"Reply Later"},
+				{"id":5,"kind":"trailbox","name":"Paper Trail"}
+			]`))
+			return
+		}
+
+		recorded.method = r.Method
+		recorded.path = r.URL.Path
+		if r.URL.Path == "/topics/100/entries" {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`<article id="entry_501" data-entry-id="501">
+				<span id="sender_entry_501">Alice</span>
+				<time datetime="2026-08-19T09:00:00Z"></time>
+				<iframe srcdoc="&lt;div class=&quot;trix-content&quot;&gt;Message body&lt;/div&gt;"></iframe>
+			</article>`))
+			return
+		}
+
+		_ = json.NewDecoder(r.Body).Decode(&recorded.body)
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(server.Close)
+
+	client := hey.NewClient(
+		&hey.Config{BaseURL: server.URL},
+		&hey.StaticTokenProvider{Token: "test-token"},
+		hey.WithMaxRetries(0),
+	)
+	vc := testVC()
+	vc.sdk = client
+	vc.ctx = context.Background()
+	v := newMailView(vc)
+	v.Resize(vc.width, vc.height)
+	v.boxes = orderBoxes(testBoxes())
+	v.Update(postingsLoadedMsg{postings: testPostings()})
+	return v, recorded
 }
 
 // --- Init ---
@@ -105,6 +170,88 @@ func TestMailViewIgnoresUnrelatedMessages(t *testing.T) {
 
 // --- Posting actions ---
 
+func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		path    string
+		boxID   int64
+		removes bool
+		notice  string
+		seen    bool
+	}{
+		{"reply later", "l", "/postings/moves.json", 4, false, "moved to Reply Later", false},
+		{"set aside", "a", "/postings/moves.json", 3, true, "moved to Set Aside", false},
+		{"seen", "e", "/postings/seen.json", 0, false, "marked as seen", true},
+		{"feed", "d", "/postings/moves.json", 2, true, "moved to The Feed", false},
+		{"paper trail", "p", "/postings/moves.json", 5, true, "moved to Paper Trail", false},
+		{"trash", "t", "/postings/trash.json", 0, true, "moved to Trash", false},
+		{"mute", "-", "/postings/mutings.json", 0, true, "muted", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, recorded := mailWithTestServer(t, http.StatusNoContent)
+
+			msg := runCmd(v.HandleContentKey(keyPress(tt.key)))
+			done, ok := msg.(postingActionDoneMsg)
+			if !ok || done.err != nil {
+				t.Fatalf("posting command returned %#v", msg)
+			}
+			v.Update(done)
+
+			if recorded.method != http.MethodPost || recorded.path != tt.path {
+				t.Errorf("request = %s %s, want POST %s", recorded.method, recorded.path, tt.path)
+			}
+			if len(recorded.body.PostingIDs) != 1 || recorded.body.PostingIDs[0] != 100 {
+				t.Errorf("posting_ids = %v, want [100]", recorded.body.PostingIDs)
+			}
+			if tt.boxID != 0 && recorded.body.BoxID != tt.boxID {
+				t.Errorf("box_id = %d, want %d", recorded.body.BoxID, tt.boxID)
+			}
+
+			wantPostings := 2
+			if tt.removes {
+				wantPostings = 1
+			}
+			if len(v.postingList.postings) != wantPostings {
+				t.Errorf("posting count = %d, want %d", len(v.postingList.postings), wantPostings)
+			}
+			if tt.seen && !v.postingList.postings[0].Seen {
+				t.Error("selected posting should be marked seen")
+			}
+			if v.notice != tt.notice || !strings.Contains(v.View(), tt.notice) {
+				t.Errorf("notice = %q, want visible %q", v.notice, tt.notice)
+			}
+		})
+	}
+}
+
+func TestMailViewPostingKeyFailureKeepsPosting(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusInternalServerError)
+
+	msg := runCmd(v.HandleContentKey(keyPress("t")))
+	done, ok := msg.(postingActionDoneMsg)
+	if !ok || done.err == nil {
+		t.Fatalf("posting command returned %#v, want an action error", msg)
+	}
+	errCmd, consumed := v.Update(done)
+
+	if !consumed || errCmd == nil {
+		t.Fatal("failed action should return an error command")
+	}
+	errResult := runCmd(errCmd)
+	if _, ok := errResult.(errMsg); !ok {
+		t.Errorf("error command returned %T, want errMsg", errResult)
+	}
+	if len(v.postingList.postings) != 2 {
+		t.Error("failed action should keep the selected posting")
+	}
+	if v.notice != "" {
+		t.Errorf("failed action notice = %q, want empty", v.notice)
+	}
+}
+
 func TestMailViewPostingActionRemoves(t *testing.T) {
 	v := mailWithPostings()
 	if len(v.postingList.postings) != 2 {
@@ -146,6 +293,27 @@ func TestMailViewPostingActionError(t *testing.T) {
 }
 
 // --- Content key handling ---
+
+func TestMailViewEnterOpensSelectedThread(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusOK)
+
+	msg := runCmd(v.HandleContentKey(keyPress("enter")))
+	loaded, ok := msg.(topicLoadedMsg)
+	if !ok {
+		t.Fatalf("open command returned %T, want topicLoadedMsg", msg)
+	}
+	v.Update(loaded)
+
+	if recorded.method != http.MethodGet || recorded.path != "/topics/100/entries" {
+		t.Errorf("request = %s %s, want GET /topics/100/entries", recorded.method, recorded.path)
+	}
+	if !v.inThread || v.topicID != 100 || v.topicName != "Hello world" {
+		t.Errorf("thread state = open:%v id:%d name:%q", v.inThread, v.topicID, v.topicName)
+	}
+	if !strings.Contains(v.View(), "Alice") || !strings.Contains(v.View(), "Message body") {
+		t.Errorf("thread view does not contain the fetched entry: %q", v.View())
+	}
+}
 
 func TestMailViewContentKeyUpDown(t *testing.T) {
 	v := mailWithPostings()
@@ -296,6 +464,7 @@ func TestMailViewHelpBindingsInThread(t *testing.T) {
 
 func TestMailViewBoxShortcut(t *testing.T) {
 	v := mailWithPostings()
+	v.notice = "previous action"
 	cmd := v.handleBoxShortcut("F") // The Feed
 	if cmd == nil {
 		t.Fatal("box shortcut 'F' should return a command")
@@ -305,6 +474,9 @@ func TestMailViewBoxShortcut(t *testing.T) {
 	}
 	if !v.loading {
 		t.Error("should be loading after box switch")
+	}
+	if v.notice != "" {
+		t.Errorf("box switch should clear the previous notice, got %q", v.notice)
 	}
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -6,9 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	tea "charm.land/bubbletea/v2"
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/models"
@@ -316,6 +320,26 @@ func TestMailViewPostingKeyFailureKeepsPosting(t *testing.T) {
 	}
 }
 
+func TestMailViewPostingActionCopiesSelectedPostingBeforeAsyncRequest(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+
+	cmd := v.HandleContentKey(keyPress("t"))
+	v.Update(postingActionDoneMsg{
+		action: "moved to Trash", boxID: 1, postingID: 100, removes: true,
+	})
+	done, ok := runCmd(cmd).(postingActionDoneMsg)
+	if !ok {
+		t.Fatalf("posting command returned %T, want postingActionDoneMsg", done)
+	}
+
+	if len(recorded.body.PostingIDs) != 1 || recorded.body.PostingIDs[0] != 100 {
+		t.Errorf("request posting_ids = %v, want the originally selected posting [100]", recorded.body.PostingIDs)
+	}
+	if done.postingID != 100 {
+		t.Errorf("completion posting ID = %d, want 100", done.postingID)
+	}
+}
+
 func TestMailViewPostingCompletionUpdatesOriginatingPosting(t *testing.T) {
 	v, _ := mailWithTestServer(t, http.StatusNoContent)
 	v.Resize(80, 2)
@@ -443,6 +467,116 @@ func TestMailViewEnterOpensSelectedThread(t *testing.T) {
 	}
 	if !strings.Contains(v.View(), "Alice") || !strings.Contains(v.View(), "Message body") {
 		t.Errorf("thread view does not contain the fetched entry: %q", v.View())
+	}
+}
+
+func TestMailViewFetchesThreadMessagesConcurrentlyInOrder(t *testing.T) {
+	const entryCount = 12
+
+	var active atomic.Int64
+	var maximum atomic.Int64
+	started := make(chan struct{}, entryCount)
+	release := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/topics/100.json" {
+			entries := make([]map[string]any, entryCount)
+			for i := range entries {
+				entries[i] = map[string]any{"id": 501 + i, "kind": "message"}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 100, "name": "Thread", "entries": entries})
+			return
+		}
+
+		idText := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/messages/"), ".json")
+		id, err := strconv.ParseInt(idText, 10, 64)
+		if err != nil {
+			http.Error(w, "bad message ID", http.StatusBadRequest)
+			return
+		}
+
+		current := active.Add(1)
+		for {
+			previous := maximum.Load()
+			if current <= previous || maximum.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+		started <- struct{}{}
+		<-release
+		active.Add(-1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": id, "subject": fmt.Sprintf("Message %d", id), "content": fmt.Sprintf("body %d", id),
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client := hey.NewClient(
+		&hey.Config{BaseURL: server.URL},
+		&hey.StaticTokenProvider{Token: "test-token"},
+		hey.WithMaxRetries(0),
+	)
+	vc := testVC()
+	vc.sdk = client
+	vc.ctx = context.Background()
+	v := newMailView(vc)
+	v.boxes = orderBoxes(testBoxes())
+	v.Update(currentPostingsLoaded(v, testPostings()))
+
+	result := make(chan tea.Msg, 1)
+	cmd := v.HandleContentKey(keyPress("enter"))
+	go func() { result <- cmd() }()
+
+	startedCount := 0
+	deadline := time.NewTimer(2 * time.Second)
+waitForLimit:
+	for startedCount < maxConcurrentMessageFetches {
+		select {
+		case <-started:
+			startedCount++
+		case <-deadline.C:
+			break waitForLimit
+		}
+	}
+	if !deadline.Stop() {
+		select {
+		case <-deadline.C:
+		default:
+		}
+	}
+
+	if startedCount == maxConcurrentMessageFetches {
+		select {
+		case <-started:
+			startedCount++
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	observedConcurrency := maximum.Load()
+	close(release)
+	loaded, ok := (<-result).(topicLoadedMsg)
+	if !ok {
+		t.Fatalf("thread command did not return topicLoadedMsg")
+	}
+
+	if startedCount < maxConcurrentMessageFetches {
+		t.Errorf("started %d concurrent message requests, want %d", startedCount, maxConcurrentMessageFetches)
+	}
+	if observedConcurrency <= 1 {
+		t.Errorf("message requests were sequential, maximum concurrency = %d", observedConcurrency)
+	}
+	if observedConcurrency > maxConcurrentMessageFetches {
+		t.Errorf("message request concurrency = %d, limit = %d", observedConcurrency, maxConcurrentMessageFetches)
+	}
+	if len(loaded.entries) != entryCount {
+		t.Fatalf("loaded %d entries, want %d", len(loaded.entries), entryCount)
+	}
+	for i, entry := range loaded.entries {
+		wantID := int64(501 + i)
+		if entry.ID != wantID {
+			t.Errorf("entry %d ID = %d, want %d", i, entry.ID, wantID)
+		}
 	}
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -22,8 +22,16 @@ func mailWithPostings() *mailView {
 	v := newMailView(testVC())
 	v.boxes = orderBoxes(testBoxes())
 	v.boxIndex = 0
-	v.Update(postingsLoadedMsg{postings: testPostings()})
+	v.Update(currentPostingsLoaded(v, testPostings()))
 	return v
+}
+
+func currentPostingsLoaded(v *mailView, postings []models.Posting) postingsLoadedMsg {
+	return postingsLoadedMsg{
+		requestID: v.activeRequestID,
+		boxID:     v.currentBoxID(),
+		postings:  postings,
+	}
 }
 
 type recordedMailRequest struct {
@@ -80,7 +88,7 @@ func mailWithTestServer(t *testing.T, status int) (*mailView, *recordedMailReque
 	v := newMailView(vc)
 	v.Resize(vc.width, vc.height)
 	v.boxes = orderBoxes(testBoxes())
-	v.Update(postingsLoadedMsg{postings: testPostings()})
+	v.Update(currentPostingsLoaded(v, testPostings()))
 	return v, recorded
 }
 
@@ -128,7 +136,7 @@ func TestMailViewHandlesPostingsLoaded(t *testing.T) {
 	v.boxes = testBoxes()
 	v.loading = true
 
-	_, consumed := v.Update(postingsLoadedMsg{postings: testPostings()})
+	_, consumed := v.Update(currentPostingsLoaded(v, testPostings()))
 	if !consumed {
 		t.Error("postingsLoadedMsg should be consumed")
 	}
@@ -140,20 +148,73 @@ func TestMailViewHandlesPostingsLoaded(t *testing.T) {
 	}
 }
 
+func TestMailViewIgnoresPostingLoadFromEarlierBoxVisit(t *testing.T) {
+	v := mailWithPostings()
+
+	v.SubnavRight()
+	stale := currentPostingsLoaded(v, []models.Posting{{ID: 200, Summary: "The Feed message"}})
+	v.SubnavLeft()
+	current := currentPostingsLoaded(v, []models.Posting{{ID: 300, Summary: "Current Imbox message"}})
+	v.Update(current)
+	v.Update(stale)
+
+	if len(v.postingList.postings) != 1 || v.postingList.postings[0].ID != 300 {
+		t.Errorf("an earlier box visit overwrote the current postings: %v", v.postingList.postings)
+	}
+}
+
+func TestMailViewReportsCurrentPostingLoadFailure(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusBadRequest)
+
+	failed, ok := runCmd(v.SubnavRight()).(postingsLoadedMsg)
+	if !ok || failed.err == nil {
+		t.Fatalf("posting load returned %#v, want an error", failed)
+	}
+	cmd, consumed := v.Update(failed)
+
+	if !consumed || cmd == nil {
+		t.Fatal("current posting load error should be reported")
+	}
+	if _, ok := runCmd(cmd).(errMsg); !ok {
+		t.Error("current posting load error should produce errMsg")
+	}
+	if v.loading {
+		t.Error("failed current posting load should stop loading")
+	}
+}
+
+func TestMailViewIgnoresPostingErrorFromEarlierBoxVisit(t *testing.T) {
+	v := mailWithPostings()
+
+	v.SubnavRight()
+	stale := currentPostingsLoaded(v, nil)
+	stale.err = fmt.Errorf("old box failed")
+	v.SubnavLeft()
+	cmd, consumed := v.Update(stale)
+
+	if !consumed || cmd != nil {
+		t.Error("an earlier box error should be ignored")
+	}
+	if !v.loading {
+		t.Error("an earlier box error should not stop the current box load")
+	}
+}
+
 func TestMailViewHandlesTopicLoaded(t *testing.T) {
 	v := mailWithPostings()
 	v.loading = true
 
 	_, consumed := v.Update(topicLoadedMsg{
 		boxID:   1,
+		topicID: 100,
 		title:   "Test topic",
 		entries: []models.Entry{{Creator: models.Contact{Name: "Alice"}, Body: "hello"}},
 	})
 	if !consumed {
 		t.Error("topicLoadedMsg should be consumed")
 	}
-	if !v.inThread {
-		t.Error("should be in thread after topic loaded")
+	if !v.inThread || v.topicID != 100 || v.topicName != "Test topic" {
+		t.Errorf("thread state = open:%v id:%d name:%q", v.inThread, v.topicID, v.topicName)
 	}
 	if v.loading {
 		t.Error("loading should be false")
@@ -287,7 +348,7 @@ func TestMailViewIgnoresPostingCompletionAfterBoxSwitch(t *testing.T) {
 		t.Fatalf("posting command returned %T, want postingActionDoneMsg", msg)
 	}
 	v.SubnavRight()
-	v.Update(postingsLoadedMsg{postings: []models.Posting{{ID: 200, Summary: "Other box"}}})
+	v.Update(currentPostingsLoaded(v, []models.Posting{{ID: 200, Summary: "Other box"}}))
 	v.Update(done)
 
 	if len(v.postingList.postings) != 1 || v.postingList.postings[0].ID != 200 {
@@ -307,7 +368,7 @@ func TestMailViewReportsPostingFailureAfterBoxSwitch(t *testing.T) {
 		t.Fatalf("posting command returned %#v, want an action error", msg)
 	}
 	v.SubnavRight()
-	v.Update(postingsLoadedMsg{postings: []models.Posting{{ID: 200, Summary: "Other box"}}})
+	v.Update(currentPostingsLoaded(v, []models.Posting{{ID: 200, Summary: "Other box"}}))
 	errCmd, consumed := v.Update(done)
 
 	if !consumed || errCmd == nil {
@@ -397,20 +458,86 @@ func TestMailViewIgnoresThreadLoadAfterBoxSwitch(t *testing.T) {
 	}
 }
 
+func TestMailViewIgnoresThreadLoadAfterReturningToOriginBox(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusOK)
+
+	loaded := runCmd(v.HandleContentKey(keyPress("enter")))
+	v.SubnavRight()
+	v.SubnavLeft()
+	v.Update(loaded)
+
+	if v.inThread {
+		t.Error("a stale thread load should not reopen after returning to its source box")
+	}
+	if !v.loading {
+		t.Error("a stale thread load should not stop the current box load")
+	}
+}
+
+func TestMailViewIgnoresEarlierThreadLoadInSameBox(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusOK)
+
+	earlier := runCmd(v.HandleContentKey(keyPress("enter")))
+	v.postingList.moveDown()
+	_ = v.openSelected()
+	v.Update(earlier)
+
+	if v.inThread {
+		t.Error("an earlier thread load should not replace a newer open request")
+	}
+	if !v.loading {
+		t.Error("an earlier thread load should not stop the newer open request")
+	}
+}
+
 func TestMailViewIgnoresReplyLoadAfterBoxSwitch(t *testing.T) {
 	v := mailWithPostings()
+	v.inThread = true
+	_ = v.loadReplyContext(100, "Hello world")
+	loaded := replyContextLoadedMsg{
+		requestID: v.activeRequestID,
+		boxID:     1,
+		topicID:   100,
+		topicName: "Hello world",
+		entryID:   501,
+		to:        []string{"jane@example.com"},
+	}
 
 	v.SubnavRight()
-	cmd, consumed := v.Update(replyContextLoadedMsg{
-		boxID: 1, topicID: 100, topicName: "Hello world", entryID: 501,
-		to: []string{"jane@example.com"},
-	})
+	cmd, consumed := v.Update(loaded)
 
 	if !consumed {
 		t.Error("stale reply context should be consumed")
 	}
 	if cmd != nil || v.compose != nil {
 		t.Error("stale reply context should not open the reply form")
+	}
+}
+
+func TestMailViewIgnoresReplyLoadAfterThreadExit(t *testing.T) {
+	v := mailWithPostings()
+	v.inThread = true
+	_ = v.loadReplyContext(100, "Hello world")
+	loaded := replyContextLoadedMsg{
+		requestID: v.activeRequestID,
+		boxID:     1,
+		topicID:   100,
+		topicName: "Hello world",
+		entryID:   501,
+		to:        []string{"jane@example.com"},
+	}
+
+	v.ExitThread()
+	cmd, consumed := v.Update(loaded)
+
+	if !consumed || cmd != nil {
+		t.Error("a canceled reply load should be ignored")
+	}
+	if v.compose != nil {
+		t.Error("a canceled reply load should not open the reply form")
+	}
+	if v.loading {
+		t.Error("a canceled reply load should not keep loading")
 	}
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func testVC() *viewContext {
-	return &viewContext{styles: newStyles(), width: 80, height: 30}
+	return &viewContext{ctx: context.Background(), styles: newStyles(), width: 80, height: 30}
 }
 
 func mailWithPostings() *mailView {
@@ -340,6 +340,33 @@ func TestMailViewPostingActionCopiesSelectedPostingBeforeAsyncRequest(t *testing
 	}
 }
 
+func TestMailViewPostingCompletionInvalidatesConcurrentReload(t *testing.T) {
+	v := mailWithPostings()
+
+	v.SubnavRight()
+	v.SubnavLeft()
+	staleRequestID := v.activeRequestID
+	stale := currentPostingsLoaded(v, testPostings())
+
+	refresh, consumed := v.Update(postingActionDoneMsg{
+		action: "moved to Trash", boxID: 1, postingID: 100, removes: true,
+	})
+	if !consumed || refresh == nil {
+		t.Fatal("action completion should replace a concurrent reload with a fresh reload")
+	}
+	if v.activeRequestID == staleRequestID {
+		t.Fatal("action completion should invalidate the concurrent reload")
+	}
+
+	v.Update(stale)
+	if v.postingIndex(100) >= 0 {
+		t.Error("stale reload restored the posting removed by the completed action")
+	}
+	if !v.loading {
+		t.Error("stale reload should not stop the post-action refresh")
+	}
+}
+
 func TestMailViewPostingCompletionUpdatesOriginatingPosting(t *testing.T) {
 	v, _ := mailWithTestServer(t, http.StatusNoContent)
 	v.Resize(80, 2)
@@ -577,6 +604,69 @@ waitForLimit:
 		if entry.ID != wantID {
 			t.Errorf("entry %d ID = %d, want %d", i, entry.ID, wantID)
 		}
+	}
+}
+
+func TestMailViewCancelPendingDetailStopsMessageRequests(t *testing.T) {
+	messageStarted := make(chan struct{})
+	messageCanceled := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/topics/100.json":
+			_, _ = w.Write([]byte(`{"id":100,"name":"Hello world","entries":[{"id":501,"kind":"message"}]}`))
+		case "/messages/501.json":
+			close(messageStarted)
+			<-r.Context().Done()
+			close(messageCanceled)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := hey.NewClient(
+		&hey.Config{BaseURL: server.URL},
+		&hey.StaticTokenProvider{Token: "test-token"},
+		hey.WithMaxRetries(0),
+	)
+	vc := testVC()
+	vc.sdk = client
+	v := newMailView(vc)
+	v.boxes = orderBoxes(testBoxes())
+	v.Update(currentPostingsLoaded(v, testPostings()))
+
+	result := make(chan tea.Msg, 1)
+	cmd := v.HandleContentKey(keyPress("enter"))
+	go func() { result <- cmd() }()
+
+	select {
+	case <-messageStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("message request did not start")
+	}
+
+	if !v.CancelPendingDetail() {
+		t.Fatal("pending thread load should be cancellable")
+	}
+	select {
+	case <-messageCanceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceling the detail load did not cancel its HTTP request")
+	}
+
+	select {
+	case msg := <-result:
+		loaded, ok := msg.(topicLoadedMsg)
+		if !ok || loaded.err == nil {
+			t.Fatalf("canceled command returned %#v, want topicLoadedMsg with an error", msg)
+		}
+		if cmd, consumed := v.Update(loaded); !consumed || cmd != nil {
+			t.Error("canceled detail result should be ignored without reporting an error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled detail command did not return")
 	}
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -301,6 +301,47 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 	}
 }
 
+func TestMailViewMoveWithinCurrentBoxKeepsPosting(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		kind  string
+		boxID int64
+	}{
+		{"reply later", "l", hey.BoxKindLater, 4},
+		{"set aside", "a", hey.BoxKindSetAside, 3},
+		{"feed", "d", hey.BoxKindFeed, 2},
+		{"paper trail", "p", hey.BoxKindTrail, 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, recorded := mailWithTestServer(t, http.StatusNoContent)
+			v.boxes = []models.Box{{ID: tt.boxID, Kind: tt.kind, Name: tt.name}}
+			v.boxIndex = 0
+
+			msg := runCmd(v.HandleContentKey(keyPress(tt.key)))
+			done, ok := msg.(postingActionDoneMsg)
+			if !ok || done.err != nil {
+				t.Fatalf("posting command returned %#v", msg)
+			}
+			if done.removes {
+				t.Fatal("move within the current box should keep the posting visible")
+			}
+			v.Update(done)
+
+			if len(v.postingList.postings) != len(testPostings()) || v.postingList.postings[0].ID != 100 {
+				t.Errorf("move within current box changed postings: %v", v.postingList.postings)
+			}
+			if recorded.body.BoxID == nil {
+				t.Errorf("box_id is omitted, want %d", tt.boxID)
+			} else if *recorded.body.BoxID != tt.boxID {
+				t.Errorf("box_id = %d, want %d", *recorded.body.BoxID, tt.boxID)
+			}
+		})
+	}
+}
+
 func TestMailViewPostingKeyFailureKeepsPosting(t *testing.T) {
 	v, _ := mailWithTestServer(t, http.StatusInternalServerError)
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -198,6 +198,9 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 			if !ok || done.err != nil {
 				t.Fatalf("posting command returned %#v", msg)
 			}
+			if done.boxID != 1 || done.postingID != 100 {
+				t.Errorf("action origin = box %d posting %d, want box 1 posting 100", done.boxID, done.postingID)
+			}
 			v.Update(done)
 
 			if recorded.method != http.MethodPost || recorded.path != tt.path {
@@ -252,13 +255,49 @@ func TestMailViewPostingKeyFailureKeepsPosting(t *testing.T) {
 	}
 }
 
+func TestMailViewPostingCompletionUpdatesOriginatingPosting(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusNoContent)
+
+	msg := runCmd(v.HandleContentKey(keyPress("t")))
+	done, ok := msg.(postingActionDoneMsg)
+	if !ok {
+		t.Fatalf("posting command returned %T, want postingActionDoneMsg", msg)
+	}
+	v.postingList.moveDown()
+	v.Update(done)
+
+	if len(v.postingList.postings) != 1 || v.postingList.postings[0].ID != 101 {
+		t.Errorf("postings after completion = %v, want only posting 101", v.postingList.postings)
+	}
+}
+
+func TestMailViewIgnoresPostingCompletionAfterBoxSwitch(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusNoContent)
+
+	msg := runCmd(v.HandleContentKey(keyPress("t")))
+	done, ok := msg.(postingActionDoneMsg)
+	if !ok {
+		t.Fatalf("posting command returned %T, want postingActionDoneMsg", msg)
+	}
+	v.SubnavRight()
+	v.Update(postingsLoadedMsg{postings: []models.Posting{{ID: 200, Summary: "Other box"}}})
+	v.Update(done)
+
+	if len(v.postingList.postings) != 1 || v.postingList.postings[0].ID != 200 {
+		t.Errorf("stale completion changed the new box: %v", v.postingList.postings)
+	}
+	if v.notice != "" {
+		t.Errorf("stale completion notice = %q, want empty", v.notice)
+	}
+}
+
 func TestMailViewPostingActionRemoves(t *testing.T) {
 	v := mailWithPostings()
 	if len(v.postingList.postings) != 2 {
 		t.Fatalf("expected 2 postings, got %d", len(v.postingList.postings))
 	}
 
-	v.Update(postingActionDoneMsg{action: "moved to Trash", removes: true})
+	v.Update(postingActionDoneMsg{action: "moved to Trash", boxID: 1, postingID: 100, removes: true})
 	if len(v.postingList.postings) != 1 {
 		t.Errorf("expected 1 posting after remove, got %d", len(v.postingList.postings))
 	}
@@ -270,7 +309,7 @@ func TestMailViewPostingActionMarksSeen(t *testing.T) {
 		t.Fatal("first posting should be unseen")
 	}
 
-	v.Update(postingActionDoneMsg{action: "marked as seen"})
+	v.Update(postingActionDoneMsg{action: "marked as seen", boxID: 1, postingID: 100})
 	if !v.postingList.postings[0].Seen {
 		t.Error("first posting should be seen after action")
 	}
@@ -278,7 +317,7 @@ func TestMailViewPostingActionMarksSeen(t *testing.T) {
 
 func TestMailViewPostingActionError(t *testing.T) {
 	v := mailWithPostings()
-	cmd, consumed := v.Update(postingActionDoneMsg{err: fmt.Errorf("network error")})
+	cmd, consumed := v.Update(postingActionDoneMsg{boxID: 1, postingID: 100, err: fmt.Errorf("network error")})
 
 	if !consumed {
 		t.Error("postingActionDoneMsg with error should be consumed")
@@ -372,12 +411,20 @@ func TestMailViewSubnavLeftRight(t *testing.T) {
 	}
 
 	// Go right
+	v.inThread = true
+	v.notice = "previous action"
 	v.SubnavRight()
 	if v.boxIndex != 1 {
 		t.Errorf("after SubnavRight: boxIndex = %d, want 1", v.boxIndex)
 	}
 	if !v.loading {
 		t.Error("SubnavRight should set loading")
+	}
+	if v.inThread {
+		t.Error("SubnavRight should close the open thread")
+	}
+	if v.notice != "" {
+		t.Errorf("SubnavRight should clear the previous notice, got %q", v.notice)
 	}
 
 	v.loading = false
@@ -464,6 +511,7 @@ func TestMailViewHelpBindingsInThread(t *testing.T) {
 
 func TestMailViewBoxShortcut(t *testing.T) {
 	v := mailWithPostings()
+	v.inThread = true
 	v.notice = "previous action"
 	cmd := v.handleBoxShortcut("F") // The Feed
 	if cmd == nil {
@@ -477,6 +525,9 @@ func TestMailViewBoxShortcut(t *testing.T) {
 	}
 	if v.notice != "" {
 		t.Errorf("box switch should clear the previous notice, got %q", v.notice)
+	}
+	if v.inThread {
+		t.Error("box switch should close the open thread")
 	}
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -44,7 +44,7 @@ type recordedMailRequest struct {
 	requests []string
 	body     struct {
 		PostingIDs []int64 `json:"posting_ids"`
-		BoxID      int64   `json:"box_id"`
+		BoxID      *int64  `json:"box_id"`
 	}
 }
 
@@ -274,8 +274,14 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 			if len(recorded.body.PostingIDs) != 1 || recorded.body.PostingIDs[0] != 100 {
 				t.Errorf("posting_ids = %v, want [100]", recorded.body.PostingIDs)
 			}
-			if tt.boxID != 0 && recorded.body.BoxID != tt.boxID {
-				t.Errorf("box_id = %d, want %d", recorded.body.BoxID, tt.boxID)
+			if tt.boxID == 0 {
+				if recorded.body.BoxID != nil {
+					t.Errorf("box_id = %d, want field omitted", *recorded.body.BoxID)
+				}
+			} else if recorded.body.BoxID == nil {
+				t.Errorf("box_id is omitted, want %d", tt.boxID)
+			} else if *recorded.body.BoxID != tt.boxID {
+				t.Errorf("box_id = %d, want %d", *recorded.body.BoxID, tt.boxID)
 			}
 
 			wantPostings := 2
@@ -849,6 +855,23 @@ func TestMailViewSubnavLeftRight(t *testing.T) {
 	v.SubnavRight()
 	if v.boxIndex != 2 {
 		t.Errorf("SubnavRight at end: boxIndex = %d, want 2", v.boxIndex)
+	}
+}
+
+func TestMailViewBoxSwitchClearsPostingsDuringLoad(t *testing.T) {
+	v := mailWithPostings()
+
+	if cmd := v.SubnavRight(); cmd == nil {
+		t.Fatal("box switch should start loading the new box")
+	}
+	if len(v.postingList.postings) != 0 {
+		t.Fatalf("postings during box load = %v, want none", v.postingList.postings)
+	}
+
+	for _, key := range []string{"enter", "r", "t"} {
+		if cmd := v.HandleContentKey(keyPress(key)); cmd != nil {
+			t.Errorf("key %q acted on a posting from the previous box", key)
+		}
 	}
 }
 

--- a/internal/tui/section_view.go
+++ b/internal/tui/section_view.go
@@ -62,3 +62,9 @@ type sectionView interface {
 type inputCapturer interface {
 	CapturingInput() bool
 }
+
+// pendingDetailCanceler is implemented by section views whose detail reads can
+// be canceled before the detail view opens.
+type pendingDetailCanceler interface {
+	CancelPendingDetail() bool
+}

--- a/internal/tui/translate_test.go
+++ b/internal/tui/translate_test.go
@@ -66,6 +66,35 @@ func TestSDKBoxToModel(t *testing.T) {
 	}
 }
 
+func TestSDKMessageToEntry(t *testing.T) {
+	created := time.Date(2026, 8, 18, 9, 30, 0, 0, time.UTC)
+	updated := time.Date(2026, 8, 18, 11, 0, 0, 0, time.UTC)
+
+	got := sdkMessageToEntry(generated.Entry{
+		Id: 501, Kind: "message", Summary: "Thread summary", CreatedAt: created,
+		AlternativeSenderName: "Support", AppUrl: "https://app.hey.com/messages/501",
+		Creator: generated.Contact{Id: 42, Name: "Jane Dawson", EmailAddress: "jane@example.com"},
+	}, generated.Message{
+		Id: 501, Subject: "Thread subject", Content: "<p>Message body</p>", UpdatedAt: updated,
+	})
+
+	if got.ID != 501 || got.Kind != "message" || got.Summary != "Thread summary" {
+		t.Errorf("identity fields wrong: %+v", got)
+	}
+	if got.CreatedAt != "2026-08-18T09:30:00Z" || got.UpdatedAt != "2026-08-18T11:00:00Z" {
+		t.Errorf("timestamps = %q / %q", got.CreatedAt, got.UpdatedAt)
+	}
+	if got.Body != "<p>Message body</p>" || got.BodyHTML != got.Body {
+		t.Errorf("body = %q / %q", got.Body, got.BodyHTML)
+	}
+	if got.Creator.ID != 42 || got.Creator.EmailAddress != "jane@example.com" {
+		t.Errorf("creator = %+v", got.Creator)
+	}
+	if got.AlternativeSenderName != "Support" || got.AppURL != "https://app.hey.com/messages/501" {
+		t.Errorf("sender or URL wrong: %+v", got)
+	}
+}
+
 func TestSDKCalendarToModel(t *testing.T) {
 	got := sdkCalendarToModel(generated.Calendar{
 		Id: 4732, Name: "Rob Zolkos", Kind: "personal",

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -261,7 +261,7 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.activeView.ExitThread()
 			m.updateHelpBindings()
 			m.activeView.Resize(m.vc.width, m.vc.height)
-			return m, nil
+			return m, m.syncLoading(nil)
 		}
 		return m, nil
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -263,6 +263,10 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.activeView.Resize(m.vc.width, m.vc.height)
 			return m, m.syncLoading(nil)
 		}
+		if canceler, ok := m.activeView.(pendingDetailCanceler); ok && canceler.CancelPendingDetail() {
+			m.updateHelpBindings()
+			return m, m.syncLoading(nil)
+		}
 		return m, nil
 	}
 
@@ -358,8 +362,8 @@ func formatTimestamp(ts time.Time) string {
 
 var imageHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
-func fetchImageData(imgURL string) []byte {
-	req, err := http.NewRequestWithContext(context.Background(), "GET", imgURL, nil)
+func fetchImageData(ctx context.Context, imgURL string) []byte {
+	req, err := http.NewRequestWithContext(ctx, "GET", imgURL, nil)
 	if err != nil {
 		return nil
 	}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -27,7 +27,7 @@ func modelWithBoxes() model {
 	updated, _ := m.Update(boxesLoadedMsg(testBoxes()))
 	m = updated.(model)
 	// Simulate postings loaded for first box
-	updated, _ = m.Update(postingsLoadedMsg{postings: testPostings()})
+	updated, _ = m.Update(currentPostingsLoaded(m.mailView, testPostings()))
 	return updated.(model)
 }
 
@@ -219,6 +219,25 @@ func TestQExitsThread(t *testing.T) {
 	result := updated.(model)
 	if result.activeView.InThread() {
 		t.Error("q should exit thread")
+	}
+}
+
+func TestQExitsPendingReplyLoad(t *testing.T) {
+	m := modelWithBoxes()
+	m.mailView.inThread = true
+	m.mailView.topicID = 100
+	m.mailView.topicName = "Hello world"
+
+	updated, _ := m.Update(keyPress("r"))
+	m = updated.(model)
+	if !m.mailView.loading || !m.loading {
+		t.Fatal("reply should start loading")
+	}
+
+	updated, _ = m.Update(keyPress("q"))
+	result := updated.(model)
+	if result.mailView.loading || result.loading {
+		t.Error("q should stop a canceled reply load")
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -241,6 +241,39 @@ func TestQExitsPendingReplyLoad(t *testing.T) {
 	}
 }
 
+func TestQExitsPendingReplyLoadFromPostingList(t *testing.T) {
+	m := modelWithBoxes()
+
+	updated, cmd := m.Update(keyPress("r"))
+	m = updated.(model)
+	if cmd == nil || !m.mailView.loading || !m.loading {
+		t.Fatal("reply from the posting list should start loading")
+	}
+	requestID := m.mailView.activeRequestID
+
+	updated, _ = m.Update(keyPress("q"))
+	m = updated.(model)
+	if m.mailView.loading || m.loading {
+		t.Error("q should stop a reply started from the posting list")
+	}
+	if m.mailView.activeRequestKind != mailRequestNone || m.mailView.requestCancel != nil {
+		t.Error("q should clear the pending reply request")
+	}
+
+	updated, _ = m.Update(replyContextLoadedMsg{
+		requestID: requestID,
+		boxID:     1,
+		topicID:   100,
+		topicName: "Hello world",
+		entryID:   501,
+		to:        []string{"jane@example.com"},
+	})
+	m = updated.(model)
+	if m.mailView.compose != nil {
+		t.Error("a canceled reply load should not open the reply form")
+	}
+}
+
 func TestBoxShortcutExitsThread(t *testing.T) {
 	m := modelWithBoxes()
 	m.mailView.inThread = true

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -222,6 +222,17 @@ func TestQExitsThread(t *testing.T) {
 	}
 }
 
+func TestBoxShortcutExitsThread(t *testing.T) {
+	m := modelWithBoxes()
+	m.mailView.inThread = true
+
+	updated, _ := m.Update(keyPress("F"))
+	result := updated.(model)
+	if result.activeView.InThread() {
+		t.Error("switching boxes should exit thread")
+	}
+}
+
 // --- Content list ---
 
 func TestContentListNavigation(t *testing.T) {


### PR DESCRIPTION
## Summary

- exercise every TUI posting-action key through `HandleContentKey` and the SDK HTTP boundary
- verify endpoint, posting ID, destination box, optimistic removal, seen state, and failure behavior
- show one-shot success notices for posting actions and clear them when switching boxes
- cover opening a selected posting and rendering its fetched thread

Basecamp card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10216118313

## Validation

- `mise exec -- make test`
- `mise exec -- go test -race ./internal/tui`
- `mise exec golangci-lint@2.12.2 -- golangci-lint run ./...`
- built and authenticated the current `./bin/hey` against the production account
- sent dedicated validation messages only to the approved test address
- drove the rebuilt TUI through Imbox -> Set Aside -> Trash
- confirmed each action removed the selected message and displayed its success notice
- confirmed switching to Set Aside showed the moved message and cleared the prior notice
- confirmed typed topic/message reads render a production thread
- confirmed Reply Later removes the message from Imbox and it appears in Reply Later
- confirmed rapid box round trips do not apply stale postings or reopen stale threads
- confirmed canceling a pending reply does not reopen compose
- confirmed a production 10-entry thread opens with bounded concurrent reads
- rebased onto current `origin/main`

TUI statement coverage increased from 56.5% to 61.6%. `doPostingAction` is now at 100%, `openSelected` at 85.7%, `handlePostingAction` at 65.5%, and `fetchTopic` at 62.9%.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end tests for TUI posting actions and hardens asynchronous mail reads. Old: stale loads/completions could update the wrong box/thread and box switches left old postings visible. New: reads are scoped by request and box; switching boxes clears postings and closes threads; pressing q cancels pending details. Side effects: actions show a one‑shot notice and refresh postings; thread fetches use bounded concurrency.

- Posting actions include `boxID` and `postingID`. Completions only update that posting in the same box, set a notice, ignore stale completions after a box switch, invalidate any concurrent reload, and start a fresh reload. Moves within the current box keep the posting visible and send `box_id`; moves to another box/trash/mute remove it.
- Switching boxes exits any open thread, clears the notice, clears the posting list while loading, and starts a new postings request; number‑key shortcuts behave the same.
- All mail reads carry `requestID` and `boxID` (`postingsLoadedMsg`, `topicLoadedMsg`, `replyContextLoadedMsg`). Loads/errors from earlier requests or other boxes are ignored. Pressing q cancels a pending thread or reply load and stops its HTTP request.
- Opening a posting fetches its thread via the SDK (`Topics().Get`, `Messages().Get`) with bounded concurrent message fetches (limit 6); adds `sdkMessageToEntry`; image fetches use the request context.
- Tests drive posting‑action keys through the SDK HTTP boundary; verify endpoints, `posting_ids`, and optional `box_id`; assert same‑box moves keep the posting, removal/seen behavior, failure handling, ignoring stale loads/completions, canceling detail stops HTTP, clearing stale postings on box switch, and rendering a fetched thread.
- Adds direct dependency on `golang.org/x/sync`.

<sup>Written for commit 4a45dba615cccf1fb4362d43e80002acd1eaa2a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

