### PR TITLE
Add ignore and stop-ignoring actions

### DIFF
--- a/.surface
+++ b/.surface
@@ -53,6 +53,7 @@ hey habit complete
 hey habit complete --date
 hey habit uncomplete
 hey habit uncomplete --date
+hey ignore
 hey journal
 hey journal list
 hey journal list --all
@@ -74,6 +75,7 @@ hey setup
 hey skill
 hey skill install
 hey spam
+hey stop-ignoring
 hey threads
 hey timetrack
 hey timetrack current

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -24,6 +24,8 @@ The legacy `internal/client/` is used only for HTML-scraping gap operations mark
 | `/postings/moves.json` | POST | SDK `Postings().Move` | `hey move <id> --to <box>`, TUI `m` | covered |
 | `/postings/trash.json` | POST | SDK `Postings().MoveToTrash` | `hey trash <id>`, TUI `t` | covered |
 | `/postings/spam.json` | POST | SDK `Postings().MarkSpam` | `hey spam <id>`, TUI `s` | covered |
+| `/postings/mutings.json` | POST | SDK `Postings().Mute` | `hey ignore <id>`, TUI `-` | covered |
+| `/postings/mutings.json` | DELETE | SDK `Postings().Unmute` | `hey stop-ignoring <id>`, TUI `+` | covered |
 | `/calendar/days/{date}/habits/{id}/completions.json` | POST | SDK `Habits().Complete` | `hey habit complete <id>` | covered |
 | `/calendar/days/{date}/habits/{id}/completions.json` | DELETE | SDK `Habits().Uncomplete` | `hey habit uncomplete <id>` | covered |
 | `/calendar/days/{date}/journal_entry.json` | GET | SDK `Journal().Get` | `hey journal read [date]` | partial: falls back to legacy |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ hey auth logout   # clear credentials
 
 Run `hey` to launch the interactive terminal UI.
 
-Navigate between mailboxes and email threads. Use Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `t` to trash, `s` to mark as spam, and Escape or `q` to go back.
+Navigate between mailboxes and email threads. Use Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `t` to trash, `s` to mark as spam, `-` to ignore, `+` to stop ignoring, and Escape or `q` to go back.
 
 ## CLI Commands
 
@@ -79,9 +79,11 @@ hey move 12345 --to feed           # move a thread to another box
 hey move 12345 67890 --to "paper trail"  # move multiple threads
 hey trash 12345                    # move a thread to Trash
 hey spam 12345                     # mark a thread as spam
+hey ignore 12345                   # ignore future activity on a thread
+hey stop-ignoring 12345            # resume attention for a thread
 ```
 
-`hey move`, `hey trash`, and `hey spam` take the `id` values returned by `hey box --json`. Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone.
+These actions take the `id` values returned by `hey box --json`. Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 
 ### Calendars
 

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -17,7 +17,7 @@ var curatedCategories = []struct {
 }{
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "threads", "compose", "reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam"},
+		names:   []string{"boxes", "box", "threads", "compose", "reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -27,7 +27,7 @@ func TestCuratedCommandHelpUsesUserFacingLanguage(t *testing.T) {
 
 func TestEmailCommandHelpKeepsPostingAsAnInternalTerm(t *testing.T) {
 	root := newRootCmd()
-	for _, name := range []string{"boxes", "box", "seen", "unseen", "move", "trash", "spam"} {
+	for _, name := range []string{"boxes", "box", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"} {
 		t.Run(name, func(t *testing.T) {
 			command, _, err := root.Find([]string{name})
 			if err != nil {
@@ -63,18 +63,20 @@ USAGE
   hey                     Open the interactive app
 
 EMAIL
-  boxes    List your HEY boxes
-  box      List email threads in a box
-  threads  Read a thread
-  compose  Write and send a new email
-  reply    Reply to a thread
-  forward  Forward the latest message in a thread
-  drafts   List draft emails
-  seen     Mark email threads as seen
-  unseen   Mark email threads as unseen
-  move     Move email threads to another box
-  trash    Move email threads to Trash
-  spam     Mark email threads as spam
+  boxes          List your HEY boxes
+  box            List email threads in a box
+  threads        Read a thread
+  compose        Write and send a new email
+  reply          Reply to a thread
+  forward        Forward the latest message in a thread
+  drafts         List draft emails
+  seen           Mark email threads as seen
+  unseen         Mark email threads as unseen
+  move           Move email threads to another box
+  trash          Move email threads to Trash
+  spam           Mark email threads as spam
+  ignore         Ignore email threads
+  stop-ignoring  Stop ignoring email threads
 
 CALENDAR & TASKS
   calendars   List calendars

--- a/internal/cmd/ignore.go
+++ b/internal/cmd/ignore.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type ignoreCommand struct {
+	cmd *cobra.Command
+}
+
+func newIgnoreCommand() *ignoreCommand {
+	ignoreCommand := &ignoreCommand{}
+	ignoreCommand.cmd = &cobra.Command{
+		Use:   "ignore <id>...",
+		Short: "Ignore email threads",
+		Long:  "Ignore one or more email threads so new replies do not bring them back to your attention.",
+		Example: `  hey ignore 12345
+  hey ignore 12345 67890`,
+		Annotations: map[string]string{
+			"agent_notes": "Accepts one or more box item IDs from hey box output. Ignored threads remain in their box and can be restored with hey stop-ignoring.",
+		},
+		RunE: ignoreCommand.run,
+		Args: usageMinOneArg(),
+	}
+
+	return ignoreCommand
+}
+
+func (c *ignoreCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	ids, err := parseIntArgs(args)
+	if err != nil {
+		return err
+	}
+
+	if err := sdk.Postings().Mute(cmd.Context(), ids...); err != nil {
+		return convertSDKError(err)
+	}
+
+	summary := fmt.Sprintf("%d %s ignored", len(ids), threadNoun(len(ids)))
+	if writer.IsStyled() {
+		fmt.Fprintln(cmd.OutOrStdout(), summary+".")
+		return nil
+	}
+
+	return writeOK(nil, output.WithSummary(summary))
+}

--- a/internal/cmd/ignore_test.go
+++ b/internal/cmd/ignore_test.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type recordedIgnoring struct {
+	method     string
+	path       string
+	postingIDs []int64
+	status     int
+	requests   int
+}
+
+func ignoringServer(t *testing.T) (*httptest.Server, *recordedIgnoring) {
+	t.Helper()
+	recorded := &recordedIgnoring{status: http.StatusNoContent}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorded.requests++
+		recorded.method = r.Method
+		recorded.path = r.URL.Path
+
+		if r.Method == http.MethodDelete {
+			for _, value := range strings.Split(r.URL.Query().Get("posting_ids"), ",") {
+				if value == "" {
+					continue
+				}
+				var id int64
+				_, _ = fmt.Sscan(value, &id)
+				recorded.postingIDs = append(recorded.postingIDs, id)
+			}
+		} else {
+			var body struct {
+				PostingIDs []int64 `json:"posting_ids"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			recorded.postingIDs = body.PostingIDs
+		}
+
+		if r.URL.Path != "/postings/mutings.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(recorded.status)
+	}))
+	t.Cleanup(server.Close)
+	return server, recorded
+}
+
+func runIgnoring(t *testing.T, server *httptest.Server, command string, args ...string) (output.Response, error) {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(append([]string{command, "--json", "--base-url", server.URL}, args...))
+
+	err := root.Execute()
+	var resp output.Response
+	if buf.Len() > 0 {
+		_ = json.Unmarshal(buf.Bytes(), &resp)
+	}
+	return resp, err
+}
+
+func TestIgnoreAndStopIgnoring(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		method  string
+		args    []string
+		summary string
+	}{
+		{"ignore one", "ignore", http.MethodPost, []string{"12345"}, "1 thread ignored"},
+		{"ignore multiple", "ignore", http.MethodPost, []string{"12345", "67890"}, "2 threads ignored"},
+		{"stop ignoring one", "stop-ignoring", http.MethodDelete, []string{"12345"}, "Stopped ignoring 1 thread"},
+		{"stop ignoring multiple", "stop-ignoring", http.MethodDelete, []string{"12345", "67890"}, "Stopped ignoring 2 threads"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, recorded := ignoringServer(t)
+			resp, err := runIgnoring(t, server, tt.command, tt.args...)
+			if err != nil {
+				t.Fatalf("%s failed: %v", tt.command, err)
+			}
+			if recorded.method != tt.method || recorded.path != "/postings/mutings.json" {
+				t.Errorf("request = %s %s, want %s /postings/mutings.json", recorded.method, recorded.path, tt.method)
+			}
+			if len(recorded.postingIDs) != len(tt.args) {
+				t.Fatalf("posting_ids = %v, want %d IDs", recorded.postingIDs, len(tt.args))
+			}
+			for i, want := range []int64{12345, 67890}[:len(tt.args)] {
+				if recorded.postingIDs[i] != want {
+					t.Errorf("posting_ids[%d] = %d, want %d", i, recorded.postingIDs[i], want)
+				}
+			}
+			if resp.Summary != tt.summary {
+				t.Errorf("summary = %q, want %q", resp.Summary, tt.summary)
+			}
+		})
+	}
+}
+
+func TestIgnoreAndStopIgnoringRequireIDs(t *testing.T) {
+	for _, command := range []string{"ignore", "stop-ignoring"} {
+		t.Run(command, func(t *testing.T) {
+			server, recorded := ignoringServer(t)
+			_, err := runIgnoring(t, server, command)
+			if err == nil || !strings.Contains(err.Error(), "Usage:") {
+				t.Fatalf("missing ID should produce a usage error, got %v", err)
+			}
+			if recorded.requests != 0 {
+				t.Errorf("missing ID made %d requests", recorded.requests)
+			}
+		})
+	}
+}
+
+func TestIgnoreAndStopIgnoringRejectInvalidIDsBeforeRequest(t *testing.T) {
+	for _, command := range []string{"ignore", "stop-ignoring"} {
+		t.Run(command, func(t *testing.T) {
+			server, recorded := ignoringServer(t)
+			_, err := runIgnoring(t, server, command, "not-an-id")
+			var cliErr *apierr.Error
+			if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+				t.Fatalf("invalid ID should produce a usage error, got %v", err)
+			}
+			if recorded.requests != 0 {
+				t.Errorf("invalid ID made %d requests", recorded.requests)
+			}
+		})
+	}
+}
+
+func TestIgnoreAndStopIgnoringReportServerFailures(t *testing.T) {
+	for _, command := range []string{"ignore", "stop-ignoring"} {
+		t.Run(command, func(t *testing.T) {
+			server, recorded := ignoringServer(t)
+			recorded.status = http.StatusUnprocessableEntity
+			if _, err := runIgnoring(t, server, command, "12345"); err == nil {
+				t.Fatal("server failure should be reported")
+			}
+		})
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -135,6 +135,8 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newMoveCommand().cmd)
 	root.AddCommand(newTrashCommand().cmd)
 	root.AddCommand(newSpamCommand().cmd)
+	root.AddCommand(newIgnoreCommand().cmd)
+	root.AddCommand(newStopIgnoringCommand().cmd)
 	root.AddCommand(newSetupCommand())
 	root.AddCommand(newTuiCommand().cmd)
 	root.AddCommand(newSkillCommand().cmd)

--- a/internal/cmd/stop_ignoring.go
+++ b/internal/cmd/stop_ignoring.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type stopIgnoringCommand struct {
+	cmd *cobra.Command
+}
+
+func newStopIgnoringCommand() *stopIgnoringCommand {
+	stopIgnoringCommand := &stopIgnoringCommand{}
+	stopIgnoringCommand.cmd = &cobra.Command{
+		Use:   "stop-ignoring <id>...",
+		Short: "Stop ignoring email threads",
+		Long:  "Stop ignoring one or more email threads so new replies can bring them back to your attention.",
+		Example: `  hey stop-ignoring 12345
+  hey stop-ignoring 12345 67890`,
+		Annotations: map[string]string{
+			"agent_notes": "Accepts one or more box item IDs from hey box output. Reverses hey ignore for each thread.",
+		},
+		RunE: stopIgnoringCommand.run,
+		Args: usageMinOneArg(),
+	}
+
+	return stopIgnoringCommand
+}
+
+func (c *stopIgnoringCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	ids, err := parseIntArgs(args)
+	if err != nil {
+		return err
+	}
+
+	if err := sdk.Postings().Unmute(cmd.Context(), ids...); err != nil {
+		return convertSDKError(err)
+	}
+
+	summary := fmt.Sprintf("Stopped ignoring %d %s", len(ids), threadNoun(len(ids)))
+	if writer.IsStyled() {
+		fmt.Fprintln(cmd.OutOrStdout(), summary+".")
+		return nil
+	}
+
+	return writeOK(nil, output.WithSummary(summary))
+}

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -126,6 +126,9 @@ func (c *contentList) view() string {
 		if subject == "" {
 			subject = p.Creator.Name
 		}
+		if p.Muted {
+			subject = "[Ignored] " + subject
+		}
 		if p.VisibleEntryCount > 1 {
 			subject += fmt.Sprintf(" (%d)", p.VisibleEntryCount)
 		}

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -48,11 +48,21 @@ type topicLoadedMsg struct {
 	err       error
 }
 
+type postingActionEffect int
+
+const (
+	postingActionNone postingActionEffect = iota
+	postingActionRemove
+	postingActionSeen
+	postingActionIgnore
+	postingActionStopIgnoring
+)
+
 type postingActionDoneMsg struct {
 	action    string
 	boxID     int64
 	postingID int64
-	removes   bool
+	effect    postingActionEffect
 	err       error
 }
 
@@ -194,17 +204,25 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		}
 		v.notice = msg.action
 		idx := v.postingIndex(msg.postingID)
-		if msg.removes && idx >= 0 {
-			v.postingList.postings = append(v.postingList.postings[:idx], v.postingList.postings[idx+1:]...)
-			if v.postingList.cursor > idx {
-				v.postingList.cursor--
+		if idx >= 0 {
+			switch msg.effect {
+			case postingActionNone:
+			case postingActionRemove:
+				v.postingList.postings = append(v.postingList.postings[:idx], v.postingList.postings[idx+1:]...)
+				if v.postingList.cursor > idx {
+					v.postingList.cursor--
+				}
+				if v.postingList.cursor >= len(v.postingList.postings) && v.postingList.cursor > 0 {
+					v.postingList.cursor--
+				}
+				v.postingList.ensureVisible()
+			case postingActionSeen:
+				v.postingList.postings[idx].Seen = true
+			case postingActionIgnore:
+				v.postingList.postings[idx].Muted = true
+			case postingActionStopIgnoring:
+				v.postingList.postings[idx].Muted = false
 			}
-			if v.postingList.cursor >= len(v.postingList.postings) && v.postingList.cursor > 0 {
-				v.postingList.cursor--
-			}
-			v.postingList.ensureVisible()
-		} else if msg.action == "Thread marked as seen" && idx >= 0 {
-			v.postingList.postings[idx].Seen = true
 		}
 		if v.activeRequestKind == mailRequestPostings {
 			return v.requestPostings(v.currentBoxID()), true
@@ -260,6 +278,10 @@ func (v *mailView) HelpBindings() []helpBinding {
 	if v.inThread {
 		return []helpBinding{{"r", "reply"}, {"f", "forward"}}
 	}
+	ignoreBinding := helpBinding{"-", "ignore"}
+	if selected := v.postingList.selectedPosting(); selected != nil && selected.Muted {
+		ignoreBinding = helpBinding{"+", "stop ignoring"}
+	}
 	return []helpBinding{
 		{"c", "compose"},
 		{"r", "reply"},
@@ -272,7 +294,7 @@ func (v *mailView) HelpBindings() []helpBinding {
 		{"p", "paper trail"},
 		{"t", "trash"},
 		{"s", "spam"},
-		{"-", "mute"},
+		ignoreBinding,
 	}
 }
 
@@ -489,7 +511,7 @@ func (v *mailView) startMove() {
 }
 
 func (v *mailView) movePostingToBox(postingID int64, destination models.Box) tea.Cmd {
-	return v.doPostingAction("Thread moved to "+destination.Name, true, v.currentBoxID(), postingID, func() error {
+	return v.doPostingAction("Thread moved to "+destination.Name, postingActionRemove, v.currentBoxID(), postingID, func() error {
 		return v.vc.sdk.Postings().Move(v.vc.ctx, destination.ID, postingID)
 	})
 }
@@ -512,7 +534,7 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 			return v.vc.sdk.Postings().MoveToSetAside(v.vc.ctx, p.ID)
 		})
 	case "e":
-		return v.doPostingAction("Thread marked as seen", false, boxID, p.ID, func() error {
+		return v.doPostingAction("Thread marked as seen", postingActionSeen, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MarkSeen(v.vc.ctx, []int64{p.ID})
 		})
 	case "d":
@@ -524,16 +546,28 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 			return v.vc.sdk.Postings().MoveToPaperTrail(v.vc.ctx, p.ID)
 		})
 	case "t":
-		return v.doPostingAction("Thread moved to Trash", true, boxID, p.ID, func() error {
+		return v.doPostingAction("Thread moved to Trash", postingActionRemove, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToTrash(v.vc.ctx, p.ID)
 		})
 	case "s":
-		return v.doPostingAction("Thread marked as spam", true, boxID, p.ID, func() error {
+		return v.doPostingAction("Thread marked as spam", postingActionRemove, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MarkSpam(v.vc.ctx, p.ID)
 		})
 	case "-":
-		return v.doPostingAction("Thread muted", true, boxID, p.ID, func() error {
+		if p.Muted {
+			v.notice = "Already ignoring thread"
+			return nil
+		}
+		return v.doPostingAction("Thread ignored", postingActionIgnore, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().Mute(v.vc.ctx, p.ID)
+		})
+	case "+":
+		if !p.Muted {
+			v.notice = "Thread is not ignored"
+			return nil
+		}
+		return v.doPostingAction("Stopped ignoring thread", postingActionStopIgnoring, boxID, p.ID, func() error {
+			return v.vc.sdk.Postings().Unmute(v.vc.ctx, p.ID)
 		})
 	case "r":
 		topicID := p.ResolveTopicID()
@@ -556,7 +590,7 @@ func (v *mailView) moveSelectedToKnownBox(name, kind string, boxID, postingID in
 		v.notice = "Already in " + name
 		return nil
 	}
-	return v.doPostingAction("Thread moved to "+name, true, boxID, postingID, fn)
+	return v.doPostingAction("Thread moved to "+name, postingActionRemove, boxID, postingID, fn)
 }
 
 func (v *mailView) movesOutOfCurrentBox(destinationKind string) bool {
@@ -566,14 +600,14 @@ func (v *mailView) movesOutOfCurrentBox(destinationKind string) bool {
 	return !strings.EqualFold(v.boxes[v.boxIndex].Kind, destinationKind)
 }
 
-func (v *mailView) doPostingAction(label string, removes bool, boxID, postingID int64, fn func() error) tea.Cmd {
+func (v *mailView) doPostingAction(label string, effect postingActionEffect, boxID, postingID int64, fn func() error) tea.Cmd {
 	return func() tea.Msg {
 		err := fn()
 		return postingActionDoneMsg{
 			action:    label,
 			boxID:     boxID,
 			postingID: postingID,
-			removes:   removes,
+			effect:    effect,
 			err:       err,
 		}
 	}

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -75,7 +75,15 @@ func mailWithTestServer(t *testing.T, status int) (*mailView, *recordedMailReque
 		case "/messages/501.json":
 			_, _ = w.Write([]byte(`{"id":501,"subject":"Hello world","content":"<p>Message body</p>","created_at":"2026-08-19T09:00:00Z","creator":{"id":10,"name":"Alice"}}`))
 		default:
-			_ = json.NewDecoder(r.Body).Decode(&recorded.body)
+			if r.Method == http.MethodDelete {
+				for _, value := range strings.Split(r.URL.Query().Get("posting_ids"), ",") {
+					if id, err := strconv.ParseInt(value, 10, 64); err == nil {
+						recorded.body.PostingIDs = append(recorded.body.PostingIDs, id)
+					}
+				}
+			} else {
+				_ = json.NewDecoder(r.Body).Decode(&recorded.body)
+			}
 			w.WriteHeader(status)
 		}
 	}))
@@ -237,22 +245,21 @@ func TestMailViewIgnoresUnrelatedMessages(t *testing.T) {
 
 func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 	tests := []struct {
-		name    string
-		key     string
-		path    string
-		boxID   int64
-		removes bool
-		notice  string
-		seen    bool
+		name   string
+		key    string
+		path   string
+		boxID  int64
+		effect postingActionEffect
+		notice string
 	}{
-		{"reply later", "l", "/postings/moves.json", 4, true, "Thread moved to Reply Later", false},
-		{"set aside", "a", "/postings/moves.json", 3, true, "Thread moved to Set Aside", false},
-		{"seen", "e", "/postings/seen.json", 0, false, "Thread marked as seen", true},
-		{"feed", "d", "/postings/moves.json", 2, true, "Thread moved to The Feed", false},
-		{"paper trail", "p", "/postings/moves.json", 5, true, "Thread moved to Paper Trail", false},
-		{"trash", "t", "/postings/trash.json", 0, true, "Thread moved to Trash", false},
-		{"spam", "s", "/postings/spam.json", 0, true, "Thread marked as spam", false},
-		{"mute", "-", "/postings/mutings.json", 0, true, "Thread muted", false},
+		{"reply later", "l", "/postings/moves.json", 4, postingActionRemove, "Thread moved to Reply Later"},
+		{"set aside", "a", "/postings/moves.json", 3, postingActionRemove, "Thread moved to Set Aside"},
+		{"seen", "e", "/postings/seen.json", 0, postingActionSeen, "Thread marked as seen"},
+		{"feed", "d", "/postings/moves.json", 2, postingActionRemove, "Thread moved to The Feed"},
+		{"paper trail", "p", "/postings/moves.json", 5, postingActionRemove, "Thread moved to Paper Trail"},
+		{"trash", "t", "/postings/trash.json", 0, postingActionRemove, "Thread moved to Trash"},
+		{"spam", "s", "/postings/spam.json", 0, postingActionRemove, "Thread marked as spam"},
+		{"ignore", "-", "/postings/mutings.json", 0, postingActionIgnore, "Thread ignored"},
 	}
 
 	for _, tt := range tests {
@@ -266,6 +273,9 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 			}
 			if done.boxID != 1 || done.postingID != 100 {
 				t.Errorf("action origin = box %d posting %d, want box 1 posting 100", done.boxID, done.postingID)
+			}
+			if done.effect != tt.effect {
+				t.Errorf("action effect = %v, want %v", done.effect, tt.effect)
 			}
 			v.Update(done)
 
@@ -286,17 +296,76 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 			}
 
 			wantPostings := 2
-			if tt.removes {
+			if tt.effect == postingActionRemove {
 				wantPostings = 1
 			}
 			if len(v.postingList.postings) != wantPostings {
 				t.Errorf("posting count = %d, want %d", len(v.postingList.postings), wantPostings)
 			}
-			if tt.seen && !v.postingList.postings[0].Seen {
+			if tt.effect == postingActionSeen && !v.postingList.postings[0].Seen {
 				t.Error("selected posting should be marked seen")
+			}
+			if tt.effect == postingActionIgnore && !v.postingList.postings[0].Muted {
+				t.Error("selected posting should be ignored")
 			}
 			if v.notice != tt.notice || !strings.Contains(v.View(), tt.notice) {
 				t.Errorf("notice = %q, want visible %q", v.notice, tt.notice)
+			}
+		})
+	}
+}
+
+func TestMailViewStopIgnoringCallsDeleteAndKeepsThreadVisible(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.postingList.postings[0].Muted = true
+
+	msg := runCmd(v.HandleContentKey(keyPress("+")))
+	done, ok := msg.(postingActionDoneMsg)
+	if !ok || done.err != nil {
+		t.Fatalf("stop-ignoring command returned %#v", msg)
+	}
+	if recorded.method != http.MethodDelete || recorded.path != "/postings/mutings.json" {
+		t.Errorf("request = %s %s, want DELETE /postings/mutings.json", recorded.method, recorded.path)
+	}
+	if len(recorded.body.PostingIDs) != 1 || recorded.body.PostingIDs[0] != 100 {
+		t.Errorf("posting_ids = %v, want [100]", recorded.body.PostingIDs)
+	}
+
+	v.Update(done)
+	if len(v.postingList.postings) != 2 {
+		t.Errorf("posting count = %d, want ignored thread to remain visible", len(v.postingList.postings))
+	}
+	if v.postingList.postings[0].Muted {
+		t.Error("selected posting should no longer be ignored")
+	}
+	if v.notice != "Stopped ignoring thread" {
+		t.Errorf("notice = %q, want %q", v.notice, "Stopped ignoring thread")
+	}
+}
+
+func TestMailViewIgnoreActionsSkipThreadsAlreadyInRequestedState(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		muted  bool
+		notice string
+	}{
+		{"already ignored", "-", true, "Already ignoring thread"},
+		{"not ignored", "+", false, "Thread is not ignored"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, recorded := mailWithTestServer(t, http.StatusNoContent)
+			v.postingList.postings[0].Muted = tt.muted
+			if cmd := v.HandleContentKey(keyPress(tt.key)); cmd != nil {
+				t.Fatal("redundant action should not start a request")
+			}
+			if len(recorded.requests) != 0 {
+				t.Errorf("redundant action made requests: %v", recorded.requests)
+			}
+			if v.notice != tt.notice {
+				t.Errorf("notice = %q, want %q", v.notice, tt.notice)
 			}
 		})
 	}
@@ -456,7 +525,7 @@ func TestMailViewPostingActionCopiesSelectedPostingBeforeAsyncRequest(t *testing
 
 	cmd := v.HandleContentKey(keyPress("t"))
 	v.Update(postingActionDoneMsg{
-		action: "Thread moved to Trash", boxID: 1, postingID: 100, removes: true,
+		action: "Thread moved to Trash", boxID: 1, postingID: 100, effect: postingActionRemove,
 	})
 	done, ok := runCmd(cmd).(postingActionDoneMsg)
 	if !ok {
@@ -480,7 +549,7 @@ func TestMailViewPostingCompletionInvalidatesConcurrentReload(t *testing.T) {
 	stale := currentPostingsLoaded(v, testPostings())
 
 	refresh, consumed := v.Update(postingActionDoneMsg{
-		action: "Thread moved to Trash", boxID: 1, postingID: 100, removes: true,
+		action: "Thread moved to Trash", boxID: 1, postingID: 100, effect: postingActionRemove,
 	})
 	if !consumed || refresh == nil {
 		t.Fatal("action completion should replace a concurrent reload with a fresh reload")
@@ -570,7 +639,7 @@ func TestMailViewPostingActionRemoves(t *testing.T) {
 		t.Fatalf("expected 2 postings, got %d", len(v.postingList.postings))
 	}
 
-	v.Update(postingActionDoneMsg{action: "Thread moved to Trash", boxID: 1, postingID: 100, removes: true})
+	v.Update(postingActionDoneMsg{action: "Thread moved to Trash", boxID: 1, postingID: 100, effect: postingActionRemove})
 	if len(v.postingList.postings) != 1 {
 		t.Errorf("expected 1 posting after remove, got %d", len(v.postingList.postings))
 	}
@@ -582,7 +651,7 @@ func TestMailViewPostingActionMarksSeen(t *testing.T) {
 		t.Fatal("first posting should be unseen")
 	}
 
-	v.Update(postingActionDoneMsg{action: "Thread marked as seen", boxID: 1, postingID: 100})
+	v.Update(postingActionDoneMsg{action: "Thread marked as seen", boxID: 1, postingID: 100, effect: postingActionSeen})
 	if !v.postingList.postings[0].Seen {
 		t.Error("first posting should be seen after action")
 	}
@@ -1051,6 +1120,15 @@ func TestMailViewRendersPostings(t *testing.T) {
 	}
 }
 
+func TestMailViewRendersIgnoredThread(t *testing.T) {
+	v := mailWithPostings()
+	v.Resize(80, 30)
+	v.postingList.postings[0].Muted = true
+	if view := v.View(); !strings.Contains(view, "[Ignored] Hello world") {
+		t.Errorf("ignored thread state is not visible: %q", view)
+	}
+}
+
 func TestMailViewRendersEmptyList(t *testing.T) {
 	v := newMailView(testVC())
 	v.Resize(80, 30)
@@ -1073,11 +1151,24 @@ func TestMailViewHelpBindings(t *testing.T) {
 	for _, b := range bindings {
 		keys[b.key] = true
 	}
-	for _, expected := range []string{"r", "f", "m", "e", "l", "a", "t", "s"} {
+	for _, expected := range []string{"r", "f", "m", "e", "l", "a", "t", "s", "-"} {
 		if !keys[expected] {
 			t.Errorf("missing help binding for key %q", expected)
 		}
 	}
+}
+
+func TestMailViewHelpBindingsStopIgnoringForIgnoredThread(t *testing.T) {
+	v := mailWithPostings()
+	v.postingList.postings[0].Muted = true
+
+	bindings := v.HelpBindings()
+	for _, binding := range bindings {
+		if binding.key == "+" && binding.desc == "stop ignoring" {
+			return
+		}
+	}
+	t.Errorf("ignored thread help does not offer stop ignoring: %v", bindings)
 }
 
 func TestMailViewHelpBindingsInMovePicker(t *testing.T) {

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -27,9 +27,13 @@ triggers:
   - hey move
   - hey trash
   - hey spam
+  - hey ignore
+  - hey stop-ignoring
   - move email
   - trash email
   - mark as spam
+  - ignore email thread
+  - stop ignoring email thread
   - mark as read
   - mark as seen
   - mark as unseen
@@ -110,6 +114,8 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 | Move email threads | `hey move 12345 --to feed` |
 | Move email threads to Trash | `hey trash 12345` |
 | Mark email threads as spam | `hey spam 12345` |
+| Ignore email threads | `hey ignore 12345` |
+| Stop ignoring email threads | `hey stop-ignoring 12345` |
 | Complete habit | `hey habit complete 123` |
 | Uncomplete habit | `hey habit uncomplete 123` |
 | Start time tracking | `hey timetrack start` |
@@ -137,6 +143,8 @@ Want to read email?
 ├── Move to another box? → hey move <id> --to <box>
 ├── Move to Trash? → hey trash <id>
 ├── Mark as spam? → hey spam <id>
+├── Ignore future activity? → hey ignore <id>
+├── Stop ignoring? → hey stop-ignoring <id>
 └── Launch interactive UI? → hey (no args, launches TUI)
 ```
 
@@ -178,7 +186,7 @@ hey box 123 --json                            # List emails in box (by ID)
 
 Box names: `imbox`, `feedbox`, `trailbox`, `asidebox`, `laterbox`, `bubblebox`
 
-**Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. The `postings` array is the API representation of the email threads in that box. Each item has: `id` (box item ID), `topic_id` (thread ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`. Use `id` for `hey seen`, `hey unseen`, `hey move`, `hey trash`, and `hey spam`. Use `topic_id` for `hey threads`, `hey reply`, and `hey forward`.
+**Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. The `postings` array is the API representation of the email threads in that box. Each item has: `id` (box item ID), `topic_id` (thread ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`. Use `id` for `hey seen`, `hey unseen`, `hey move`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring`. Use `topic_id` for `hey threads`, `hey reply`, and `hey forward`.
 
 ### Email - Threads
 
@@ -187,7 +195,7 @@ hey threads <topic_id> --json                 # Read full email thread
 hey threads <topic_id> --html                 # Read with raw HTML content
 ```
 
-**ID note:** Every email thread returned by `hey box` has an `id` (its box item ID) and a `topic_id` (its thread ID). `hey seen`, `hey unseen`, `hey move`, `hey trash`, and `hey spam` expect `id`. `hey threads`, `hey reply`, and `hey forward` expect `topic_id`. The `app_url` field also contains the thread ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
+**ID note:** Every email thread returned by `hey box` has an `id` (its box item ID) and a `topic_id` (its thread ID). `hey seen`, `hey unseen`, `hey move`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring` expect `id`. `hey threads`, `hey reply`, and `hey forward` expect `topic_id`. The `app_url` field also contains the thread ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
 
 ### Email - Reply, Forward & Compose
 
@@ -232,6 +240,17 @@ hey spam 12345 67890                          # Mark multiple threads as spam
 ```
 
 Takes box item IDs (the `id` field from `hey box --json`). Trashing a shared thread removes your access instead of deleting it for everyone. Marking a thread as spam moves it to Spam and trains HEY's filters.
+
+### Email - Ignoring Threads
+
+```bash
+hey ignore 12345                              # Ignore one thread
+hey ignore 12345 67890                        # Ignore multiple threads
+hey stop-ignoring 12345                       # Stop ignoring one thread
+hey stop-ignoring 12345 67890                 # Stop ignoring multiple threads
+```
+
+Takes box item IDs (the `id` field from `hey box --json`). Ignored threads remain in their box; new replies do not bring them back to your attention. `hey stop-ignoring` reverses the action.
 
 ### Drafts
 

--- a/tests/smoke/ignore_test.go
+++ b/tests/smoke/ignore_test.go
@@ -1,0 +1,75 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type ignorePosting struct {
+	ID    int  `json:"id"`
+	Muted bool `json:"muted"`
+}
+
+func TestIgnoreAndStopIgnoring(t *testing.T) {
+	type BoxResp struct {
+		Postings []ignorePosting `json:"postings"`
+	}
+
+	box := dataAs[BoxResp](t, heyJSON(t, "box", "imbox"))
+	if len(box.Postings) == 0 {
+		t.Skip("no threads in Imbox to ignore")
+	}
+	posting := box.Postings[0]
+	postingID := intStr(posting.ID)
+
+	if posting.Muted {
+		heyOK(t, "stop-ignoring", postingID, "--json")
+		t.Cleanup(func() { heyOK(t, "ignore", postingID, "--json") })
+	} else {
+		t.Cleanup(func() { heyOK(t, "stop-ignoring", postingID, "--json") })
+	}
+
+	stdout := heyOK(t, "ignore", postingID, "--json")
+	var ignoreResp Response
+	if err := json.Unmarshal([]byte(stdout), &ignoreResp); err != nil {
+		t.Fatalf("failed to parse ignore response: %v", err)
+	}
+	assertContains(t, ignoreResp.Summary, "1 thread ignored")
+
+	afterIgnore := dataAs[BoxResp](t, heyJSON(t, "box", "imbox"))
+	if !postingMuted(afterIgnore.Postings, posting.ID) {
+		t.Error("thread is not ignored after hey ignore")
+	}
+
+	stdout = heyOK(t, "stop-ignoring", postingID, "--json")
+	var stopResp Response
+	if err := json.Unmarshal([]byte(stdout), &stopResp); err != nil {
+		t.Fatalf("failed to parse stop-ignoring response: %v", err)
+	}
+	assertContains(t, stopResp.Summary, "Stopped ignoring 1 thread")
+
+	afterStop := dataAs[BoxResp](t, heyJSON(t, "box", "imbox"))
+	if postingMuted(afterStop.Postings, posting.ID) {
+		t.Error("thread is still ignored after hey stop-ignoring")
+	}
+}
+
+func postingMuted(postings []ignorePosting, id int) bool {
+	for _, posting := range postings {
+		if posting.ID == id {
+			return posting.Muted
+		}
+	}
+	return false
+}
+
+func TestIgnoreAndStopIgnoringValidation(t *testing.T) {
+	for _, command := range []string{"ignore", "stop-ignoring"} {
+		t.Run(command+" requires an ID", func(t *testing.T) {
+			heyFail(t, command, "--json")
+		})
+		t.Run(command+" rejects invalid IDs", func(t *testing.T) {
+			heyFail(t, command, "not-a-number", "--json")
+		})
+	}
+}

--- a/tests/smoke/ignore_test.go
+++ b/tests/smoke/ignore_test.go
@@ -37,7 +37,11 @@ func TestIgnoreAndStopIgnoring(t *testing.T) {
 	assertContains(t, ignoreResp.Summary, "1 thread ignored")
 
 	afterIgnore := dataAs[BoxResp](t, heyJSON(t, "box", "imbox"))
-	if !postingMuted(afterIgnore.Postings, posting.ID) {
+	muted, found := findPostingMute(afterIgnore.Postings, posting.ID)
+	if !found {
+		t.Fatal("ignored thread disappeared from Imbox")
+	}
+	if !muted {
 		t.Error("thread is not ignored after hey ignore")
 	}
 
@@ -49,18 +53,22 @@ func TestIgnoreAndStopIgnoring(t *testing.T) {
 	assertContains(t, stopResp.Summary, "Stopped ignoring 1 thread")
 
 	afterStop := dataAs[BoxResp](t, heyJSON(t, "box", "imbox"))
-	if postingMuted(afterStop.Postings, posting.ID) {
+	muted, found = findPostingMute(afterStop.Postings, posting.ID)
+	if !found {
+		t.Fatal("thread disappeared from Imbox after hey stop-ignoring")
+	}
+	if muted {
 		t.Error("thread is still ignored after hey stop-ignoring")
 	}
 }
 
-func postingMuted(postings []ignorePosting, id int) bool {
+func findPostingMute(postings []ignorePosting, id int) (muted, found bool) {
 	for _, posting := range postings {
 		if posting.ID == id {
-			return posting.Muted
+			return posting.Muted, true
 		}
 	}
-	return false
+	return false, false
 }
 
 func TestIgnoreAndStopIgnoringValidation(t *testing.T) {


### PR DESCRIPTION
## Summary

- use HEY’s web UI terminology with bulk `hey ignore <id>...` and `hey stop-ignoring <id>...` commands
- back both commands with the SDK’s typed posting mute/unmute operations while keeping internal API terminology out of user-facing help
- align the TUI with HEY’s `-` Ignore and `+` Stop Ignoring shortcuts
- keep ignored threads visible, label them `[Ignored]`, and offer the context-appropriate reversal action
- skip redundant TUI requests for threads already in the requested state
- replace action-label string coupling with explicit posting action effects for remove, seen, ignore, and stop-ignoring transitions
- update root help, command metadata, README, embedded skill, API coverage, smoke coverage, and the public surface baseline

## Validation

- `make check`
- `make race-test`
- smoke test package compilation
- local build and rendered CLI help/command metadata
- authenticated CLI ignore/stop-ignoring validation on a hey-cli PR notification; verified `muted` changed to true and then returned to false
- authenticated TUI validation with `-` and `+`; verified the row stayed visible, `[Ignored]` and contextual help rendered, and the account state was restored

The HEY web UI labels these actions “Ignore” and “Stop Ignoring”; mute/unmute remains only the underlying SDK/API terminology.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ignore and stop-ignoring actions in CLI and TUI to match HEY’s web UI. Previously “-” muted a thread and removed it; now “-” ignores the thread but keeps it visible with “[Ignored]”, and “+” stops ignoring.

- CLI: adds `hey ignore <id>...` and `hey stop-ignoring <id>...` backed by SDK mute/unmute; requires at least one box item ID; returns concise JSON summaries; curated help, README, `.surface`, and `skills/hey` updated.
- TUI: introduces explicit posting action effects (remove, seen, ignore, stop-ignoring); keeps ignored threads visible and prefixes subjects with “[Ignored]”; shows “- ignore” or “+ stop ignoring” contextually; skips redundant requests when the thread is already in the requested state.
- API/tests: documents `/postings/mutings.json` POST/DELETE coverage; adds command unit tests and TUI tests for effects; adds a smoke test that asserts ignored threads remain visible and verifies summaries and state transitions.

<sup>Written for commit bcd7073b48c81f96bc09e41925c7f2d6fd6d83f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

