### PR TITLE
Add CLI and TUI email forwarding

### DIFF
--- a/.surface
+++ b/.surface
@@ -43,6 +43,11 @@ hey doctor
 hey drafts
 hey drafts --all
 hey drafts --limit
+hey forward
+hey forward --bcc
+hey forward --cc
+hey forward --message
+hey forward --to
 hey habit
 hey habit complete
 hey habit complete --date

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -17,9 +17,10 @@ The legacy `internal/client/` is used only for HTML-scraping gap operations mark
 | `/calendars/{id}/recordings.json` | GET | SDK `Calendars().GetRecordings` | `hey recordings <calendar-id>`, `hey todo list`, `hey timetrack list`, `hey journal list` | covered |
 | `/topics/{id}/entries` | GET (HTML) | Legacy `GetTopicEntries` | `hey threads <id>` | gap: SDK Entry lacks body |
 | `/entries/drafts.json` | GET | SDK `Entries().ListDrafts` | `hey drafts` | covered |
-| `/topics/messages` | POST | SDK `Messages().Create` | `hey compose` | covered |
-| `/topics/{id}/messages` | POST | SDK `Messages().CreateTopicMessage` | `hey compose --topic` | covered |
+| `/messages.json` | POST | SDK `Messages().Create` | `hey compose`, `hey forward <topic-id>` | covered |
 | `/entries/{id}/replies` | POST | SDK `Entries().CreateReply` | `hey reply <topic-id>` | covered |
+| `/topics/{id}.json` | GET | SDK `Topics().Get` | `hey forward <topic-id>` | covered |
+| `/entries/{id}/forwards/new.json` | GET | SDK `Entries().NewForward` | `hey forward <topic-id>` | covered |
 | `/calendar/days/{date}/habits/{id}/completions.json` | POST | SDK `Habits().Complete` | `hey habit complete <id>` | covered |
 | `/calendar/days/{date}/habits/{id}/completions.json` | DELETE | SDK `Habits().Uncomplete` | `hey habit uncomplete <id>` | covered |
 | `/calendar/days/{date}/journal_entry.json` | GET | SDK `Journal().Get` | `hey journal read [date]` | partial: falls back to legacy |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ hey auth logout   # clear credentials
 
 Run `hey` to launch the interactive terminal UI.
 
-Navigate between mailboxes, postings, and full email threads. Use Enter to drill in, Escape/Backspace to go back, and `/` to filter lists.
+Navigate between mailboxes, postings, and full email threads. Use Enter to open a thread, `r` to reply, `f` to forward, and Escape or `q` to go back.
 
 ## CLI Commands
 
@@ -71,6 +71,7 @@ hey boxes                          # list mailboxes
 hey box imbox                      # list postings in a box (by name or ID)
 hey threads 123                    # read a full email thread
 hey reply 123 -m "Thanks!"        # reply to a thread (or omit -m to open $EDITOR)
+hey forward 123 --to alice@example.com -m "For your review"  # forward the latest message
 hey compose --to user@example.com --subject "Hello"  # compose a new message
 hey compose --to user@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello"  # with CC/BCC
 hey drafts                         # list drafts

--- a/internal/cmd/forward.go
+++ b/internal/cmd/forward.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type forwardCommand struct {
+	cmd     *cobra.Command
+	to      string
+	cc      string
+	bcc     string
+	message string
+}
+
+func newForwardCommand() *forwardCommand {
+	forwardCommand := &forwardCommand{}
+	forwardCommand.cmd = &cobra.Command{
+		Use:   "forward <thread-id>",
+		Short: "Forward the latest message in a thread",
+		Annotations: map[string]string{
+			"agent_notes": "Forwards the latest entry in a thread with HEY's quoted content. Accepts comma-separated recipients and an optional note via -m.",
+		},
+		Example: `  hey forward 12345 --to alice@example.com
+  hey forward 12345 --to alice@example.com --cc bob@example.org -m "For your review"`,
+		RunE: forwardCommand.run,
+		Args: usageExactOneArg(),
+	}
+
+	forwardCommand.cmd.Flags().StringVar(&forwardCommand.to, "to", "", "Recipient email address(es)")
+	forwardCommand.cmd.Flags().StringVar(&forwardCommand.cc, "cc", "", "CC recipient email address(es)")
+	forwardCommand.cmd.Flags().StringVar(&forwardCommand.bcc, "bcc", "", "BCC recipient email address(es)")
+	forwardCommand.cmd.Flags().StringVarP(&forwardCommand.message, "message", "m", "", "Optional note above the forwarded message")
+
+	return forwardCommand
+}
+
+func (c *forwardCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	threadID, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return output.ErrUsage(fmt.Sprintf("invalid thread ID: %s", args[0]))
+	}
+
+	to := parseAddresses(c.to)
+	cc := parseAddresses(c.cc)
+	bcc := parseAddresses(c.bcc)
+	if len(to)+len(cc)+len(bcc) == 0 {
+		return output.ErrUsageHint("at least one recipient is required", "hey forward <thread-id> --to <email>")
+	}
+
+	ctx := cmd.Context()
+	topic, err := sdk.Topics().Get(ctx, threadID)
+	if err != nil {
+		return convertSDKError(err)
+	}
+	if topic == nil || len(topic.Entries) == 0 {
+		return output.ErrNotFound("entries for thread", args[0])
+	}
+	entryID := topic.Entries[len(topic.Entries)-1].Id
+
+	draft, err := sdk.Entries().NewForward(ctx, entryID)
+	if err != nil {
+		return convertSDKError(err)
+	}
+	if draft == nil {
+		return output.ErrNotFound("forward draft for thread", args[0])
+	}
+
+	content := htmlutil.PrependText(draft.Content, c.message)
+	if err := sdk.Messages().Create(ctx, draft.Subject, content, to, cc, bcc); err != nil {
+		return convertSDKError(err)
+	}
+
+	if writer.IsStyled() {
+		fmt.Fprintln(cmd.OutOrStdout(), "Message forwarded.")
+		return nil
+	}
+
+	return writeOK(map[string]any{
+		"thread_id": threadID,
+		"entry_id":  entryID,
+		"subject":   draft.Subject,
+		"to":        to,
+		"cc":        cc,
+		"bcc":       bcc,
+	}, output.WithSummary("Message forwarded"))
+}

--- a/internal/cmd/forward_test.go
+++ b/internal/cmd/forward_test.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+)
+
+type sentForward struct {
+	Requests []string
+	Subject  string
+	Content  string
+	To       []string
+	CC       []string
+	BCC      []string
+}
+
+func forwardServer(t *testing.T, entriesJSON string) (*httptest.Server, *sentForward) {
+	t.Helper()
+	sent := &sentForward{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sent.Requests = append(sent.Requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/topics/7.json":
+			fmt.Fprintf(w, `{"id":7,"name":"Quarterly planning","entries":%s}`, entriesJSON)
+		case "/entries/12/forwards/new.json":
+			fmt.Fprint(w, `{"subject":"Fwd: Quarterly planning","content":"<div>Quoted message</div>"}`)
+		case "/identity.json":
+			fmt.Fprint(w, `{"id":1,"senders":[{"id":42,"default":true}]}`)
+		case "/messages.json":
+			var body struct {
+				Message struct {
+					Subject string `json:"subject"`
+					Content string `json:"content"`
+				} `json:"message"`
+				Entry struct {
+					Addressed struct {
+						Directly    []string `json:"directly"`
+						Copied      []string `json:"copied"`
+						Blindcopied []string `json:"blindcopied"`
+					} `json:"addressed"`
+				} `json:"entry"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			sent.Subject = body.Message.Subject
+			sent.Content = body.Message.Content
+			sent.To = body.Entry.Addressed.Directly
+			sent.CC = body.Entry.Addressed.Copied
+			sent.BCC = body.Entry.Addressed.Blindcopied
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, sent
+}
+
+func TestForwardSendsLatestEntryDraft(t *testing.T) {
+	server, sent := forwardServer(t, `[{"id":11},{"id":12}]`)
+
+	err := runCLI(t, server, "forward", "7",
+		"--to", "alice@example.com",
+		"--cc", "bob@example.org",
+		"--bcc", "carol@example.com",
+		"-m", "For your review\nThanks & take care",
+	)
+	if err != nil {
+		t.Fatalf("forward failed: %v", err)
+	}
+
+	wantRequests := []string{
+		"GET /topics/7.json",
+		"GET /entries/12/forwards/new.json",
+		"GET /identity.json",
+		"POST /messages.json",
+	}
+	if strings.Join(sent.Requests, ",") != strings.Join(wantRequests, ",") {
+		t.Errorf("requests = %v, want %v", sent.Requests, wantRequests)
+	}
+	if sent.Subject != "Fwd: Quarterly planning" {
+		t.Errorf("subject = %q", sent.Subject)
+	}
+	wantContent := `<div>For your review<br>Thanks &amp; take care</div><br><div>Quoted message</div>`
+	if sent.Content != wantContent {
+		t.Errorf("content = %q, want %q", sent.Content, wantContent)
+	}
+	if len(sent.To) != 1 || sent.To[0] != "alice@example.com" {
+		t.Errorf("to = %v", sent.To)
+	}
+	if len(sent.CC) != 1 || sent.CC[0] != "bob@example.org" {
+		t.Errorf("cc = %v", sent.CC)
+	}
+	if len(sent.BCC) != 1 || sent.BCC[0] != "carol@example.com" {
+		t.Errorf("bcc = %v", sent.BCC)
+	}
+}
+
+func TestForwardRequiresRecipient(t *testing.T) {
+	server, sent := forwardServer(t, `[{"id":12}]`)
+
+	err := runCLI(t, server, "forward", "7")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+		t.Fatalf("forward without a recipient should be a usage error, got %v", err)
+	}
+	if len(sent.Requests) != 0 {
+		t.Errorf("forward made requests before validating recipients: %v", sent.Requests)
+	}
+}
+
+func TestForwardRequiresThreadEntry(t *testing.T) {
+	server, sent := forwardServer(t, `[]`)
+
+	err := runCLI(t, server, "forward", "7", "--to", "alice@example.com")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "not_found" {
+		t.Fatalf("forward without an entry should be a not-found error, got %v", err)
+	}
+	if len(sent.Requests) != 1 || sent.Requests[0] != "GET /topics/7.json" {
+		t.Errorf("requests = %v, want only the topic read", sent.Requests)
+	}
+}

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -17,7 +17,7 @@ var curatedCategories = []struct {
 }{
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "threads", "compose", "reply", "drafts", "seen", "unseen"},
+		names:   []string{"boxes", "box", "threads", "compose", "reply", "forward", "drafts", "seen", "unseen"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -45,6 +45,7 @@ EMAIL
   threads  Read a thread
   compose  Write and send a new email
   reply    Reply to a thread
+  forward  Forward the latest message in a thread
   drafts   List draft emails
   seen     Mark messages as seen
   unseen   Mark messages as unseen

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -121,6 +121,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newBoxCommand().cmd)
 	root.AddCommand(newThreadsCommand().cmd)
 	root.AddCommand(newReplyCommand().cmd)
+	root.AddCommand(newForwardCommand().cmd)
 	root.AddCommand(newComposeCommand().cmd)
 	root.AddCommand(newDraftsCommand().cmd)
 	root.AddCommand(newCalendarsCommand().cmd)

--- a/internal/cmd/topic.go
+++ b/internal/cmd/topic.go
@@ -21,7 +21,7 @@ func newThreadsCommand() *topicCommand {
 		Use:   "threads <id>",
 		Short: "Read a thread",
 		Annotations: map[string]string{
-			"agent_notes": "Returns a thread with all entries. Use entry IDs with hey reply.",
+			"agent_notes": "Returns a thread with all entries. Use the topic ID with hey reply or hey forward.",
 		},
 		Example: `  hey threads 12345
   hey threads 12345 --json`,
@@ -88,6 +88,11 @@ func (c *topicCommand) run(cmd *cobra.Command, args []string) error {
 				Action:      "reply",
 				Command:     fmt.Sprintf("hey reply %d", threadID),
 				Description: "Reply to this thread",
+			},
+			output.Breadcrumb{
+				Action:      "forward",
+				Command:     fmt.Sprintf("hey forward %d --to <email>", threadID),
+				Description: "Forward the latest message",
 			},
 		),
 	)

--- a/internal/htmlutil/htmlutil.go
+++ b/internal/htmlutil/htmlutil.go
@@ -3,6 +3,7 @@ package htmlutil
 import (
 	"encoding/json"
 	"fmt"
+	stdhtml "html"
 	"strings"
 
 	"golang.org/x/net/html"
@@ -22,6 +23,17 @@ func ToText(s string) string {
 		result = strings.ReplaceAll(result, "\n\n\n", "\n\n")
 	}
 	return strings.TrimSpace(result)
+}
+
+// PrependText adds a plain-text note before existing HTML content.
+func PrependText(content, note string) string {
+	note = strings.TrimSpace(strings.ReplaceAll(note, "\r\n", "\n"))
+	if note == "" {
+		return content
+	}
+	escaped := stdhtml.EscapeString(note)
+	escaped = strings.ReplaceAll(escaped, "\n", "<br>")
+	return "<div>" + escaped + "</div><br>" + content
 }
 
 // ExtractImageURLs finds image URLs from <img src> tags and

--- a/internal/htmlutil/htmlutil_test.go
+++ b/internal/htmlutil/htmlutil_test.go
@@ -97,6 +97,21 @@ func TestToTextTrixFigure(t *testing.T) {
 	}
 }
 
+func TestPrependText(t *testing.T) {
+	got := PrependText(`<div>Forwarded message</div>`, "For your review\nThanks & take care")
+	want := `<div>For your review<br>Thanks &amp; take care</div><br><div>Forwarded message</div>`
+	if got != want {
+		t.Errorf("PrependText() = %q, want %q", got, want)
+	}
+}
+
+func TestPrependTextWithoutNote(t *testing.T) {
+	content := `<div>Forwarded message</div>`
+	if got := PrependText(content, "  "); got != content {
+		t.Errorf("PrependText() = %q, want unchanged content", got)
+	}
+}
+
 func TestExtractImageURLs(t *testing.T) {
 	h := `<p>Hello</p><img src="https://example.com/a.png"><img src="https://example.com/b.jpg">`
 	urls := ExtractImageURLs(h)

--- a/internal/tui/calendar.go
+++ b/internal/tui/calendar.go
@@ -126,6 +126,9 @@ func (v *calendarView) View() string {
 }
 
 func (v *calendarView) HelpBindings() []helpBinding {
+	if v.inThread {
+		return nil
+	}
 	return []helpBinding{
 		{"v", v.viewMode.next().String() + " view"},
 	}

--- a/internal/tui/compose.go
+++ b/internal/tui/compose.go
@@ -27,6 +27,18 @@ type replyContextLoadedMsg struct {
 	err       error
 }
 
+// forwardContextLoadedMsg carries HEY's prefilled subject and quoted message
+// for forwarding the latest entry in a thread.
+type forwardContextLoadedMsg struct {
+	requestID uint64
+	boxID     int64
+	topicID   int64
+	topicName string
+	subject   string
+	content   string
+	err       error
+}
+
 // composeSentMsg reports the outcome of a send.
 type composeSentMsg struct {
 	label string
@@ -40,6 +52,7 @@ type composeMode int
 const (
 	composeNew composeMode = iota
 	composeReply
+	composeForward
 )
 
 // composeField indexes the inputs in a form. Body is always the last field.
@@ -53,15 +66,16 @@ const (
 	fieldBody
 )
 
-// composeForm is the in-TUI editor for a new message or a reply. It owns its
-// inputs, validation and status; sending is done by mailView so the form stays
-// free of SDK calls.
+// composeForm is the in-TUI editor for a new message, reply or forward. It owns
+// its inputs, validation and status; sending is done by mailView so the form
+// stays free of SDK calls.
 type composeForm struct {
-	mode      composeMode
-	topicName string
-	entryID   int64 // reply target (composeReply only)
+	mode             composeMode
+	topicName        string
+	entryID          int64 // reply target (composeReply only)
+	forwardedContent string
 
-	inputs []textinput.Model // to, cc, bcc, subject (subject only for composeNew)
+	inputs []textinput.Model // to, cc, bcc, subject (subject omitted for replies)
 	body   textarea.Model
 	focus  int // index into inputs, or len(inputs) for body
 
@@ -77,7 +91,7 @@ type composeForm struct {
 func newComposeForm(mode composeMode, s styles) *composeForm {
 	f := &composeForm{mode: mode, styles: s}
 	labels := []string{"To", "Cc", "Bcc"}
-	if mode == composeNew {
+	if mode != composeReply {
 		labels = append(labels, "Subject")
 	}
 	for _, l := range labels {
@@ -116,6 +130,15 @@ func newReplyForm(ctxMsg replyContextLoadedMsg, s styles) *composeForm {
 	return f
 }
 
+func newForwardForm(ctxMsg forwardContextLoadedMsg, s styles) *composeForm {
+	f := newComposeForm(composeForward, s)
+	f.topicName = ctxMsg.topicName
+	f.forwardedContent = ctxMsg.content
+	f.inputs[fieldSubject].SetValue(ctxMsg.subject)
+	f.body.Placeholder = "Add a note…"
+	return f
+}
+
 func (f *composeForm) bodyIndex() int { return len(f.inputs) }
 
 func (f *composeForm) init() tea.Cmd {
@@ -150,20 +173,23 @@ func (f *composeForm) values() (to, cc, bcc []string, subject, body string) {
 	to = parseAddressList(f.inputs[fieldTo].Value())
 	cc = parseAddressList(f.inputs[fieldCc].Value())
 	bcc = parseAddressList(f.inputs[fieldBcc].Value())
-	if f.mode == composeNew {
+	if f.mode != composeReply {
 		subject = strings.TrimSpace(f.inputs[fieldSubject].Value())
 	}
 	body = strings.TrimSpace(f.body.Value())
+	if f.mode == composeForward {
+		body = htmlutil.PrependText(f.forwardedContent, body)
+	}
 	return
 }
 
 // validate returns a user-facing problem, or "" when the form can be sent.
 func (f *composeForm) validate() string {
 	to, cc, bcc, subject, body := f.values()
-	if f.mode == composeNew && len(to)+len(cc)+len(bcc) == 0 {
+	if f.mode != composeReply && len(to)+len(cc)+len(bcc) == 0 {
 		return "Add at least one recipient"
 	}
-	if f.mode == composeNew && subject == "" {
+	if f.mode != composeReply && subject == "" {
 		return "Subject is required"
 	}
 	if body == "" {
@@ -228,11 +254,15 @@ func (f *composeForm) helpBindings() []helpBinding {
 func (f *composeForm) view() string {
 	var b strings.Builder
 	title := "New message"
-	if f.mode == composeReply {
+	switch f.mode {
+	case composeNew:
+	case composeReply:
 		title = "Reply"
-		if f.topicName != "" {
-			title += ": " + f.topicName
-		}
+	case composeForward:
+		title = "Forward"
+	}
+	if f.mode != composeNew && f.topicName != "" {
+		title += ": " + f.topicName
 	}
 	b.WriteString(f.styles.title.Render(title))
 	b.WriteString("\n")
@@ -247,6 +277,10 @@ func (f *composeForm) view() string {
 	b.WriteString("\n")
 	b.WriteString(f.body.View())
 	b.WriteString("\n")
+	if f.mode == composeForward {
+		b.WriteString(labelStyle.Render("The original message will be included."))
+		b.WriteString("\n")
+	}
 
 	if f.status != "" {
 		st := lipgloss.NewStyle().Foreground(colorMuted)
@@ -316,6 +350,47 @@ func (v *mailView) loadReplyContext(topicID int64, topicName string) tea.Cmd {
 	}
 }
 
+// loadForwardContext fetches HEY's prefilled forward for the latest entry in
+// the thread, then opens the forward form on forwardContextLoadedMsg.
+func (v *mailView) loadForwardContext(topicID int64, topicName string) tea.Cmd {
+	sdk := v.vc.sdk
+	boxID := v.currentBoxID()
+	requestID, ctx := v.beginRequest(mailRequestForward)
+	return func() tea.Msg {
+		topic, err := sdk.Topics().Get(ctx, topicID)
+		if err != nil {
+			return forwardContextLoadedMsg{requestID: requestID, boxID: boxID, err: err}
+		}
+		if topic == nil || len(topic.Entries) == 0 {
+			return forwardContextLoadedMsg{
+				requestID: requestID,
+				boxID:     boxID,
+				err:       fmt.Errorf("no entries found in thread %d", topicID),
+			}
+		}
+		entryID := topic.Entries[len(topic.Entries)-1].Id
+		draft, err := sdk.Entries().NewForward(ctx, entryID)
+		if err != nil {
+			return forwardContextLoadedMsg{requestID: requestID, boxID: boxID, err: err}
+		}
+		if draft == nil {
+			return forwardContextLoadedMsg{
+				requestID: requestID,
+				boxID:     boxID,
+				err:       fmt.Errorf("thread %d returned no forward draft", topicID),
+			}
+		}
+		return forwardContextLoadedMsg{
+			requestID: requestID,
+			boxID:     boxID,
+			topicID:   topicID,
+			topicName: topicName,
+			subject:   draft.Subject,
+			content:   draft.Content,
+		}
+	}
+}
+
 // send submits the open form through the SDK.
 func (v *mailView) send() tea.Cmd {
 	f := v.compose
@@ -328,6 +403,11 @@ func (v *mailView) send() tea.Cmd {
 		return func() tea.Msg {
 			err := sdk.Entries().CreateReply(ctx, entryID, body, to, cc, bcc)
 			return composeSentMsg{label: "Reply sent", err: err}
+		}
+	case composeForward:
+		return func() tea.Msg {
+			err := sdk.Messages().Create(ctx, subject, body, to, cc, bcc)
+			return composeSentMsg{label: "Message forwarded", err: err}
 		}
 	default:
 		return func() tea.Msg {

--- a/internal/tui/compose_test.go
+++ b/internal/tui/compose_test.go
@@ -300,6 +300,27 @@ func TestForwardFormLoadsLatestEntryAndSends(t *testing.T) {
 	}
 }
 
+func TestForwardCompletionNoticeIsVisibleInThread(t *testing.T) {
+	v := mailWithPostings()
+	v.Resize(80, 30)
+	v.inThread = true
+	v.topicViewport.SetContent("Original thread")
+	v.compose = newForwardForm(forwardContextLoadedMsg{
+		topicName: "Quarterly planning",
+		subject:   "Fwd: Quarterly planning",
+		content:   "<div>Quoted message</div>",
+	}, v.vc.styles)
+
+	v.Update(composeSentMsg{label: "Message forwarded"})
+
+	if v.compose != nil {
+		t.Error("forward form should close after sending")
+	}
+	if view := v.View(); !strings.Contains(view, "Message forwarded") || !strings.Contains(view, "Original thread") {
+		t.Errorf("thread view should show the forwarding notice, got %q", view)
+	}
+}
+
 func TestForwardKeyInThreadLoadsContext(t *testing.T) {
 	v := mailWithPostings()
 	v.inThread = true

--- a/internal/tui/compose_test.go
+++ b/internal/tui/compose_test.go
@@ -44,17 +44,22 @@ func composeTestServer(t *testing.T) (*mailView, *struct {
 		body         map[string]any
 	}{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/identity.json" {
-			w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/identity.json":
 			_, _ = w.Write([]byte(`{"id":1,"email_address":"me@hey.com","senders":[{"id":42,"default":true}]}`))
-			return
+		case "/topics/100.json":
+			_, _ = w.Write([]byte(`{"id":100,"name":"Quarterly planning","entries":[{"id":500},{"id":501}]}`))
+		case "/entries/501/forwards/new.json":
+			_, _ = w.Write([]byte(`{"subject":"Fwd: Quarterly planning","content":"<div>Quoted message</div>"}`))
+		default:
+			rec.method, rec.path = r.Method, r.URL.Path
+			if b, _ := io.ReadAll(r.Body); len(b) > 0 {
+				_ = json.Unmarshal(b, &rec.body)
+			}
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{}`))
 		}
-		rec.method, rec.path = r.Method, r.URL.Path
-		if b, _ := io.ReadAll(r.Body); len(b) > 0 {
-			_ = json.Unmarshal(b, &rec.body)
-		}
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte(`{}`))
 	}))
 	t.Cleanup(srv.Close)
 	sdk := hey.NewClient(&hey.Config{BaseURL: srv.URL}, &hey.StaticTokenProvider{Token: "t"}, hey.WithMaxRetries(0))
@@ -234,6 +239,74 @@ func TestReplyFormPrefillsAndSends(t *testing.T) {
 	addressed := rec.body["entry"].(map[string]any)["addressed"].(map[string]any)
 	if got := addressed["directly"].([]any); len(got) != 1 || got[0] != "jane@x.com" {
 		t.Errorf("directly = %v", got)
+	}
+}
+
+func TestForwardFormLoadsLatestEntryAndSends(t *testing.T) {
+	v, rec := composeTestServer(t)
+	v.Resize(80, 30)
+
+	loaded := runCmd(v.HandleContentKey(keyPress("f")))
+	ctxMsg, ok := loaded.(forwardContextLoadedMsg)
+	if !ok || ctxMsg.err != nil {
+		t.Fatalf("forward command returned %#v", loaded)
+	}
+	if ctxMsg.subject != "Fwd: Quarterly planning" || ctxMsg.content != "<div>Quoted message</div>" {
+		t.Errorf("forward draft = subject %q content %q", ctxMsg.subject, ctxMsg.content)
+	}
+	v.Update(ctxMsg)
+
+	f := v.compose
+	if f == nil || f.mode != composeForward {
+		t.Fatal("forward context should open a forward form")
+	}
+	if f.inputs[fieldSubject].Value() != "Fwd: Quarterly planning" {
+		t.Errorf("subject = %q", f.inputs[fieldSubject].Value())
+	}
+	if !strings.Contains(v.View(), "Forward: Hello world") || !strings.Contains(v.View(), "original message will be included") {
+		t.Errorf("forward form view = %q", v.View())
+	}
+
+	typeText(v, "alice@example.com")
+	for range 4 {
+		v.HandleContentKey(keyPress("tab"))
+	}
+	typeText(v, "For your review")
+
+	msg := runCmd(v.HandleContentKey(ctrlS()))
+	sent, ok := msg.(composeSentMsg)
+	if !ok || sent.err != nil || sent.label != "Message forwarded" {
+		t.Fatalf("expected Message forwarded, got %#v", msg)
+	}
+	if rec.method != http.MethodPost || rec.path != "/messages.json" {
+		t.Errorf("sent %s %s, want POST /messages.json", rec.method, rec.path)
+	}
+	message := rec.body["message"].(map[string]any)
+	if message["subject"] != "Fwd: Quarterly planning" {
+		t.Errorf("message subject = %v", message["subject"])
+	}
+	wantContent := `<div>For your review</div><br><div>Quoted message</div>`
+	if message["content"] != wantContent {
+		t.Errorf("message content = %q, want %q", message["content"], wantContent)
+	}
+	addressed := rec.body["entry"].(map[string]any)["addressed"].(map[string]any)
+	if got := addressed["directly"].([]any); len(got) != 1 || got[0] != "alice@example.com" {
+		t.Errorf("directly = %v", got)
+	}
+
+	v.Update(sent)
+	if v.compose != nil || v.notice != "Message forwarded" {
+		t.Errorf("forward completion = compose %v notice %q", v.compose, v.notice)
+	}
+}
+
+func TestForwardKeyInThreadLoadsContext(t *testing.T) {
+	v := mailWithPostings()
+	v.inThread = true
+	v.topicID = 123
+	cmd := v.HandleContentKey(keyPress("f"))
+	if cmd == nil || !v.loading || v.activeRequestKind != mailRequestForward {
+		t.Fatal("'f' in a thread should start loading the forward context")
 	}
 }
 

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -232,6 +232,9 @@ func (v *mailView) View() string {
 		return v.compose.view()
 	}
 	if v.inThread {
+		if v.notice != "" {
+			return v.vc.styles.title.Render(v.notice) + "\n" + v.topicViewport.View()
+		}
 		return v.topicViewport.View()
 	}
 	if v.notice != "" {

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -26,6 +26,7 @@ const (
 	mailRequestPostings
 	mailRequestTopic
 	mailRequestReply
+	mailRequestForward
 )
 
 type boxesLoadedMsg []models.Box
@@ -71,7 +72,7 @@ type mailView struct {
 	inThread      bool
 	loading       bool
 
-	compose           *composeForm // non-nil while a new message or reply is being written
+	compose           *composeForm // non-nil while a message, reply or forward is being written
 	notice            string       // one-shot confirmation shown above the posting list
 	activeRequestID   uint64       // identifies the only mail read allowed to update the view
 	activeRequestKind mailRequestKind
@@ -158,6 +159,18 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.compose.resize(v.vc.width, v.vc.height)
 		return v.compose.init(), true
 
+	case forwardContextLoadedMsg:
+		if msg.requestID != v.activeRequestID || msg.boxID != v.currentBoxID() {
+			return nil, true
+		}
+		v.finishRequest(msg.requestID)
+		if msg.err != nil {
+			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
+		v.compose = newForwardForm(msg, v.vc.styles)
+		v.compose.resize(v.vc.width, v.vc.height)
+		return v.compose.init(), true
+
 	case composeSentMsg:
 		if v.compose == nil {
 			return nil, true
@@ -235,7 +248,7 @@ func (v *mailView) HelpBindings() []helpBinding {
 		return v.compose.helpBindings()
 	}
 	if v.inThread {
-		return []helpBinding{{"r", "reply"}}
+		return []helpBinding{{"r", "reply"}, {"f", "forward"}}
 	}
 	return []helpBinding{
 		{"c", "compose"},
@@ -286,6 +299,9 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		if msg.String() == "r" && v.topicID != 0 {
 			return v.loadReplyContext(v.topicID, v.topicName)
 		}
+		if msg.String() == "f" && v.topicID != 0 {
+			return v.loadForwardContext(v.topicID, v.topicName)
+		}
 		var cmd tea.Cmd
 		v.topicViewport, cmd = v.topicViewport.Update(msg)
 		return cmd
@@ -315,7 +331,7 @@ func (v *mailView) ExitThread() {
 }
 
 func (v *mailView) CancelPendingDetail() bool {
-	if v.activeRequestKind != mailRequestTopic && v.activeRequestKind != mailRequestReply {
+	if v.activeRequestKind != mailRequestTopic && v.activeRequestKind != mailRequestReply && v.activeRequestKind != mailRequestForward {
 		return false
 	}
 	v.cancelRequest()
@@ -471,7 +487,7 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 		if topicID == 0 {
 			topicID = p.ID
 		}
-		return v.requestTopic(v.currentBoxID(), topicID, p.Summary)
+		return v.loadForwardContext(topicID, p.Summary)
 	}
 	return nil
 }

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -785,6 +785,29 @@ func TestMailViewIgnoresReplyLoadAfterBoxSwitch(t *testing.T) {
 	}
 }
 
+func TestMailViewIgnoresForwardLoadAfterBoxSwitch(t *testing.T) {
+	v := mailWithPostings()
+	_ = v.loadForwardContext(100, "Hello world")
+	loaded := forwardContextLoadedMsg{
+		requestID: v.activeRequestID,
+		boxID:     1,
+		topicID:   100,
+		topicName: "Hello world",
+		subject:   "Fwd: Hello world",
+		content:   "<div>Hello world</div>",
+	}
+
+	v.SubnavRight()
+	cmd, consumed := v.Update(loaded)
+
+	if !consumed || cmd != nil {
+		t.Error("stale forward context should be ignored")
+	}
+	if v.compose != nil {
+		t.Error("stale forward context should not open the forward form")
+	}
+}
+
 func TestMailViewIgnoresReplyLoadAfterThreadExit(t *testing.T) {
 	v := mailWithPostings()
 	v.inThread = true
@@ -977,8 +1000,8 @@ func TestMailViewHelpBindingsInThread(t *testing.T) {
 	v := mailWithPostings()
 	v.inThread = true
 	bindings := v.HelpBindings()
-	if len(bindings) != 1 || bindings[0].key != "r" {
-		t.Errorf("thread mode should offer only reply, got %v", bindings)
+	if len(bindings) != 2 || bindings[0].key != "r" || bindings[1].key != "f" {
+		t.Errorf("thread mode should offer reply and forward, got %v", bindings)
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -192,11 +192,14 @@ func (m *model) updateHelpBindings() {
 	if ic, ok := m.activeView.(inputCapturer); ok && ic.CapturingInput() {
 		bindings = append(m.activeView.HelpBindings(), quitHint)
 	} else if m.activeView.InThread() {
-		bindings = []helpBinding{
-			{"↑↓", "scroll"},
-			{"esc/q", "back"},
-			quitHint,
-		}
+		extra := m.activeView.HelpBindings()
+		bindings = make([]helpBinding, 0, 3+len(extra))
+		bindings = append(bindings,
+			helpBinding{"↑↓", "scroll"},
+			helpBinding{"esc/q", "back"},
+		)
+		bindings = append(bindings, extra...)
+		bindings = append(bindings, quitHint)
 	} else {
 		switch m.focus {
 		case rowSection:

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -216,6 +216,20 @@ func TestThreadHelpIncludesMailActions(t *testing.T) {
 	}
 }
 
+func TestCalendarDetailHelpOmitsListActions(t *testing.T) {
+	m := sizedModel()
+	m.section = sectionCalendar
+	m.activeView = m.calendarView
+	m.calendarView.inThread = true
+	m.updateHelpBindings()
+
+	for _, binding := range m.help.bindings {
+		if binding.key == "v" {
+			t.Errorf("calendar detail help advertises inactive view toggle: %v", m.help.bindings)
+		}
+	}
+}
+
 func TestEscExitsThread(t *testing.T) {
 	m := modelWithBoxes()
 	m.mailView.inThread = true

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -200,6 +200,22 @@ func TestSingleCtrlCDoesNotQuit(t *testing.T) {
 
 // --- Navigation: Esc/q in thread goes back ---
 
+func TestThreadHelpIncludesMailActions(t *testing.T) {
+	m := modelWithBoxes()
+	m.mailView.inThread = true
+	m.updateHelpBindings()
+
+	keys := make(map[string]bool)
+	for _, binding := range m.help.bindings {
+		keys[binding.key] = true
+	}
+	for _, want := range []string{"↑↓", "esc/q", "r", "f"} {
+		if !keys[want] {
+			t.Errorf("thread help is missing %q: %v", want, m.help.bindings)
+		}
+	}
+}
+
 func TestEscExitsThread(t *testing.T) {
 	m := modelWithBoxes()
 	m.mailView.inThread = true
@@ -271,6 +287,36 @@ func TestQExitsPendingReplyLoadFromPostingList(t *testing.T) {
 	m = updated.(model)
 	if m.mailView.compose != nil {
 		t.Error("a canceled reply load should not open the reply form")
+	}
+}
+
+func TestQExitsPendingForwardLoadFromPostingList(t *testing.T) {
+	m := modelWithBoxes()
+
+	updated, cmd := m.Update(keyPress("f"))
+	m = updated.(model)
+	if cmd == nil || !m.mailView.loading || m.mailView.activeRequestKind != mailRequestForward {
+		t.Fatal("forward from the posting list should start loading")
+	}
+	requestID := m.mailView.activeRequestID
+
+	updated, _ = m.Update(keyPress("q"))
+	m = updated.(model)
+	if m.mailView.loading || m.loading {
+		t.Error("q should stop a forward started from the posting list")
+	}
+
+	updated, _ = m.Update(forwardContextLoadedMsg{
+		requestID: requestID,
+		boxID:     1,
+		topicID:   100,
+		topicName: "Hello world",
+		subject:   "Fwd: Hello world",
+		content:   "<div>Hello world</div>",
+	})
+	m = updated.(model)
+	if m.mailView.compose != nil {
+		t.Error("a canceled forward load should not open the forward form")
 	}
 }
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -13,6 +13,7 @@ triggers:
   - hey box
   - hey threads
   - hey reply
+  - hey forward
   - hey compose
   - hey drafts
   # Calendar actions
@@ -40,6 +41,7 @@ triggers:
   - read email
   - send email
   - reply to email
+  - forward email
   - compose email
   - list mailboxes
   - check calendar
@@ -86,6 +88,7 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 | List emails in a box | `hey box imbox --json` |
 | Read email thread | `hey threads <topic_id> --json` |
 | Reply to email | `hey reply <topic_id> -m "Thanks!"` |
+| Forward email | `hey forward <topic_id> --to alice@example.com -m "For your review"` |
 | Compose email | `hey compose --to user@example.com --subject "Hello"` |
 | Compose with CC/BCC | `hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello"` |
 | List drafts | `hey drafts --json` |
@@ -131,6 +134,8 @@ Want to read email?
 Want to send email?
 ├── Reply to thread? → hey reply <topic_id> -m "message"
 │   └── Open editor? → hey reply <topic_id> (omit -m to open $EDITOR)
+├── Forward latest message? → hey forward <topic_id> --to <email>
+│   └── Add a note? → add -m "note"
 ├── Compose new? → hey compose --to <email> --subject "Subject"
 │   ├── With body? → hey compose --to <email> --subject "Subject" -m "Body"
 │   ├── With CC? → add --cc <email>
@@ -161,7 +166,7 @@ hey box 123 --json                            # List emails in box (by ID)
 
 Box names: `imbox`, `feedbox`, `trailbox`, `asidebox`, `laterbox`, `bubblebox`
 
-**Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. Each posting has: `id` (posting ID), `topic_id` (topic ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`. Use `topic_id` for `hey threads` and `hey reply`.
+**Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. Each posting has: `id` (posting ID), `topic_id` (topic ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`. Use `topic_id` for `hey threads`, `hey reply`, and `hey forward`.
 
 ### Email - Threads
 
@@ -170,13 +175,15 @@ hey threads <topic_id> --json                 # Read full email thread
 hey threads <topic_id> --html                 # Read with raw HTML content
 ```
 
-**ID note:** `hey box` returns postings with an `id` (posting ID) and a `topic_id` (topic ID). `hey threads` and `hey reply` expect the **topic ID** — use `topic_id` directly. The `app_url` field also contains the topic ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
+**ID note:** `hey box` returns postings with an `id` (posting ID) and a `topic_id` (topic ID). `hey threads`, `hey reply`, and `hey forward` expect the **topic ID** — use `topic_id` directly. The `app_url` field also contains the topic ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
 
-### Email - Reply & Compose
+### Email - Reply, Forward & Compose
 
 ```bash
 hey reply <topic_id> -m "Thanks!"             # Reply with inline message
 hey reply <topic_id>                          # Reply via $EDITOR
+hey forward <topic_id> --to alice@example.com                 # Forward the latest message
+hey forward <topic_id> --to alice@example.com -m "Please review"  # Forward with a note
 hey compose --to user@example.com --subject "Hello"         # Compose new (opens $EDITOR)
 hey compose --to user@example.com --subject "Hi" -m "Body"  # With inline body
 hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Project update" -m "Body"  # With CC/BCC

--- a/tests/smoke/compose_test.go
+++ b/tests/smoke/compose_test.go
@@ -148,6 +148,38 @@ func TestReply(t *testing.T) {
 	assertContains(t, html, uid)
 }
 
+func TestForward(t *testing.T) {
+	resp := heyJSON(t, "box", "imbox")
+	type Posting struct {
+		AppURL string `json:"app_url"`
+	}
+	type BoxResp struct {
+		Postings []Posting `json:"postings"`
+	}
+	data := dataAs[BoxResp](t, resp)
+	if len(data.Postings) == 0 {
+		t.Skip("no postings in imbox to forward")
+	}
+	topicID := extractTopicID(data.Postings[0].AppURL)
+	if topicID == "" {
+		t.Fatalf("could not extract topic ID from app_url: %s", data.Postings[0].AppURL)
+	}
+
+	stdout, stderr, code := hey(t, "forward", topicID,
+		"--to", "david@basecamp.com",
+		"-m", fmt.Sprintf("Forward smoke test %s", uniqueID()),
+		"--json",
+	)
+	if code != 0 {
+		t.Skipf("forward is unavailable on this server (exit %d): %s", code, stderr)
+	}
+	var forwardResp Response
+	if err := json.Unmarshal([]byte(stdout), &forwardResp); err != nil {
+		t.Fatalf("failed to parse forward response: %v", err)
+	}
+	assertContains(t, forwardResp.Summary, "Message forwarded")
+}
+
 func TestDrafts(t *testing.T) {
 	resp := heyJSON(t, "drafts")
 	// Just verify the command succeeds and returns valid data.
@@ -188,4 +220,8 @@ func TestThreadsNoArgument(t *testing.T) {
 
 func TestReplyNoArgument(t *testing.T) {
 	heyFail(t, "reply", "--json")
+}
+
+func TestForwardNoArgument(t *testing.T) {
+	heyFail(t, "forward", "--to", "david@basecamp.com", "--json")
 }


### PR DESCRIPTION
## Summary

- add `hey forward <thread-id>` with To/Cc/Bcc recipients and an optional note
- resolve the latest thread entry through typed SDK operations, preserve HEY’s quoted forward content, and send through `Messages.Create`
- make `f` open a real forward form from both the TUI posting list and thread view
- preserve request cancellation and stale-result protection while a forward draft loads
- document the command in help, README, API coverage, the embedded agent skill, surface compatibility, and smoke coverage

Basecamp card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892798

## Validation

- `GOWORK=off make check`
- `GOWORK=off go test -race -count=1 ./internal/...`
- `GOWORK=off make build`
- built `./bin/hey` and used the existing production OAuth account against `https://app.hey.com`
- forwarded the public PR #170 notification thread to `rob@zolkos.com` with the CLI and verified the sent subject, latest entry, recipients, and note through the receiving HEY account
- drove the rebuilt TUI through `f` → recipient → note → send and confirmed the `Message forwarded` notice
- verified the TUI-forwarded copy retained both the original quoted content and its validation note

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds email forwarding to the CLI and TUI so users can forward the latest message in a thread with recipients and an optional note. Previously unavailable; now `hey forward <thread-id>` and TUI key `f` open a forward form. Thread help shows reply/forward actions; calendar detail hides list-only shortcuts.

- CLI: `hey forward <thread-id> --to/--cc/--bcc [-m]` requires at least one recipient, prepends the note via `htmlutil.PrependText`, resolves the latest entry with `Topics().Get` + `Entries().NewForward`, sends with `Messages().Create`, and prints “Message forwarded.” (`--json` returns a summary).
- TUI: Press `f` from the posting list or thread to open a forward form with a prefilled subject and included original; the body placeholder is “Add a note…”. Sending closes the form and shows “Message forwarded” above the postings and in thread view. Thread help lists `r` and `f`; calendar detail help omits inactive list actions. Forward loads are cancelable and stale results are ignored after box/thread changes; Esc/q cancels a pending forward load.
- Docs/tests: Help, README, `.surface`, `API-COVERAGE.md`, and `skills/hey/SKILL.md` updated; unit and smoke tests cover CLI/TUI flows.

<sup>Written for commit e9cf74be5990b70890359e13322101d2597be4c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

