### PR TITLE
Add CLI and TUI email search

### DIFF
--- a/.surface
+++ b/.surface
@@ -70,6 +70,21 @@ hey recordings --limit
 hey recordings --starts-on
 hey reply
 hey reply --message
+hey search
+hey search --all
+hey search --any
+hey search --attachment
+hey search --date
+hey search --exact
+hey search --from
+hey search --in
+hey search --label
+hey search --none
+hey search --page
+hey search --required
+hey search --subject
+hey search --to
+hey search filters
 hey seen
 hey setup
 hey skill

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -13,6 +13,8 @@ The legacy `internal/client/` is used only for HTML-scraping gap operations mark
 | `/asidebox.json` | GET | SDK `Boxes().GetAsidebox` | `hey box asidebox` | covered |
 | `/laterbox.json` | GET | SDK `Boxes().GetLaterbox` | `hey box laterbox` | covered |
 | `/bubblebox.json` | GET | SDK `Boxes().GetBubblebox` | `hey box bubblebox` | covered |
+| `/advanced_search.json` | GET | SDK `Search().Search` | `hey search`, TUI `/` | covered |
+| `/advanced_search_filters.json` | GET | SDK `Search().Filters` | `hey search filters` | covered |
 | `/calendars.json` | GET | SDK `Calendars().List` | `hey calendars` | covered |
 | `/calendars/{id}/recordings.json` | GET | SDK `Calendars().GetRecordings` | `hey recordings <calendar-id>`, `hey todo list`, `hey timetrack list`, `hey journal list` | covered |
 | `/topics/{id}/entries` | GET (HTML) | Legacy `GetTopicEntries` | `hey threads <id>` | gap: SDK Entry lacks body |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ hey ignore 12345                   # ignore future activity on a thread
 hey stop-ignoring 12345            # resume attention for a thread
 ```
 
-Search accepts free text plus `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. Use `--page` for one page or `--all` to fetch up to 100 pages; capped searches report the next page for continuation. Search results include `id` for organization actions, `topic_id` for reading the thread, and the matching message summaries.
+Search accepts free text plus `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. Use `--page` for one page or `--all` to fetch up to 100 pages; capped searches report the next page for continuation. Search results include `topic_id` for reading the thread and the matching message summaries. Results with an active box item also include `id` for organization actions.
 
 Organization actions take the `id` values returned by `hey box --json` or `hey search --json`. Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ hey auth logout   # clear credentials
 
 Run `hey` to launch the interactive terminal UI.
 
-Navigate between mailboxes and email threads. Use Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `t` to trash, `s` to mark as spam, `-` to ignore, `+` to stop ignoring, and Escape or `q` to go back.
+Navigate between mailboxes and email threads. Use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `t` to trash, `s` to mark as spam, `-` to ignore, `+` to stop ignoring, and Escape or `q` to go back. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
 
 ## CLI Commands
 
@@ -69,6 +69,9 @@ All commands support `--json` for raw JSON output and `--base-url` to override t
 ```bash
 hey boxes                          # list mailboxes
 hey box imbox                      # list email threads in a box (by name or ID)
+hey search "quarterly planning"    # search threads and matching messages
+hey search --from jane@example.com --date last_30_days  # refine a search
+hey search filters                 # list available refinement values
 hey threads 123                    # read a full email thread
 hey reply 123 -m "Thanks!"        # reply to a thread (or omit -m to open $EDITOR)
 hey forward 123 --to alice@example.com -m "For your review"  # forward the latest message
@@ -83,7 +86,9 @@ hey ignore 12345                   # ignore future activity on a thread
 hey stop-ignoring 12345            # resume attention for a thread
 ```
 
-These actions take the `id` values returned by `hey box --json`. Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
+Search accepts free text plus `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. Use `--page` for one page or `--all` to fetch every page. Search results include `id` for organization actions, `topic_id` for reading the thread, and the matching message summaries.
+
+Organization actions take the `id` values returned by `hey box --json` or `hey search --json`. Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 
 ### Calendars
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ hey ignore 12345                   # ignore future activity on a thread
 hey stop-ignoring 12345            # resume attention for a thread
 ```
 
-Search accepts free text plus `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. Use `--page` for one page or `--all` to fetch every page. Search results include `id` for organization actions, `topic_id` for reading the thread, and the matching message summaries.
+Search accepts free text plus `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. Use `--page` for one page or `--all` to fetch up to 100 pages; capped searches report the next page for continuation. Search results include `id` for organization actions, `topic_id` for reading the thread, and the matching message summaries.
 
 Organization actions take the `id` values returned by `hey box --json` or `hey search --json`. Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -17,7 +17,7 @@ var curatedCategories = []struct {
 }{
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "threads", "compose", "reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
+		names:   []string{"boxes", "box", "search", "threads", "compose", "reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -27,7 +27,7 @@ func TestCuratedCommandHelpUsesUserFacingLanguage(t *testing.T) {
 
 func TestEmailCommandHelpKeepsPostingAsAnInternalTerm(t *testing.T) {
 	root := newRootCmd()
-	for _, name := range []string{"boxes", "box", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"} {
+	for _, name := range []string{"boxes", "box", "search", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"} {
 		t.Run(name, func(t *testing.T) {
 			command, _, err := root.Find([]string{name})
 			if err != nil {
@@ -65,6 +65,7 @@ USAGE
 EMAIL
   boxes          List your HEY boxes
   box            List email threads in a box
+  search         Search email threads and messages
   threads        Read a thread
   compose        Write and send a new email
   reply          Reply to a thread

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -119,6 +119,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newAuthCommand().cmd)
 	root.AddCommand(newBoxesCommand().cmd)
 	root.AddCommand(newBoxCommand().cmd)
+	root.AddCommand(newSearchCommand().cmd)
 	root.AddCommand(newThreadsCommand().cmd)
 	root.AddCommand(newReplyCommand().cmd)
 	root.AddCommand(newForwardCommand().cmd)

--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -108,17 +108,13 @@ func (c *searchCommand) run(cmd *cobra.Command, args []string) error {
 	}
 	results := makeSearchResults(matches)
 
+	notice := searchTruncationNotice(params.Page, pages, truncated)
 	if writer.IsStyled() {
 		printSearchResults(cmd, results)
-		if truncated {
-			fmt.Fprintf(cmd.OutOrStdout(), "\nSearch stopped after %d pages. Continue with --page %d.\n", pages, params.Page+pages)
+		if notice != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n", notice)
 		}
 		return nil
-	}
-
-	notice := ""
-	if truncated {
-		notice = fmt.Sprintf("Search stopped after %d pages. Continue with --page %d.", pages, params.Page+pages)
 	}
 	return writeOK(results,
 		output.WithSummary(searchSummary(len(results))),
@@ -272,4 +268,11 @@ func printSearchResults(cmd *cobra.Command, results []searchResult) {
 
 func searchSummary(count int) string {
 	return fmt.Sprintf("%d matching %s", count, threadNoun(count))
+}
+
+func searchTruncationNotice(startPage, pages int, truncated bool) string {
+	if !truncated {
+		return ""
+	}
+	return fmt.Sprintf("Search stopped after %d pages. Continue with --page %d.", pages, startPage+pages)
 }

--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+const maxSearchPages = 100
+
+var searchYearPattern = regexp.MustCompile(`^20\d{2}$`)
+
+type searchCommand struct {
+	cmd *cobra.Command
+
+	required   string
+	any        string
+	none       string
+	exact      string
+	from       string
+	to         string
+	subject    string
+	date       string
+	in         string
+	label      string
+	attachment string
+	page       int
+	all        bool
+}
+
+type searchResult struct {
+	ID        int64             `json:"id,omitempty"`
+	TopicID   int64             `json:"topic_id"`
+	Subject   string            `json:"subject"`
+	UpdatedAt time.Time         `json:"updated_at,omitempty"`
+	Messages  []generated.Entry `json:"messages"`
+}
+
+type searchPageFetcher func(context.Context, hey.SearchParams) (*generated.AdvancedSearchResult, error)
+
+func newSearchCommand() *searchCommand {
+	searchCommand := &searchCommand{}
+	searchCommand.cmd = &cobra.Command{
+		Use:   "search [query]",
+		Short: "Search email threads and messages",
+		Long:  "Search email threads and matching messages. Combine an optional free-text query with advanced refinements.",
+		Annotations: map[string]string{
+			"agent_notes": "Returns one result per thread. id is the box item ID for organization actions, topic_id opens the thread, and messages contains the matching message summaries. Use `hey search filters` to discover box, date, label, and attachment values.",
+		},
+		Example: `  hey search "quarterly planning"
+  hey search --from jane@example.com --date last_30_days
+  hey search --subject invoice --attachment pdf --all
+  hey search filters --json`,
+		RunE: searchCommand.run,
+		Args: cobra.MaximumNArgs(1),
+	}
+
+	flags := searchCommand.cmd.Flags()
+	flags.StringVar(&searchCommand.required, "required", "", "Words that must all appear")
+	flags.StringVar(&searchCommand.any, "any", "", "Words where at least one must appear")
+	flags.StringVar(&searchCommand.none, "none", "", "Words that must not appear")
+	flags.StringVar(&searchCommand.exact, "exact", "", "Exact phrase that must appear")
+	flags.StringVar(&searchCommand.from, "from", "", "Sender name or email address")
+	flags.StringVar(&searchCommand.to, "to", "", "Recipient name or email address")
+	flags.StringVar(&searchCommand.subject, "subject", "", "Words in the subject")
+	flags.StringVar(&searchCommand.date, "date", "", "Date range: last_7_days, last_30_days, last_90_days, or year")
+	flags.StringVar(&searchCommand.in, "in", "", "Box: imbox, feed, papertrail, or trash")
+	flags.StringVar(&searchCommand.label, "label", "", "Label name")
+	flags.StringVar(&searchCommand.attachment, "attachment", "", "Attachment kind, or any")
+	flags.IntVar(&searchCommand.page, "page", 1, "Results page")
+	flags.BoolVar(&searchCommand.all, "all", false, "Fetch every results page from --page onward")
+
+	searchCommand.cmd.AddCommand(newSearchFiltersCommand().cmd)
+	return searchCommand
+}
+
+func (c *searchCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	params := c.params(args)
+	if !hasSearchCriteria(params) {
+		return output.ErrUsage("provide a query or at least one search refinement")
+	}
+	if err := validateSearchParams(params); err != nil {
+		return err
+	}
+
+	matches, pages, truncated, err := collectSearchMatches(cmd.Context(), params, c.all, func(ctx context.Context, pageParams hey.SearchParams) (*generated.AdvancedSearchResult, error) {
+		result, searchErr := sdk.Search().Search(ctx, pageParams)
+		if searchErr != nil {
+			return nil, convertSDKError(searchErr)
+		}
+		return result, nil
+	})
+	if err != nil {
+		return err
+	}
+	results := makeSearchResults(matches)
+
+	if writer.IsStyled() {
+		printSearchResults(cmd, results)
+		if truncated {
+			fmt.Fprintf(cmd.OutOrStdout(), "\nSearch stopped after %d pages. Continue with --page %d.\n", pages, params.Page+pages)
+		}
+		return nil
+	}
+
+	notice := ""
+	if truncated {
+		notice = fmt.Sprintf("Search stopped after %d pages. Continue with --page %d.", pages, params.Page+pages)
+	}
+	return writeOK(results,
+		output.WithSummary(searchSummary(len(results))),
+		output.WithNotice(notice),
+		output.WithMeta("page", params.Page),
+		output.WithMeta("pages_fetched", pages),
+		output.WithBreadcrumbs(
+			output.Breadcrumb{
+				Action:      "read",
+				Command:     "hey threads <topic_id>",
+				Description: "Read a matching email thread",
+			},
+		),
+	)
+}
+
+func (c *searchCommand) params(args []string) hey.SearchParams {
+	query := ""
+	if len(args) == 1 {
+		query = strings.TrimSpace(args[0])
+	}
+	return hey.SearchParams{
+		Query:       query,
+		Page:        c.page,
+		Required:    strings.TrimSpace(c.required),
+		Any:         strings.TrimSpace(c.any),
+		None:        strings.TrimSpace(c.none),
+		ExactPhrase: strings.TrimSpace(c.exact),
+		From:        strings.TrimSpace(c.from),
+		To:          strings.TrimSpace(c.to),
+		Subject:     strings.TrimSpace(c.subject),
+		Date:        strings.TrimSpace(c.date),
+		In:          strings.TrimSpace(c.in),
+		Label:       strings.TrimSpace(c.label),
+		Attachment:  strings.TrimSpace(c.attachment),
+	}
+}
+
+func hasSearchCriteria(params hey.SearchParams) bool {
+	return params.Query != "" || params.Required != "" || params.Any != "" || params.None != "" ||
+		params.ExactPhrase != "" || params.From != "" || params.To != "" || params.Subject != "" ||
+		params.Date != "" || params.In != "" || params.Label != "" || params.Attachment != ""
+}
+
+func validateSearchParams(params hey.SearchParams) error {
+	if params.Page < 1 {
+		return output.ErrUsage("--page must be at least 1")
+	}
+	if params.Date != "" {
+		switch params.Date {
+		case "last_7_days", "last_30_days", "last_90_days":
+		default:
+			if !searchYearPattern.MatchString(params.Date) {
+				return output.ErrUsage("--date must be last_7_days, last_30_days, last_90_days, or a four-digit year beginning with 20")
+			}
+		}
+	}
+	if params.In != "" {
+		switch params.In {
+		case "imbox", "feed", "papertrail", "trash":
+		default:
+			return output.ErrUsage("--in must be imbox, feed, papertrail, or trash")
+		}
+	}
+	return nil
+}
+
+func collectSearchMatches(ctx context.Context, params hey.SearchParams, all bool, fetch searchPageFetcher) ([]generated.SearchMatch, int, bool, error) {
+	if fetch == nil {
+		return nil, 0, false, fmt.Errorf("collectSearchMatches: fetch function is nil")
+	}
+
+	page := params.Page
+	if page < 1 {
+		page = 1
+	}
+	var matches []generated.SearchMatch
+	for pages := 1; pages <= maxSearchPages; pages++ {
+		params.Page = page
+		result, err := fetch(ctx, params)
+		if err != nil {
+			return nil, pages - 1, false, err
+		}
+		if result == nil || len(result.Matches) == 0 {
+			return matches, pages, false, nil
+		}
+		matches = append(matches, result.Matches...)
+		if !all {
+			return matches, 1, false, nil
+		}
+		if pages == maxSearchPages {
+			return matches, pages, true, nil
+		}
+		page++
+	}
+	return matches, maxSearchPages, true, nil
+}
+
+func makeSearchResults(matches []generated.SearchMatch) []searchResult {
+	results := make([]searchResult, 0, len(matches))
+	for _, match := range matches {
+		results = append(results, searchResult{
+			ID:        match.PostingId,
+			TopicID:   match.Topic.Id,
+			Subject:   match.Topic.Name,
+			UpdatedAt: match.Topic.UpdatedAt,
+			Messages:  match.Entries,
+		})
+	}
+	return results
+}
+
+func printSearchResults(cmd *cobra.Command, results []searchResult) {
+	if len(results) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No matches found")
+		return
+	}
+
+	table := newTable(cmd.OutOrStdout())
+	table.addRow([]string{"ID", "Thread", "Message", "From", "Subject", "Match", "Date"})
+	for _, result := range results {
+		id := "—"
+		if result.ID != 0 {
+			id = fmt.Sprintf("%d", result.ID)
+		}
+		if len(result.Messages) == 0 {
+			table.addRow([]string{id, fmt.Sprintf("%d", result.TopicID), "—", "", truncate(result.Subject, 36), "", formatDate(result.UpdatedAt)})
+			continue
+		}
+		for _, message := range result.Messages {
+			from := message.Creator.Name
+			if from == "" {
+				from = message.Creator.EmailAddress
+			}
+			if message.AlternativeSenderName != "" {
+				from = message.AlternativeSenderName
+			}
+			table.addRow([]string{
+				id,
+				fmt.Sprintf("%d", result.TopicID),
+				fmt.Sprintf("%d", message.Id),
+				truncate(from, 24),
+				truncate(result.Subject, 36),
+				truncate(message.Summary, 50),
+				formatDate(message.CreatedAt),
+			})
+		}
+	}
+	table.print()
+}
+
+func searchSummary(count int) string {
+	return fmt.Sprintf("%d matching %s", count, threadNoun(count))
+}

--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -116,6 +116,9 @@ func (c *searchCommand) run(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	}
+	if stderrNotice := searchNoticeForStderr(writer.EffectiveFormat(), notice); stderrNotice != "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), stderrNotice)
+	}
 	return writeOK(results,
 		output.WithSummary(searchSummary(len(results))),
 		output.WithNotice(notice),
@@ -275,4 +278,11 @@ func searchTruncationNotice(startPage, pages int, truncated bool) string {
 		return ""
 	}
 	return fmt.Sprintf("Search stopped after %d pages. Continue with --page %d.", pages, startPage+pages)
+}
+
+func searchNoticeForStderr(format output.Format, notice string) string {
+	if notice == "" || format == output.FormatJSON || format == output.FormatStyled {
+		return ""
+	}
+	return "notice: " + notice
 }

--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -77,7 +77,7 @@ func newSearchCommand() *searchCommand {
 	flags.StringVar(&searchCommand.label, "label", "", "Label name")
 	flags.StringVar(&searchCommand.attachment, "attachment", "", "Attachment kind, or any")
 	flags.IntVar(&searchCommand.page, "page", 1, "Results page")
-	flags.BoolVar(&searchCommand.all, "all", false, "Fetch every results page from --page onward")
+	flags.BoolVar(&searchCommand.all, "all", false, "Fetch up to 100 results pages from --page onward")
 
 	searchCommand.cmd.AddCommand(newSearchFiltersCommand().cmd)
 	return searchCommand

--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -54,7 +54,7 @@ func newSearchCommand() *searchCommand {
 		Short: "Search email threads and messages",
 		Long:  "Search email threads and matching messages. Combine an optional free-text query with advanced refinements.",
 		Annotations: map[string]string{
-			"agent_notes": "Returns one result per thread. id is the box item ID for organization actions, topic_id opens the thread, and messages contains the matching message summaries. Use `hey search filters` to discover box, date, label, and attachment values.",
+			"agent_notes": "Returns one result per thread. id is the box item ID for organization actions when the thread has an active box item, topic_id opens the thread, and messages contains the matching message summaries. Use `hey search filters` to discover box, date, label, and attachment values.",
 		},
 		Example: `  hey search "quarterly planning"
   hey search --from jane@example.com --date last_30_days

--- a/internal/cmd/search_filters.go
+++ b/internal/cmd/search_filters.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type searchFiltersCommand struct {
+	cmd *cobra.Command
+}
+
+type searchFilters struct {
+	Boxes       []generated.SearchFilterItem `json:"boxes"`
+	Dates       []generated.SearchFilterItem `json:"dates"`
+	Labels      []generated.SearchFilterItem `json:"labels"`
+	Attachments []generated.SearchFilterItem `json:"attachments"`
+}
+
+func newSearchFiltersCommand() *searchFiltersCommand {
+	filtersCommand := &searchFiltersCommand{}
+	filtersCommand.cmd = &cobra.Command{
+		Use:   "filters",
+		Short: "List available search refinement values",
+		Annotations: map[string]string{
+			"agent_notes": "Returns the current values accepted by --in, --date, --label, and --attachment.",
+		},
+		RunE: filtersCommand.run,
+		Args: cobra.NoArgs,
+	}
+	return filtersCommand
+}
+
+func (c *searchFiltersCommand) run(cmd *cobra.Command, _ []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	result, err := sdk.Search().Filters(cmd.Context())
+	if err != nil {
+		return convertSDKError(err)
+	}
+	filters := makeSearchFilters(result)
+
+	if writer.IsStyled() {
+		printSearchFilterGroup(cmd, "Boxes", filters.Boxes)
+		printSearchFilterGroup(cmd, "Dates", filters.Dates)
+		printSearchFilterGroup(cmd, "Labels", filters.Labels)
+		printSearchFilterGroup(cmd, "Attachments", filters.Attachments)
+		return nil
+	}
+
+	return writeOK(filters,
+		output.WithSummary("Available search filters"),
+	)
+}
+
+func makeSearchFilters(result *generated.AdvancedSearchFilters) searchFilters {
+	if result == nil {
+		return searchFilters{}
+	}
+	return searchFilters{
+		Boxes:       result.RefineIn,
+		Dates:       result.RefineDates,
+		Labels:      result.RefineLabels,
+		Attachments: result.RefineAttachments,
+	}
+}
+
+func printSearchFilterGroup(cmd *cobra.Command, title string, items []generated.SearchFilterItem) {
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", title)
+	if len(items) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "  (none)")
+		fmt.Fprintln(cmd.OutOrStdout())
+		return
+	}
+	table := newTable(cmd.OutOrStdout())
+	table.addRow([]string{"Value", "Description"})
+	for _, item := range items {
+		table.addRow([]string{item.Value, item.Title})
+	}
+	table.print()
+	fmt.Fprintln(cmd.OutOrStdout())
+}

--- a/internal/cmd/search_test.go
+++ b/internal/cmd/search_test.go
@@ -1,0 +1,293 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type recordedSearch struct {
+	queries  []url.Values
+	requests int
+	status   int
+}
+
+func searchServer(t *testing.T) (*httptest.Server, *recordedSearch) {
+	t.Helper()
+	recorded := &recordedSearch{status: http.StatusOK}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorded.requests++
+		if r.URL.Path == "/advanced_search_filters.json" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"refine_in":[{"title":"Imbox","value":"imbox"}],
+				"refine_dates":[{"title":"Within the last 7 days","value":"last_7_days"}],
+				"refine_labels":[{"title":"Receipts","value":"Receipts"}],
+				"refine_attachments":[{"title":"PDF","value":"pdf"}]
+			}`))
+			return
+		}
+		if r.URL.Path != "/advanced_search.json" {
+			http.NotFound(w, r)
+			return
+		}
+		recorded.queries = append(recorded.queries, r.URL.Query())
+		if recorded.status != http.StatusOK {
+			w.WriteHeader(recorded.status)
+			return
+		}
+
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page == 0 {
+			page = 1
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(searchPageJSON(page)))
+	}))
+	t.Cleanup(server.Close)
+	return server, recorded
+}
+
+func searchPageJSON(page int) string {
+	if page > 2 {
+		return `{"matches":[]}`
+	}
+	return `{"matches":[{
+		"topic":{"id":331,"name":"Kitchen remodel","updated_at":"2026-08-18T12:00:00Z"},
+		"posting_id":4471829,
+		"entries":[{"id":5512,"summary":"The cabinets arrive on Tuesday","kind":"message","created_at":"2026-08-18T11:00:00Z","creator":{"id":7,"name":"Jane Doe","email_address":"jane@example.com"}}]
+	}]}`
+}
+
+func runSearch(t *testing.T, server *httptest.Server, args ...string) (output.Response, error) {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(append([]string{"search", "--json", "--base-url", server.URL}, args...))
+
+	err := root.Execute()
+	var resp output.Response
+	if buf.Len() > 0 {
+		_ = json.Unmarshal(buf.Bytes(), &resp)
+	}
+	return resp, err
+}
+
+func decodeSearchResults(t *testing.T, data any) []searchResult {
+	t.Helper()
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var results []searchResult
+	if err := json.Unmarshal(encoded, &results); err != nil {
+		t.Fatal(err)
+	}
+	return results
+}
+
+func TestSearchSendsQueryAndEveryRefinement(t *testing.T) {
+	server, recorded := searchServer(t)
+	resp, err := runSearch(t, server,
+		"planning",
+		"--required", "budget timeline",
+		"--any", "kitchen cabinets",
+		"--none", "cancelled",
+		"--exact", "final proposal",
+		"--from", "jane@example.com",
+		"--to", "mike@example.org",
+		"--subject", "remodel",
+		"--date", "last_30_days",
+		"--in", "imbox",
+		"--label", "Projects",
+		"--attachment", "pdf",
+		"--page", "2",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recorded.requests != 1 || len(recorded.queries) != 1 {
+		t.Fatalf("requests = %d, queries = %d, want 1", recorded.requests, len(recorded.queries))
+	}
+	query := recorded.queries[0]
+	wants := map[string]string{
+		"q":                    "planning",
+		"page":                 "2",
+		"refine[required]":     "budget timeline",
+		"refine[any]":          "kitchen cabinets",
+		"refine[none]":         "cancelled",
+		"refine[exact_phrase]": "final proposal",
+		"refine[from]":         "jane@example.com",
+		"refine[to]":           "mike@example.org",
+		"refine[subject]":      "remodel",
+		"refine[date]":         "last_30_days",
+		"refine[in]":           "imbox",
+		"refine[label]":        "Projects",
+		"refine[attachment]":   "pdf",
+	}
+	for key, want := range wants {
+		if got := query.Get(key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+
+	results := decodeSearchResults(t, resp.Data)
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].ID != 4471829 || results[0].TopicID != 331 || len(results[0].Messages) != 1 || results[0].Messages[0].Id != 5512 {
+		t.Errorf("unexpected result: %+v", results[0])
+	}
+	if resp.Summary != "1 matching thread" {
+		t.Errorf("summary = %q", resp.Summary)
+	}
+}
+
+func TestSearchAcceptsRefinementWithoutFreeText(t *testing.T) {
+	server, recorded := searchServer(t)
+	if _, err := runSearch(t, server, "--from", "jane@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if got := recorded.queries[0].Get("q"); got != "" {
+		t.Errorf("q = %q, want empty", got)
+	}
+	if got := recorded.queries[0].Get("refine[from]"); got != "jane@example.com" {
+		t.Errorf("refine[from] = %q", got)
+	}
+}
+
+func TestSearchRequiresCriteriaBeforeRequest(t *testing.T) {
+	server, recorded := searchServer(t)
+	_, err := runSearch(t, server)
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+		t.Fatalf("error = %v, want usage error", err)
+	}
+	if recorded.requests != 0 {
+		t.Errorf("requests = %d, want 0", recorded.requests)
+	}
+}
+
+func TestSearchValidatesPageDateAndBoxBeforeRequest(t *testing.T) {
+	tests := [][]string{
+		{"planning", "--page", "0"},
+		{"planning", "--date", "yesterday"},
+		{"planning", "--in", "set-aside"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			server, recorded := searchServer(t)
+			_, err := runSearch(t, server, args...)
+			var cliErr *apierr.Error
+			if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+				t.Fatalf("error = %v, want usage error", err)
+			}
+			if recorded.requests != 0 {
+				t.Errorf("requests = %d, want 0", recorded.requests)
+			}
+		})
+	}
+}
+
+func TestSearchAllFetchesUntilEmptyPage(t *testing.T) {
+	server, recorded := searchServer(t)
+	resp, err := runSearch(t, server, "planning", "--all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := decodeSearchResults(t, resp.Data)
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	if recorded.requests != 3 {
+		t.Errorf("requests = %d, want 3", recorded.requests)
+	}
+	for i, want := range []string{"", "2", "3"} {
+		if got := recorded.queries[i].Get("page"); got != want {
+			t.Errorf("request %d page = %q, want %q", i+1, got, want)
+		}
+	}
+}
+
+func TestSearchStopsAfterFirstPageByDefault(t *testing.T) {
+	server, recorded := searchServer(t)
+	if _, err := runSearch(t, server, "planning"); err != nil {
+		t.Fatal(err)
+	}
+	if recorded.requests != 1 {
+		t.Errorf("requests = %d, want 1", recorded.requests)
+	}
+}
+
+func TestSearchReportsServerFailures(t *testing.T) {
+	server, recorded := searchServer(t)
+	recorded.status = http.StatusUnprocessableEntity
+	if _, err := runSearch(t, server, "planning"); err == nil {
+		t.Fatal("expected server failure")
+	}
+}
+
+func TestSearchFiltersReturnsAvailableValues(t *testing.T) {
+	server, recorded := searchServer(t)
+	resp, err := runSearch(t, server, "filters")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recorded.requests != 1 {
+		t.Fatalf("requests = %d, want 1", recorded.requests)
+	}
+	encoded, _ := json.Marshal(resp.Data)
+	var filters searchFilters
+	if err := json.Unmarshal(encoded, &filters); err != nil {
+		t.Fatal(err)
+	}
+	if len(filters.Boxes) != 1 || filters.Boxes[0].Value != "imbox" {
+		t.Errorf("boxes = %+v", filters.Boxes)
+	}
+	if len(filters.Dates) != 1 || len(filters.Labels) != 1 || len(filters.Attachments) != 1 {
+		t.Errorf("filters = %+v", filters)
+	}
+}
+
+func TestCollectSearchMatchesRejectsNilFetcher(t *testing.T) {
+	_, _, _, err := collectSearchMatches(t.Context(), hey.SearchParams{Query: "planning", Page: 1}, false, nil)
+	if err == nil {
+		t.Fatal("expected nil fetcher error")
+	}
+}
+
+func TestMakeSearchFiltersHandlesNilResponse(t *testing.T) {
+	if got := makeSearchFilters(nil); len(got.Boxes)+len(got.Dates)+len(got.Labels)+len(got.Attachments) != 0 {
+		t.Errorf("filters = %+v, want empty", got)
+	}
+}
+
+func TestSearchSummaryUsesThreadTerminology(t *testing.T) {
+	if got := searchSummary(1); got != "1 matching thread" {
+		t.Errorf("searchSummary(1) = %q", got)
+	}
+	if got := searchSummary(2); got != "2 matching threads" {
+		t.Errorf("searchSummary(2) = %q", got)
+	}
+}

--- a/internal/cmd/search_test.go
+++ b/internal/cmd/search_test.go
@@ -256,6 +256,23 @@ func TestSearchAllReportsContinuationAtPageLimit(t *testing.T) {
 	}
 }
 
+func TestSearchTruncationNoticeUsesStderrForDataOnlyFormats(t *testing.T) {
+	notice := "Search stopped after 100 pages. Continue with --page 107."
+	for _, format := range []output.Format{output.FormatQuiet, output.FormatIDs, output.FormatCount, output.FormatMarkdown} {
+		if got := searchNoticeForStderr(format, notice); got != "notice: "+notice {
+			t.Errorf("format %d notice = %q", format, got)
+		}
+	}
+	for _, format := range []output.Format{output.FormatJSON, output.FormatStyled} {
+		if got := searchNoticeForStderr(format, notice); got != "" {
+			t.Errorf("format %d notice = %q, want empty", format, got)
+		}
+	}
+	if got := searchNoticeForStderr(output.FormatQuiet, ""); got != "" {
+		t.Errorf("empty notice = %q", got)
+	}
+}
+
 func TestSearchStopsAfterFirstPageByDefault(t *testing.T) {
 	server, recorded := searchServer(t)
 	if _, err := runSearch(t, server, "planning"); err != nil {

--- a/internal/cmd/search_test.go
+++ b/internal/cmd/search_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
@@ -227,6 +229,30 @@ func TestSearchAllFetchesUntilEmptyPage(t *testing.T) {
 		if got := recorded.queries[i].Get("page"); got != want {
 			t.Errorf("request %d page = %q, want %q", i+1, got, want)
 		}
+	}
+}
+
+func TestSearchAllReportsContinuationAtPageLimit(t *testing.T) {
+	calls := 0
+	lastPage := 0
+	firstPage := 7
+	matches, pages, truncated, err := collectSearchMatches(t.Context(), hey.SearchParams{Query: "planning", Page: firstPage}, true,
+		func(_ context.Context, params hey.SearchParams) (*generated.AdvancedSearchResult, error) {
+			calls++
+			lastPage = params.Page
+			return &generated.AdvancedSearchResult{Matches: []generated.SearchMatch{{
+				Topic: generated.Topic{Id: 1},
+			}}}, nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != maxSearchPages || pages != maxSearchPages || len(matches) != maxSearchPages || !truncated || lastPage != 106 {
+		t.Errorf("calls=%d pages=%d matches=%d truncated=%v lastPage=%d", calls, pages, len(matches), truncated, lastPage)
+	}
+	want := "Search stopped after 100 pages. Continue with --page 107."
+	if got := searchTruncationNotice(firstPage, pages, truncated); got != want {
+		t.Errorf("notice = %q, want %q", got, want)
 	}
 }
 

--- a/internal/output/writer.go
+++ b/internal/output/writer.go
@@ -164,12 +164,17 @@ func (w *Writer) writeMarkdown(data any) error {
 		return nil
 	}
 
-	first := toMap(items[0])
-	if first == nil {
+	if toMap(items[0]) == nil {
 		return w.writeQuiet(data)
 	}
 
-	headers := sortedKeys(first)
+	headerSet := make(map[string]any)
+	for _, item := range items {
+		for key := range toMap(item) {
+			headerSet[key] = nil
+		}
+	}
+	headers := sortedKeys(headerSet)
 
 	// Header row
 	var sb strings.Builder

--- a/internal/output/writer_test.go
+++ b/internal/output/writer_test.go
@@ -87,6 +87,27 @@ func TestWriterOK_IDsOnly(t *testing.T) {
 	}
 }
 
+func TestWriterOK_MarkdownIncludesOptionalFieldsFromLaterRows(t *testing.T) {
+	var buf bytes.Buffer
+	w := New(Options{Format: FormatMarkdown, Stdout: &buf})
+
+	data := []map[string]any{
+		{"name": "Archived thread"},
+		{"id": 20, "name": "Active thread"},
+	}
+	if err := w.OK(data); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "| id | name |") {
+		t.Errorf("markdown header omitted optional id: %q", output)
+	}
+	if !strings.Contains(output, "| 20 | Active thread |") {
+		t.Errorf("markdown rows omitted later id: %q", output)
+	}
+}
+
 func TestWriterErr_JSON(t *testing.T) {
 	var buf bytes.Buffer
 	w := New(Options{Format: FormatJSON, Stderr: &buf})

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -28,11 +28,12 @@ func formatDisplayDate(ts string) string {
 
 // contentList renders a scrollable list of postings with a cursor.
 type contentList struct {
-	postings  []models.Posting
-	cursor    int
-	scrollOff int
-	width     int
-	height    int // visible rows (each posting takes 2 lines)
+	postings      []models.Posting
+	cursor        int
+	scrollOff     int
+	width         int
+	height        int // visible rows (each posting takes 2 lines)
+	hideSeenState bool
 }
 
 func (c *contentList) setPostings(postings []models.Posting) {
@@ -109,7 +110,7 @@ func (c *contentList) view() string {
 		} else {
 			line1.WriteString("  ")
 		}
-		if !p.Seen {
+		if !p.Seen && !c.hideSeenState {
 			line1.WriteString(unseenDot.Render("●") + " ")
 		} else {
 			line1.WriteString("  ")

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -516,6 +516,7 @@ func (v *mailView) ExitThread() {
 func (v *mailView) clearSearch() {
 	v.searchActive = false
 	v.searchQuery = ""
+	v.notice = ""
 	v.searchPage = 0
 	v.searchList.setPostings(nil)
 	v.searchForm = nil

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -27,6 +27,7 @@ const (
 	mailRequestTopic
 	mailRequestReply
 	mailRequestForward
+	mailRequestSearch
 )
 
 type boxesLoadedMsg []models.Box
@@ -45,6 +46,14 @@ type topicLoadedMsg struct {
 	title     string
 	entries   []models.Entry
 	images    [][]byte
+	err       error
+}
+
+type searchResultsLoadedMsg struct {
+	requestID uint64
+	query     string
+	page      int
+	postings  []models.Posting
 	err       error
 }
 
@@ -82,10 +91,15 @@ type mailView struct {
 	inThread      bool
 	loading       bool
 
-	compose           *composeForm // non-nil while a message, reply or forward is being written
-	movePicker        *movePicker  // non-nil while a destination box is being selected
-	notice            string       // one-shot confirmation shown above the posting list
-	activeRequestID   uint64       // identifies the only mail read allowed to update the view
+	compose           *composeForm    // non-nil while a message, reply or forward is being written
+	movePicker        *movePicker     // non-nil while a destination box is being selected
+	searchForm        *mailSearchForm // non-nil while a search query is being entered
+	searchList        contentList
+	searchActive      bool
+	searchQuery       string
+	searchPage        int
+	notice            string // one-shot confirmation shown above the posting list
+	activeRequestID   uint64 // identifies the only mail read allowed to update the view
 	activeRequestKind mailRequestKind
 	requestCancel     context.CancelFunc
 }
@@ -128,6 +142,24 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
 		v.postingList.setPostings(msg.postings)
+		return nil, true
+
+	case searchResultsLoadedMsg:
+		if msg.requestID != v.activeRequestID {
+			return nil, true
+		}
+		v.finishRequest(msg.requestID)
+		if msg.err != nil {
+			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
+		if len(msg.postings) == 0 && v.searchActive && msg.page > v.searchPage {
+			v.notice = "No more search results"
+			return nil, true
+		}
+		v.searchActive = true
+		v.searchQuery = msg.query
+		v.searchPage = msg.page
+		v.searchList.setPostings(msg.postings)
 		return nil, true
 
 	case topicLoadedMsg:
@@ -250,6 +282,9 @@ func (v *mailView) View() string {
 	if v.compose != nil {
 		return v.compose.view()
 	}
+	if v.searchForm != nil {
+		return v.searchForm.view()
+	}
 	if v.movePicker != nil {
 		return v.movePicker.view(v.vc.styles, v.vc.width)
 	}
@@ -259,6 +294,12 @@ func (v *mailView) View() string {
 		}
 		return v.topicViewport.View()
 	}
+	if v.searchActive {
+		if v.notice != "" {
+			return v.vc.styles.title.Render(v.notice) + "\n" + v.searchList.view()
+		}
+		return v.searchList.view()
+	}
 	if v.notice != "" {
 		return v.vc.styles.title.Render(v.notice) + "\n" + v.postingList.view()
 	}
@@ -266,11 +307,16 @@ func (v *mailView) View() string {
 }
 
 // CapturingInput reports whether a form or picker is open and wants every key.
-func (v *mailView) CapturingInput() bool { return v.compose != nil || v.movePicker != nil }
+func (v *mailView) CapturingInput() bool {
+	return v.compose != nil || v.movePicker != nil || v.searchForm != nil
+}
 
 func (v *mailView) HelpBindings() []helpBinding {
 	if v.compose != nil {
 		return v.compose.helpBindings()
+	}
+	if v.searchForm != nil {
+		return v.searchForm.helpBindings()
 	}
 	if v.movePicker != nil {
 		return v.movePicker.helpBindings()
@@ -278,11 +324,15 @@ func (v *mailView) HelpBindings() []helpBinding {
 	if v.inThread {
 		return []helpBinding{{"r", "reply"}, {"f", "forward"}}
 	}
+	if v.searchActive {
+		return []helpBinding{{"enter", "open"}, {"/", "new search"}, {"n", "next page"}, {"p", "previous page"}}
+	}
 	ignoreBinding := helpBinding{"-", "ignore"}
 	if selected := v.postingList.selectedPosting(); selected != nil && selected.Muted {
 		ignoreBinding = helpBinding{"+", "stop ignoring"}
 	}
 	return []helpBinding{
+		{"/", "search"},
 		{"c", "compose"},
 		{"r", "reply"},
 		{"f", "forward"},
@@ -299,6 +349,13 @@ func (v *mailView) HelpBindings() []helpBinding {
 }
 
 func (v *mailView) SubnavItems() ([]navItem, int, string, bool) {
+	if v.searchActive || v.searchForm != nil {
+		label := "Search"
+		if v.searchQuery != "" {
+			label = fmt.Sprintf("Search: %s (page %d)", v.searchQuery, max(v.searchPage, 1))
+		}
+		return nil, 0, label, true
+	}
 	label := "Mail"
 	if v.boxIndex >= 0 && v.boxIndex < len(v.boxes) {
 		label = v.boxes[v.boxIndex].Name
@@ -307,10 +364,16 @@ func (v *mailView) SubnavItems() ([]navItem, int, string, bool) {
 }
 
 func (v *mailView) SubnavLeft() tea.Cmd {
+	if v.searchActive || v.searchForm != nil {
+		return nil
+	}
 	return v.switchBox(v.boxIndex - 1)
 }
 
 func (v *mailView) SubnavRight() tea.Cmd {
+	if v.searchActive || v.searchForm != nil {
+		return nil
+	}
 	return v.switchBox(v.boxIndex + 1)
 }
 
@@ -325,6 +388,19 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		cmd, submit := v.compose.handleKey(msg)
 		if submit {
 			return v.send()
+		}
+		return cmd
+	}
+
+	if v.searchForm != nil {
+		if msg.Key().Code == tea.KeyEscape {
+			v.searchForm = nil
+			return nil
+		}
+		cmd, query, submit := v.searchForm.handleKey(msg)
+		if submit {
+			v.searchForm = nil
+			return v.requestSearch(query, 1)
 		}
 		return cmd
 	}
@@ -359,6 +435,30 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		return cmd
 	}
 
+	if v.searchActive {
+		switch msg.Key().Code {
+		case tea.KeyUp:
+			v.searchList.moveUp()
+		case tea.KeyDown:
+			v.searchList.moveDown()
+		case tea.KeyEnter:
+			return v.openSelected()
+		default:
+			switch msg.String() {
+			case "/":
+				return v.startSearch()
+			case "n":
+				return v.requestSearch(v.searchQuery, v.searchPage+1)
+			case "p":
+				if v.searchPage > 1 {
+					return v.requestSearch(v.searchQuery, v.searchPage-1)
+				}
+				v.notice = "Already on the first search page"
+			}
+		}
+		return nil
+	}
+
 	switch msg.Key().Code {
 	case tea.KeyUp:
 		v.postingList.moveUp()
@@ -368,6 +468,8 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		return v.openSelected()
 	default:
 		switch msg.String() {
+		case "/":
+			return v.startSearch()
 		case "c":
 			return v.startCompose()
 		case "m":
@@ -380,16 +482,25 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 	return nil
 }
 
-func (v *mailView) InThread() bool { return v.inThread }
+func (v *mailView) InThread() bool { return v.inThread || v.searchActive }
 func (v *mailView) ExitThread() {
-	v.inThread = false
-	v.compose = nil
-	v.movePicker = nil
+	if v.inThread {
+		v.inThread = false
+		v.compose = nil
+		v.movePicker = nil
+		v.cancelRequest()
+		return
+	}
+	v.searchActive = false
+	v.searchQuery = ""
+	v.searchPage = 0
+	v.searchList.setPostings(nil)
+	v.searchForm = nil
 	v.cancelRequest()
 }
 
 func (v *mailView) CancelPendingDetail() bool {
-	if v.activeRequestKind != mailRequestTopic && v.activeRequestKind != mailRequestReply && v.activeRequestKind != mailRequestForward {
+	if v.activeRequestKind != mailRequestTopic && v.activeRequestKind != mailRequestReply && v.activeRequestKind != mailRequestForward && v.activeRequestKind != mailRequestSearch {
 		return false
 	}
 	v.cancelRequest()
@@ -402,7 +513,11 @@ func (v *mailView) Resize(width, height int) {
 	if v.compose != nil {
 		v.compose.resize(width, height)
 	}
+	if v.searchForm != nil {
+		v.searchForm.resize(width, height)
+	}
 	v.postingList.setSize(width, height)
+	v.searchList.setSize(width, height)
 	v.topicViewport.SetWidth(width)
 	v.topicViewport.SetHeight(height)
 }
@@ -416,7 +531,13 @@ func (v *mailView) switchBox(index int) tea.Cmd {
 	if index < 0 || index >= len(v.boxes) || index == v.boxIndex {
 		return nil
 	}
-	v.ExitThread()
+	v.inThread = false
+	v.searchActive = false
+	v.searchForm = nil
+	v.searchQuery = ""
+	v.searchPage = 0
+	v.searchList.setPostings(nil)
+	v.cancelRequest()
 	v.notice = ""
 	v.postingList.setPostings(nil)
 	v.boxIndex = index
@@ -469,6 +590,17 @@ func (v *mailView) requestPostings(boxID int64) tea.Cmd {
 	return v.fetchPostings(ctx, requestID, boxID)
 }
 
+func (v *mailView) startSearch() tea.Cmd {
+	v.searchForm = newMailSearchForm(v.searchQuery, v.vc.styles)
+	v.searchForm.resize(v.vc.width, v.vc.height)
+	return v.searchForm.init()
+}
+
+func (v *mailView) requestSearch(query string, page int) tea.Cmd {
+	requestID, ctx := v.beginRequest(mailRequestSearch)
+	return v.fetchSearchResults(ctx, requestID, query, max(page, 1))
+}
+
 func (v *mailView) requestTopic(boxID, topicID int64, title string) tea.Cmd {
 	requestID, ctx := v.beginRequest(mailRequestTopic)
 	return v.fetchTopic(ctx, requestID, boxID, topicID, title)
@@ -484,15 +616,22 @@ func (v *mailView) postingIndex(postingID int64) int {
 }
 
 func (v *mailView) openSelected() tea.Cmd {
-	p := v.postingList.selectedPosting()
-	if p == nil {
+	selected := v.postingList.selectedPosting()
+	if v.searchActive {
+		selected = v.searchList.selectedPosting()
+	}
+	if selected == nil {
 		return nil
 	}
-	topicID := p.ResolveTopicID()
+	topicID := selected.ResolveTopicID()
 	if topicID == 0 {
-		topicID = p.ID
+		topicID = selected.ID
 	}
-	return v.requestTopic(v.currentBoxID(), topicID, p.Summary)
+	title := selected.Summary
+	if v.searchActive {
+		title = selected.Name
+	}
+	return v.requestTopic(v.currentBoxID(), topicID, title)
 }
 
 // --- Posting actions ---
@@ -643,6 +782,34 @@ func sdkPostingToModel(p generated.Posting) models.Posting {
 	}
 }
 
+func sdkSearchMatchToModel(match generated.SearchMatch) models.Posting {
+	posting := models.Posting{
+		ID:        match.PostingId,
+		TopicID:   match.Topic.Id,
+		Name:      match.Topic.Name,
+		AppURL:    match.Topic.AppUrl,
+		CreatedAt: formatTimestamp(match.Topic.UpdatedAt),
+		UpdatedAt: formatTimestamp(match.Topic.UpdatedAt),
+		Creator: models.Contact{
+			ID:           match.Topic.Creator.Id,
+			Name:         match.Topic.Creator.Name,
+			EmailAddress: match.Topic.Creator.EmailAddress,
+		},
+	}
+	if len(match.Entries) > 0 {
+		entry := match.Entries[0]
+		posting.CreatedAt = formatTimestamp(entry.CreatedAt)
+		posting.Summary = entry.Summary
+		posting.AlternativeSenderName = entry.AlternativeSenderName
+		posting.Creator = models.Contact{
+			ID:           entry.Creator.Id,
+			Name:         entry.Creator.Name,
+			EmailAddress: entry.Creator.EmailAddress,
+		}
+	}
+	return posting
+}
+
 func sdkExtenzionsToModel(exts []generated.Extenzion) []models.Extenzion {
 	if len(exts) == 0 {
 		return nil
@@ -725,6 +892,24 @@ func (v *mailView) fetchPostings(ctx context.Context, requestID uint64, boxID in
 			postings = append(postings, sdkPostingToModel(p))
 		}
 		return postingsLoadedMsg{requestID: requestID, boxID: boxID, postings: postings}
+	}
+}
+
+func (v *mailView) fetchSearchResults(ctx context.Context, requestID uint64, query string, page int) tea.Cmd {
+	return func() tea.Msg {
+		result, err := v.vc.sdk.Search().Search(ctx, hey.SearchParams{Query: query, Page: page})
+		if err != nil {
+			return searchResultsLoadedMsg{requestID: requestID, query: query, page: page, err: err}
+		}
+		var matches []generated.SearchMatch
+		if result != nil {
+			matches = result.Matches
+		}
+		postings := make([]models.Posting, 0, len(matches))
+		for _, match := range matches {
+			postings = append(postings, sdkSearchMatchToModel(match))
+		}
+		return searchResultsLoadedMsg{requestID: requestID, query: query, page: page, postings: postings}
 	}
 }
 

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -108,6 +108,7 @@ func newMailView(vc *viewContext) *mailView {
 	return &mailView{
 		vc:            vc,
 		topicViewport: viewport.New(viewport.WithWidth(0), viewport.WithHeight(0)),
+		searchList:    contentList{hideSeenState: true},
 	}
 }
 

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -268,6 +268,9 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 	if v.compose != nil {
 		return v.compose.update(msg), true
 	}
+	if v.searchForm != nil {
+		return v.searchForm.update(msg), true
+	}
 
 	// Pass through to viewport if in thread
 	if v.inThread {
@@ -485,6 +488,10 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 
 func (v *mailView) InThread() bool { return v.inThread || v.searchActive }
 func (v *mailView) ExitThread() {
+	if v.searchActive && !v.inThread && (v.activeRequestKind == mailRequestTopic || v.activeRequestKind == mailRequestSearch) {
+		v.cancelRequest()
+		return
+	}
 	if v.inThread {
 		v.inThread = false
 		v.compose = nil

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -487,6 +487,16 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 }
 
 func (v *mailView) InThread() bool { return v.inThread || v.searchActive }
+
+func (v *mailView) ExitDetail(key string) {
+	if key == "q" && v.searchActive && !v.inThread && (v.activeRequestKind == mailRequestTopic || v.activeRequestKind == mailRequestSearch) {
+		v.cancelRequest()
+		v.clearSearch()
+		return
+	}
+	v.ExitThread()
+}
+
 func (v *mailView) ExitThread() {
 	if v.searchActive && !v.inThread && (v.activeRequestKind == mailRequestTopic || v.activeRequestKind == mailRequestSearch) {
 		v.cancelRequest()
@@ -499,12 +509,16 @@ func (v *mailView) ExitThread() {
 		v.cancelRequest()
 		return
 	}
+	v.clearSearch()
+	v.cancelRequest()
+}
+
+func (v *mailView) clearSearch() {
 	v.searchActive = false
 	v.searchQuery = ""
 	v.searchPage = 0
 	v.searchList.setPostings(nil)
 	v.searchForm = nil
-	v.cancelRequest()
 }
 
 func (v *mailView) CancelPendingDetail() bool {
@@ -540,11 +554,7 @@ func (v *mailView) switchBox(index int) tea.Cmd {
 		return nil
 	}
 	v.inThread = false
-	v.searchActive = false
-	v.searchForm = nil
-	v.searchQuery = ""
-	v.searchPage = 0
-	v.searchList.setPostings(nil)
+	v.clearSearch()
 	v.cancelRequest()
 	v.notice = ""
 	v.postingList.setPostings(nil)

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -610,6 +610,9 @@ func (v *mailView) requestPostings(boxID int64) tea.Cmd {
 }
 
 func (v *mailView) startSearch() tea.Cmd {
+	if v.loading || len(v.boxes) == 0 {
+		return nil
+	}
 	v.searchForm = newMailSearchForm(v.searchQuery, v.vc.styles)
 	v.searchForm.resize(v.vc.width, v.vc.height)
 	return v.searchForm.init()

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/models"
@@ -39,10 +40,11 @@ func currentPostingsLoaded(v *mailView, postings []models.Posting) postingsLoade
 }
 
 type recordedMailRequest struct {
-	method   string
-	path     string
-	requests []string
-	body     struct {
+	method     string
+	path       string
+	requests   []string
+	rawQueries []string
+	body       struct {
 		PostingIDs []int64 `json:"posting_ids"`
 		BoxID      *int64  `json:"box_id"`
 	}
@@ -68,8 +70,11 @@ func mailWithTestServer(t *testing.T, status int) (*mailView, *recordedMailReque
 		recorded.method = r.Method
 		recorded.path = r.URL.Path
 		recorded.requests = append(recorded.requests, r.Method+" "+r.URL.Path)
+		recorded.rawQueries = append(recorded.rawQueries, r.URL.RawQuery)
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
+		case "/advanced_search.json":
+			_, _ = w.Write([]byte(`{"matches":[{"topic":{"id":100,"name":"Hello world","app_url":"https://app.hey.com/topics/100","updated_at":"2026-08-19T09:00:00Z"},"posting_id":10,"entries":[{"id":501,"kind":"message","summary":"Matching message summary","created_at":"2026-08-19T09:00:00Z","creator":{"id":10,"name":"Alice"}}]}]}`))
 		case "/topics/100.json":
 			_, _ = w.Write([]byte(`{"id":100,"name":"Hello world","entries":[{"id":501,"kind":"message","summary":"Hello world","created_at":"2026-08-19T09:00:00Z","creator":{"id":10,"name":"Alice"}}]}`))
 		case "/messages/501.json":
@@ -1138,6 +1143,174 @@ func TestMailViewRendersEmptyList(t *testing.T) {
 	}
 }
 
+// --- Search ---
+
+func TestMailViewSearchFormSubmitsQueryAndRendersResults(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	if cmd := v.HandleContentKey(keyPress("/")); cmd == nil {
+		t.Fatal("opening search should focus the input")
+	}
+	if v.searchForm == nil || !v.CapturingInput() {
+		t.Fatal("search form should capture input")
+	}
+	v.searchForm.input.SetValue("quarterly planning")
+
+	cmd := v.HandleContentKey(keyPress("enter"))
+	if cmd == nil || !v.loading {
+		t.Fatal("submitting search should start a request")
+	}
+	msg := cmd()
+	loaded, ok := msg.(searchResultsLoadedMsg)
+	if !ok {
+		t.Fatalf("search command returned %T", msg)
+	}
+	v.Update(loaded)
+
+	if recorded.path != "/advanced_search.json" || len(recorded.rawQueries) == 0 || !strings.Contains(recorded.rawQueries[len(recorded.rawQueries)-1], "q=quarterly+planning") {
+		t.Errorf("search request = %s?%v", recorded.path, recorded.rawQueries)
+	}
+	if !v.searchActive || v.searchQuery != "quarterly planning" || v.searchPage != 1 {
+		t.Errorf("search state = active:%v query:%q page:%d", v.searchActive, v.searchQuery, v.searchPage)
+	}
+	if len(v.searchList.postings) != 1 || v.searchList.postings[0].ResolveTopicID() != 100 {
+		t.Errorf("search postings = %+v", v.searchList.postings)
+	}
+	view := v.View()
+	if !strings.Contains(view, "Hello world") || !strings.Contains(view, "Matching message summary") {
+		t.Errorf("search result does not show thread and matching-message context: %q", view)
+	}
+	_, _, label, _ := v.SubnavItems()
+	if !strings.Contains(label, "quarterly planning") || !strings.Contains(label, "page 1") {
+		t.Errorf("search label = %q", label)
+	}
+}
+
+func TestMailViewSearchRequiresWords(t *testing.T) {
+	v := mailWithPostings()
+	v.HandleContentKey(keyPress("/"))
+	cmd := v.HandleContentKey(keyPress("enter"))
+	if cmd != nil {
+		t.Fatal("empty search should not submit")
+	}
+	if v.searchForm == nil || !strings.Contains(v.searchForm.view(), "Enter words to search for") {
+		t.Error("empty search should keep the form open with guidance")
+	}
+}
+
+func TestMailViewSearchEscapeClosesForm(t *testing.T) {
+	v := mailWithPostings()
+	v.HandleContentKey(keyPress("/"))
+	v.HandleContentKey(keyPress("esc"))
+	if v.searchForm != nil || v.CapturingInput() {
+		t.Error("escape should close the search form")
+	}
+}
+
+func TestMailViewIgnoresStaleSearchResults(t *testing.T) {
+	v := mailWithPostings()
+	v.activeRequestID = 2
+	v.Update(searchResultsLoadedMsg{
+		requestID: 1,
+		query:     "stale",
+		page:      1,
+		postings:  []models.Posting{{ID: 99}},
+	})
+	if v.searchActive || len(v.searchList.postings) != 0 {
+		t.Error("stale search results changed the view")
+	}
+}
+
+func TestMailViewSearchPagination(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.searchActive = true
+	v.searchQuery = "quarterly planning"
+	v.searchPage = 1
+	v.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
+
+	next := v.HandleContentKey(keyPress("n"))
+	if next == nil {
+		t.Fatal("next page should start a request")
+	}
+	nextMsg := next().(searchResultsLoadedMsg)
+	v.Update(nextMsg)
+	if v.searchPage != 2 || !strings.Contains(recorded.rawQueries[len(recorded.rawQueries)-1], "page=2") {
+		t.Errorf("next page state = %d, queries = %v", v.searchPage, recorded.rawQueries)
+	}
+
+	previous := v.HandleContentKey(keyPress("p"))
+	if previous == nil {
+		t.Fatal("previous page should start a request")
+	}
+	previousMsg := previous().(searchResultsLoadedMsg)
+	v.Update(previousMsg)
+	if v.searchPage != 1 {
+		t.Errorf("previous page = %d, want 1", v.searchPage)
+	}
+}
+
+func TestMailViewEmptyNextSearchPagePreservesResults(t *testing.T) {
+	v := mailWithPostings()
+	v.searchActive = true
+	v.searchQuery = "quarterly planning"
+	v.searchPage = 1
+	v.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100}})
+	v.activeRequestID = 3
+
+	v.Update(searchResultsLoadedMsg{requestID: 3, query: v.searchQuery, page: 2})
+	if v.searchPage != 1 || len(v.searchList.postings) != 1 {
+		t.Errorf("empty next page replaced results: page=%d postings=%v", v.searchPage, v.searchList.postings)
+	}
+	if v.notice != "No more search results" {
+		t.Errorf("notice = %q", v.notice)
+	}
+}
+
+func TestMailViewSearchResultOpensThreadAndReturnsToResults(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusNoContent)
+	v.searchActive = true
+	v.searchQuery = "quarterly planning"
+	v.searchPage = 1
+	v.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
+
+	open := v.HandleContentKey(keyPress("enter"))
+	if open == nil {
+		t.Fatal("enter should open the selected search result")
+	}
+	v.Update(open())
+	if !v.inThread || !v.searchActive || v.topicID != 100 {
+		t.Errorf("thread state = open:%v search:%v id:%d", v.inThread, v.searchActive, v.topicID)
+	}
+
+	v.ExitThread()
+	if v.inThread || !v.searchActive || len(v.searchList.postings) != 1 {
+		t.Error("closing a searched thread should return to search results")
+	}
+	v.ExitThread()
+	if v.searchActive {
+		t.Error("closing search results should return to the box")
+	}
+}
+
+func TestSDKSearchMatchToModelPreservesActionAndThreadIDs(t *testing.T) {
+	match := generated.SearchMatch{
+		PostingId: 10,
+		Topic: generated.Topic{
+			Id:     100,
+			Name:   "Hello world",
+			AppUrl: "https://app.hey.com/topics/100",
+		},
+		Entries: []generated.Entry{{
+			Id:      501,
+			Summary: "Matching message summary",
+			Creator: generated.Contact{Name: "Alice"},
+		}},
+	}
+	posting := sdkSearchMatchToModel(match)
+	if posting.ID != 10 || posting.ResolveTopicID() != 100 || posting.Name != "Hello world" || posting.Summary != "Matching message summary" || posting.Creator.Name != "Alice" {
+		t.Errorf("posting = %+v", posting)
+	}
+}
+
 // --- Help bindings ---
 
 func TestMailViewHelpBindings(t *testing.T) {
@@ -1151,7 +1324,7 @@ func TestMailViewHelpBindings(t *testing.T) {
 	for _, b := range bindings {
 		keys[b.key] = true
 	}
-	for _, expected := range []string{"r", "f", "m", "e", "l", "a", "t", "s", "-"} {
+	for _, expected := range []string{"/", "r", "f", "m", "e", "l", "a", "t", "s", "-"} {
 		if !keys[expected] {
 			t.Errorf("missing help binding for key %q", expected)
 		}
@@ -1187,6 +1360,21 @@ func TestMailViewHelpBindingsInThread(t *testing.T) {
 	bindings := v.HelpBindings()
 	if len(bindings) != 2 || bindings[0].key != "r" || bindings[1].key != "f" {
 		t.Errorf("thread mode should offer reply and forward, got %v", bindings)
+	}
+}
+
+func TestMailViewHelpBindingsInSearchResults(t *testing.T) {
+	v := mailWithPostings()
+	v.searchActive = true
+	bindings := v.HelpBindings()
+	keys := make(map[string]bool)
+	for _, binding := range bindings {
+		keys[binding.key] = true
+	}
+	for _, expected := range []string{"enter", "/", "n", "p"} {
+		if !keys[expected] {
+			t.Errorf("search results missing help binding %q: %v", expected, bindings)
+		}
 	}
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -1145,6 +1145,24 @@ func TestMailViewRendersEmptyList(t *testing.T) {
 
 // --- Search ---
 
+func TestMailViewSearchWaitsForMailboxLoad(t *testing.T) {
+	v := newMailView(testVC())
+	v.loading = true
+	if cmd := v.HandleContentKey(keyPress("/")); cmd != nil || v.searchForm != nil {
+		t.Error("search should not start before boxes load")
+	}
+
+	v.Update(boxesLoadedMsg(testBoxes()))
+	if cmd := v.HandleContentKey(keyPress("/")); cmd != nil || v.searchForm != nil {
+		t.Error("search should not start while the first box loads")
+	}
+
+	v.Update(currentPostingsLoaded(v, testPostings()))
+	if cmd := v.HandleContentKey(keyPress("/")); cmd == nil || v.searchForm == nil {
+		t.Error("search should start after the mailbox finishes loading")
+	}
+}
+
 func TestMailViewSearchFormSubmitsQueryAndRendersResults(t *testing.T) {
 	v, recorded := mailWithTestServer(t, http.StatusNoContent)
 	if cmd := v.HandleContentKey(keyPress("/")); cmd == nil {

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -1179,6 +1179,9 @@ func TestMailViewSearchFormSubmitsQueryAndRendersResults(t *testing.T) {
 	if !strings.Contains(view, "Hello world") || !strings.Contains(view, "Matching message summary") {
 		t.Errorf("search result does not show thread and matching-message context: %q", view)
 	}
+	if strings.Contains(view, "●") {
+		t.Errorf("search result shows an unread marker without a read state: %q", view)
+	}
 	_, _, label, _ := v.SubnavItems()
 	if !strings.Contains(label, "quarterly planning") || !strings.Contains(label, "page 1") {
 		t.Errorf("search label = %q", label)

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -1209,6 +1209,14 @@ func TestMailViewSearchEscapeClosesForm(t *testing.T) {
 	}
 }
 
+func TestMailViewSearchFormConsumesComponentMessages(t *testing.T) {
+	v := mailWithPostings()
+	v.HandleContentKey(keyPress("/"))
+	if _, consumed := v.Update(struct{}{}); !consumed {
+		t.Error("open search form should consume component messages")
+	}
+}
+
 func TestMailViewIgnoresStaleSearchResults(t *testing.T) {
 	v := mailWithPostings()
 	v.activeRequestID = 2
@@ -1265,6 +1273,28 @@ func TestMailViewEmptyNextSearchPagePreservesResults(t *testing.T) {
 	}
 	if v.notice != "No more search results" {
 		t.Errorf("notice = %q", v.notice)
+	}
+}
+
+func TestMailViewCancelPendingSearchResultPreservesResults(t *testing.T) {
+	v := mailWithPostings()
+	v.searchActive = true
+	v.searchQuery = "quarterly planning"
+	v.searchPage = 1
+	v.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
+
+	if cmd := v.HandleContentKey(keyPress("enter")); cmd == nil {
+		t.Fatal("enter should start loading the selected thread")
+	}
+	if v.activeRequestKind != mailRequestTopic || !v.loading {
+		t.Fatalf("request state = kind:%d loading:%v", v.activeRequestKind, v.loading)
+	}
+	v.ExitThread()
+	if !v.searchActive || v.searchQuery != "quarterly planning" || v.searchPage != 1 || len(v.searchList.postings) != 1 {
+		t.Error("canceling a pending searched thread should preserve search results")
+	}
+	if v.loading || v.activeRequestKind != mailRequestNone {
+		t.Errorf("pending request was not canceled: kind=%d loading=%v", v.activeRequestKind, v.loading)
 	}
 }
 

--- a/internal/tui/nav.go
+++ b/internal/tui/nav.go
@@ -149,9 +149,13 @@ func journalNavItems(dates []string) []navItem {
 //
 //	——————————————————— label ———————————————————
 func renderRule(width int, label string) string {
-	if label == "" {
+	if width <= 0 {
+		return ""
+	}
+	if label == "" || width < 3 {
 		return lipgloss.NewStyle().Foreground(colorMuted).Render(strings.Repeat("─", width))
 	}
+	label = truncateStr(label, width-2)
 	padded := " " + label + " "
 	padLen := lipgloss.Width(padded)
 	ruleLen := max(width-padLen, 0)

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -1,0 +1,69 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+type mailSearchForm struct {
+	input  textinput.Model
+	status string
+	styles styles
+}
+
+func newMailSearchForm(query string, styles styles) *mailSearchForm {
+	input := textinput.New()
+	input.Prompt = ""
+	input.Placeholder = "Search threads and messages…"
+	input.SetValue(query)
+	return &mailSearchForm{input: input, styles: styles}
+}
+
+func (f *mailSearchForm) init() tea.Cmd {
+	return f.input.Focus()
+}
+
+func (f *mailSearchForm) resize(width, _ int) {
+	f.input.SetWidth(max(width-12, 10))
+}
+
+func (f *mailSearchForm) handleKey(msg tea.KeyPressMsg) (tea.Cmd, string, bool) {
+	if msg.Key().Code == tea.KeyEnter {
+		query := strings.TrimSpace(f.input.Value())
+		if query == "" {
+			f.status = "Enter words to search for"
+			return nil, "", false
+		}
+		return nil, query, true
+	}
+	return f.update(msg), "", false
+}
+
+func (f *mailSearchForm) update(msg tea.Msg) tea.Cmd {
+	var cmd tea.Cmd
+	f.input, cmd = f.input.Update(msg)
+	return cmd
+}
+
+func (f *mailSearchForm) helpBindings() []helpBinding {
+	return []helpBinding{
+		{"enter", "search"},
+		{"esc", "cancel"},
+	}
+}
+
+func (f *mailSearchForm) view() string {
+	var b strings.Builder
+	b.WriteString(f.styles.title.Render("Search email"))
+	b.WriteString("\n\n")
+	b.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Render("Search: "))
+	b.WriteString(f.input.View())
+	if f.status != "" {
+		b.WriteString("\n\n")
+		b.WriteString(lipgloss.NewStyle().Foreground(colorError).Render(f.status))
+	}
+	return b.String()
+}

--- a/internal/tui/section_view.go
+++ b/internal/tui/section_view.go
@@ -68,3 +68,9 @@ type inputCapturer interface {
 type pendingDetailCanceler interface {
 	CancelPendingDetail() bool
 }
+
+// detailExiter lets a section preserve the distinct back and exit behavior of
+// Escape and q while a nested view or request is active.
+type detailExiter interface {
+	ExitDetail(key string)
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -261,7 +261,11 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	if msg.Key().Code == tea.KeyEscape || key == "q" {
 		if m.activeView.InThread() {
-			m.activeView.ExitThread()
+			if exiter, ok := m.activeView.(detailExiter); ok {
+				exiter.ExitDetail(key)
+			} else {
+				m.activeView.ExitThread()
+			}
 			m.updateHelpBindings()
 			m.activeView.Resize(m.vc.width, m.vc.height)
 			return m, m.syncLoading(nil)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -288,6 +288,25 @@ func TestQExitsSearchResults(t *testing.T) {
 	}
 }
 
+func TestEscCancelsPendingSearchResultAndPreservesResults(t *testing.T) {
+	m := modelWithBoxes()
+	m.mailView.searchActive = true
+	m.mailView.searchQuery = "quarterly planning"
+	m.mailView.searchPage = 1
+	m.mailView.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
+	m.mailView.requestTopic(m.mailView.currentBoxID(), 100, "Hello world")
+	m.loading = true
+
+	updated, _ := m.Update(keyPress("esc"))
+	result := updated.(model)
+	if !result.mailView.searchActive || result.mailView.searchQuery != "quarterly planning" || len(result.mailView.searchList.postings) != 1 {
+		t.Error("escape during thread load should preserve search results")
+	}
+	if result.mailView.loading || result.loading {
+		t.Error("escape should cancel the pending thread load")
+	}
+}
+
 func TestEscExitsThread(t *testing.T) {
 	m := modelWithBoxes()
 	m.mailView.inThread = true

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -308,6 +308,25 @@ func TestEscCancelsPendingSearchResultAndPreservesResults(t *testing.T) {
 	}
 }
 
+func TestQExitsSearchDuringPendingResult(t *testing.T) {
+	m := modelWithBoxes()
+	m.mailView.searchActive = true
+	m.mailView.searchQuery = "quarterly planning"
+	m.mailView.searchPage = 1
+	m.mailView.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
+	m.mailView.requestTopic(m.mailView.currentBoxID(), 100, "Hello world")
+	m.loading = true
+
+	updated, _ := m.Update(keyPress("q"))
+	result := updated.(model)
+	if result.mailView.searchActive || len(result.mailView.searchList.postings) != 0 {
+		t.Error("q during thread load should exit search results")
+	}
+	if result.mailView.loading || result.loading {
+		t.Error("q should cancel the pending thread load")
+	}
+}
+
 func TestEscExitsThread(t *testing.T) {
 	m := modelWithBoxes()
 	m.mailView.inThread = true

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -281,11 +281,15 @@ func TestQExitsSearchResults(t *testing.T) {
 	m := modelWithBoxes()
 	m.mailView.searchActive = true
 	m.mailView.searchQuery = "quarterly planning"
+	m.mailView.notice = "No more search results"
 
 	updated, _ := m.Update(keyPress("q"))
 	result := updated.(model)
 	if result.mailView.searchActive || result.activeView.InThread() {
 		t.Error("q should exit search results")
+	}
+	if result.mailView.notice != "" {
+		t.Errorf("q left a stale search notice: %q", result.mailView.notice)
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/basecamp/hey-cli/internal/models"
 )
@@ -460,6 +461,15 @@ func TestContentListSelectedPosting(t *testing.T) {
 }
 
 // --- View rendering ---
+
+func TestRenderRuleBoundsLongLabels(t *testing.T) {
+	for _, width := range []int{1, 10, 24} {
+		rule := renderRule(width, "Search: a query that is much wider than the terminal (page 1)")
+		if got := lipgloss.Width(rule); got != width {
+			t.Errorf("renderRule(%d) width = %d, want %d: %q", width, got, width, rule)
+		}
+	}
+}
 
 func TestViewShowsHeader(t *testing.T) {
 	m := modelWithBoxes()

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -253,6 +253,41 @@ func TestMovePickerOwnsNavigationKeys(t *testing.T) {
 	}
 }
 
+func TestSearchFormOwnsNavigationKeys(t *testing.T) {
+	m := modelWithBoxes()
+	m.focus = rowContent
+
+	updated, _ := m.Update(keyPress("/"))
+	m = updated.(model)
+	if m.mailView.searchForm == nil || !m.mailView.CapturingInput() {
+		t.Fatal("/ should open the search form")
+	}
+
+	updated, _ = m.Update(keyPress("tab"))
+	m = updated.(model)
+	if m.focus != rowContent || m.mailView.searchForm == nil {
+		t.Error("tab should remain inside the search form")
+	}
+
+	updated, _ = m.Update(keyPress("esc"))
+	m = updated.(model)
+	if m.mailView.searchForm != nil || m.mailView.CapturingInput() {
+		t.Error("escape should close the search form")
+	}
+}
+
+func TestQExitsSearchResults(t *testing.T) {
+	m := modelWithBoxes()
+	m.mailView.searchActive = true
+	m.mailView.searchQuery = "quarterly planning"
+
+	updated, _ := m.Update(keyPress("q"))
+	result := updated.(model)
+	if result.mailView.searchActive || result.activeView.InThread() {
+		t.Error("q should exit search results")
+	}
+}
+
 func TestEscExitsThread(t *testing.T) {
 	m := modelWithBoxes()
 	m.mailView.inThread = true

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -200,11 +200,11 @@ Box names: `imbox`, `feedbox`, `trailbox`, `asidebox`, `laterbox`, `bubblebox`
 ```bash
 hey search "quarterly planning" --json         # Free-text search
 hey search --from jane@example.com --date last_30_days --json  # Refined search
-hey search --subject invoice --attachment pdf --all --json     # Search every page
+hey search --subject invoice --attachment pdf --all --json     # Search up to 100 pages
 hey search filters --json                      # Available box, date, label, and attachment values
 ```
 
-Search refinements are `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. `--page` selects one result page; `--all` fetches every page from that point onward.
+Search refinements are `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. `--page` selects one result page; `--all` fetches up to 100 pages from that point onward. When the cap is reached, the response notice provides the next `--page` value for continuation.
 
 **Response format:** `data` contains one item per matching thread. Each result has `id` (box item ID for organization actions), `topic_id` (thread ID for `hey threads`, `hey reply`, and `hey forward`), `subject`, `updated_at`, and `messages` containing the matching message IDs, senders, dates, and summaries. A result can omit `id` when the thread has no active box item.
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -11,6 +11,7 @@ triggers:
   # Email actions
   - hey boxes
   - hey box
+  - hey search
   - hey threads
   - hey reply
   - hey forward
@@ -54,6 +55,8 @@ triggers:
   - forward email
   - compose email
   - list mailboxes
+  - search email
+  - find email
   - check calendar
   - add todo
   - complete todo
@@ -96,6 +99,8 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 |------|---------|
 | List mailboxes | `hey boxes --json` |
 | List emails in a box | `hey box imbox --json` |
+| Search email | `hey search "quarterly planning" --json` |
+| List search filters | `hey search filters --json` |
 | Read email thread | `hey threads <topic_id> --json` |
 | Reply to email | `hey reply <topic_id> -m "Thanks!"` |
 | Forward email | `hey forward <topic_id> --to alice@example.com -m "For your review"` |
@@ -137,6 +142,8 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 Want to read email?
 ├── Which mailbox? → hey boxes --json
 ├── List emails in box? → hey box <name|id> --json
+├── Search threads and messages? → hey search <query> --json
+├── Need available refinements? → hey search filters --json
 ├── Read full thread? → hey threads <topic_id> --json
 ├── Mark as seen? → hey seen <id>
 ├── Mark as unseen? → hey unseen <id>
@@ -187,6 +194,19 @@ hey box 123 --json                            # List emails in box (by ID)
 Box names: `imbox`, `feedbox`, `trailbox`, `asidebox`, `laterbox`, `bubblebox`
 
 **Response format:** `hey box` returns `{"box": {...}, "postings": [...]}`. The `postings` array is the API representation of the email threads in that box. Each item has: `id` (box item ID), `topic_id` (thread ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`. Use `id` for `hey seen`, `hey unseen`, `hey move`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring`. Use `topic_id` for `hey threads`, `hey reply`, and `hey forward`.
+
+### Email - Search
+
+```bash
+hey search "quarterly planning" --json         # Free-text search
+hey search --from jane@example.com --date last_30_days --json  # Refined search
+hey search --subject invoice --attachment pdf --all --json     # Search every page
+hey search filters --json                      # Available box, date, label, and attachment values
+```
+
+Search refinements are `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. `--page` selects one result page; `--all` fetches every page from that point onward.
+
+**Response format:** `data` contains one item per matching thread. Each result has `id` (box item ID for organization actions), `topic_id` (thread ID for `hey threads`, `hey reply`, and `hey forward`), `subject`, `updated_at`, and `messages` containing the matching message IDs, senders, dates, and summaries. A result can omit `id` when the thread has no active box item.
 
 ### Email - Threads
 

--- a/tests/smoke/search_test.go
+++ b/tests/smoke/search_test.go
@@ -36,14 +36,22 @@ func TestSearchFreeTextAndRefinements(t *testing.T) {
 	boxResp := heyJSON(t, "box", "imbox")
 	box := dataAs[struct {
 		Postings []struct {
+			Kind string `json:"kind"`
 			Name string `json:"name"`
 		} `json:"postings"`
 	}](t, boxResp)
-	if len(box.Postings) == 0 || strings.TrimSpace(box.Postings[0].Name) == "" {
+	var subject string
+	for _, posting := range box.Postings {
+		if posting.Kind != "bundle" && strings.TrimSpace(posting.Name) != "" {
+			subject = posting.Name
+			break
+		}
+	}
+	if subject == "" {
 		t.Skip("no Imbox thread available for read-only search validation")
 	}
 
-	query := strings.Fields(box.Postings[0].Name)[0]
+	query := strings.Fields(subject)[0]
 	freeText := dataAs[[]smokeSearchResult](t, heyJSON(t, "search", query))
 	for _, result := range freeText {
 		if result.TopicID == 0 {
@@ -51,7 +59,10 @@ func TestSearchFreeTextAndRefinements(t *testing.T) {
 		}
 	}
 
-	refined := dataAs[[]smokeSearchResult](t, heyJSON(t, "search", "--subject", box.Postings[0].Name, "--in", "imbox", "--page", "1"))
+	refined := dataAs[[]smokeSearchResult](t, heyJSON(t, "search", "--subject", subject, "--in", "imbox", "--page", "1"))
+	if len(refined) == 0 {
+		t.Fatal("subject and box refinements did not find the known Imbox thread")
+	}
 	for _, result := range refined {
 		if result.TopicID == 0 {
 			t.Error("refined search result has no topic_id")

--- a/tests/smoke/search_test.go
+++ b/tests/smoke/search_test.go
@@ -1,0 +1,64 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+type smokeSearchResult struct {
+	ID       int               `json:"id"`
+	TopicID  int               `json:"topic_id"`
+	Subject  string            `json:"subject"`
+	Messages []json.RawMessage `json:"messages"`
+}
+
+func TestSearchFilters(t *testing.T) {
+	resp := heyJSON(t, "search", "filters")
+	filters := dataAs[struct {
+		Boxes       []json.RawMessage `json:"boxes"`
+		Dates       []json.RawMessage `json:"dates"`
+		Labels      []json.RawMessage `json:"labels"`
+		Attachments []json.RawMessage `json:"attachments"`
+	}](t, resp)
+	if len(filters.Boxes) == 0 {
+		t.Error("expected at least one box search filter")
+	}
+	if len(filters.Dates) == 0 {
+		t.Error("expected at least one date search filter")
+	}
+	if len(filters.Attachments) == 0 {
+		t.Error("expected at least one attachment search filter")
+	}
+}
+
+func TestSearchFreeTextAndRefinements(t *testing.T) {
+	boxResp := heyJSON(t, "box", "imbox")
+	box := dataAs[struct {
+		Postings []struct {
+			Name string `json:"name"`
+		} `json:"postings"`
+	}](t, boxResp)
+	if len(box.Postings) == 0 || strings.TrimSpace(box.Postings[0].Name) == "" {
+		t.Skip("no Imbox thread available for read-only search validation")
+	}
+
+	query := strings.Fields(box.Postings[0].Name)[0]
+	freeText := dataAs[[]smokeSearchResult](t, heyJSON(t, "search", query))
+	for _, result := range freeText {
+		if result.TopicID == 0 {
+			t.Error("free-text search result has no topic_id")
+		}
+	}
+
+	refined := dataAs[[]smokeSearchResult](t, heyJSON(t, "search", "--subject", box.Postings[0].Name, "--in", "imbox", "--page", "1"))
+	for _, result := range refined {
+		if result.TopicID == 0 {
+			t.Error("refined search result has no topic_id")
+		}
+	}
+}
+
+func TestSearchRequiresCriteria(t *testing.T) {
+	heyFail(t, "search")
+}

--- a/tests/smoke/search_test.go
+++ b/tests/smoke/search_test.go
@@ -51,8 +51,10 @@ func TestSearchFreeTextAndRefinements(t *testing.T) {
 		t.Skip("no Imbox thread available for read-only search validation")
 	}
 
-	query := strings.Fields(subject)[0]
-	freeText := dataAs[[]smokeSearchResult](t, heyJSON(t, "search", query))
+	freeText := dataAs[[]smokeSearchResult](t, heyJSON(t, "search", subject))
+	if len(freeText) == 0 {
+		t.Fatal("free-text search did not find the known Imbox thread")
+	}
 	for _, result := range freeText {
 		if result.TopicID == 0 {
 			t.Error("free-text search result has no topic_id")


### PR DESCRIPTION
## Summary

- add `hey search [query]` with free-text, word, sender, recipient, subject, date, box, label, and attachment refinements
- add `--page` and bounded `--all` pagination with actionable `id`, `topic_id`, and matching-message data
- add `hey search filters` for HEY’s current box, date, label, and attachment values
- add `/` search to the mail TUI with input capture, matching-message summaries, navigable results, thread opening, next/previous pages, empty-page handling, cancellation, and stale-response protection
- update root help, command metadata, surface compatibility, README, embedded skill, API coverage, and smoke coverage

## Validation

- `GOWORK=off make check`
- `GOWORK=off make race-test`
- smoke test package compilation
- local build and rendered CLI help/command metadata
- authenticated read-only CLI validation covering filter discovery, free text, required words, any words, excluded words, exact phrase, sender, recipient, subject, date range, box, label, attachment, a specific page, and all-pages traversal
- authenticated read-only TUI validation covering free-text search, result rendering, opening a matching thread, result pagination, and returning to the mailbox

Authenticated validation reports intentionally omit queries and result details to keep account content private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds email search to the CLI and TUI to find threads and matching messages. Previously there was no search; now `hey search` and TUI `/` return one result per thread with actionable identifiers. Also fixes `--markdown` output to include optional fields from later rows.

- **CLI**
  - Adds `hey search [query]` with `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, `--attachment`; accepts refinements without free text.
  - Supports `--page` and bounded `--all` (up to 100 pages). When capped, prints a continuation notice with the next `--page`; in data-only formats the notice is written to stderr. Validates `--page`, `--date`, and `--in`.
  - Returns one result per thread with `id` (box item when present), `topic_id` (for reading), and matching `messages`. `hey search filters` lists current values for `--in`, `--date`, `--label`, and `--attachment`.
  - Markdown tables now include optional fields from later rows to avoid missing columns in `--markdown` output.
  - Updates root help, README, `API-COVERAGE.md` for `/advanced_search.json` and `/advanced_search_filters.json`, `.surface`, `skills/hey` docs, and smoke tests.

- **TUI**
  - `/` opens search, Enter submits, Esc cancels input; waits for the mailbox to finish loading before opening the form. Subnav shows “Search: <query> (page N)” within terminal width.
  - Results show the thread and matching-message summary; unread markers are hidden. Enter opens the thread; closing a thread returns to results.
  - `n`/`p` paginate; ignores stale responses; preserves results when a page is empty and shows a notice.
  - Distinguishes back and exit: Esc cancels a pending thread load and preserves results; `q` exits search results and clears any notices.

<sup>Written for commit d6f0afb1f78cb99bb4d96a6d1e4ce9a8e31c5e3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

