### PR TITLE
Clarify CLI help wording

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -20,8 +20,8 @@ func newAuthCommand() *authCommand {
 	ac := &authCommand{}
 	ac.cmd = &cobra.Command{
 		Use:   "auth",
-		Short: "Manage authentication",
-		Long:  "Manage authentication with the HEY server via Launchpad OAuth.",
+		Short: "Sign in, sign out, and check login status",
+		Long:  "Sign in to HEY, sign out, or check your login status.",
 		Annotations: map[string]string{
 			"agent_notes": "Use status to check auth before other commands. Returns token expiry info in JSON. Use login --token for non-interactive auth.",
 		},

--- a/internal/cmd/box.go
+++ b/internal/cmd/box.go
@@ -26,8 +26,8 @@ func newBoxCommand() *boxCommand {
 	boxCommand := &boxCommand{}
 	boxCommand.cmd = &cobra.Command{
 		Use:   "box <name|id>",
-		Short: "List postings in a mailbox",
-		Long:  "List postings in a mailbox. Accepts a box name (imbox, feedbox, etc.) or numeric ID.",
+		Short: "List messages in a box",
+		Long:  "List messages in a HEY box. Accepts a box name (imbox, feedbox, etc.) or numeric ID.",
 		Annotations: map[string]string{
 			"agent_notes": "Accepts box name or numeric ID. Returns postings (threads). Use thread IDs with hey threads.",
 		},
@@ -38,7 +38,7 @@ func newBoxCommand() *boxCommand {
 		Args: validateBoxArgs,
 	}
 
-	boxCommand.cmd.Flags().IntVar(&boxCommand.limit, "limit", 0, "Maximum number of postings to show")
+	boxCommand.cmd.Flags().IntVar(&boxCommand.limit, "limit", 0, "Maximum number of messages to show")
 	boxCommand.cmd.Flags().BoolVar(&boxCommand.all, "all", false, "Fetch all results (override --limit)")
 
 	return boxCommand

--- a/internal/cmd/boxes.go
+++ b/internal/cmd/boxes.go
@@ -20,7 +20,7 @@ func newBoxesCommand() *boxesCommand {
 	boxesCommand := &boxesCommand{}
 	boxesCommand.cmd = &cobra.Command{
 		Use:   "boxes",
-		Short: "List mailboxes",
+		Short: "List your HEY boxes",
 		Annotations: map[string]string{
 			"agent_notes": "Returns all mailbox types. Use --ids-only to pipe IDs to hey box.",
 		},

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -25,7 +25,7 @@ func newComposeCommand() *composeCommand {
 	composeCommand := &composeCommand{}
 	composeCommand.cmd = &cobra.Command{
 		Use:   "compose",
-		Short: "Compose a new message",
+		Short: "Write and send a new email",
 		Annotations: map[string]string{
 			"agent_notes": "Starts a new thread with --to (optionally --cc/--bcc), which requires --subject, or replies to an existing one with --thread-id, which does not: a reply carries the thread's subject and goes to that thread's recipients.",
 		},

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -16,7 +16,7 @@ func newConfigCommand() *configCommand {
 	configCommand := &configCommand{}
 	configCommand.cmd = &cobra.Command{
 		Use:   "config",
-		Short: "Manage configuration",
+		Short: "View and change settings",
 	}
 
 	configCommand.cmd.AddCommand(newConfigShowCommand())

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -18,7 +18,7 @@ import (
 func newDoctorCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "doctor",
-		Short: "Check system health and configuration",
+		Short: "Find login and configuration problems",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			checks := runDoctorChecks()
 

--- a/internal/cmd/drafts.go
+++ b/internal/cmd/drafts.go
@@ -20,7 +20,7 @@ func newDraftsCommand() *draftsCommand {
 	draftsCommand := &draftsCommand{}
 	draftsCommand.cmd = &cobra.Command{
 		Use:   "drafts",
-		Short: "List drafts",
+		Short: "List draft emails",
 		Annotations: map[string]string{
 			"agent_notes": "Returns saved draft messages with IDs, summaries, and subjects.",
 		},

--- a/internal/cmd/habit.go
+++ b/internal/cmd/habit.go
@@ -18,7 +18,7 @@ func newHabitCommand() *habitCommand {
 	habitCommand := &habitCommand{}
 	habitCommand.cmd = &cobra.Command{
 		Use:   "habit",
-		Short: "Manage habit completions",
+		Short: "Track completed habits",
 		Annotations: map[string]string{
 			"agent_notes": "Subcommands: complete, uncomplete. Requires habit ID from calendar recordings.",
 		},

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -54,13 +54,13 @@ func customHelpFunc(defaultHelp func(*cobra.Command, []string)) func(*cobra.Comm
 func renderRootHelp(w io.Writer, cmd *cobra.Command) {
 	var b strings.Builder
 
-	b.WriteString("CLI for HEY\n")
+	b.WriteString("Read, send, and organize HEY email and calendars from your terminal.\n")
 
 	// USAGE
 	b.WriteString("\n")
 	b.WriteString(bold.format("USAGE") + "\n")
 	b.WriteString("  hey <command> [flags]\n")
-	b.WriteString("  hey                     Launch the interactive TUI\n")
+	b.WriteString("  hey                     Open the interactive app\n")
 
 	// Build lookup from command name → registered cobra.Command
 	registered := make(map[string]*cobra.Command, len(cmd.Commands()))
@@ -102,11 +102,11 @@ func renderRootHelp(w io.Writer, cmd *cobra.Command) {
 		desc  string
 	}
 	flags := []flagEntry{
-		{"", "--json", "Output as JSON envelope"},
+		{"", "--json", "Output JSON with metadata"},
 		{"", "--markdown", "Output as Markdown"},
-		{"", "--quiet", "Output raw data without envelope"},
-		{"-v", "--verbose", "Increase verbosity"},
-		{"", "--help", "Show help for command"},
+		{"", "--quiet", "Output result data only"},
+		{"-v", "--verbose", "Show request details"},
+		{"", "--help", "Show help"},
 		{"", "--version", "Show version"},
 	}
 	for _, f := range flags {
@@ -124,7 +124,7 @@ func renderRootHelp(w io.Writer, cmd *cobra.Command) {
 		"$ hey boxes",
 		"$ hey box imbox",
 		"$ hey threads 123",
-		`$ hey compose --to "someone@hey.com" -m "Hello!"`,
+		`$ hey compose --to alice@example.com --subject "Lunch plans" -m "Are you free Friday?"`,
 	}
 	for _, ex := range examples {
 		b.WriteString(italic.format("  "+ex) + "\n")

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCuratedCommandHelpUsesUserFacingLanguage(t *testing.T) {
+	root := newRootCmd()
+	tests := map[string]string{
+		"auth":  "Sign in to HEY, sign out, or check your login status.",
+		"setup": "Sign in and prepare HEY for first use.",
+	}
+
+	for name, expected := range tests {
+		t.Run(name, func(t *testing.T) {
+			command, _, err := root.Find([]string{name})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if command.Long != expected {
+				t.Fatalf("unexpected %s description: %q", name, command.Long)
+			}
+		})
+	}
+}
+
+func TestRenderRootHelpUsesUserFacingLanguage(t *testing.T) {
+	originalColorDisabled := colorDisabled
+	colorDisabled = true
+	t.Cleanup(func() { colorDisabled = originalColorDisabled })
+
+	var output strings.Builder
+	renderRootHelp(&output, newRootCmd())
+
+	const expected = `Read, send, and organize HEY email and calendars from your terminal.
+
+USAGE
+  hey <command> [flags]
+  hey                     Open the interactive app
+
+EMAIL
+  boxes    List your HEY boxes
+  box      List messages in a box
+  threads  Read a thread
+  compose  Write and send a new email
+  reply    Reply to a thread
+  drafts   List draft emails
+  seen     Mark messages as seen
+  unseen   Mark messages as unseen
+
+CALENDAR & TASKS
+  calendars   List calendars
+  recordings  List events, to-dos, and other calendar entries
+  todo        Create and manage to-dos
+  habit       Track completed habits
+  timetrack   Track time
+  journal     Read and write journal entries
+
+AUTH & CONFIG
+  auth    Sign in, sign out, and check login status
+  config  View and change settings
+  setup   Set up HEY for first use
+  doctor  Find login and configuration problems
+
+FLAGS
+      --json       Output JSON with metadata
+      --markdown   Output as Markdown
+      --quiet      Output result data only
+  -v, --verbose    Show request details
+      --help       Show help
+      --version    Show version
+
+EXAMPLES
+  $ hey boxes
+  $ hey box imbox
+  $ hey threads 123
+  $ hey compose --to alice@example.com --subject "Lunch plans" -m "Are you free Friday?"
+
+LEARN MORE
+  hey commands      List all available commands
+  hey <command> -h  Help for any command
+`
+
+	if output.String() != expected {
+		t.Fatalf("unexpected root help:\n%s", output.String())
+	}
+}

--- a/internal/cmd/journal.go
+++ b/internal/cmd/journal.go
@@ -19,7 +19,7 @@ func newJournalCommand() *journalCommand {
 	journalCommand := &journalCommand{}
 	journalCommand.cmd = &cobra.Command{
 		Use:   "journal",
-		Short: "Manage journal entries",
+		Short: "Read and write journal entries",
 		Annotations: map[string]string{
 			"agent_notes": "Subcommands: list, read, write. Read defaults to today. Write accepts --content, stdin, or opens $EDITOR.",
 		},

--- a/internal/cmd/recordings.go
+++ b/internal/cmd/recordings.go
@@ -24,7 +24,7 @@ func newRecordingsCommand() *recordingsCommand {
 	recordingsCommand := &recordingsCommand{}
 	recordingsCommand.cmd = &cobra.Command{
 		Use:   "recordings <calendar-id>",
-		Short: "List recordings (events, todos, etc.) for a calendar",
+		Short: "List events, to-dos, and other calendar entries",
 		Annotations: map[string]string{
 			"agent_notes": "Returns recordings grouped by type for a calendar. Defaults to today + 30 days.",
 		},
@@ -37,7 +37,7 @@ func newRecordingsCommand() *recordingsCommand {
 
 	recordingsCommand.cmd.Flags().StringVar(&recordingsCommand.startsOn, "starts-on", "", "Start date (YYYY-MM-DD, defaults to today)")
 	recordingsCommand.cmd.Flags().StringVar(&recordingsCommand.endsOn, "ends-on", "", "End date (YYYY-MM-DD, defaults to 30 days from starts-on)")
-	recordingsCommand.cmd.Flags().IntVar(&recordingsCommand.limit, "limit", 0, "Maximum number of recordings per type to show")
+	recordingsCommand.cmd.Flags().IntVar(&recordingsCommand.limit, "limit", 0, "Maximum number of calendar entries per type to show")
 	recordingsCommand.cmd.Flags().BoolVar(&recordingsCommand.all, "all", false, "Fetch all results (override --limit)")
 
 	return recordingsCommand

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -39,7 +39,7 @@ var (
 func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "hey",
-		Short: "CLI for HEY",
+		Short: "Read, send, and organize HEY email and calendars from your terminal.",
 		Long: `A CLI for HEY
 ⠀⠀⠀⠀⠀⠀⣰⠲⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
 ⠀⠀⠀⡟⢳⡀⣏⠀⠘⣆⠀⠀⠀⠀⠀⣤⣤⡄⠀⠀⢠⣤⣤⣤⣤⣤⣤⣤⣤⠀⠀⢀⣤⣤⡄⠀
@@ -97,9 +97,9 @@ func newRootCmd() *cobra.Command {
 
 	root.CompletionOptions.HiddenDefaultCmd = true
 
-	root.PersistentFlags().BoolVar(&jsonFlag, "json", false, "Output as JSON envelope")
+	root.PersistentFlags().BoolVar(&jsonFlag, "json", false, "Output JSON with metadata")
 	root.PersistentFlags().BoolVar(&htmlOutput, "html", false, "Output raw HTML (for commands that return HTML content)")
-	root.PersistentFlags().BoolVar(&quietFlag, "quiet", false, "Output raw data without envelope")
+	root.PersistentFlags().BoolVar(&quietFlag, "quiet", false, "Output result data only")
 	root.PersistentFlags().BoolVar(&idsOnly, "ids-only", false, "Output only IDs, one per line")
 	root.PersistentFlags().BoolVar(&countFlag, "count", false, "Output only the count of results")
 	root.PersistentFlags().BoolVar(&markdownF, "markdown", false, "Output as Markdown")
@@ -107,7 +107,7 @@ func newRootCmd() *cobra.Command {
 	root.PersistentFlags().BoolVar(&agentFlag, "agent", false, "Agent mode (JSON envelope, no TTY formatting)")
 	root.PersistentFlags().MarkHidden("agent") //nolint:errcheck,gosec // flag exists
 	root.PersistentFlags().StringVar(&baseURL, "base-url", "", "Override server URL")
-	root.PersistentFlags().CountVarP(&verboseFlag, "verbose", "v", "Increase verbosity (request logging)")
+	root.PersistentFlags().CountVarP(&verboseFlag, "verbose", "v", "Show request details")
 	root.PersistentFlags().BoolVar(&statsFlag, "stats", false, "Include request stats in response meta")
 
 	root.Version = version.Version

--- a/internal/cmd/seen.go
+++ b/internal/cmd/seen.go
@@ -17,7 +17,7 @@ func newSeenCommand() *seenCommand {
 	seenCommand := &seenCommand{}
 	seenCommand.cmd = &cobra.Command{
 		Use:   "seen <posting-id>...",
-		Short: "Mark postings as seen",
+		Short: "Mark messages as seen",
 		Example: `  hey seen 12345
   hey seen 12345 67890`,
 		Annotations: map[string]string{
@@ -64,7 +64,7 @@ func newUnseenCommand() *unseenCommand {
 	unseenCommand := &unseenCommand{}
 	unseenCommand.cmd = &cobra.Command{
 		Use:   "unseen <posting-id>...",
-		Short: "Mark postings as unseen",
+		Short: "Mark messages as unseen",
 		Example: `  hey unseen 12345
   hey unseen 12345 67890`,
 		Annotations: map[string]string{

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -14,8 +14,8 @@ import (
 func newSetupCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "setup",
-		Short: "First-run setup wizard",
-		Long:  "Walks through initial authentication setup for hey CLI.",
+		Short: "Set up HEY for first use",
+		Long:  "Sign in and prepare HEY for first use.",
 		Annotations: map[string]string{
 			"agent_notes": "Run this on first use. Performs OAuth login. Equivalent to hey auth login.",
 		},

--- a/internal/cmd/timetrack.go
+++ b/internal/cmd/timetrack.go
@@ -16,7 +16,7 @@ func newTimetrackCommand() *timetrackCommand {
 	timetrackCommand := &timetrackCommand{}
 	timetrackCommand.cmd = &cobra.Command{
 		Use:   "timetrack",
-		Short: "Manage time tracking",
+		Short: "Track time",
 		Annotations: map[string]string{
 			"agent_notes": "Subcommands: start, stop, current, list. Use current to check if tracking is active before start/stop.",
 		},

--- a/internal/cmd/todo.go
+++ b/internal/cmd/todo.go
@@ -17,7 +17,7 @@ func newTodoCommand() *todoCommand {
 	todoCommand := &todoCommand{}
 	todoCommand.cmd = &cobra.Command{
 		Use:   "todo",
-		Short: "Manage todos",
+		Short: "Create and manage to-dos",
 		Annotations: map[string]string{
 			"agent_notes": "Subcommands: list, add, complete, uncomplete, delete. Use list --ids-only to pipe IDs to complete/delete.",
 		},

--- a/internal/cmd/topic.go
+++ b/internal/cmd/topic.go
@@ -19,7 +19,7 @@ func newThreadsCommand() *topicCommand {
 	threadsCommand := &topicCommand{}
 	threadsCommand.cmd = &cobra.Command{
 		Use:   "threads <id>",
-		Short: "Read an email thread",
+		Short: "Read a thread",
 		Annotations: map[string]string{
 			"agent_notes": "Returns a thread with all entries. Use entry IDs with hey reply.",
 		},


### PR DESCRIPTION
## Summary

Make the CLI help clearer and more useful to HEY users.

- Replace internal terms such as "postings", "recordings", and "JSON envelope".
- Describe commands by what users can do.
- Replace "TUI" with "interactive app" in user-facing help.
- Fix the compose example by adding the required subject.
- Use a safe `example.com` address.
- Add regression tests for the root help output.

This changes help text only. It does not change command behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies CLI help to use user-facing language and fixes examples; command behavior is unchanged. This makes the root help and command summaries clearer (messages/calendar entries, not internal terms).

- Replaces “postings”, “recordings”, “JSON envelope”, and “TUI” with “messages”, “calendar entries”, “JSON with metadata”, and “interactive app” across command help and root flags.
- Updates examples: adds required subject to compose and uses alice@example.com.
- Adds regression tests for curated command descriptions and exact root help output.
- No migration needed; scripts and flags are unchanged.

<sup>Written for commit cc89de568a5bd0efe9c66d29f357c718b58b95ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

