### PR TITLE
Add CLI and TUI posting moves

### DIFF
--- a/.surface
+++ b/.surface
@@ -60,6 +60,8 @@ hey journal list --limit
 hey journal read
 hey journal write
 hey journal write --content
+hey move
+hey move --to
 hey recordings
 hey recordings --all
 hey recordings --ends-on

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -21,6 +21,7 @@ The legacy `internal/client/` is used only for HTML-scraping gap operations mark
 | `/entries/{id}/replies` | POST | SDK `Entries().CreateReply` | `hey reply <topic-id>` | covered |
 | `/topics/{id}.json` | GET | SDK `Topics().Get` | `hey forward <topic-id>` | covered |
 | `/entries/{id}/forwards/new.json` | GET | SDK `Entries().NewForward` | `hey forward <topic-id>` | covered |
+| `/postings/moves.json` | POST | SDK `Postings().Move` | `hey move <posting-id> --to <box>`, TUI `m` | covered |
 | `/calendar/days/{date}/habits/{id}/completions.json` | POST | SDK `Habits().Complete` | `hey habit complete <id>` | covered |
 | `/calendar/days/{date}/habits/{id}/completions.json` | DELETE | SDK `Habits().Uncomplete` | `hey habit uncomplete <id>` | covered |
 | `/calendar/days/{date}/journal_entry.json` | GET | SDK `Journal().Get` | `hey journal read [date]` | partial: falls back to legacy |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ hey auth logout   # clear credentials
 
 Run `hey` to launch the interactive terminal UI.
 
-Navigate between mailboxes, postings, and full email threads. Use Enter to open a thread, `r` to reply, `f` to forward, and Escape or `q` to go back.
+Navigate between mailboxes, postings, and full email threads. Use Enter to open a thread, `r` to reply, `f` to forward, `m` to move a posting, and Escape or `q` to go back.
 
 ## CLI Commands
 
@@ -75,7 +75,11 @@ hey forward 123 --to alice@example.com -m "For your review"  # forward the lates
 hey compose --to user@example.com --subject "Hello"  # compose a new message
 hey compose --to user@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello"  # with CC/BCC
 hey drafts                         # list drafts
+hey move 12345 --to feed           # move a posting to another box
+hey move 12345 67890 --to "paper trail"  # move multiple postings
 ```
+
+`hey move` takes posting IDs from `hey box --json`. Destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`.
 
 ### Calendars
 

--- a/internal/cmd/box.go
+++ b/internal/cmd/box.go
@@ -110,6 +110,11 @@ func (c *boxCommand) run(cmd *cobra.Command, args []string) error {
 				Description: "Read an email thread",
 			},
 			output.Breadcrumb{
+				Action:      "move",
+				Command:     "hey move <posting-id> --to <box>",
+				Description: "Move a message to another box",
+			},
+			output.Breadcrumb{
 				Action:      "compose",
 				Command:     "hey compose --to <email> --subject <subject>",
 				Description: "Compose a new message",

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -17,7 +17,7 @@ var curatedCategories = []struct {
 }{
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "threads", "compose", "reply", "forward", "drafts", "seen", "unseen"},
+		names:   []string{"boxes", "box", "threads", "compose", "reply", "forward", "drafts", "seen", "unseen", "move"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -49,6 +49,7 @@ EMAIL
   drafts   List draft emails
   seen     Mark messages as seen
   unseen   Mark messages as unseen
+  move     Move messages to another box
 
 CALENDAR & TASKS
   calendars   List calendars

--- a/internal/cmd/move.go
+++ b/internal/cmd/move.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type moveCommand struct {
+	cmd *cobra.Command
+	to  string
+}
+
+func newMoveCommand() *moveCommand {
+	moveCommand := &moveCommand{}
+	moveCommand.cmd = &cobra.Command{
+		Use:   "move <posting-id>...",
+		Short: "Move messages to another box",
+		Long:  "Move one or more HEY postings to Imbox, The Feed, Set Aside, Reply Later, or Paper Trail.",
+		Example: `  hey move 12345 --to feed
+  hey move 12345 67890 --to "paper trail"
+  hey move 12345 --to 987`,
+		Annotations: map[string]string{
+			"agent_notes": "Accepts posting IDs from hey box output. --to accepts a box name, kind, or ID. Use HEY's scheduled Bubble Up flow for Bubble Up.",
+		},
+		RunE: moveCommand.run,
+		Args: usageMinOneArg(),
+	}
+
+	moveCommand.cmd.Flags().StringVar(&moveCommand.to, "to", "", "Destination box name, kind, or ID (required)")
+
+	return moveCommand
+}
+
+func (c *moveCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(c.to) == "" {
+		return output.ErrUsage("destination box is required (use --to <box>)")
+	}
+
+	ids, err := parseIntArgs(args)
+	if err != nil {
+		return err
+	}
+
+	destination, err := resolveMoveDestination(cmd.Context(), c.to)
+	if err != nil {
+		return err
+	}
+
+	if err := sdk.Postings().Move(cmd.Context(), destination.Id, ids...); err != nil {
+		return convertSDKError(err)
+	}
+
+	summary := fmt.Sprintf("%d posting(s) moved to %s", len(ids), destination.Name)
+	if writer.IsStyled() {
+		fmt.Fprintln(cmd.OutOrStdout(), summary+".")
+		return nil
+	}
+
+	return writeOK(nil, output.WithSummary(summary))
+}
+
+func resolveMoveDestination(ctx context.Context, nameOrID string) (*generated.Box, error) {
+	boxes, err := sdk.Boxes().List(ctx)
+	if err != nil {
+		return nil, convertSDKError(err)
+	}
+	if boxes == nil {
+		return nil, output.ErrNotFound("box", nameOrID)
+	}
+
+	if id, err := strconv.ParseInt(nameOrID, 10, 64); err == nil {
+		for i := range *boxes {
+			if (*boxes)[i].Id == id {
+				return validateMoveDestination(&(*boxes)[i])
+			}
+		}
+		return nil, output.ErrNotFound("box", nameOrID)
+	}
+
+	query := canonicalBoxName(nameOrID)
+	for i := range *boxes {
+		box := &(*boxes)[i]
+		if canonicalBoxName(box.Kind) == query || canonicalBoxName(box.Name) == query {
+			return validateMoveDestination(box)
+		}
+	}
+
+	return nil, output.ErrNotFound("box", nameOrID)
+}
+
+func validateMoveDestination(box *generated.Box) (*generated.Box, error) {
+	if strings.EqualFold(box.Kind, hey.BoxKindBubbleUp) {
+		return nil, output.ErrUsage("Bubble Up requires a scheduled date and is not supported by hey move")
+	}
+	return box, nil
+}
+
+func canonicalBoxName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.NewReplacer(" ", "", "-", "", "_", "").Replace(name)
+
+	switch name {
+	case "feed", "thefeed":
+		return hey.BoxKindFeed
+	case "aside", "setaside":
+		return hey.BoxKindSetAside
+	case "later", "replylater":
+		return hey.BoxKindLater
+	case "trail", "papertrail":
+		return hey.BoxKindTrail
+	case "bubble", "bubbleup", "bubbled", "bubbledup":
+		return hey.BoxKindBubbleUp
+	}
+	return name
+}

--- a/internal/cmd/move_test.go
+++ b/internal/cmd/move_test.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type recordedMove struct {
+	requests   []string
+	postingIDs []int64
+	boxID      int64
+	moveStatus int
+}
+
+func moveServer(t *testing.T) (*httptest.Server, *recordedMove) {
+	t.Helper()
+	recorded := &recordedMove{moveStatus: http.StatusNoContent}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorded.requests = append(recorded.requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/boxes.json":
+			_, _ = w.Write([]byte(`[
+				{"id":1,"kind":"imbox","name":"Imbox"},
+				{"id":2,"kind":"feedbox","name":"The Feed"},
+				{"id":3,"kind":"asidebox","name":"Set Aside"},
+				{"id":4,"kind":"laterbox","name":"Reply Later"},
+				{"id":5,"kind":"trailbox","name":"Paper Trail"},
+				{"id":6,"kind":"bubblebox","name":"Bubble Up"}
+			]`))
+		case "/postings/moves.json":
+			var body struct {
+				PostingIDs []int64 `json:"posting_ids"`
+				BoxID      int64   `json:"box_id"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			recorded.postingIDs = body.PostingIDs
+			recorded.boxID = body.BoxID
+			w.WriteHeader(recorded.moveStatus)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, recorded
+}
+
+func runMove(t *testing.T, server *httptest.Server, args ...string) (output.Response, error) {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(append([]string{"move", "--json", "--base-url", server.URL}, args...))
+
+	err := root.Execute()
+	var resp output.Response
+	if buf.Len() > 0 {
+		_ = json.Unmarshal(buf.Bytes(), &resp)
+	}
+	return resp, err
+}
+
+func TestMovePostingsToNamedBox(t *testing.T) {
+	server, recorded := moveServer(t)
+
+	resp, err := runMove(t, server, "12345", "67890", "--to", "paper-trail")
+	if err != nil {
+		t.Fatalf("move failed: %v", err)
+	}
+	if got := strings.Join(recorded.requests, ","); got != "GET /boxes.json,POST /postings/moves.json" {
+		t.Errorf("requests = %q", got)
+	}
+	if recorded.boxID != 5 {
+		t.Errorf("box_id = %d, want 5", recorded.boxID)
+	}
+	if len(recorded.postingIDs) != 2 || recorded.postingIDs[0] != 12345 || recorded.postingIDs[1] != 67890 {
+		t.Errorf("posting_ids = %v", recorded.postingIDs)
+	}
+	if resp.Summary != "2 posting(s) moved to Paper Trail" {
+		t.Errorf("summary = %q", resp.Summary)
+	}
+}
+
+func TestMoveDestinationAliases(t *testing.T) {
+	tests := []struct {
+		to    string
+		boxID int64
+	}{
+		{"imbox", 1},
+		{"feed", 2},
+		{"The Feed", 2},
+		{"aside", 3},
+		{"set_aside", 3},
+		{"later", 4},
+		{"reply later", 4},
+		{"trail", 5},
+		{"paper trail", 5},
+		{"5", 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.to, func(t *testing.T) {
+			server, recorded := moveServer(t)
+			if _, err := runMove(t, server, "12345", "--to", tt.to); err != nil {
+				t.Fatalf("move failed: %v", err)
+			}
+			if recorded.boxID != tt.boxID {
+				t.Errorf("box_id = %d, want %d", recorded.boxID, tt.boxID)
+			}
+		})
+	}
+}
+
+func TestMoveRejectsBubbleUp(t *testing.T) {
+	for _, to := range []string{"bubble", "Bubble Up", "bubblebox", "6"} {
+		t.Run(to, func(t *testing.T) {
+			server, recorded := moveServer(t)
+			_, err := runMove(t, server, "12345", "--to", to)
+			var cliErr *apierr.Error
+			if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+				t.Fatalf("Bubble Up should produce a usage error, got %v", err)
+			}
+			if len(recorded.requests) != 1 || recorded.requests[0] != "GET /boxes.json" {
+				t.Errorf("requests = %v, want only box discovery", recorded.requests)
+			}
+		})
+	}
+}
+
+func TestMoveRequiresDestination(t *testing.T) {
+	server, recorded := moveServer(t)
+
+	_, err := runMove(t, server, "12345")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+		t.Fatalf("missing destination should produce a usage error, got %v", err)
+	}
+	if len(recorded.requests) != 0 {
+		t.Errorf("missing destination made requests: %v", recorded.requests)
+	}
+}
+
+func TestMoveRejectsInvalidPostingIDBeforeRequests(t *testing.T) {
+	server, recorded := moveServer(t)
+
+	_, err := runMove(t, server, "not-an-id", "--to", "feed")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+		t.Fatalf("invalid posting should produce a usage error, got %v", err)
+	}
+	if len(recorded.requests) != 0 {
+		t.Errorf("invalid posting made requests: %v", recorded.requests)
+	}
+}
+
+func TestMoveRejectsUnknownDestination(t *testing.T) {
+	server, recorded := moveServer(t)
+
+	_, err := runMove(t, server, "12345", "--to", "archive")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "not_found" {
+		t.Fatalf("unknown destination should produce a not-found error, got %v", err)
+	}
+	if len(recorded.requests) != 1 || recorded.requests[0] != "GET /boxes.json" {
+		t.Errorf("requests = %v, want only box discovery", recorded.requests)
+	}
+}
+
+func TestMoveReportsServerFailure(t *testing.T) {
+	server, recorded := moveServer(t)
+	recorded.moveStatus = http.StatusUnprocessableEntity
+
+	_, err := runMove(t, server, "12345", "--to", "feed")
+	if err == nil {
+		t.Fatal("move should report the server failure")
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -132,6 +132,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newJournalCommand().cmd)
 	root.AddCommand(newSeenCommand().cmd)
 	root.AddCommand(newUnseenCommand().cmd)
+	root.AddCommand(newMoveCommand().cmd)
 	root.AddCommand(newSetupCommand())
 	root.AddCommand(newTuiCommand().cmd)
 	root.AddCommand(newSkillCommand().cmd)

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -73,6 +73,7 @@ type mailView struct {
 	loading       bool
 
 	compose           *composeForm // non-nil while a message, reply or forward is being written
+	movePicker        *movePicker  // non-nil while a destination box is being selected
 	notice            string       // one-shot confirmation shown above the posting list
 	activeRequestID   uint64       // identifies the only mail read allowed to update the view
 	activeRequestKind mailRequestKind
@@ -231,6 +232,9 @@ func (v *mailView) View() string {
 	if v.compose != nil {
 		return v.compose.view()
 	}
+	if v.movePicker != nil {
+		return v.movePicker.view(v.vc.styles, v.vc.width)
+	}
 	if v.inThread {
 		if v.notice != "" {
 			return v.vc.styles.title.Render(v.notice) + "\n" + v.topicViewport.View()
@@ -243,12 +247,15 @@ func (v *mailView) View() string {
 	return v.postingList.view()
 }
 
-// CapturingInput reports whether a form is open and wants every key.
-func (v *mailView) CapturingInput() bool { return v.compose != nil }
+// CapturingInput reports whether a form or picker is open and wants every key.
+func (v *mailView) CapturingInput() bool { return v.compose != nil || v.movePicker != nil }
 
 func (v *mailView) HelpBindings() []helpBinding {
 	if v.compose != nil {
 		return v.compose.helpBindings()
+	}
+	if v.movePicker != nil {
+		return v.movePicker.helpBindings()
 	}
 	if v.inThread {
 		return []helpBinding{{"r", "reply"}, {"f", "forward"}}
@@ -257,6 +264,7 @@ func (v *mailView) HelpBindings() []helpBinding {
 		{"c", "compose"},
 		{"r", "reply"},
 		{"f", "forward"},
+		{"m", "move"},
 		{"e", "seen"},
 		{"l", "reply later"},
 		{"a", "set aside"},
@@ -298,6 +306,24 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		return cmd
 	}
 
+	if v.movePicker != nil {
+		if msg.Key().Code == tea.KeyEscape {
+			v.movePicker = nil
+			return nil
+		}
+		if msg.Key().Code == tea.KeyEnter {
+			picker := v.movePicker
+			destination := picker.selected()
+			v.movePicker = nil
+			if destination == nil {
+				return nil
+			}
+			return v.movePostingToBox(picker.postingID, *destination)
+		}
+		v.movePicker.update(msg)
+		return nil
+	}
+
 	if v.inThread {
 		if msg.String() == "r" && v.topicID != 0 {
 			return v.loadReplyContext(v.topicID, v.topicName)
@@ -318,10 +344,15 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 	case tea.KeyEnter:
 		return v.openSelected()
 	default:
-		if msg.String() == "c" {
+		switch msg.String() {
+		case "c":
 			return v.startCompose()
+		case "m":
+			v.startMove()
+			return nil
+		default:
+			return v.handlePostingAction(msg.String())
 		}
-		return v.handlePostingAction(msg.String())
 	}
 	return nil
 }
@@ -330,6 +361,7 @@ func (v *mailView) InThread() bool { return v.inThread }
 func (v *mailView) ExitThread() {
 	v.inThread = false
 	v.compose = nil
+	v.movePicker = nil
 	v.cancelRequest()
 }
 
@@ -442,6 +474,25 @@ func (v *mailView) openSelected() tea.Cmd {
 
 // --- Posting actions ---
 
+func (v *mailView) startMove() {
+	selected := v.postingList.selectedPosting()
+	if selected == nil {
+		return
+	}
+	picker := newMovePicker(*selected, v.boxes, v.currentBoxID())
+	if len(picker.destinations) == 0 {
+		v.notice = "No other boxes available"
+		return
+	}
+	v.movePicker = picker
+}
+
+func (v *mailView) movePostingToBox(postingID int64, destination models.Box) tea.Cmd {
+	return v.doPostingAction("moved to "+destination.Name, true, v.currentBoxID(), postingID, func() error {
+		return v.vc.sdk.Postings().Move(v.vc.ctx, destination.ID, postingID)
+	})
+}
+
 func (v *mailView) handlePostingAction(key string) tea.Cmd {
 	selected := v.postingList.selectedPosting()
 	if selected == nil {
@@ -452,11 +503,11 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 
 	switch key {
 	case "l":
-		return v.doPostingAction("moved to Reply Later", v.movesOutOfCurrentBox(hey.BoxKindLater), boxID, p.ID, func() error {
+		return v.moveSelectedToKnownBox("Reply Later", hey.BoxKindLater, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToReplyLater(v.vc.ctx, p.ID)
 		})
 	case "a":
-		return v.doPostingAction("moved to Set Aside", v.movesOutOfCurrentBox(hey.BoxKindSetAside), boxID, p.ID, func() error {
+		return v.moveSelectedToKnownBox("Set Aside", hey.BoxKindSetAside, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToSetAside(v.vc.ctx, p.ID)
 		})
 	case "e":
@@ -464,11 +515,11 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 			return v.vc.sdk.Postings().MarkSeen(v.vc.ctx, []int64{p.ID})
 		})
 	case "d":
-		return v.doPostingAction("moved to The Feed", v.movesOutOfCurrentBox(hey.BoxKindFeed), boxID, p.ID, func() error {
+		return v.moveSelectedToKnownBox("The Feed", hey.BoxKindFeed, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToFeed(v.vc.ctx, p.ID)
 		})
 	case "p":
-		return v.doPostingAction("moved to Paper Trail", v.movesOutOfCurrentBox(hey.BoxKindTrail), boxID, p.ID, func() error {
+		return v.moveSelectedToKnownBox("Paper Trail", hey.BoxKindTrail, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToPaperTrail(v.vc.ctx, p.ID)
 		})
 	case "t":
@@ -493,6 +544,14 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 		return v.loadForwardContext(topicID, p.Summary)
 	}
 	return nil
+}
+
+func (v *mailView) moveSelectedToKnownBox(name, kind string, boxID, postingID int64, fn func() error) tea.Cmd {
+	if !v.movesOutOfCurrentBox(kind) {
+		v.notice = "Already in " + name
+		return nil
+	}
+	return v.doPostingAction("moved to "+name, true, boxID, postingID, fn)
 }
 
 func (v *mailView) movesOutOfCurrentBox(destinationKind string) bool {

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -301,17 +301,104 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 	}
 }
 
-func TestMailViewMoveWithinCurrentBoxKeepsPosting(t *testing.T) {
+func TestMailViewMovePickerMovesToSelectedBox(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.boxes = []models.Box{
+		{ID: 1, Kind: hey.BoxKindImbox, Name: "Imbox"},
+		{ID: 2, Kind: hey.BoxKindFeed, Name: "The Feed"},
+		{ID: 3, Kind: hey.BoxKindSetAside, Name: "Set Aside"},
+		{ID: 4, Kind: hey.BoxKindLater, Name: "Reply Later"},
+		{ID: 5, Kind: hey.BoxKindTrail, Name: "Paper Trail"},
+		{ID: 6, Kind: hey.BoxKindBubbleUp, Name: "Bubble Up"},
+	}
+
+	if cmd := v.HandleContentKey(keyPress("m")); cmd != nil {
+		t.Fatal("opening the move picker should not start a request")
+	}
+	if !v.CapturingInput() || v.movePicker == nil {
+		t.Fatal("move picker should capture input")
+	}
+	if len(v.movePicker.destinations) != 4 {
+		t.Fatalf("destinations = %v, want four boxes", v.movePicker.destinations)
+	}
+	if view := v.View(); strings.Contains(view, "Bubble Up") || strings.Contains(view, "\n  Imbox") {
+		t.Errorf("move picker offered an ineligible destination: %q", view)
+	}
+
+	msg := runCmd(v.HandleContentKey(keyPress("enter")))
+	done, ok := msg.(postingActionDoneMsg)
+	if !ok || done.err != nil {
+		t.Fatalf("move command returned %#v", msg)
+	}
+	if v.movePicker != nil || v.CapturingInput() {
+		t.Error("move picker should close after choosing a destination")
+	}
+	if recorded.body.BoxID == nil || *recorded.body.BoxID != 2 {
+		t.Errorf("box_id = %v, want 2", recorded.body.BoxID)
+	}
+	if len(recorded.body.PostingIDs) != 1 || recorded.body.PostingIDs[0] != 100 {
+		t.Errorf("posting_ids = %v, want [100]", recorded.body.PostingIDs)
+	}
+
+	v.Update(done)
+	if v.postingIndex(100) >= 0 {
+		t.Error("moved posting should leave the current box")
+	}
+	if v.notice != "moved to The Feed" {
+		t.Errorf("notice = %q", v.notice)
+	}
+}
+
+func TestMailViewMovePickerSelectsWithArrowKeys(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.boxes = []models.Box{
+		{ID: 1, Kind: hey.BoxKindImbox, Name: "Imbox"},
+		{ID: 2, Kind: hey.BoxKindFeed, Name: "The Feed"},
+		{ID: 3, Kind: hey.BoxKindSetAside, Name: "Set Aside"},
+	}
+
+	v.HandleContentKey(keyPress("m"))
+	v.HandleContentKey(keyPress("down"))
+	msg := runCmd(v.HandleContentKey(keyPress("enter")))
+	if done, ok := msg.(postingActionDoneMsg); !ok || done.err != nil {
+		t.Fatalf("move command returned %#v", msg)
+	}
+	if recorded.body.BoxID == nil || *recorded.body.BoxID != 3 {
+		t.Errorf("box_id = %v, want 3", recorded.body.BoxID)
+	}
+}
+
+func TestMailViewMovePickerCancelsWithoutRequest(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.boxes = []models.Box{
+		{ID: 1, Kind: hey.BoxKindImbox, Name: "Imbox"},
+		{ID: 2, Kind: hey.BoxKindFeed, Name: "The Feed"},
+	}
+
+	v.HandleContentKey(keyPress("m"))
+	if cmd := v.HandleContentKey(keyPress("esc")); cmd != nil {
+		t.Fatal("canceling the move picker should not return a command")
+	}
+	if v.movePicker != nil || v.CapturingInput() {
+		t.Error("escape should close the move picker")
+	}
+	if len(recorded.requests) != 0 {
+		t.Errorf("canceling made requests: %v", recorded.requests)
+	}
+}
+
+func TestMailViewMoveWithinCurrentBoxSkipsRequest(t *testing.T) {
 	tests := []struct {
-		name  string
-		key   string
-		kind  string
-		boxID int64
+		name    string
+		key     string
+		kind    string
+		boxID   int64
+		display string
 	}{
-		{"reply later", "l", hey.BoxKindLater, 4},
-		{"set aside", "a", hey.BoxKindSetAside, 3},
-		{"feed", "d", hey.BoxKindFeed, 2},
-		{"paper trail", "p", hey.BoxKindTrail, 5},
+		{"reply later", "l", hey.BoxKindLater, 4, "Reply Later"},
+		{"set aside", "a", hey.BoxKindSetAside, 3, "Set Aside"},
+		{"feed", "d", hey.BoxKindFeed, 2, "The Feed"},
+		{"paper trail", "p", hey.BoxKindTrail, 5, "Paper Trail"},
 	}
 
 	for _, tt := range tests {
@@ -320,23 +407,17 @@ func TestMailViewMoveWithinCurrentBoxKeepsPosting(t *testing.T) {
 			v.boxes = []models.Box{{ID: tt.boxID, Kind: tt.kind, Name: tt.name}}
 			v.boxIndex = 0
 
-			msg := runCmd(v.HandleContentKey(keyPress(tt.key)))
-			done, ok := msg.(postingActionDoneMsg)
-			if !ok || done.err != nil {
-				t.Fatalf("posting command returned %#v", msg)
+			if cmd := v.HandleContentKey(keyPress(tt.key)); cmd != nil {
+				t.Fatal("move within the current box should not start a request")
 			}
-			if done.removes {
-				t.Fatal("move within the current box should keep the posting visible")
-			}
-			v.Update(done)
-
 			if len(v.postingList.postings) != len(testPostings()) || v.postingList.postings[0].ID != 100 {
 				t.Errorf("move within current box changed postings: %v", v.postingList.postings)
 			}
-			if recorded.body.BoxID == nil {
-				t.Errorf("box_id is omitted, want %d", tt.boxID)
-			} else if *recorded.body.BoxID != tt.boxID {
-				t.Errorf("box_id = %d, want %d", *recorded.body.BoxID, tt.boxID)
+			if len(recorded.requests) != 0 {
+				t.Errorf("move within current box made requests: %v", recorded.requests)
+			}
+			if v.notice != "Already in "+tt.display {
+				t.Errorf("notice = %q, want %q", v.notice, "Already in "+tt.display)
 			}
 		})
 	}
@@ -989,10 +1070,20 @@ func TestMailViewHelpBindings(t *testing.T) {
 	for _, b := range bindings {
 		keys[b.key] = true
 	}
-	for _, expected := range []string{"r", "f", "e", "l", "a", "t"} {
+	for _, expected := range []string{"r", "f", "m", "e", "l", "a", "t"} {
 		if !keys[expected] {
 			t.Errorf("missing help binding for key %q", expected)
 		}
+	}
+}
+
+func TestMailViewHelpBindingsInMovePicker(t *testing.T) {
+	v := mailWithPostings()
+	v.HandleContentKey(keyPress("m"))
+
+	bindings := v.HelpBindings()
+	if len(bindings) != 3 || bindings[0].key != "↑↓" || bindings[1].key != "enter" || bindings[2].key != "esc" {
+		t.Errorf("move picker help = %v", bindings)
 	}
 }
 

--- a/internal/tui/move.go
+++ b/internal/tui/move.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/models"
+)
+
+type movePicker struct {
+	postingID    int64
+	summary      string
+	destinations []models.Box
+	cursor       int
+}
+
+func newMovePicker(posting models.Posting, boxes []models.Box, currentBoxID int64) *movePicker {
+	destinations := make([]models.Box, 0, len(boxes))
+	for _, box := range boxes {
+		if box.ID == currentBoxID || strings.EqualFold(box.Kind, hey.BoxKindBubbleUp) || strings.EqualFold(box.Name, "Bubble Up") {
+			continue
+		}
+		destinations = append(destinations, box)
+	}
+	return &movePicker{
+		postingID:    posting.ID,
+		summary:      posting.Summary,
+		destinations: destinations,
+	}
+}
+
+func (p *movePicker) selected() *models.Box {
+	if p.cursor < 0 || p.cursor >= len(p.destinations) {
+		return nil
+	}
+	return &p.destinations[p.cursor]
+}
+
+func (p *movePicker) update(msg tea.KeyPressMsg) {
+	switch msg.Key().Code {
+	case tea.KeyUp:
+		if p.cursor > 0 {
+			p.cursor--
+		}
+	case tea.KeyDown:
+		if p.cursor < len(p.destinations)-1 {
+			p.cursor++
+		}
+	}
+}
+
+func (p *movePicker) view(styles styles, width int) string {
+	contentWidth := max(width-4, 1)
+	var b strings.Builder
+	b.WriteString(styles.title.Render("Move message"))
+	if p.summary != "" {
+		fmt.Fprintf(&b, "\n%s", truncateStr(p.summary, contentWidth))
+	}
+	b.WriteString("\n\n")
+	for i, box := range p.destinations {
+		prefix := "  "
+		name := box.Name
+		if i == p.cursor {
+			prefix = "› "
+			name = styles.title.Render(name)
+		}
+		fmt.Fprintf(&b, "%s%s\n", prefix, name)
+	}
+	b.WriteString("\n")
+	b.WriteString(strings.Join(wrapText("Moving to a box other than Imbox marks the message as seen.", contentWidth), "\n"))
+	return b.String()
+}
+
+func (p *movePicker) helpBindings() []helpBinding {
+	return []helpBinding{
+		{"↑↓", "select"},
+		{"enter", "move"},
+		{"esc", "cancel"},
+	}
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -230,6 +230,29 @@ func TestCalendarDetailHelpOmitsListActions(t *testing.T) {
 	}
 }
 
+func TestMovePickerOwnsNavigationKeys(t *testing.T) {
+	m := modelWithBoxes()
+	m.focus = rowContent
+
+	updated, _ := m.Update(keyPress("m"))
+	m = updated.(model)
+	if m.mailView.movePicker == nil || !m.mailView.CapturingInput() {
+		t.Fatal("m should open the move picker")
+	}
+
+	updated, _ = m.Update(keyPress("tab"))
+	m = updated.(model)
+	if m.focus != rowContent || m.mailView.movePicker == nil {
+		t.Error("tab should remain inside the move picker")
+	}
+
+	updated, _ = m.Update(keyPress("esc"))
+	m = updated.(model)
+	if m.mailView.movePicker != nil || m.mailView.CapturingInput() {
+		t.Error("escape should close the move picker")
+	}
+}
+
 func TestEscExitsThread(t *testing.T) {
 	m := modelWithBoxes()
 	m.mailView.inThread = true

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -24,6 +24,8 @@ triggers:
   # Seen/unseen
   - hey seen
   - hey unseen
+  - hey move
+  - move email
   - mark as read
   - mark as seen
   - mark as unseen
@@ -101,6 +103,7 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 | Delete todo | `hey todo delete 123` |
 | Mark as seen | `hey seen 12345` |
 | Mark as unseen | `hey unseen 12345` |
+| Move postings | `hey move 12345 --to feed` |
 | Complete habit | `hey habit complete 123` |
 | Uncomplete habit | `hey habit uncomplete 123` |
 | Start time tracking | `hey timetrack start` |
@@ -125,6 +128,7 @@ Want to read email?
 ├── Read full thread? → hey threads <topic_id> --json
 ├── Mark as seen? → hey seen <posting-id>
 ├── Mark as unseen? → hey unseen <posting-id>
+├── Move to another box? → hey move <posting-id> --to <box>
 └── Launch interactive UI? → hey (no args, launches TUI)
 ```
 
@@ -200,6 +204,15 @@ hey unseen 12345 67890                        # Mark multiple postings as unseen
 ```
 
 Takes posting IDs (the `id` field from `hey box` output).
+
+### Email - Moving Postings
+
+```bash
+hey move 12345 --to imbox                     # Move one posting
+hey move 12345 67890 --to "paper trail"       # Move multiple postings
+```
+
+Takes posting IDs (the `id` field from `hey box --json`). `--to` accepts a box name, kind, or ID. Supported destinations are Imbox, The Feed, Set Aside, Reply Later, and Paper Trail. Bubble Up requires a scheduled date and is not supported by this command.
 
 ### Drafts
 

--- a/tests/smoke/boxes_test.go
+++ b/tests/smoke/boxes_test.go
@@ -171,6 +171,66 @@ func TestBoxesAll(t *testing.T) {
 	}
 }
 
+func TestMovePosting(t *testing.T) {
+	resp := heyJSON(t, "box", "imbox", "--limit", "10")
+	type Posting struct {
+		ID   int  `json:"id"`
+		Seen bool `json:"seen"`
+	}
+	type BoxResponse struct {
+		Postings []Posting `json:"postings"`
+	}
+	imbox := dataAs[BoxResponse](t, resp)
+	postingID := 0
+	for _, posting := range imbox.Postings {
+		if posting.Seen {
+			postingID = posting.ID
+			break
+		}
+	}
+	if postingID == 0 {
+		t.Skip("no seen postings in Imbox to move without changing unread state")
+	}
+
+	stdout, stderr, code := hey(t, "move", intStr(postingID), "--to", "feedbox", "--json")
+	if code != 0 {
+		t.Skipf("moving postings is unavailable on this server (exit %d): %s", code, stderr)
+	}
+	t.Cleanup(func() {
+		_, cleanupStderr, cleanupCode := hey(t, "move", intStr(postingID), "--to", "imbox", "--json")
+		if cleanupCode != 0 {
+			t.Logf("could not restore posting %d to Imbox: %s", postingID, cleanupStderr)
+		}
+	})
+
+	var moveResp Response
+	if err := json.Unmarshal([]byte(stdout), &moveResp); err != nil {
+		t.Fatalf("failed to parse move response: %v", err)
+	}
+	assertContains(t, moveResp.Summary, "moved to The Feed")
+
+	feedResp := heyJSON(t, "box", "feedbox", "--all")
+	feed := dataAs[BoxResponse](t, feedResp)
+	for _, posting := range feed.Postings {
+		if posting.ID == postingID {
+			return
+		}
+	}
+	t.Errorf("posting %d did not appear in The Feed", postingID)
+}
+
+func TestMoveNoPostingID(t *testing.T) {
+	heyFail(t, "move", "--to", "feed", "--json")
+}
+
+func TestMoveNoDestination(t *testing.T) {
+	heyFail(t, "move", "12345", "--json")
+}
+
+func TestMoveRejectsBubbleUp(t *testing.T) {
+	heyFail(t, "move", "12345", "--to", "bubblebox", "--json")
+}
+
 func TestBoxNoArgument(t *testing.T) {
 	heyFail(t, "box", "--json")
 }


### PR DESCRIPTION
## Summary

- add `hey move <posting-id>... --to <box>` with bulk moves and destination lookup by name, kind, or ID
- add an `m` destination picker to the TUI while preserving the existing one-key box actions
- exclude the current box and Bubble Up from the picker, reject Bubble Up in the CLI, and avoid same-box TUI requests that could change seen state
- document posting IDs, destination semantics, and the new command across help, README, API coverage, and the embedded HEY skill

## Behavior

Supported destinations are Imbox, The Feed, Set Aside, Reply Later, and Paper Trail. Moving to boxes other than Imbox marks the posting seen, which the TUI explains before confirmation. Bubble Up continues to use HEY's scheduled flow.

## Validation

- `make check`
- `make race-test`
- smoke test package compilation
- local build and command help
- authenticated production validation:
  - moved and restored one posting through the CLI
  - moved and restored two postings in one bulk CLI request
  - moved a posting from Imbox to Paper Trail through the TUI and restored it
  - confirmed destination box membership after every move and restore
  - confirmed Bubble Up is rejected before a move request

All production-validation postings were restored to Imbox.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds posting moves to both the CLI and TUI so users can move messages between HEY boxes without the web app. Moving to non‑Imbox marks messages seen; Bubble Up is excluded and must use HEY’s scheduled flow.

- CLI: `hey move <posting-id>... --to <box>` supports bulk IDs and resolves destinations by name, kind, or ID; rejects Bubble Up; prints a concise summary; adds help and breadcrumbs.
- TUI: press `m` to open a destination picker; excludes the current box and Bubble Up; Enter moves, Esc cancels; explains that non‑Imbox moves mark the message seen; existing one‑key moves remain and skip no‑op same‑box requests.
- API/docs/tests: uses `/postings/moves.json` via SDK `Postings().Move`; updates `.surface`, README, help text, `skills/hey/SKILL.md`, and `API-COVERAGE.md`; adds unit and smoke tests for success and error cases.

<sup>Written for commit be4f041c97fe501690af27d0b7f78c4294cce87f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

