### PR TITLE
Align email terminology with HEY

### DIFF
--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -21,7 +21,7 @@ The legacy `internal/client/` is used only for HTML-scraping gap operations mark
 | `/entries/{id}/replies` | POST | SDK `Entries().CreateReply` | `hey reply <topic-id>` | covered |
 | `/topics/{id}.json` | GET | SDK `Topics().Get` | `hey forward <topic-id>` | covered |
 | `/entries/{id}/forwards/new.json` | GET | SDK `Entries().NewForward` | `hey forward <topic-id>` | covered |
-| `/postings/moves.json` | POST | SDK `Postings().Move` | `hey move <posting-id> --to <box>`, TUI `m` | covered |
+| `/postings/moves.json` | POST | SDK `Postings().Move` | `hey move <id> --to <box>`, TUI `m` | covered |
 | `/calendar/days/{date}/habits/{id}/completions.json` | POST | SDK `Habits().Complete` | `hey habit complete <id>` | covered |
 | `/calendar/days/{date}/habits/{id}/completions.json` | DELETE | SDK `Habits().Uncomplete` | `hey habit uncomplete <id>` | covered |
 | `/calendar/days/{date}/journal_entry.json` | GET | SDK `Journal().Get` | `hey journal read [date]` | partial: falls back to legacy |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ hey auth logout   # clear credentials
 
 Run `hey` to launch the interactive terminal UI.
 
-Navigate between mailboxes, postings, and full email threads. Use Enter to open a thread, `r` to reply, `f` to forward, `m` to move a posting, and Escape or `q` to go back.
+Navigate between mailboxes and email threads. Use Enter to open a thread, `r` to reply, `f` to forward, `m` to move a thread, and Escape or `q` to go back.
 
 ## CLI Commands
 
@@ -68,18 +68,18 @@ All commands support `--json` for raw JSON output and `--base-url` to override t
 
 ```bash
 hey boxes                          # list mailboxes
-hey box imbox                      # list postings in a box (by name or ID)
+hey box imbox                      # list email threads in a box (by name or ID)
 hey threads 123                    # read a full email thread
 hey reply 123 -m "Thanks!"        # reply to a thread (or omit -m to open $EDITOR)
 hey forward 123 --to alice@example.com -m "For your review"  # forward the latest message
 hey compose --to user@example.com --subject "Hello"  # compose a new message
 hey compose --to user@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello"  # with CC/BCC
 hey drafts                         # list drafts
-hey move 12345 --to feed           # move a posting to another box
-hey move 12345 67890 --to "paper trail"  # move multiple postings
+hey move 12345 --to feed           # move a thread to another box
+hey move 12345 67890 --to "paper trail"  # move multiple threads
 ```
 
-`hey move` takes posting IDs from `hey box --json`. Destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`.
+`hey move` takes the `id` values returned by `hey box --json`. Destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`.
 
 ### Calendars
 

--- a/internal/cmd/box.go
+++ b/internal/cmd/box.go
@@ -26,10 +26,10 @@ func newBoxCommand() *boxCommand {
 	boxCommand := &boxCommand{}
 	boxCommand.cmd = &cobra.Command{
 		Use:   "box <name|id>",
-		Short: "List messages in a box",
-		Long:  "List messages in a HEY box. Accepts a box name (imbox, feedbox, etc.) or numeric ID.",
+		Short: "List email threads in a box",
+		Long:  "List email threads in a HEY box. Accepts a box name (imbox, feedbox, etc.) or numeric ID.",
 		Annotations: map[string]string{
-			"agent_notes": "Accepts box name or numeric ID. Returns postings (threads). Use thread IDs with hey threads.",
+			"agent_notes": "Accepts a box name or numeric ID. Returns email threads. Use topic_id with hey threads, reply, and forward; use id with seen, unseen, and move.",
 		},
 		Example: `  hey box imbox
   hey box imbox --limit 10
@@ -38,7 +38,7 @@ func newBoxCommand() *boxCommand {
 		Args: validateBoxArgs,
 	}
 
-	boxCommand.cmd.Flags().IntVar(&boxCommand.limit, "limit", 0, "Maximum number of messages to show")
+	boxCommand.cmd.Flags().IntVar(&boxCommand.limit, "limit", 0, "Maximum number of threads to show")
 	boxCommand.cmd.Flags().BoolVar(&boxCommand.all, "all", false, "Fetch all results (override --limit)")
 
 	return boxCommand
@@ -101,7 +101,7 @@ func (c *boxCommand) run(cmd *cobra.Command, args []string) error {
 
 	resp.Postings = postings
 	return writeOK(resp,
-		output.WithSummary(fmt.Sprintf("%d postings in %s", len(postings), resp.Name)),
+		output.WithSummary(fmt.Sprintf("%d %s in %s", len(postings), threadNoun(len(postings)), resp.Name)),
 		output.WithNotice(notice),
 		output.WithBreadcrumbs(
 			output.Breadcrumb{
@@ -111,8 +111,8 @@ func (c *boxCommand) run(cmd *cobra.Command, args []string) error {
 			},
 			output.Breadcrumb{
 				Action:      "move",
-				Command:     "hey move <posting-id> --to <box>",
-				Description: "Move a message to another box",
+				Command:     "hey move <id> --to <box>",
+				Description: "Move an email thread to another box",
 			},
 			output.Breadcrumb{
 				Action:      "compose",

--- a/internal/cmd/box.go
+++ b/internal/cmd/box.go
@@ -101,7 +101,7 @@ func (c *boxCommand) run(cmd *cobra.Command, args []string) error {
 
 	resp.Postings = postings
 	return writeOK(resp,
-		output.WithSummary(fmt.Sprintf("%d %s in %s", len(postings), threadNoun(len(postings)), resp.Name)),
+		output.WithSummary(boxSummary(len(postings), resp.Name)),
 		output.WithNotice(notice),
 		output.WithBreadcrumbs(
 			output.Breadcrumb{
@@ -121,6 +121,10 @@ func (c *boxCommand) run(cmd *cobra.Command, args []string) error {
 			},
 		),
 	)
+}
+
+func boxSummary(count int, name string) string {
+	return fmt.Sprintf("%d %s in %s", count, threadNoun(count), name)
 }
 
 // resolveBox fetches a box by name or ID, using named SDK getters for

--- a/internal/cmd/box_test.go
+++ b/internal/cmd/box_test.go
@@ -82,6 +82,25 @@ func mockFetcher(pages []generated.BoxShowResponse) pageFetcher {
 	}
 }
 
+func TestBoxSummaryUsesThreadTerminology(t *testing.T) {
+	tests := []struct {
+		name  string
+		count int
+		want  string
+	}{
+		{"one thread", 1, "1 thread in Imbox"},
+		{"multiple threads", 2, "2 threads in Imbox"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := boxSummary(tt.count, "Imbox"); got != tt.want {
+				t.Errorf("boxSummary(%d) = %q, want %q", tt.count, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPaginateBoxPostings_NoFlagsSinglePage(t *testing.T) {
 	first := &generated.BoxShowResponse{
 		Postings:       makePostings(30, 0),

--- a/internal/cmd/boxes.go
+++ b/internal/cmd/boxes.go
@@ -76,7 +76,7 @@ func (c *boxesCommand) run(cmd *cobra.Command, args []string) error {
 		output.WithBreadcrumbs(output.Breadcrumb{
 			Action:      "view",
 			Command:     "hey box <name>",
-			Description: "View postings in a box",
+			Description: "View email threads in a box",
 		}),
 	)
 }

--- a/internal/cmd/formatting.go
+++ b/internal/cmd/formatting.go
@@ -89,6 +89,13 @@ func truncate(s string, maxWidth int) string {
 	return runewidth.Truncate(s, maxWidth, "...")
 }
 
+func threadNoun(count int) string {
+	if count == 1 {
+		return "thread"
+	}
+	return "threads"
+}
+
 func stdinIsTerminal() bool {
 	return term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // G115: fd fits in int
 }

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -25,6 +25,29 @@ func TestCuratedCommandHelpUsesUserFacingLanguage(t *testing.T) {
 	}
 }
 
+func TestEmailCommandHelpKeepsPostingAsAnInternalTerm(t *testing.T) {
+	root := newRootCmd()
+	for _, name := range []string{"boxes", "box", "seen", "unseen", "move"} {
+		t.Run(name, func(t *testing.T) {
+			command, _, err := root.Find([]string{name})
+			if err != nil {
+				t.Fatal(err)
+			}
+			text := strings.Join([]string{
+				command.Use,
+				command.Short,
+				command.Long,
+				command.Example,
+				command.Annotations["agent_notes"],
+				command.NonInheritedFlags().FlagUsages(),
+			}, "\n")
+			if strings.Contains(strings.ToLower(text), "posting") {
+				t.Errorf("%s exposes internal posting terminology:\n%s", name, text)
+			}
+		})
+	}
+}
+
 func TestRenderRootHelpUsesUserFacingLanguage(t *testing.T) {
 	originalColorDisabled := colorDisabled
 	colorDisabled = true
@@ -41,15 +64,15 @@ USAGE
 
 EMAIL
   boxes    List your HEY boxes
-  box      List messages in a box
+  box      List email threads in a box
   threads  Read a thread
   compose  Write and send a new email
   reply    Reply to a thread
   forward  Forward the latest message in a thread
   drafts   List draft emails
-  seen     Mark messages as seen
-  unseen   Mark messages as unseen
-  move     Move messages to another box
+  seen     Mark email threads as seen
+  unseen   Mark email threads as unseen
+  move     Move email threads to another box
 
 CALENDAR & TASKS
   calendars   List calendars

--- a/internal/cmd/move.go
+++ b/internal/cmd/move.go
@@ -22,14 +22,14 @@ type moveCommand struct {
 func newMoveCommand() *moveCommand {
 	moveCommand := &moveCommand{}
 	moveCommand.cmd = &cobra.Command{
-		Use:   "move <posting-id>...",
-		Short: "Move messages to another box",
-		Long:  "Move one or more HEY postings to Imbox, The Feed, Set Aside, Reply Later, or Paper Trail.",
+		Use:   "move <id>...",
+		Short: "Move email threads to another box",
+		Long:  "Move one or more email threads to Imbox, The Feed, Set Aside, Reply Later, or Paper Trail.",
 		Example: `  hey move 12345 --to feed
   hey move 12345 67890 --to "paper trail"
   hey move 12345 --to 987`,
 		Annotations: map[string]string{
-			"agent_notes": "Accepts posting IDs from hey box output. --to accepts a box name, kind, or ID. Use HEY's scheduled Bubble Up flow for Bubble Up.",
+			"agent_notes": "Accepts box item IDs from hey box output. --to accepts a box name, kind, or ID. Use HEY's scheduled Bubble Up flow for Bubble Up.",
 		},
 		RunE: moveCommand.run,
 		Args: usageMinOneArg(),
@@ -62,7 +62,7 @@ func (c *moveCommand) run(cmd *cobra.Command, args []string) error {
 		return convertSDKError(err)
 	}
 
-	summary := fmt.Sprintf("%d posting(s) moved to %s", len(ids), destination.Name)
+	summary := fmt.Sprintf("%d %s moved to %s", len(ids), threadNoun(len(ids)), destination.Name)
 	if writer.IsStyled() {
 		fmt.Fprintln(cmd.OutOrStdout(), summary+".")
 		return nil

--- a/internal/cmd/move_test.go
+++ b/internal/cmd/move_test.go
@@ -93,7 +93,7 @@ func TestMovePostingsToNamedBox(t *testing.T) {
 	if len(recorded.postingIDs) != 2 || recorded.postingIDs[0] != 12345 || recorded.postingIDs[1] != 67890 {
 		t.Errorf("posting_ids = %v", recorded.postingIDs)
 	}
-	if resp.Summary != "2 posting(s) moved to Paper Trail" {
+	if resp.Summary != "2 threads moved to Paper Trail" {
 		t.Errorf("summary = %q", resp.Summary)
 	}
 }

--- a/internal/cmd/seen.go
+++ b/internal/cmd/seen.go
@@ -16,12 +16,12 @@ type seenCommand struct {
 func newSeenCommand() *seenCommand {
 	seenCommand := &seenCommand{}
 	seenCommand.cmd = &cobra.Command{
-		Use:   "seen <posting-id>...",
-		Short: "Mark messages as seen",
+		Use:   "seen <id>...",
+		Short: "Mark email threads as seen",
 		Example: `  hey seen 12345
   hey seen 12345 67890`,
 		Annotations: map[string]string{
-			"agent_notes": "Accepts one or more posting IDs. Marks each as seen/read.",
+			"agent_notes": "Accepts one or more box item IDs from hey box output. Marks each email thread as seen/read.",
 		},
 		RunE: seenCommand.run,
 		Args: usageMinOneArg(),
@@ -44,7 +44,7 @@ func (c *seenCommand) run(cmd *cobra.Command, args []string) error {
 		return convertSDKError(err)
 	}
 
-	summary := fmt.Sprintf("%d posting(s) marked as seen", len(ids))
+	summary := fmt.Sprintf("%d %s marked as seen", len(ids), threadNoun(len(ids)))
 
 	if writer.IsStyled() {
 		fmt.Fprintln(cmd.OutOrStdout(), summary+".")
@@ -63,12 +63,12 @@ type unseenCommand struct {
 func newUnseenCommand() *unseenCommand {
 	unseenCommand := &unseenCommand{}
 	unseenCommand.cmd = &cobra.Command{
-		Use:   "unseen <posting-id>...",
-		Short: "Mark messages as unseen",
+		Use:   "unseen <id>...",
+		Short: "Mark email threads as unseen",
 		Example: `  hey unseen 12345
   hey unseen 12345 67890`,
 		Annotations: map[string]string{
-			"agent_notes": "Accepts one or more posting IDs. Marks each as unseen/unread.",
+			"agent_notes": "Accepts one or more box item IDs from hey box output. Marks each email thread as unseen/unread.",
 		},
 		RunE: unseenCommand.run,
 		Args: usageMinOneArg(),
@@ -91,7 +91,7 @@ func (c *unseenCommand) run(cmd *cobra.Command, args []string) error {
 		return convertSDKError(err)
 	}
 
-	summary := fmt.Sprintf("%d posting(s) marked as unseen", len(ids))
+	summary := fmt.Sprintf("%d %s marked as unseen", len(ids), threadNoun(len(ids)))
 
 	if writer.IsStyled() {
 		fmt.Fprintln(cmd.OutOrStdout(), summary+".")
@@ -106,7 +106,7 @@ func parseIntArgs(args []string) ([]int64, error) {
 	for _, arg := range args {
 		id, err := strconv.ParseInt(arg, 10, 64)
 		if err != nil {
-			return nil, output.ErrUsage(fmt.Sprintf("invalid posting ID: %s", arg))
+			return nil, output.ErrUsage(fmt.Sprintf("invalid ID: %s", arg))
 		}
 		ids = append(ids, id)
 	}

--- a/internal/cmd/seen_test.go
+++ b/internal/cmd/seen_test.go
@@ -100,8 +100,8 @@ func TestSeenSingle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if resp.Summary != "1 posting(s) marked as seen" {
-		t.Errorf("summary = %q, want %q", resp.Summary, "1 posting(s) marked as seen")
+	if resp.Summary != "1 thread marked as seen" {
+		t.Errorf("summary = %q, want %q", resp.Summary, "1 thread marked as seen")
 	}
 }
 
@@ -113,8 +113,8 @@ func TestSeenMultiple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if resp.Summary != "2 posting(s) marked as seen" {
-		t.Errorf("summary = %q, want %q", resp.Summary, "2 posting(s) marked as seen")
+	if resp.Summary != "2 threads marked as seen" {
+		t.Errorf("summary = %q, want %q", resp.Summary, "2 threads marked as seen")
 	}
 }
 
@@ -139,6 +139,9 @@ func TestSeenInvalidID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for non-numeric ID")
 	}
+	if err.Error() != "invalid ID: abc" {
+		t.Errorf("error = %q, want %q", err, "invalid ID: abc")
+	}
 }
 
 func TestUnseenSingle(t *testing.T) {
@@ -149,8 +152,8 @@ func TestUnseenSingle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if resp.Summary != "1 posting(s) marked as unseen" {
-		t.Errorf("summary = %q, want %q", resp.Summary, "1 posting(s) marked as unseen")
+	if resp.Summary != "1 thread marked as unseen" {
+		t.Errorf("summary = %q, want %q", resp.Summary, "1 thread marked as unseen")
 	}
 }
 
@@ -162,8 +165,8 @@ func TestUnseenMultiple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if resp.Summary != "2 posting(s) marked as unseen" {
-		t.Errorf("summary = %q, want %q", resp.Summary, "2 posting(s) marked as unseen")
+	if resp.Summary != "2 threads marked as unseen" {
+		t.Errorf("summary = %q, want %q", resp.Summary, "2 threads marked as unseen")
 	}
 }
 

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -203,7 +203,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 				v.postingList.cursor--
 			}
 			v.postingList.ensureVisible()
-		} else if msg.action == "marked as seen" && idx >= 0 {
+		} else if msg.action == "Thread marked as seen" && idx >= 0 {
 			v.postingList.postings[idx].Seen = true
 		}
 		if v.activeRequestKind == mailRequestPostings {
@@ -488,7 +488,7 @@ func (v *mailView) startMove() {
 }
 
 func (v *mailView) movePostingToBox(postingID int64, destination models.Box) tea.Cmd {
-	return v.doPostingAction("moved to "+destination.Name, true, v.currentBoxID(), postingID, func() error {
+	return v.doPostingAction("Thread moved to "+destination.Name, true, v.currentBoxID(), postingID, func() error {
 		return v.vc.sdk.Postings().Move(v.vc.ctx, destination.ID, postingID)
 	})
 }
@@ -511,7 +511,7 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 			return v.vc.sdk.Postings().MoveToSetAside(v.vc.ctx, p.ID)
 		})
 	case "e":
-		return v.doPostingAction("marked as seen", false, boxID, p.ID, func() error {
+		return v.doPostingAction("Thread marked as seen", false, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MarkSeen(v.vc.ctx, []int64{p.ID})
 		})
 	case "d":
@@ -523,11 +523,11 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 			return v.vc.sdk.Postings().MoveToPaperTrail(v.vc.ctx, p.ID)
 		})
 	case "t":
-		return v.doPostingAction("moved to Trash", true, boxID, p.ID, func() error {
+		return v.doPostingAction("Thread moved to Trash", true, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToTrash(v.vc.ctx, p.ID)
 		})
 	case "-":
-		return v.doPostingAction("muted", true, boxID, p.ID, func() error {
+		return v.doPostingAction("Thread muted", true, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().Mute(v.vc.ctx, p.ID)
 		})
 	case "r":
@@ -551,7 +551,7 @@ func (v *mailView) moveSelectedToKnownBox(name, kind string, boxID, postingID in
 		v.notice = "Already in " + name
 		return nil
 	}
-	return v.doPostingAction("moved to "+name, true, boxID, postingID, fn)
+	return v.doPostingAction("Thread moved to "+name, true, boxID, postingID, fn)
 }
 
 func (v *mailView) movesOutOfCurrentBox(destinationKind string) bool {

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -245,13 +245,13 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 		notice  string
 		seen    bool
 	}{
-		{"reply later", "l", "/postings/moves.json", 4, true, "moved to Reply Later", false},
-		{"set aside", "a", "/postings/moves.json", 3, true, "moved to Set Aside", false},
-		{"seen", "e", "/postings/seen.json", 0, false, "marked as seen", true},
-		{"feed", "d", "/postings/moves.json", 2, true, "moved to The Feed", false},
-		{"paper trail", "p", "/postings/moves.json", 5, true, "moved to Paper Trail", false},
-		{"trash", "t", "/postings/trash.json", 0, true, "moved to Trash", false},
-		{"mute", "-", "/postings/mutings.json", 0, true, "muted", false},
+		{"reply later", "l", "/postings/moves.json", 4, true, "Thread moved to Reply Later", false},
+		{"set aside", "a", "/postings/moves.json", 3, true, "Thread moved to Set Aside", false},
+		{"seen", "e", "/postings/seen.json", 0, false, "Thread marked as seen", true},
+		{"feed", "d", "/postings/moves.json", 2, true, "Thread moved to The Feed", false},
+		{"paper trail", "p", "/postings/moves.json", 5, true, "Thread moved to Paper Trail", false},
+		{"trash", "t", "/postings/trash.json", 0, true, "Thread moved to Trash", false},
+		{"mute", "-", "/postings/mutings.json", 0, true, "Thread muted", false},
 	}
 
 	for _, tt := range tests {
@@ -321,7 +321,9 @@ func TestMailViewMovePickerMovesToSelectedBox(t *testing.T) {
 	if len(v.movePicker.destinations) != 4 {
 		t.Fatalf("destinations = %v, want four boxes", v.movePicker.destinations)
 	}
-	if view := v.View(); strings.Contains(view, "Bubble Up") || strings.Contains(view, "\n  Imbox") {
+	if view := v.View(); !strings.Contains(view, "Move thread") || !strings.Contains(view, "marks the thread as seen") {
+		t.Errorf("move picker does not use thread terminology: %q", view)
+	} else if strings.Contains(view, "Bubble Up") || strings.Contains(view, "\n  Imbox") {
 		t.Errorf("move picker offered an ineligible destination: %q", view)
 	}
 
@@ -344,7 +346,7 @@ func TestMailViewMovePickerMovesToSelectedBox(t *testing.T) {
 	if v.postingIndex(100) >= 0 {
 		t.Error("moved posting should leave the current box")
 	}
-	if v.notice != "moved to The Feed" {
+	if v.notice != "Thread moved to The Feed" {
 		t.Errorf("notice = %q", v.notice)
 	}
 }
@@ -453,7 +455,7 @@ func TestMailViewPostingActionCopiesSelectedPostingBeforeAsyncRequest(t *testing
 
 	cmd := v.HandleContentKey(keyPress("t"))
 	v.Update(postingActionDoneMsg{
-		action: "moved to Trash", boxID: 1, postingID: 100, removes: true,
+		action: "Thread moved to Trash", boxID: 1, postingID: 100, removes: true,
 	})
 	done, ok := runCmd(cmd).(postingActionDoneMsg)
 	if !ok {
@@ -477,7 +479,7 @@ func TestMailViewPostingCompletionInvalidatesConcurrentReload(t *testing.T) {
 	stale := currentPostingsLoaded(v, testPostings())
 
 	refresh, consumed := v.Update(postingActionDoneMsg{
-		action: "moved to Trash", boxID: 1, postingID: 100, removes: true,
+		action: "Thread moved to Trash", boxID: 1, postingID: 100, removes: true,
 	})
 	if !consumed || refresh == nil {
 		t.Fatal("action completion should replace a concurrent reload with a fresh reload")
@@ -567,7 +569,7 @@ func TestMailViewPostingActionRemoves(t *testing.T) {
 		t.Fatalf("expected 2 postings, got %d", len(v.postingList.postings))
 	}
 
-	v.Update(postingActionDoneMsg{action: "moved to Trash", boxID: 1, postingID: 100, removes: true})
+	v.Update(postingActionDoneMsg{action: "Thread moved to Trash", boxID: 1, postingID: 100, removes: true})
 	if len(v.postingList.postings) != 1 {
 		t.Errorf("expected 1 posting after remove, got %d", len(v.postingList.postings))
 	}
@@ -579,7 +581,7 @@ func TestMailViewPostingActionMarksSeen(t *testing.T) {
 		t.Fatal("first posting should be unseen")
 	}
 
-	v.Update(postingActionDoneMsg{action: "marked as seen", boxID: 1, postingID: 100})
+	v.Update(postingActionDoneMsg{action: "Thread marked as seen", boxID: 1, postingID: 100})
 	if !v.postingList.postings[0].Seen {
 		t.Error("first posting should be seen after action")
 	}

--- a/internal/tui/move.go
+++ b/internal/tui/move.go
@@ -56,7 +56,7 @@ func (p *movePicker) update(msg tea.KeyPressMsg) {
 func (p *movePicker) view(styles styles, width int) string {
 	contentWidth := max(width-4, 1)
 	var b strings.Builder
-	b.WriteString(styles.title.Render("Move message"))
+	b.WriteString(styles.title.Render("Move thread"))
 	if p.summary != "" {
 		fmt.Fprintf(&b, "\n%s", truncateStr(p.summary, contentWidth))
 	}
@@ -71,7 +71,7 @@ func (p *movePicker) view(styles styles, width int) string {
 		fmt.Fprintf(&b, "%s%s\n", prefix, name)
 	}
 	b.WriteString("\n")
-	b.WriteString(strings.Join(wrapText("Moving to a box other than Imbox marks the message as seen.", contentWidth), "\n"))
+	b.WriteString(strings.Join(wrapText("Moving to a box other than Imbox marks the thread as seen.", contentWidth), "\n"))
 	return b.String()
 }
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -103,7 +103,7 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 | Delete todo | `hey todo delete 123` |
 | Mark as seen | `hey seen 12345` |
 | Mark as unseen | `hey unseen 12345` |
-| Move postings | `hey move 12345 --to feed` |
+| Move email threads | `hey move 12345 --to feed` |
 | Complete habit | `hey habit complete 123` |
 | Uncomplete habit | `hey habit uncomplete 123` |
 | Start time tracking | `hey timetrack start` |
@@ -126,9 +126,9 @@ Want to read email?
 ├── Which mailbox? → hey boxes --json
 ├── List emails in box? → hey box <name|id> --json
 ├── Read full thread? → hey threads <topic_id> --json
-├── Mark as seen? → hey seen <posting-id>
-├── Mark as unseen? → hey unseen <posting-id>
-├── Move to another box? → hey move <posting-id> --to <box>
+├── Mark as seen? → hey seen <id>
+├── Mark as unseen? → hey unseen <id>
+├── Move to another box? → hey move <id> --to <box>
 └── Launch interactive UI? → hey (no args, launches TUI)
 ```
 
@@ -170,7 +170,7 @@ hey box 123 --json                            # List emails in box (by ID)
 
 Box names: `imbox`, `feedbox`, `trailbox`, `asidebox`, `laterbox`, `bubblebox`
 
-**Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. Each posting has: `id` (posting ID), `topic_id` (topic ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`. Use `topic_id` for `hey threads`, `hey reply`, and `hey forward`.
+**Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. The `postings` array is the API representation of the email threads in that box. Each item has: `id` (box item ID), `topic_id` (thread ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`. Use `id` for `hey seen`, `hey unseen`, and `hey move`. Use `topic_id` for `hey threads`, `hey reply`, and `hey forward`.
 
 ### Email - Threads
 
@@ -179,7 +179,7 @@ hey threads <topic_id> --json                 # Read full email thread
 hey threads <topic_id> --html                 # Read with raw HTML content
 ```
 
-**ID note:** `hey box` returns postings with an `id` (posting ID) and a `topic_id` (topic ID). `hey threads`, `hey reply`, and `hey forward` expect the **topic ID** — use `topic_id` directly. The `app_url` field also contains the topic ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
+**ID note:** Every email thread returned by `hey box` has an `id` (its box item ID) and a `topic_id` (its thread ID). `hey seen`, `hey unseen`, and `hey move` expect `id`. `hey threads`, `hey reply`, and `hey forward` expect `topic_id`. The `app_url` field also contains the thread ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
 
 ### Email - Reply, Forward & Compose
 
@@ -197,22 +197,22 @@ hey compose --thread-id 12345 -m "msg"                       # Reply to an exist
 ### Email - Seen/Unseen
 
 ```bash
-hey seen 12345                                # Mark posting as seen
-hey seen 12345 67890                          # Mark multiple postings as seen
-hey unseen 12345                              # Mark posting as unseen
-hey unseen 12345 67890                        # Mark multiple postings as unseen
+hey seen 12345                                # Mark a thread as seen
+hey seen 12345 67890                          # Mark multiple threads as seen
+hey unseen 12345                              # Mark a thread as unseen
+hey unseen 12345 67890                        # Mark multiple threads as unseen
 ```
 
-Takes posting IDs (the `id` field from `hey box` output).
+Takes box item IDs (the `id` field from `hey box` output).
 
-### Email - Moving Postings
+### Email - Moving Threads
 
 ```bash
-hey move 12345 --to imbox                     # Move one posting
-hey move 12345 67890 --to "paper trail"       # Move multiple postings
+hey move 12345 --to imbox                     # Move one thread
+hey move 12345 67890 --to "paper trail"       # Move multiple threads
 ```
 
-Takes posting IDs (the `id` field from `hey box --json`). `--to` accepts a box name, kind, or ID. Supported destinations are Imbox, The Feed, Set Aside, Reply Later, and Paper Trail. Bubble Up requires a scheduled date and is not supported by this command.
+Takes box item IDs (the `id` field from `hey box --json`). `--to` accepts a box name, kind, or ID. Supported destinations are Imbox, The Feed, Set Aside, Reply Later, and Paper Trail. Bubble Up requires a scheduled date and is not supported by this command.
 
 ### Drafts
 

--- a/tests/smoke/seen_test.go
+++ b/tests/smoke/seen_test.go
@@ -71,7 +71,7 @@ func TestSeenMultiple(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &resp2); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
-	assertContains(t, resp2.Summary, "2 posting(s) marked as seen")
+	assertContains(t, resp2.Summary, "2 threads marked as seen")
 }
 
 func TestSeenInvalidID(t *testing.T) {


### PR DESCRIPTION
## Summary

- use **email thread** for items listed in boxes and **thread** for move, seen, unseen, trash, and mute actions
- reserve **message** for individual entries inside a thread
- remove the internal term **posting** from CLI help, summaries, errors, breadcrumbs, README copy, TUI notices, and the move picker
- simplify `seen`, `unseen`, and `move` usage to `<id>` and explain the distinction between box item `id` and thread `topic_id`
- preserve SDK types, endpoint names, internal Go names, and the machine-facing `postings` JSON field

This follows the HEY web UI: onboarding copy talks about moving emails, the move UI says “Move this thread to…”, posting controller notices say “The thread was…” / “threads were…”, and message refers to an entry within a thread.

## Validation

- `make check`
- `make race-test`
- smoke test package compilation
- local build
- audited command metadata, flags, rendered help, summaries, breadcrumbs, README, embedded skill, TUI picker, and TUI action notices
- added regression coverage preventing `posting` from reappearing in user-facing email command help
- authenticated read-only validation of `hey box` summary and breadcrumbs
- manually rendered the authenticated TUI move picker and canceled without mutation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns user-facing email terminology with HEY across CLI, TUI, and docs so users see threads, not postings. Old behavior used “posting” in help, summaries, notices, and errors; new behavior uses “thread/threads”, pluralizes summaries correctly, updates `seen`, `unseen`, and `move` usage to `<id>`, and clarifies the box item `id` vs thread `topic_id`.

- Preserves SDK types, endpoint names, internal Go names, and the machine-facing `postings` JSON field; no API or schema changes.
- CLI: `hey box` describes “email threads”, summary reads “1 thread” / “N threads in <box>”, breadcrumbs/examples updated, `seen|unseen|move` usage is `<id>`, and errors say “invalid ID”.
- TUI: notices use “Thread …” (moved, marked as seen, muted, etc.); move picker title is “Move thread” and copy says “marks the thread as seen”.
- Docs: README and `skills/hey/SKILL.md` use thread terminology and explain when to use `id` vs `topic_id`.
- Tests: updated for new wording, added coverage to prevent “posting” in email command help, and verify box summary pluralization.

Bold Migration
- Update tests or scripts that assert on CLI/TUI text from “posting(s)”/“invalid posting ID” to “thread/threads”/“invalid ID”.
- Continue passing `id` from `hey box --json` to `seen|unseen|move`, and use `topic_id` for `threads|reply|forward`.

<sup>Written for commit d55b210bc80954ff8ced86238e7949082121c34d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

