### PR TITLE
Add CLI and TUI contact management

### DIFF
--- a/.surface
+++ b/.surface
@@ -39,6 +39,27 @@ hey compose --to
 hey config
 hey config set
 hey config show
+hey contacts
+hey contacts add
+hey contacts add --account-user-id
+hey contacts add --alias
+hey contacts add --email
+hey contacts add --name
+hey contacts hide
+hey contacts list
+hey contacts list --all
+hey contacts list --page
+hey contacts note
+hey contacts note delete
+hey contacts note set
+hey contacts note set --note
+hey contacts note show
+hey contacts show
+hey contacts show-again
+hey contacts update
+hey contacts update --alias
+hey contacts update --email
+hey contacts update --name
 hey doctor
 hey drafts
 hey drafts --all

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -15,6 +15,15 @@ The legacy `internal/client/` is used only for HTML-scraping gap operations mark
 | `/bubblebox.json` | GET | SDK `Boxes().GetBubblebox` | `hey box bubblebox` | covered |
 | `/advanced_search.json` | GET | SDK `Search().Search` | `hey search`, TUI `/` | covered |
 | `/advanced_search_filters.json` | GET | SDK `Search().Filters` | `hey search filters` | covered |
+| `/contacts.json` | GET | SDK `Contacts().List` | `hey contacts list`, Contacts TUI | covered |
+| `/contacts/{id}.json` | GET | SDK `Contacts().Get` | `hey contacts show`, Contacts TUI | covered |
+| `/contacts.json` | POST | SDK `Contacts().Create` | `hey contacts add`, Contacts TUI | covered |
+| `/contacts/{id}.json` | PATCH | SDK `Contacts().Update` | `hey contacts update`, Contacts TUI | covered |
+| `/contacts/{id}.json` | DELETE | SDK `Contacts().Hide` | `hey contacts hide`, Contacts TUI | covered |
+| `/contacts/{id}/reveal.json` | POST | SDK `Contacts().Reveal` | `hey contacts show-again`, Contacts TUI | covered |
+| `/contacts/{id}/note.json` | GET | SDK `Contacts().Note` | `hey contacts note show`, Contacts TUI | covered |
+| `/contacts/{id}/note.json` | PATCH | SDK `Contacts().SetNote` | `hey contacts note set`, Contacts TUI | covered |
+| `/contacts/{id}/note.json` | DELETE | SDK `Contacts().DeleteNote` | `hey contacts note delete`, Contacts TUI | covered |
 | `/calendars.json` | GET | SDK `Calendars().List` | `hey calendars` | covered |
 | `/calendars/{id}/recordings.json` | GET | SDK `Calendars().GetRecordings` | `hey recordings <calendar-id>`, `hey todo list`, `hey timetrack list`, `hey journal list` | covered |
 | `/topics/{id}/entries` | GET (HTML) | Legacy `GetTopicEntries` | `hey threads <id>` | gap: SDK Entry lacks body |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ hey auth logout   # clear credentials
 
 Run `hey` to launch the interactive terminal UI.
 
-Navigate between mailboxes and email threads. Use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `t` to trash, `s` to mark as spam, `-` to ignore, `+` to stop ignoring, and Escape or `q` to go back. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
+Navigate between Mail, Contacts, Calendar, and Journal. In Mail, use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
+
+Press Shift+O to open Contacts. Use Enter to view a contact, `a` to add, `e` to edit, `n` to edit the private note, `x` twice to delete a note, `h` to hide, and `u` to show the most recently hidden contact again. Escape or `q` goes back.
 
 ## CLI Commands
 
@@ -72,6 +74,14 @@ hey box imbox                      # list email threads in a box (by name or ID)
 hey search "quarterly planning"    # search threads and matching messages
 hey search --from jane@example.com --date last_30_days  # refine a search
 hey search filters                 # list available refinement values
+hey contacts list                  # list contacts
+hey contacts show 12345            # view a contact and private note
+hey contacts add --name "Jane Doe" --email jane@example.com
+hey contacts update 12345 --name "Jane Dawson"
+hey contacts hide 12345            # hide without permanently deleting
+hey contacts show-again 12345      # show a hidden contact again
+hey contacts note set 12345 "Prefers email"
+hey contacts note delete 12345
 hey threads 123                    # read a full email thread
 hey reply 123 -m "Thanks!"        # reply to a thread (or omit -m to open $EDITOR)
 hey forward 123 --to alice@example.com -m "For your review"  # forward the latest message
@@ -87,6 +97,8 @@ hey stop-ignoring 12345            # resume attention for a thread
 ```
 
 Search accepts free text plus `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. Use `--page` for one page or `--all` to fetch up to 100 pages; capped searches report the next page for continuation. Search results include `topic_id` for reading the thread and the matching message summaries. Results with an active box item also include `id` for organization actions.
+
+Contact updates preserve omitted name, email, and alias fields. Supplying `--alias` replaces the complete alias list; `--alias=` clears it. Contact notes accept positional content, `--note`, stdin, or `$EDITOR`. HEY hides contacts rather than permanently deleting them; hidden contacts leave lists, autocomplete, and search, and can be shown again by ID.
 
 Organization actions take the `id` values returned by `hey box --json` or `hey search --json`. Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 

--- a/internal/cmd/contact_note.go
+++ b/internal/cmd/contact_note.go
@@ -1,0 +1,22 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+type contactNoteCommand struct {
+	cmd *cobra.Command
+}
+
+func newContactNoteCommand() *contactNoteCommand {
+	noteCommand := &contactNoteCommand{}
+	noteCommand.cmd = &cobra.Command{
+		Use:   "note",
+		Short: "Manage private contact notes",
+		Annotations: map[string]string{
+			"agent_notes": "Private notes support show, set, and delete. Set accepts --note, positional content, stdin, or $EDITOR.",
+		},
+	}
+	noteCommand.cmd.AddCommand(newContactNoteShowCommand().cmd)
+	noteCommand.cmd.AddCommand(newContactNoteSetCommand().cmd)
+	noteCommand.cmd.AddCommand(newContactNoteDeleteCommand().cmd)
+	return noteCommand
+}

--- a/internal/cmd/contact_note_delete.go
+++ b/internal/cmd/contact_note_delete.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactNoteDeleteCommand struct {
+	cmd *cobra.Command
+}
+
+func newContactNoteDeleteCommand() *contactNoteDeleteCommand {
+	deleteCommand := &contactNoteDeleteCommand{}
+	deleteCommand.cmd = &cobra.Command{
+		Use:     "delete <id>",
+		Short:   "Delete a private contact note",
+		Long:    "Permanently delete the private note from a contact. The contact remains unchanged.",
+		Example: `  hey contacts note delete 12345`,
+		RunE:    deleteCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return deleteCommand
+}
+
+func (c *contactNoteDeleteCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	contactID, err := parseContactID(args[0])
+	if err != nil {
+		return err
+	}
+	if err := sdk.Contacts().DeleteNote(cmd.Context(), contactID); err != nil {
+		return convertSDKError(err)
+	}
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Private note for contact %d deleted.\n", contactID)
+		return nil
+	}
+	return writeOK(map[string]int64{"id": contactID},
+		output.WithSummary("Private contact note deleted"),
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "write", Command: fmt.Sprintf("hey contacts note set %d", contactID), Description: "Add a private note"}),
+	)
+}

--- a/internal/cmd/contact_note_set.go
+++ b/internal/cmd/contact_note_set.go
@@ -45,14 +45,11 @@ func (c *contactNoteSetCommand) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	content := c.note
-	if len(args) == 2 {
-		if cmd.Flags().Changed("note") {
-			return output.ErrUsage("--note and positional note are mutually exclusive")
-		}
-		content = args[1]
+	content, inputProvided, err := contactNoteInput(cmd.Flags().Changed("note"), c.note, args)
+	if err != nil {
+		return err
 	}
-	if content == "" {
+	if !inputProvided {
 		if !stdinIsTerminal() {
 			content, err = readStdin()
 			if err != nil {
@@ -89,6 +86,19 @@ func (c *contactNoteSetCommand) run(cmd *cobra.Command, args []string) error {
 		output.WithSummary("Private contact note saved"),
 		output.WithBreadcrumbs(output.Breadcrumb{Action: "read", Command: fmt.Sprintf("hey contacts note show %d", contactID), Description: "Read the private note"}),
 	)
+}
+
+func contactNoteInput(flagChanged bool, flagValue string, args []string) (string, bool, error) {
+	if len(args) == 2 {
+		if flagChanged {
+			return "", false, output.ErrUsage("--note and positional note are mutually exclusive")
+		}
+		return args[1], true, nil
+	}
+	if flagChanged {
+		return flagValue, true, nil
+	}
+	return "", false, nil
 }
 
 type contactNoteFetcher func(context.Context, int64) (*generated.ContactNote, error)

--- a/internal/cmd/contact_note_set.go
+++ b/internal/cmd/contact_note_set.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/editor"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactNoteSetCommand struct {
+	cmd  *cobra.Command
+	note string
+}
+
+func newContactNoteSetCommand() *contactNoteSetCommand {
+	setCommand := &contactNoteSetCommand{}
+	setCommand.cmd = &cobra.Command{
+		Use:   "set <id> [note]",
+		Short: "Write or edit a private contact note",
+		Annotations: map[string]string{
+			"agent_notes": "Accepts --note, positional content, stdin, or opens $EDITOR with the existing note. Use the delete subcommand to clear a note.",
+		},
+		Example: `  hey contacts note set 12345 "Prefers email"
+  hey contacts note set 12345 --note "Prefers email"
+  echo "Prefers email" | hey contacts note set 12345`,
+		RunE: setCommand.run,
+		Args: cobra.MatchAll(usageMinOneArg(), cobra.MaximumNArgs(2)),
+	}
+	setCommand.cmd.Flags().StringVarP(&setCommand.note, "note", "n", "", "Private note content (or opens $EDITOR)")
+	return setCommand
+}
+
+func (c *contactNoteSetCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	contactID, err := parseContactID(args[0])
+	if err != nil {
+		return err
+	}
+
+	content := c.note
+	if len(args) == 2 {
+		if cmd.Flags().Changed("note") {
+			return output.ErrUsage("--note and positional note are mutually exclusive")
+		}
+		content = args[1]
+	}
+	if content == "" {
+		if !stdinIsTerminal() {
+			content, err = readStdin()
+			if err != nil {
+				return err
+			}
+		} else {
+			existing := ""
+			if note, getErr := sdk.Contacts().Note(cmd.Context(), contactID); getErr == nil && note != nil {
+				existing = note.Note
+			}
+			content, err = editor.Open(existing)
+			if err != nil {
+				return output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
+			}
+		}
+	}
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return output.ErrUsage("note cannot be empty; use `hey contacts note delete <id>` to clear it")
+	}
+
+	note, err := sdk.Contacts().SetNote(cmd.Context(), contactID, content)
+	if err != nil {
+		return convertContactWriteError(err)
+	}
+	if note == nil {
+		return output.ErrAPI(0, "contact note save returned no data")
+	}
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Private note for contact %d saved.\n", contactID)
+		return nil
+	}
+	return writeOK(note,
+		output.WithSummary("Private contact note saved"),
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "read", Command: fmt.Sprintf("hey contacts note show %d", contactID), Description: "Read the private note"}),
+	)
+}

--- a/internal/cmd/contact_note_set.go
+++ b/internal/cmd/contact_note_set.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
 
 	"github.com/basecamp/hey-cli/internal/editor"
 	"github.com/basecamp/hey-cli/internal/output"
@@ -56,9 +59,9 @@ func (c *contactNoteSetCommand) run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 		} else {
-			existing := ""
-			if note, getErr := sdk.Contacts().Note(cmd.Context(), contactID); getErr == nil && note != nil {
-				existing = note.Note
+			existing, getErr := contactNoteForEditor(cmd.Context(), contactID, sdk.Contacts().Note)
+			if getErr != nil {
+				return convertSDKError(getErr)
 			}
 			content, err = editor.Open(existing)
 			if err != nil {
@@ -86,4 +89,17 @@ func (c *contactNoteSetCommand) run(cmd *cobra.Command, args []string) error {
 		output.WithSummary("Private contact note saved"),
 		output.WithBreadcrumbs(output.Breadcrumb{Action: "read", Command: fmt.Sprintf("hey contacts note show %d", contactID), Description: "Read the private note"}),
 	)
+}
+
+type contactNoteFetcher func(context.Context, int64) (*generated.ContactNote, error)
+
+func contactNoteForEditor(ctx context.Context, contactID int64, fetch contactNoteFetcher) (string, error) {
+	note, err := fetch(ctx, contactID)
+	if err != nil {
+		return "", err
+	}
+	if note == nil {
+		return "", nil
+	}
+	return note.Note, nil
 }

--- a/internal/cmd/contact_note_show.go
+++ b/internal/cmd/contact_note_show.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactNoteShowCommand struct {
+	cmd *cobra.Command
+}
+
+func newContactNoteShowCommand() *contactNoteShowCommand {
+	showCommand := &contactNoteShowCommand{}
+	showCommand.cmd = &cobra.Command{
+		Use:   "show <id>",
+		Short: "Read a private contact note",
+		Example: `  hey contacts note show 12345
+  hey contacts note show 12345 --json`,
+		RunE: showCommand.run,
+		Args: usageExactOneArg(),
+	}
+	return showCommand
+}
+
+func (c *contactNoteShowCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	contactID, err := parseContactID(args[0])
+	if err != nil {
+		return err
+	}
+	note, err := sdk.Contacts().Note(cmd.Context(), contactID)
+	if err != nil {
+		return convertSDKError(err)
+	}
+	if note == nil {
+		return output.ErrNotFound("contact note", args[0])
+	}
+	if writer.IsStyled() {
+		if note.Note == "" {
+			fmt.Fprintln(cmd.OutOrStdout(), "(empty)")
+		} else if htmlOutput {
+			fmt.Fprintln(cmd.OutOrStdout(), note.NoteHtml)
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), note.Note)
+		}
+		return nil
+	}
+	return writeOK(note,
+		output.WithSummary(fmt.Sprintf("Private note for contact %d", contactID)),
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "edit", Command: fmt.Sprintf("hey contacts note set %d", contactID), Description: "Edit the private note"}),
+	)
+}

--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactsCommand struct {
+	cmd *cobra.Command
+}
+
+func newContactsCommand() *contactsCommand {
+	contactsCommand := &contactsCommand{}
+	contactsCommand.cmd = &cobra.Command{
+		Use:   "contacts",
+		Short: "Manage contacts",
+		Long:  "List, view, add, edit, hide, and annotate HEY contacts.",
+		Annotations: map[string]string{
+			"agent_notes": "Contact IDs come from `hey contacts list`. Hiding is reversible with `hey contacts show-again <id>`. Private notes are managed under `hey contacts note`.",
+		},
+	}
+
+	contactsCommand.cmd.AddCommand(newContactsListCommand().cmd)
+	contactsCommand.cmd.AddCommand(newContactsShowCommand().cmd)
+	contactsCommand.cmd.AddCommand(newContactsAddCommand().cmd)
+	contactsCommand.cmd.AddCommand(newContactsUpdateCommand().cmd)
+	contactsCommand.cmd.AddCommand(newContactsHideCommand().cmd)
+	contactsCommand.cmd.AddCommand(newContactsShowAgainCommand().cmd)
+	contactsCommand.cmd.AddCommand(newContactNoteCommand().cmd)
+	return contactsCommand
+}
+
+func parseContactID(value string) (int64, error) {
+	id, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, output.ErrUsage(fmt.Sprintf("invalid contact ID: %s", value))
+	}
+	return id, nil
+}
+
+func contactNoun(count int) string {
+	if count == 1 {
+		return "contact"
+	}
+	return "contacts"
+}
+
+func convertContactWriteError(err error) error {
+	var conflict *hey.ContactConflictError
+	if !errors.As(err, &conflict) {
+		return convertSDKError(err)
+	}
+	ids := make([]string, 0, len(conflict.ConflictingContactIDs))
+	for _, id := range conflict.ConflictingContactIDs {
+		ids = append(ids, strconv.FormatInt(id, 10))
+	}
+	hint := fmt.Sprintf("The written contact is %d.", conflict.ContactID)
+	if len(ids) > 0 {
+		hint += " Conflicting contact IDs: " + strings.Join(ids, ", ") + "."
+	}
+	return &output.Error{Code: "conflict", Message: conflict.Error(), Hint: hint, HTTPStatus: 409, Cause: err}
+}

--- a/internal/cmd/contacts_add.go
+++ b/internal/cmd/contacts_add.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactsAddCommand struct {
+	cmd           *cobra.Command
+	name          string
+	email         string
+	aliases       []string
+	accountUserID int64
+}
+
+func newContactsAddCommand() *contactsAddCommand {
+	addCommand := &contactsAddCommand{}
+	addCommand.cmd = &cobra.Command{
+		Use:   "add",
+		Short: "Add a contact",
+		Annotations: map[string]string{
+			"agent_notes": "Name and email are required. Repeat --alias for alternate email addresses. --account-user-id selects an account when the HEY identity has more than one.",
+		},
+		Example: `  hey contacts add --name "Jane Doe" --email jane@example.com
+  hey contacts add --name "Jane Doe" --email jane@example.com --alias jane.doe@example.org`,
+		RunE: addCommand.run,
+		Args: cobra.NoArgs,
+	}
+	flags := addCommand.cmd.Flags()
+	flags.StringVar(&addCommand.name, "name", "", "Contact name (required)")
+	flags.StringVar(&addCommand.email, "email", "", "Primary email address (required)")
+	flags.StringSliceVar(&addCommand.aliases, "alias", nil, "Alternate email address (repeatable)")
+	flags.Int64Var(&addCommand.accountUserID, "account-user-id", 0, "Account user ID for multi-account identities")
+	return addCommand
+}
+
+func (c *contactsAddCommand) run(cmd *cobra.Command, _ []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	name := strings.TrimSpace(c.name)
+	email := strings.TrimSpace(c.email)
+	if name == "" {
+		return output.ErrUsage("--name is required")
+	}
+	if email == "" {
+		return output.ErrUsage("--email is required")
+	}
+	aliases := cleanContactAliases(c.aliases)
+	if err := validateDistinctContactEmails(email, aliases); err != nil {
+		return err
+	}
+
+	contact, err := sdk.Contacts().Create(cmd.Context(), hey.ContactParams{
+		Name:                name,
+		EmailAddress:        email,
+		AliasEmailAddresses: aliases,
+		AccountUserID:       c.accountUserID,
+	})
+	if err != nil {
+		return convertContactWriteError(err)
+	}
+	if contact == nil {
+		return output.ErrAPI(0, "contact add returned no data")
+	}
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Contact added: %s <%s> (#%d)\n", contact.Name, contact.EmailAddress, contact.Id)
+		return nil
+	}
+	return writeOK(contact,
+		output.WithSummary("Contact added"),
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "view", Command: fmt.Sprintf("hey contacts show %d", contact.Id), Description: "View the contact"}),
+	)
+}
+
+func cleanContactAliases(values []string) []string {
+	aliases := make([]string, 0, len(values))
+	for _, value := range values {
+		if alias := strings.TrimSpace(value); alias != "" {
+			aliases = append(aliases, alias)
+		}
+	}
+	return aliases
+}
+
+func validateDistinctContactEmails(email string, aliases []string) error {
+	seen := map[string]bool{strings.ToLower(email): true}
+	for _, alias := range aliases {
+		key := strings.ToLower(alias)
+		if seen[key] {
+			return output.ErrUsage(fmt.Sprintf("duplicate contact email address: %s", alias))
+		}
+		seen[key] = true
+	}
+	return nil
+}

--- a/internal/cmd/contacts_hide.go
+++ b/internal/cmd/contacts_hide.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactsHideCommand struct {
+	cmd *cobra.Command
+}
+
+func newContactsHideCommand() *contactsHideCommand {
+	hideCommand := &contactsHideCommand{}
+	hideCommand.cmd = &cobra.Command{
+		Use:   "hide <id>",
+		Short: "Hide a contact",
+		Long:  "Hide a contact from contact lists, autocomplete, and search results. The contact remains available by ID and can be shown again.",
+		Annotations: map[string]string{
+			"agent_notes": "This is reversible. Use `hey contacts show-again <id>` to show the contact again.",
+		},
+		Example: `  hey contacts hide 12345`,
+		RunE:    hideCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return hideCommand
+}
+
+func (c *contactsHideCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	contactID, err := parseContactID(args[0])
+	if err != nil {
+		return err
+	}
+	if err := sdk.Contacts().Hide(cmd.Context(), contactID); err != nil {
+		return convertSDKError(err)
+	}
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Contact %d hidden.\n", contactID)
+		return nil
+	}
+	return writeOK(map[string]int64{"id": contactID},
+		output.WithSummary("Contact hidden"),
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "show_again", Command: fmt.Sprintf("hey contacts show-again %d", contactID), Description: "Show the contact again"}),
+	)
+}

--- a/internal/cmd/contacts_list.go
+++ b/internal/cmd/contacts_list.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+const maxContactPages = 100
+
+type contactsListCommand struct {
+	cmd  *cobra.Command
+	page int
+	all  bool
+}
+
+type contactPageFetcher func(context.Context, *generated.ListContactsParams) (*generated.ListContactsResponseContent, error)
+
+func newContactsListCommand() *contactsListCommand {
+	listCommand := &contactsListCommand{}
+	listCommand.cmd = &cobra.Command{
+		Use:   "list",
+		Short: "List contacts",
+		Annotations: map[string]string{
+			"agent_notes": "Returns contact IDs, names, and email addresses. Use --all to fetch up to 100 pages.",
+		},
+		Example: `  hey contacts list
+  hey contacts list --page 2 --json
+  hey contacts list --all --json`,
+		RunE: listCommand.run,
+		Args: cobra.NoArgs,
+	}
+	listCommand.cmd.Flags().IntVar(&listCommand.page, "page", 1, "Results page")
+	listCommand.cmd.Flags().BoolVar(&listCommand.all, "all", false, "Fetch up to 100 results pages from --page onward")
+	return listCommand
+}
+
+func (c *contactsListCommand) run(cmd *cobra.Command, _ []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	if c.page < 1 {
+		return output.ErrUsage("--page must be at least 1")
+	}
+
+	contacts, pages, truncated, err := collectContacts(cmd.Context(), c.page, c.all,
+		func(ctx context.Context, params *generated.ListContactsParams) (*generated.ListContactsResponseContent, error) {
+			result, listErr := sdk.Contacts().List(ctx, params)
+			if listErr != nil {
+				return nil, convertSDKError(listErr)
+			}
+			return result, nil
+		})
+	if err != nil {
+		return err
+	}
+	notice := contactTruncationNotice(c.page, pages, truncated)
+
+	if writer.IsStyled() {
+		if len(contacts) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No contacts found")
+			return nil
+		}
+		table := newTable(cmd.OutOrStdout())
+		table.addRow([]string{"ID", "Name", "Email", "Updated"})
+		for _, contact := range contacts {
+			table.addRow([]string{
+				fmt.Sprintf("%d", contact.Id),
+				truncate(contact.Name, 32),
+				truncate(contact.EmailAddress, 42),
+				formatDate(contact.UpdatedAt),
+			})
+		}
+		table.print()
+		if notice != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n", notice)
+		}
+		return nil
+	}
+	if stderrNotice := paginationNoticeForStderr(writer.EffectiveFormat(), notice); stderrNotice != "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), stderrNotice)
+	}
+	return writeOK(contacts,
+		output.WithSummary(fmt.Sprintf("%d %s", len(contacts), contactNoun(len(contacts)))),
+		output.WithNotice(notice),
+		output.WithMeta("page", c.page),
+		output.WithMeta("pages_fetched", pages),
+		output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "view",
+			Command:     "hey contacts show <id>",
+			Description: "View a contact",
+		}),
+	)
+}
+
+func collectContacts(ctx context.Context, startPage int, all bool, fetch contactPageFetcher) ([]generated.Contact, int, bool, error) {
+	if fetch == nil {
+		return nil, 0, false, fmt.Errorf("collectContacts: fetch function is nil")
+	}
+	page := max(startPage, 1)
+	var contacts []generated.Contact
+	for pages := 1; pages <= maxContactPages; pages++ {
+		pageValue := strconv.Itoa(page)
+		params := &generated.ListContactsParams{Page: &pageValue}
+		result, err := fetch(ctx, params)
+		if err != nil {
+			return nil, pages - 1, false, err
+		}
+		if result == nil || len(*result) == 0 {
+			return contacts, pages, false, nil
+		}
+		contacts = append(contacts, (*result)...)
+		if !all {
+			return contacts, 1, false, nil
+		}
+		if pages == maxContactPages {
+			return contacts, pages, true, nil
+		}
+		page++
+	}
+	return contacts, maxContactPages, true, nil
+}
+
+func contactTruncationNotice(startPage, pages int, truncated bool) string {
+	if !truncated {
+		return ""
+	}
+	return fmt.Sprintf("Contact listing stopped after %d pages. Continue with --page %d.", pages, startPage+pages)
+}

--- a/internal/cmd/contacts_show.go
+++ b/internal/cmd/contacts_show.go
@@ -109,6 +109,8 @@ func printContactDetails(cmd *cobra.Command, result contactShowResult) {
 	fmt.Fprintln(w, "\nPrivate note:")
 	if result.Note == "" {
 		fmt.Fprintln(w, "(empty)")
+	} else if htmlOutput && result.NoteHTML != "" {
+		fmt.Fprintln(w, result.NoteHTML)
 	} else {
 		fmt.Fprintln(w, result.Note)
 	}

--- a/internal/cmd/contacts_show.go
+++ b/internal/cmd/contacts_show.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactsShowCommand struct {
+	cmd *cobra.Command
+}
+
+type contactShowResult struct {
+	generated.ContactDetail
+	Note     string `json:"note"`
+	NoteHTML string `json:"note_html,omitempty"`
+}
+
+func newContactsShowCommand() *contactsShowCommand {
+	showCommand := &contactsShowCommand{}
+	showCommand.cmd = &cobra.Command{
+		Use:   "show <id>",
+		Short: "View a contact",
+		Annotations: map[string]string{
+			"agent_notes": "Returns contact details, aliases, screening status, and the private note.",
+		},
+		Example: `  hey contacts show 12345
+  hey contacts show 12345 --json`,
+		RunE: showCommand.run,
+		Args: usageExactOneArg(),
+	}
+	return showCommand
+}
+
+func (c *contactsShowCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	contactID, err := parseContactID(args[0])
+	if err != nil {
+		return err
+	}
+
+	var contact *generated.ContactDetail
+	var note *generated.ContactNote
+	group, ctx := errgroup.WithContext(cmd.Context())
+	group.Go(func() error {
+		var getErr error
+		contact, getErr = sdk.Contacts().Get(ctx, contactID)
+		if getErr != nil {
+			return convertSDKError(getErr)
+		}
+		return nil
+	})
+	group.Go(func() error {
+		var getErr error
+		note, getErr = sdk.Contacts().Note(ctx, contactID)
+		if getErr != nil {
+			return convertSDKError(getErr)
+		}
+		return nil
+	})
+	if err := group.Wait(); err != nil {
+		return err
+	}
+	if contact == nil {
+		return output.ErrNotFound("contact", args[0])
+	}
+
+	result := contactShowResult{ContactDetail: *contact}
+	if note != nil {
+		result.Note = note.Note
+		result.NoteHTML = note.NoteHtml
+	}
+	if writer.IsStyled() {
+		printContactDetails(cmd, result)
+		return nil
+	}
+	return writeOK(result,
+		output.WithSummary(fmt.Sprintf("Contact %d", contactID)),
+		output.WithBreadcrumbs(
+			output.Breadcrumb{Action: "edit", Command: fmt.Sprintf("hey contacts update %d", contactID), Description: "Edit this contact"},
+			output.Breadcrumb{Action: "note", Command: fmt.Sprintf("hey contacts note set %d", contactID), Description: "Edit the private note"},
+		),
+	)
+}
+
+func printContactDetails(cmd *cobra.Command, result contactShowResult) {
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "%s\n", result.Name)
+	fmt.Fprintf(w, "ID: %d\n", result.Id)
+	fmt.Fprintf(w, "Email: %s\n", result.EmailAddress)
+	if len(result.Aliases) > 0 {
+		aliases := make([]string, 0, len(result.Aliases))
+		for _, alias := range result.Aliases {
+			aliases = append(aliases, alias.EmailAddress)
+		}
+		fmt.Fprintf(w, "Aliases: %s\n", strings.Join(aliases, ", "))
+	}
+	if result.Clearance.Status != "" {
+		fmt.Fprintf(w, "Screening: %s\n", result.Clearance.Status)
+	}
+	fmt.Fprintln(w, "\nPrivate note:")
+	if result.Note == "" {
+		fmt.Fprintln(w, "(empty)")
+	} else {
+		fmt.Fprintln(w, result.Note)
+	}
+}

--- a/internal/cmd/contacts_show_again.go
+++ b/internal/cmd/contacts_show_again.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactsShowAgainCommand struct {
+	cmd *cobra.Command
+}
+
+func newContactsShowAgainCommand() *contactsShowAgainCommand {
+	showAgainCommand := &contactsShowAgainCommand{}
+	showAgainCommand.cmd = &cobra.Command{
+		Use:   "show-again <id>",
+		Short: "Show a hidden contact again",
+		Annotations: map[string]string{
+			"agent_notes": "Reverses `hey contacts hide <id>`.",
+		},
+		Example: `  hey contacts show-again 12345`,
+		RunE:    showAgainCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return showAgainCommand
+}
+
+func (c *contactsShowAgainCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	contactID, err := parseContactID(args[0])
+	if err != nil {
+		return err
+	}
+	contact, err := sdk.Contacts().Reveal(cmd.Context(), contactID)
+	if err != nil {
+		return convertSDKError(err)
+	}
+	if contact == nil {
+		return output.ErrNotFound("contact", args[0])
+	}
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Contact shown again: %s <%s> (#%d)\n", contact.Name, contact.EmailAddress, contact.Id)
+		return nil
+	}
+	return writeOK(contact,
+		output.WithSummary("Contact shown again"),
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "view", Command: fmt.Sprintf("hey contacts show %d", contact.Id), Description: "View the contact"}),
+	)
+}

--- a/internal/cmd/contacts_test.go
+++ b/internal/cmd/contacts_test.go
@@ -1,0 +1,384 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type recordedContactRequest struct {
+	Method string
+	Path   string
+	Query  string
+	Body   []byte
+}
+
+type recordedContacts struct {
+	mu       sync.Mutex
+	requests []recordedContactRequest
+	statuses map[string]int
+}
+
+func (r *recordedContacts) snapshot() []recordedContactRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedContactRequest(nil), r.requests...)
+}
+
+func contactsServer(t *testing.T) (*httptest.Server, *recordedContacts) {
+	t.Helper()
+	recorded := &recordedContacts{statuses: make(map[string]int)}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body := new(bytes.Buffer)
+		_, _ = body.ReadFrom(req.Body)
+		recorded.mu.Lock()
+		recorded.requests = append(recorded.requests, recordedContactRequest{Method: req.Method, Path: req.URL.Path, Query: req.URL.RawQuery, Body: body.Bytes()})
+		status := recorded.statuses[req.Method+" "+req.URL.Path]
+		recorded.mu.Unlock()
+		if status != 0 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			if status == http.StatusConflict {
+				_, _ = w.Write([]byte(`{"errors":["Some email addresses are already in use for other contacts"],"contact_id":9,"conflicting_contact_ids":[4,5]}`))
+			}
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/contacts.json":
+			if req.URL.Query().Get("page") == "2" {
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			_, _ = w.Write([]byte(`[{
+				"id":7,"account_id":1,"name":"Jane Doe","email_address":"jane@example.com","updated_at":"2026-08-18T12:00:00Z"
+			}]`))
+		case req.Method == http.MethodPost && req.URL.Path == "/contacts.json":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":8,"account_id":1,"name":"Jane Dawson","email_address":"jane.dawson@example.com"}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/contacts/7.json":
+			_, _ = w.Write([]byte(`{
+				"id":7,"account_id":1,"name":"Jane Doe","email_address":"jane@example.com",
+				"aliases":[{"id":17,"name":"Jane Doe","email_address":"jane.doe@example.org"}],
+				"clearance":{"id":3,"status":"approved"}
+			}`))
+		case req.Method == http.MethodPatch && req.URL.Path == "/contacts/7.json":
+			_, _ = w.Write([]byte(`{"id":7,"account_id":1,"name":"Jane Dawson","email_address":"jane@example.com"}`))
+		case req.Method == http.MethodDelete && req.URL.Path == "/contacts/7.json":
+			w.WriteHeader(http.StatusNoContent)
+		case req.Method == http.MethodPost && req.URL.Path == "/contacts/7/reveal.json":
+			_, _ = w.Write([]byte(`{"id":7,"account_id":1,"name":"Jane Doe","email_address":"jane@example.com"}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/contacts/7/note.json":
+			_, _ = w.Write([]byte(`{"contact_id":7,"note":"Prefers email","note_html":"<p>Prefers email</p>"}`))
+		case req.Method == http.MethodPatch && req.URL.Path == "/contacts/7/note.json":
+			_, _ = w.Write([]byte(`{"contact_id":7,"note":"Prefers a call","note_html":"<p>Prefers a call</p>"}`))
+		case req.Method == http.MethodDelete && req.URL.Path == "/contacts/7/note.json":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, recorded
+}
+
+func runContacts(t *testing.T, server *httptest.Server, args ...string) (output.Response, error) {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	root.SetArgs(append([]string{"contacts", "--json", "--base-url", server.URL}, args...))
+	err := root.Execute()
+	var resp output.Response
+	if stdout.Len() > 0 {
+		_ = json.Unmarshal(stdout.Bytes(), &resp)
+	}
+	return resp, err
+}
+
+func decodeContactData[T any](t *testing.T, data any) T {
+	t.Helper()
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result T
+	if err := json.Unmarshal(encoded, &result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func TestContactsListAndPagination(t *testing.T) {
+	server, recorded := contactsServer(t)
+	resp, err := runContacts(t, server, "list", "--all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contacts := decodeContactData[[]generated.Contact](t, resp.Data)
+	if len(contacts) != 1 || contacts[0].Id != 7 {
+		t.Errorf("contacts = %+v", contacts)
+	}
+	requests := recorded.snapshot()
+	if len(requests) != 2 || !strings.Contains(requests[0].Query, "page=1") || !strings.Contains(requests[1].Query, "page=2") {
+		t.Errorf("requests = %+v", requests)
+	}
+	if resp.Summary != "1 contact" {
+		t.Errorf("summary = %q", resp.Summary)
+	}
+}
+
+func TestContactsShowIncludesAliasesAndPrivateNote(t *testing.T) {
+	server, recorded := contactsServer(t)
+	resp, err := runContacts(t, server, "show", "7")
+	if err != nil {
+		t.Fatalf("show failed: %v; requests=%+v", err, recorded.snapshot())
+	}
+	result := decodeContactData[contactShowResult](t, resp.Data)
+	if result.Id != 7 || len(result.Aliases) != 1 || result.Note != "Prefers email" || result.Clearance.Status != "approved" {
+		t.Errorf("result = %+v", result)
+	}
+	requests := recorded.snapshot()
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want contact and note", len(requests))
+	}
+}
+
+func TestContactsAddSendsFieldsAndAccount(t *testing.T) {
+	server, recorded := contactsServer(t)
+	resp, err := runContacts(t, server, "add", "--name", "Jane Dawson", "--email", "jane.dawson@example.com", "--alias", "jd@example.org", "--account-user-id", "42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contact := decodeContactData[generated.Contact](t, resp.Data)
+	if contact.Id != 8 || resp.Summary != "Contact added" {
+		t.Errorf("contact = %+v, summary = %q", contact, resp.Summary)
+	}
+	requests := recorded.snapshot()
+	if len(requests) != 1 || requests[0].Method != http.MethodPost {
+		t.Fatalf("requests = %+v", requests)
+	}
+	var body generated.CreateContactRequestContent
+	if err := json.Unmarshal(requests[0].Body, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.ActingUserId != 42 || body.Contact.Name != "Jane Dawson" || body.Contact.EmailAddress != "jane.dawson@example.com" || len(body.Contact.AliasEmailAddresses) != 1 {
+		t.Errorf("body = %+v", body)
+	}
+}
+
+func TestContactsUpdatePreservesOmittedFields(t *testing.T) {
+	server, recorded := contactsServer(t)
+	resp, err := runContacts(t, server, "update", "7", "--name", "Jane Dawson")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Summary != "Contact updated" {
+		t.Errorf("summary = %q", resp.Summary)
+	}
+	requests := recorded.snapshot()
+	if len(requests) != 2 || requests[0].Method != http.MethodGet || requests[1].Method != http.MethodPatch {
+		t.Fatalf("requests = %+v", requests)
+	}
+	var body generated.ContactRequestContent
+	if err := json.Unmarshal(requests[1].Body, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Contact.Name != "Jane Dawson" || body.Contact.EmailAddress != "jane@example.com" || len(body.Contact.AliasEmailAddresses) != 1 || body.Contact.AliasEmailAddresses[0] != "jane.doe@example.org" {
+		t.Errorf("merged update body = %+v", body)
+	}
+}
+
+func TestContactsUpdateClearsAliases(t *testing.T) {
+	server, recorded := contactsServer(t)
+	if _, err := runContacts(t, server, "update", "7", "--alias="); err != nil {
+		t.Fatal(err)
+	}
+	requests := recorded.snapshot()
+	var body generated.ContactRequestContent
+	if err := json.Unmarshal(requests[1].Body, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Contact.AliasEmailAddresses != nil {
+		t.Errorf("aliases = %#v, want the empty replacement omitted so the server applies its empty-list default", body.Contact.AliasEmailAddresses)
+	}
+	if body.Contact.Name != "Jane Doe" || body.Contact.EmailAddress != "jane@example.com" {
+		t.Errorf("clear-alias update did not preserve contact fields: %+v", body.Contact)
+	}
+}
+
+func TestContactsHideAndReveal(t *testing.T) {
+	server, recorded := contactsServer(t)
+	if resp, err := runContacts(t, server, "hide", "7"); err != nil || resp.Summary != "Contact hidden" {
+		t.Fatalf("hide: response=%+v error=%v", resp, err)
+	}
+	if resp, err := runContacts(t, server, "show-again", "7"); err != nil || resp.Summary != "Contact shown again" {
+		t.Fatalf("reveal: response=%+v error=%v", resp, err)
+	}
+	requests := recorded.snapshot()
+	if len(requests) != 2 || requests[0].Method != http.MethodDelete || requests[1].Method != http.MethodPost {
+		t.Errorf("requests = %+v", requests)
+	}
+}
+
+func TestContactNotesShowSetAndDelete(t *testing.T) {
+	server, recorded := contactsServer(t)
+	show, err := runContacts(t, server, "note", "show", "7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if note := decodeContactData[generated.ContactNote](t, show.Data); note.Note != "Prefers email" {
+		t.Errorf("show note = %+v", note)
+	}
+	set, err := runContacts(t, server, "note", "set", "7", "Prefers a call")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if note := decodeContactData[generated.ContactNote](t, set.Data); note.Note != "Prefers a call" {
+		t.Errorf("set note = %+v", note)
+	}
+	if deleted, err := runContacts(t, server, "note", "delete", "7"); err != nil || deleted.Summary != "Private contact note deleted" {
+		t.Fatalf("delete: response=%+v error=%v", deleted, err)
+	}
+	requests := recorded.snapshot()
+	if len(requests) != 3 {
+		t.Fatalf("requests = %+v", requests)
+	}
+	var body generated.ContactNoteRequestContent
+	if err := json.Unmarshal(requests[1].Body, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Contact.Note != "Prefers a call" {
+		t.Errorf("note body = %+v", body)
+	}
+}
+
+func TestContactNoteSetPreservesMultilineContent(t *testing.T) {
+	server, recorded := contactsServer(t)
+	content := "First line\nSecond line"
+	if _, err := runContacts(t, server, "note", "set", "7", content); err != nil {
+		t.Fatal(err)
+	}
+	requests := recorded.snapshot()
+	if len(requests) != 1 {
+		t.Fatalf("requests = %+v", requests)
+	}
+	var body generated.ContactNoteRequestContent
+	if err := json.Unmarshal(requests[0].Body, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Contact.Note != content {
+		t.Errorf("note = %q, want %q", body.Contact.Note, content)
+	}
+}
+
+func TestContactCommandsValidateBeforeRequests(t *testing.T) {
+	tests := [][]string{
+		{"add", "--name", "Jane"},
+		{"add", "--email", "jane@example.com"},
+		{"add", "--name", "Jane", "--email", "jane@example.com", "--alias", "jane@example.com"},
+		{"update", "7"},
+		{"show", "not-an-id"},
+		{"note", "set", "7", ""},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			server, recorded := contactsServer(t)
+			_, err := runContacts(t, server, args...)
+			var cliErr *apierr.Error
+			if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+				t.Fatalf("error = %v, want usage", err)
+			}
+			if len(recorded.snapshot()) != 0 {
+				t.Errorf("validation made requests: %+v", recorded.snapshot())
+			}
+		})
+	}
+}
+
+func TestContactConflictIncludesMergeIDs(t *testing.T) {
+	server, recorded := contactsServer(t)
+	recorded.mu.Lock()
+	recorded.statuses[http.MethodPost+" /contacts.json"] = http.StatusConflict
+	recorded.mu.Unlock()
+	_, err := runContacts(t, server, "add", "--name", "Jane", "--email", "jane@example.com")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "conflict" || !strings.Contains(cliErr.Hint, "4, 5") || !strings.Contains(cliErr.Hint, "9") {
+		t.Fatalf("conflict error = %#v", err)
+	}
+}
+
+func TestCollectContactsReportsPageCap(t *testing.T) {
+	calls := 0
+	lastPage := 0
+	contacts, pages, truncated, err := collectContacts(t.Context(), 7, true,
+		func(_ context.Context, params *generated.ListContactsParams) (*generated.ListContactsResponseContent, error) {
+			calls++
+			lastPage, _ = strconv.Atoi(*params.Page)
+			result := generated.ListContactsResponseContent{{Id: int64(calls)}}
+			return &result, nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != maxContactPages || pages != maxContactPages || len(contacts) != maxContactPages || !truncated || lastPage != 106 {
+		t.Errorf("calls=%d pages=%d contacts=%d truncated=%v lastPage=%d", calls, pages, len(contacts), truncated, lastPage)
+	}
+	want := "Contact listing stopped after 100 pages. Continue with --page 107."
+	if got := contactTruncationNotice(7, pages, truncated); got != want {
+		t.Errorf("notice = %q, want %q", got, want)
+	}
+}
+
+func TestParseContactIDAndNoun(t *testing.T) {
+	if id, err := parseContactID("123"); err != nil || id != 123 {
+		t.Errorf("parseContactID = %d, %v", id, err)
+	}
+	for _, value := range []string{"0", "-1", "nope"} {
+		if _, err := parseContactID(value); err == nil {
+			t.Errorf("parseContactID(%q) should fail", value)
+		}
+	}
+	if contactNoun(1) != "contact" || contactNoun(2) != "contacts" {
+		t.Errorf("contact nouns are wrong: %q %q", contactNoun(1), contactNoun(2))
+	}
+}
+
+func TestCollectContactsRejectsNilFetcher(t *testing.T) {
+	if _, _, _, err := collectContacts(t.Context(), 1, false, nil); err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestContactListPageErrorIsReturned(t *testing.T) {
+	want := fmt.Errorf("list failed")
+	_, _, _, err := collectContacts(t.Context(), 1, false, func(context.Context, *generated.ListContactsParams) (*generated.ListContactsResponseContent, error) {
+		return nil, want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+}

--- a/internal/cmd/contacts_test.go
+++ b/internal/cmd/contacts_test.go
@@ -295,6 +295,21 @@ func TestContactNoteSetPreservesMultilineContent(t *testing.T) {
 	}
 }
 
+func TestContactNoteForEditorReturnsReadErrors(t *testing.T) {
+	want := errors.New("note read failed")
+	if _, err := contactNoteForEditor(t.Context(), 7, func(context.Context, int64) (*generated.ContactNote, error) {
+		return nil, want
+	}); !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+	content, err := contactNoteForEditor(t.Context(), 7, func(context.Context, int64) (*generated.ContactNote, error) {
+		return &generated.ContactNote{ContactId: 7, Note: "Existing note"}, nil
+	})
+	if err != nil || content != "Existing note" {
+		t.Errorf("content = %q, error = %v", content, err)
+	}
+}
+
 func TestContactCommandsValidateBeforeRequests(t *testing.T) {
 	tests := [][]string{
 		{"add", "--name", "Jane"},

--- a/internal/cmd/contacts_test.go
+++ b/internal/cmd/contacts_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	"github.com/spf13/cobra"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/output"
@@ -164,6 +165,24 @@ func TestContactsShowIncludesAliasesAndPrivateNote(t *testing.T) {
 	requests := recorded.snapshot()
 	if len(requests) != 2 {
 		t.Fatalf("requests = %d, want contact and note", len(requests))
+	}
+}
+
+func TestContactsShowHonorsHTMLOutput(t *testing.T) {
+	original := htmlOutput
+	htmlOutput = true
+	t.Cleanup(func() { htmlOutput = original })
+
+	var output bytes.Buffer
+	command := &cobra.Command{}
+	command.SetOut(&output)
+	printContactDetails(command, contactShowResult{
+		ContactDetail: generated.ContactDetail{Id: 7, Name: "Jane Doe", EmailAddress: "jane@example.com"},
+		Note:          "Plain note",
+		NoteHTML:      "<p>Rich note</p>",
+	})
+	if !strings.Contains(output.String(), "<p>Rich note</p>") || strings.Contains(output.String(), "Plain note") {
+		t.Errorf("HTML contact detail output = %q", output.String())
 	}
 }
 

--- a/internal/cmd/contacts_test.go
+++ b/internal/cmd/contacts_test.go
@@ -295,6 +295,33 @@ func TestContactNoteSetPreservesMultilineContent(t *testing.T) {
 	}
 }
 
+func TestContactNoteInputDistinguishesExplicitEmptyContent(t *testing.T) {
+	tests := []struct {
+		name        string
+		flagChanged bool
+		flagValue   string
+		args        []string
+		want        string
+		provided    bool
+		wantErr     bool
+	}{
+		{name: "no inline input", args: []string{"7"}},
+		{name: "empty flag", flagChanged: true, args: []string{"7"}, provided: true},
+		{name: "empty positional", args: []string{"7", ""}, provided: true},
+		{name: "flag value", flagChanged: true, flagValue: "Private", args: []string{"7"}, want: "Private", provided: true},
+		{name: "positional value", args: []string{"7", "Private"}, want: "Private", provided: true},
+		{name: "conflicting inputs", flagChanged: true, flagValue: "One", args: []string{"7", "Two"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, provided, err := contactNoteInput(tt.flagChanged, tt.flagValue, tt.args)
+			if (err != nil) != tt.wantErr || got != tt.want || provided != tt.provided {
+				t.Errorf("contactNoteInput = %q, %v, %v", got, provided, err)
+			}
+		})
+	}
+}
+
 func TestContactNoteForEditorReturnsReadErrors(t *testing.T) {
 	want := errors.New("note read failed")
 	if _, err := contactNoteForEditor(t.Context(), 7, func(context.Context, int64) (*generated.ContactNote, error) {

--- a/internal/cmd/contacts_test.go
+++ b/internal/cmd/contacts_test.go
@@ -237,8 +237,17 @@ func TestContactsUpdateClearsAliases(t *testing.T) {
 		t.Fatal(err)
 	}
 	requests := recorded.snapshot()
+	var patch recordedContactRequest
+	for _, request := range requests {
+		if request.Method == http.MethodPatch {
+			patch = request
+		}
+	}
+	if patch.Method == "" {
+		t.Fatalf("requests contain no PATCH: %+v", requests)
+	}
 	var body generated.ContactRequestContent
-	if err := json.Unmarshal(requests[1].Body, &body); err != nil {
+	if err := json.Unmarshal(patch.Body, &body); err != nil {
 		t.Fatal(err)
 	}
 	if body.Contact.AliasEmailAddresses != nil {
@@ -246,6 +255,28 @@ func TestContactsUpdateClearsAliases(t *testing.T) {
 	}
 	if body.Contact.Name != "Jane Doe" || body.Contact.EmailAddress != "jane@example.com" {
 		t.Errorf("clear-alias update did not preserve contact fields: %+v", body.Contact)
+	}
+}
+
+func TestContactsUpdateValidatesAliasesAgainstExistingPrimary(t *testing.T) {
+	tests := [][]string{
+		{"update", "7", "--alias", "jane@example.com"},
+		{"update", "7", "--alias", "duplicate@example.org", "--alias", "duplicate@example.org"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			server, recorded := contactsServer(t)
+			_, err := runContacts(t, server, args...)
+			var cliErr *apierr.Error
+			if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+				t.Fatalf("error = %v, want usage", err)
+			}
+			for _, request := range recorded.snapshot() {
+				if request.Method == http.MethodPatch {
+					t.Errorf("invalid aliases reached PATCH: %+v", recorded.snapshot())
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cmd/contacts_update.go
+++ b/internal/cmd/contacts_update.go
@@ -71,8 +71,28 @@ func (c *contactsUpdateCommand) run(cmd *cobra.Command, args []string) error {
 	if aliasesChanged {
 		params.AliasEmailAddresses = cleanContactAliases(c.aliases)
 	}
-	if params.EmailAddress != "" {
-		if validationErr := validateDistinctContactEmails(params.EmailAddress, params.AliasEmailAddresses); validationErr != nil {
+	if emailChanged || aliasesChanged {
+		validationEmail := params.EmailAddress
+		validationAliases := params.AliasEmailAddresses
+		if validationEmail == "" || validationAliases == nil {
+			current, getErr := sdk.Contacts().Get(cmd.Context(), contactID)
+			if getErr != nil {
+				return convertSDKError(getErr)
+			}
+			if current == nil {
+				return output.ErrNotFound("contact", args[0])
+			}
+			if validationEmail == "" {
+				validationEmail = current.EmailAddress
+			}
+			if validationAliases == nil {
+				validationAliases = make([]string, 0, len(current.Aliases))
+				for _, alias := range current.Aliases {
+					validationAliases = append(validationAliases, alias.EmailAddress)
+				}
+			}
+		}
+		if validationErr := validateDistinctContactEmails(validationEmail, validationAliases); validationErr != nil {
 			return validationErr
 		}
 	}

--- a/internal/cmd/contacts_update.go
+++ b/internal/cmd/contacts_update.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactsUpdateCommand struct {
+	cmd     *cobra.Command
+	name    string
+	email   string
+	aliases []string
+}
+
+func newContactsUpdateCommand() *contactsUpdateCommand {
+	updateCommand := &contactsUpdateCommand{}
+	updateCommand.cmd = &cobra.Command{
+		Use:   "update <id>",
+		Short: "Edit a contact",
+		Long:  "Edit a contact. Omitted name and email fields stay unchanged. Supplying --alias replaces the complete alias list; use --alias= to clear it.",
+		Annotations: map[string]string{
+			"agent_notes": "At least one field is required. Repeat --alias to replace aliases. --alias= clears every alias.",
+		},
+		Example: `  hey contacts update 12345 --name "Jane Doe"
+  hey contacts update 12345 --email jane@example.com --alias jane.doe@example.org
+  hey contacts update 12345 --alias=`,
+		RunE: updateCommand.run,
+		Args: usageExactOneArg(),
+	}
+	flags := updateCommand.cmd.Flags()
+	flags.StringVar(&updateCommand.name, "name", "", "New contact name")
+	flags.StringVar(&updateCommand.email, "email", "", "New primary email address")
+	flags.StringSliceVar(&updateCommand.aliases, "alias", nil, "Replacement alternate email address (repeatable)")
+	return updateCommand
+}
+
+func (c *contactsUpdateCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	contactID, err := parseContactID(args[0])
+	if err != nil {
+		return err
+	}
+	nameChanged := cmd.Flags().Changed("name")
+	emailChanged := cmd.Flags().Changed("email")
+	aliasesChanged := cmd.Flags().Changed("alias")
+	if !nameChanged && !emailChanged && !aliasesChanged {
+		return output.ErrUsage("provide at least one of --name, --email, or --alias")
+	}
+
+	params := hey.ContactParams{}
+	if nameChanged {
+		params.Name = strings.TrimSpace(c.name)
+		if params.Name == "" {
+			return output.ErrUsage("--name cannot be empty")
+		}
+	}
+	if emailChanged {
+		params.EmailAddress = strings.TrimSpace(c.email)
+		if params.EmailAddress == "" {
+			return output.ErrUsage("--email cannot be empty")
+		}
+	}
+	if aliasesChanged {
+		params.AliasEmailAddresses = cleanContactAliases(c.aliases)
+	}
+	if params.EmailAddress != "" {
+		if validationErr := validateDistinctContactEmails(params.EmailAddress, params.AliasEmailAddresses); validationErr != nil {
+			return validationErr
+		}
+	}
+
+	contact, err := sdk.Contacts().Update(cmd.Context(), contactID, params)
+	if err != nil {
+		return convertContactWriteError(err)
+	}
+	if contact == nil {
+		return output.ErrNotFound("contact", args[0])
+	}
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Contact updated: %s <%s> (#%d)\n", contact.Name, contact.EmailAddress, contact.Id)
+		return nil
+	}
+	return writeOK(contact,
+		output.WithSummary("Contact updated"),
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "view", Command: fmt.Sprintf("hey contacts show %d", contact.Id), Description: "View the contact"}),
+	)
+}

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -17,7 +17,7 @@ var curatedCategories = []struct {
 }{
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "search", "threads", "compose", "reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
+		names:   []string{"boxes", "box", "search", "contacts", "threads", "compose", "reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
 	},
 	{
 		heading: "CALENDAR & TASKS",
@@ -54,7 +54,7 @@ func customHelpFunc(defaultHelp func(*cobra.Command, []string)) func(*cobra.Comm
 func renderRootHelp(w io.Writer, cmd *cobra.Command) {
 	var b strings.Builder
 
-	b.WriteString("Read, send, and organize HEY email and calendars from your terminal.\n")
+	b.WriteString("Read, send, and organize HEY email, contacts, and calendars from your terminal.\n")
 
 	// USAGE
 	b.WriteString("\n")

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestCuratedCommandHelpUsesUserFacingLanguage(t *testing.T) {
@@ -48,6 +51,32 @@ func TestEmailCommandHelpKeepsPostingAsAnInternalTerm(t *testing.T) {
 	}
 }
 
+func TestContactCommandHelpUsesHEYTerminology(t *testing.T) {
+	root := newRootCmd()
+	contacts, _, err := root.Find([]string{"contacts"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var text strings.Builder
+	var walk func(*cobra.Command)
+	walk = func(command *cobra.Command) {
+		fmt.Fprintln(&text, command.Use, command.Short, command.Long, command.Example, command.Annotations["agent_notes"])
+		for _, child := range command.Commands() {
+			walk(child)
+		}
+	}
+	walk(contacts)
+	lower := strings.ToLower(text.String())
+	if strings.Contains(lower, "reveal") || strings.Contains(lower, "delete a contact") {
+		t.Errorf("contact help exposes internal or destructive terminology:\n%s", text.String())
+	}
+	for _, want := range []string{"hide a contact", "show a hidden contact again", "delete a private contact note"} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("contact help missing %q:\n%s", want, text.String())
+		}
+	}
+}
+
 func TestRenderRootHelpUsesUserFacingLanguage(t *testing.T) {
 	originalColorDisabled := colorDisabled
 	colorDisabled = true
@@ -56,7 +85,7 @@ func TestRenderRootHelpUsesUserFacingLanguage(t *testing.T) {
 	var output strings.Builder
 	renderRootHelp(&output, newRootCmd())
 
-	const expected = `Read, send, and organize HEY email and calendars from your terminal.
+	const expected = `Read, send, and organize HEY email, contacts, and calendars from your terminal.
 
 USAGE
   hey <command> [flags]
@@ -66,6 +95,7 @@ EMAIL
   boxes          List your HEY boxes
   box            List email threads in a box
   search         Search email threads and messages
+  contacts       Manage contacts
   threads        Read a thread
   compose        Write and send a new email
   reply          Reply to a thread

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -39,7 +39,7 @@ var (
 func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "hey",
-		Short: "Read, send, and organize HEY email and calendars from your terminal.",
+		Short: "Read, send, and organize HEY email, contacts, and calendars from your terminal.",
 		Long: `A CLI for HEY
 ⠀⠀⠀⠀⠀⠀⣰⠲⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
 ⠀⠀⠀⡟⢳⡀⣏⠀⠘⣆⠀⠀⠀⠀⠀⣤⣤⡄⠀⠀⢠⣤⣤⣤⣤⣤⣤⣤⣤⠀⠀⢀⣤⣤⡄⠀
@@ -120,6 +120,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newBoxesCommand().cmd)
 	root.AddCommand(newBoxCommand().cmd)
 	root.AddCommand(newSearchCommand().cmd)
+	root.AddCommand(newContactsCommand().cmd)
 	root.AddCommand(newThreadsCommand().cmd)
 	root.AddCommand(newReplyCommand().cmd)
 	root.AddCommand(newForwardCommand().cmd)

--- a/internal/cmd/sdk.go
+++ b/internal/cmd/sdk.go
@@ -96,6 +96,10 @@ func convertSDKError(err error) error {
 		return output.ErrRateLimit(retryAfter)
 	case hey.CodeNetwork:
 		return output.ErrNetwork(err)
+	case hey.CodeValidation:
+		return &output.Error{Code: "validation", Message: sdkErr.Message, Hint: sdkErr.Hint, HTTPStatus: sdkErr.HTTPStatus, Cause: err}
+	case hey.CodeConflict:
+		return &output.Error{Code: "conflict", Message: sdkErr.Message, Hint: sdkErr.Hint, HTTPStatus: sdkErr.HTTPStatus, Cause: err}
 	default:
 		return output.ErrAPI(sdkErr.HTTPStatus, sdkErr.Message)
 	}

--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -116,7 +116,7 @@ func (c *searchCommand) run(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	}
-	if stderrNotice := searchNoticeForStderr(writer.EffectiveFormat(), notice); stderrNotice != "" {
+	if stderrNotice := paginationNoticeForStderr(writer.EffectiveFormat(), notice); stderrNotice != "" {
 		fmt.Fprintln(cmd.ErrOrStderr(), stderrNotice)
 	}
 	return writeOK(results,
@@ -280,7 +280,7 @@ func searchTruncationNotice(startPage, pages int, truncated bool) string {
 	return fmt.Sprintf("Search stopped after %d pages. Continue with --page %d.", pages, startPage+pages)
 }
 
-func searchNoticeForStderr(format output.Format, notice string) string {
+func paginationNoticeForStderr(format output.Format, notice string) string {
 	if notice == "" || format == output.FormatJSON || format == output.FormatStyled {
 		return ""
 	}

--- a/internal/cmd/search_test.go
+++ b/internal/cmd/search_test.go
@@ -259,16 +259,16 @@ func TestSearchAllReportsContinuationAtPageLimit(t *testing.T) {
 func TestSearchTruncationNoticeUsesStderrForDataOnlyFormats(t *testing.T) {
 	notice := "Search stopped after 100 pages. Continue with --page 107."
 	for _, format := range []output.Format{output.FormatQuiet, output.FormatIDs, output.FormatCount, output.FormatMarkdown} {
-		if got := searchNoticeForStderr(format, notice); got != "notice: "+notice {
+		if got := paginationNoticeForStderr(format, notice); got != "notice: "+notice {
 			t.Errorf("format %d notice = %q", format, got)
 		}
 	}
 	for _, format := range []output.Format{output.FormatJSON, output.FormatStyled} {
-		if got := searchNoticeForStderr(format, notice); got != "" {
+		if got := paginationNoticeForStderr(format, notice); got != "" {
 			t.Errorf("format %d notice = %q, want empty", format, got)
 		}
 	}
-	if got := searchNoticeForStderr(output.FormatQuiet, ""); got != "" {
+	if got := paginationNoticeForStderr(output.FormatQuiet, ""); got != "" {
 		t.Errorf("empty notice = %q", got)
 	}
 }

--- a/internal/models/box.go
+++ b/internal/models/box.go
@@ -68,8 +68,11 @@ func (p *Posting) ResolveTopicID() int64 {
 }
 
 type Contact struct {
-	ID           int64  `json:"id"`
-	Name         string `json:"name"`
-	EmailAddress string `json:"email_address"`
-	Avatar       string `json:"avatar,omitempty"`
+	ID           int64     `json:"id"`
+	AccountID    int64     `json:"account_id,omitempty"`
+	Name         string    `json:"name"`
+	EmailAddress string    `json:"email_address"`
+	Avatar       string    `json:"avatar,omitempty"`
+	UpdatedAt    string    `json:"updated_at,omitempty"`
+	Aliases      []Contact `json:"aliases,omitempty"`
 }

--- a/internal/tui/contact_form.go
+++ b/internal/tui/contact_form.go
@@ -1,0 +1,230 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/basecamp/hey-cli/internal/models"
+)
+
+type contactFormMode int
+
+const (
+	contactFormAdd contactFormMode = iota
+	contactFormEdit
+)
+
+type contactForm struct {
+	mode      contactFormMode
+	contactID int64
+	inputs    []textinput.Model
+	focus     int
+	status    string
+	isError   bool
+	saving    bool
+	styles    styles
+}
+
+const (
+	contactFieldName = iota
+	contactFieldEmail
+	contactFieldAliases
+)
+
+func newContactForm(mode contactFormMode, contact models.Contact, styles styles) *contactForm {
+	form := &contactForm{mode: mode, contactID: contact.ID, styles: styles}
+	placeholders := []string{"Jane Doe", "jane@example.com", "jane.doe@example.org, jane@example.net"}
+	for _, placeholder := range placeholders {
+		input := textinput.New()
+		input.Prompt = ""
+		input.Placeholder = placeholder
+		form.inputs = append(form.inputs, input)
+	}
+	if mode == contactFormEdit {
+		form.inputs[contactFieldName].SetValue(contact.Name)
+		form.inputs[contactFieldEmail].SetValue(contact.EmailAddress)
+		aliases := make([]string, 0, len(contact.Aliases))
+		for _, alias := range contact.Aliases {
+			aliases = append(aliases, alias.EmailAddress)
+		}
+		form.inputs[contactFieldAliases].SetValue(strings.Join(aliases, ", "))
+	}
+	return form
+}
+
+func (f *contactForm) init() tea.Cmd { return f.focusCurrent() }
+
+func (f *contactForm) focusCurrent() tea.Cmd {
+	for i := range f.inputs {
+		f.inputs[i].Blur()
+	}
+	return f.inputs[f.focus].Focus()
+}
+
+func (f *contactForm) resize(width, _ int) {
+	for i := range f.inputs {
+		f.inputs[i].SetWidth(max(width-12, 10))
+	}
+}
+
+func (f *contactForm) values() (name, email string, aliases []string) {
+	name = strings.TrimSpace(f.inputs[contactFieldName].Value())
+	email = strings.TrimSpace(f.inputs[contactFieldEmail].Value())
+	for _, value := range strings.Split(f.inputs[contactFieldAliases].Value(), ",") {
+		if alias := strings.TrimSpace(value); alias != "" {
+			aliases = append(aliases, alias)
+		}
+	}
+	return
+}
+
+func (f *contactForm) validate() string {
+	name, email, aliases := f.values()
+	if name == "" {
+		return "Name is required"
+	}
+	if email == "" {
+		return "Email is required"
+	}
+	seen := map[string]bool{strings.ToLower(email): true}
+	for _, alias := range aliases {
+		key := strings.ToLower(alias)
+		if seen[key] {
+			return "Email addresses must be unique"
+		}
+		seen[key] = true
+	}
+	return ""
+}
+
+func (f *contactForm) handleKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
+	if f.saving {
+		return nil, false
+	}
+	switch {
+	case msg.Key().Code == tea.KeyTab && msg.Key().Mod == tea.ModShift:
+		f.focus = (f.focus + len(f.inputs) - 1) % len(f.inputs)
+		return f.focusCurrent(), false
+	case msg.Key().Code == tea.KeyTab || msg.Key().Code == tea.KeyEnter:
+		f.focus = (f.focus + 1) % len(f.inputs)
+		return f.focusCurrent(), false
+	case msg.String() == "ctrl+s":
+		if problem := f.validate(); problem != "" {
+			f.status = problem
+			f.isError = true
+			return nil, false
+		}
+		f.saving = true
+		f.status = "Saving…"
+		f.isError = false
+		return nil, true
+	}
+	return f.update(msg), false
+}
+
+func (f *contactForm) update(msg tea.Msg) tea.Cmd {
+	var cmd tea.Cmd
+	f.inputs[f.focus], cmd = f.inputs[f.focus].Update(msg)
+	return cmd
+}
+
+func (f *contactForm) helpBindings() []helpBinding {
+	return []helpBinding{{"tab", "next field"}, {"ctrl+s", "save"}, {"esc", "cancel"}}
+}
+
+func (f *contactForm) view() string {
+	title := "Add contact"
+	if f.mode == contactFormEdit {
+		title = "Edit contact"
+	}
+	labels := []string{"Name", "Email", "Aliases"}
+	labelStyle := lipgloss.NewStyle().Foreground(colorMuted)
+	var b strings.Builder
+	b.WriteString(f.styles.title.Render(title))
+	b.WriteString("\n\n")
+	for i := range f.inputs {
+		fmt.Fprintf(&b, "%s %s\n", labelStyle.Render(fmt.Sprintf("%8s:", labels[i])), f.inputs[i].View())
+	}
+	b.WriteString(labelStyle.Render("Aliases are comma-separated and replace the complete list."))
+	if f.status != "" {
+		style := labelStyle
+		if f.isError {
+			style = lipgloss.NewStyle().Foreground(colorError)
+		}
+		b.WriteString("\n\n" + style.Render(f.status))
+	}
+	return b.String()
+}
+
+type contactNoteForm struct {
+	contactID int64
+	input     textarea.Model
+	status    string
+	isError   bool
+	saving    bool
+	styles    styles
+}
+
+func newContactNoteForm(contactID int64, note string, styles styles) *contactNoteForm {
+	input := textarea.New()
+	input.Prompt = ""
+	input.ShowLineNumbers = false
+	input.Placeholder = "Add a private note…"
+	input.SetValue(note)
+	return &contactNoteForm{contactID: contactID, input: input, styles: styles}
+}
+
+func (f *contactNoteForm) init() tea.Cmd { return f.input.Focus() }
+
+func (f *contactNoteForm) resize(width, height int) {
+	f.input.SetWidth(max(width-4, 10))
+	f.input.SetHeight(max(height-5, 3))
+}
+
+func (f *contactNoteForm) handleKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
+	if f.saving {
+		return nil, false
+	}
+	if msg.String() == "ctrl+s" {
+		if strings.TrimSpace(f.input.Value()) == "" {
+			f.status = "Note is empty; cancel and use x to delete it"
+			f.isError = true
+			return nil, false
+		}
+		f.saving = true
+		f.status = "Saving…"
+		f.isError = false
+		return nil, true
+	}
+	return f.update(msg), false
+}
+
+func (f *contactNoteForm) update(msg tea.Msg) tea.Cmd {
+	var cmd tea.Cmd
+	f.input, cmd = f.input.Update(msg)
+	return cmd
+}
+
+func (f *contactNoteForm) helpBindings() []helpBinding {
+	return []helpBinding{{"ctrl+s", "save note"}, {"esc", "cancel"}}
+}
+
+func (f *contactNoteForm) view() string {
+	var b strings.Builder
+	b.WriteString(f.styles.title.Render("Private contact note"))
+	b.WriteString("\n\n")
+	b.WriteString(f.input.View())
+	if f.status != "" {
+		style := lipgloss.NewStyle().Foreground(colorMuted)
+		if f.isError {
+			style = lipgloss.NewStyle().Foreground(colorError)
+		}
+		b.WriteString("\n" + style.Render(f.status))
+	}
+	return b.String()
+}

--- a/internal/tui/contact_form.go
+++ b/internal/tui/contact_form.go
@@ -75,6 +75,7 @@ func (f *contactForm) resize(width, _ int) {
 func (f *contactForm) values() (name, email string, aliases []string) {
 	name = strings.TrimSpace(f.inputs[contactFieldName].Value())
 	email = strings.TrimSpace(f.inputs[contactFieldEmail].Value())
+	aliases = make([]string, 0)
 	for _, value := range strings.Split(f.inputs[contactFieldAliases].Value(), ",") {
 		if alias := strings.TrimSpace(value); alias != "" {
 			aliases = append(aliases, alias)

--- a/internal/tui/contacts.go
+++ b/internal/tui/contacts.go
@@ -142,6 +142,12 @@ func (v *contactsView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		}
 		v.finishRequest(msg.requestID)
 		if msg.err != nil {
+			var conflict *hey.ContactConflictError
+			if errors.As(msg.err, &conflict) && conflict.ContactID != 0 {
+				v.contactForm = nil
+				v.notice = contactSaveFailure(msg.err)
+				return v.requestContactDetail(conflict.ContactID), true
+			}
 			if v.contactForm != nil {
 				v.contactForm.saving = false
 				v.contactForm.status = contactSaveFailure(msg.err)
@@ -365,6 +371,13 @@ func (v *contactsView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 }
 
 func (v *contactsView) InThread() bool { return v.inDetail }
+
+func (v *contactsView) ExitDetail(_ string) {
+	if v.loading && v.activeRequestKind == contactRequestMutation {
+		return
+	}
+	v.ExitThread()
+}
 
 func (v *contactsView) ExitThread() {
 	v.inDetail = false

--- a/internal/tui/contacts.go
+++ b/internal/tui/contacts.go
@@ -1,0 +1,664 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/models"
+)
+
+type contactRequestKind int
+
+const (
+	contactRequestNone contactRequestKind = iota
+	contactRequestList
+	contactRequestDetail
+	contactRequestMutation
+)
+
+type contactsLoadedMsg struct {
+	requestID uint64
+	page      int
+	contacts  []models.Contact
+	err       error
+}
+
+type contactDetailLoadedMsg struct {
+	requestID uint64
+	contact   models.Contact
+	note      string
+	err       error
+}
+
+type contactSavedMsg struct {
+	requestID  uint64
+	originalID int64
+	contact    models.Contact
+	created    bool
+	err        error
+}
+
+type contactHiddenMsg struct {
+	requestID uint64
+	contact   models.Contact
+	err       error
+}
+
+type contactRevealedMsg struct {
+	requestID uint64
+	contact   models.Contact
+	err       error
+}
+
+type contactNoteSavedMsg struct {
+	requestID uint64
+	note      string
+	deleted   bool
+	err       error
+}
+
+type contactsView struct {
+	vc *viewContext
+
+	list              contactList
+	loaded            bool
+	page              int
+	detail            models.Contact
+	note              string
+	inDetail          bool
+	detailView        viewport.Model
+	contactForm       *contactForm
+	noteForm          *contactNoteForm
+	lastHiddenID      int64
+	confirmNoteDelete bool
+	notice            string
+	loading           bool
+
+	activeRequestID   uint64
+	activeRequestKind contactRequestKind
+	requestCancel     context.CancelFunc
+}
+
+func newContactsView(vc *viewContext) *contactsView {
+	return &contactsView{
+		vc:         vc,
+		page:       1,
+		detailView: viewport.New(viewport.WithWidth(0), viewport.WithHeight(0)),
+	}
+}
+
+func (v *contactsView) Init() tea.Cmd {
+	if v.loaded {
+		return nil
+	}
+	return v.requestContacts(1)
+}
+
+func (v *contactsView) Update(msg tea.Msg) (tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case contactsLoadedMsg:
+		if msg.requestID != v.activeRequestID {
+			return nil, true
+		}
+		v.finishRequest(msg.requestID)
+		if msg.err != nil {
+			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
+		if len(msg.contacts) == 0 && v.loaded && msg.page > v.page {
+			v.notice = "No more contacts"
+			return nil, true
+		}
+		v.loaded = true
+		v.page = msg.page
+		v.list.setContacts(msg.contacts)
+		return nil, true
+
+	case contactDetailLoadedMsg:
+		if msg.requestID != v.activeRequestID {
+			return nil, true
+		}
+		v.finishRequest(msg.requestID)
+		if msg.err != nil {
+			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
+		v.detail = msg.contact
+		v.note = msg.note
+		v.inDetail = true
+		v.refreshDetailView()
+		return nil, true
+
+	case contactSavedMsg:
+		if msg.requestID != v.activeRequestID {
+			return nil, true
+		}
+		v.finishRequest(msg.requestID)
+		if msg.err != nil {
+			if v.contactForm != nil {
+				v.contactForm.saving = false
+				v.contactForm.status = contactSaveFailure(msg.err)
+				v.contactForm.isError = true
+			}
+			return nil, true
+		}
+		v.contactForm = nil
+		if msg.created {
+			v.notice = "Contact added"
+		} else {
+			v.notice = "Contact updated"
+		}
+		if msg.originalID != 0 && msg.originalID != msg.contact.ID {
+			v.list.remove(msg.originalID)
+		}
+		v.updateContactInList(msg.contact)
+		return v.requestContactDetail(msg.contact.ID), true
+
+	case contactHiddenMsg:
+		if msg.requestID != v.activeRequestID {
+			return nil, true
+		}
+		v.finishRequest(msg.requestID)
+		if msg.err != nil {
+			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
+		v.lastHiddenID = msg.contact.ID
+		v.list.remove(msg.contact.ID)
+		v.inDetail = false
+		v.detail = models.Contact{}
+		v.note = ""
+		v.notice = "Contact hidden"
+		return nil, true
+
+	case contactRevealedMsg:
+		if msg.requestID != v.activeRequestID {
+			return nil, true
+		}
+		v.finishRequest(msg.requestID)
+		if msg.err != nil {
+			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
+		v.lastHiddenID = 0
+		v.notice = "Contact shown again"
+		return v.requestContacts(v.page), true
+
+	case contactNoteSavedMsg:
+		if msg.requestID != v.activeRequestID {
+			return nil, true
+		}
+		v.finishRequest(msg.requestID)
+		if msg.err != nil {
+			if v.noteForm != nil {
+				v.noteForm.saving = false
+				v.noteForm.status = "Save failed: " + msg.err.Error()
+				v.noteForm.isError = true
+				return nil, true
+			}
+			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
+		v.noteForm = nil
+		v.note = msg.note
+		if msg.deleted {
+			v.notice = "Private note deleted"
+		} else {
+			v.notice = "Private note saved"
+		}
+		v.refreshDetailView()
+		return nil, true
+	}
+
+	if v.contactForm != nil {
+		return v.contactForm.update(msg), true
+	}
+	if v.noteForm != nil {
+		return v.noteForm.update(msg), true
+	}
+	if v.inDetail {
+		var cmd tea.Cmd
+		v.detailView, cmd = v.detailView.Update(msg)
+		return cmd, cmd != nil
+	}
+	return nil, false
+}
+
+func (v *contactsView) View() string {
+	if v.contactForm != nil {
+		return v.contactForm.view()
+	}
+	if v.noteForm != nil {
+		return v.noteForm.view()
+	}
+	if v.inDetail {
+		if v.notice != "" {
+			return v.vc.styles.title.Render(v.notice) + "\n" + v.detailView.View()
+		}
+		return v.detailView.View()
+	}
+	if v.notice != "" {
+		return v.vc.styles.title.Render(v.notice) + "\n" + v.list.view()
+	}
+	return v.list.view()
+}
+
+func (v *contactsView) HelpBindings() []helpBinding {
+	if v.contactForm != nil {
+		return v.contactForm.helpBindings()
+	}
+	if v.noteForm != nil {
+		return v.noteForm.helpBindings()
+	}
+	if v.inDetail {
+		bindings := []helpBinding{{"e", "edit"}, {"n", "edit note"}, {"h", "hide"}}
+		if v.note != "" {
+			label := "delete note"
+			if v.confirmNoteDelete {
+				label = "confirm delete"
+			}
+			bindings = append(bindings, helpBinding{"x", label})
+		}
+		return bindings
+	}
+	bindings := []helpBinding{{"a", "add"}, {"r", "refresh"}, {"n/p", "pages"}}
+	if v.lastHiddenID != 0 {
+		bindings = append(bindings, helpBinding{"u", "show again"})
+	}
+	return bindings
+}
+
+func (v *contactsView) SubnavItems() ([]navItem, int, string, bool) {
+	return nil, 0, fmt.Sprintf("Contacts (page %d)", v.page), true
+}
+
+func (v *contactsView) SubnavLeft() tea.Cmd  { return nil }
+func (v *contactsView) SubnavRight() tea.Cmd { return nil }
+
+func (v *contactsView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
+	if v.loading {
+		return nil
+	}
+	if msg.String() != "x" {
+		v.confirmNoteDelete = false
+	}
+	v.notice = ""
+	if v.contactForm != nil {
+		if msg.Key().Code == tea.KeyEscape && !v.contactForm.saving {
+			v.contactForm = nil
+			return nil
+		}
+		cmd, submit := v.contactForm.handleKey(msg)
+		if submit {
+			return v.saveContact()
+		}
+		return cmd
+	}
+	if v.noteForm != nil {
+		if msg.Key().Code == tea.KeyEscape && !v.noteForm.saving {
+			v.noteForm = nil
+			return nil
+		}
+		cmd, submit := v.noteForm.handleKey(msg)
+		if submit {
+			return v.saveNote()
+		}
+		return cmd
+	}
+	if v.inDetail {
+		switch msg.String() {
+		case "e":
+			return v.startEditContact()
+		case "n":
+			return v.startNote()
+		case "h":
+			return v.hideContact()
+		case "x":
+			if v.note != "" {
+				if !v.confirmNoteDelete {
+					v.confirmNoteDelete = true
+					v.notice = "Press x again to permanently delete this note"
+					return nil
+				}
+				v.confirmNoteDelete = false
+				return v.deleteNote()
+			}
+		}
+		var cmd tea.Cmd
+		v.detailView, cmd = v.detailView.Update(msg)
+		return cmd
+	}
+
+	switch msg.Key().Code {
+	case tea.KeyUp:
+		v.list.moveUp()
+	case tea.KeyDown:
+		v.list.moveDown()
+	case tea.KeyEnter:
+		if contact := v.list.selected(); contact != nil {
+			return v.requestContactDetail(contact.ID)
+		}
+	default:
+		switch msg.String() {
+		case "a":
+			return v.startAddContact()
+		case "r":
+			return v.requestContacts(v.page)
+		case "n":
+			return v.requestContacts(v.page + 1)
+		case "p":
+			if v.page > 1 {
+				return v.requestContacts(v.page - 1)
+			}
+			v.notice = "Already on the first contacts page"
+		case "u":
+			if v.lastHiddenID != 0 {
+				return v.revealContact(v.lastHiddenID)
+			}
+		}
+	}
+	return nil
+}
+
+func (v *contactsView) InThread() bool { return v.inDetail }
+
+func (v *contactsView) ExitThread() {
+	v.inDetail = false
+	v.contactForm = nil
+	v.noteForm = nil
+	v.detail = models.Contact{}
+	v.note = ""
+	v.confirmNoteDelete = false
+	v.cancelRequest()
+}
+
+func (v *contactsView) CancelPendingDetail() bool {
+	if v.activeRequestKind != contactRequestDetail {
+		return false
+	}
+	v.cancelRequest()
+	return true
+}
+
+func (v *contactsView) CapturingInput() bool {
+	return v.contactForm != nil || v.noteForm != nil
+}
+
+func (v *contactsView) Resize(width, height int) {
+	v.list.setSize(width, height)
+	v.detailView.SetWidth(width)
+	v.detailView.SetHeight(height)
+	if v.contactForm != nil {
+		v.contactForm.resize(width, height)
+	}
+	if v.noteForm != nil {
+		v.noteForm.resize(width, height)
+	}
+}
+
+func (v *contactsView) Loading() bool { return v.loading }
+
+func (v *contactsView) beginRequest(kind contactRequestKind) (uint64, context.Context) {
+	if v.requestCancel != nil {
+		v.requestCancel()
+	}
+	v.activeRequestID++
+	ctx, cancel := context.WithCancel(v.vc.ctx)
+	v.activeRequestKind = kind
+	v.requestCancel = cancel
+	v.loading = true
+	return v.activeRequestID, ctx
+}
+
+func (v *contactsView) finishRequest(requestID uint64) {
+	if requestID != v.activeRequestID {
+		return
+	}
+	if v.requestCancel != nil {
+		v.requestCancel()
+	}
+	v.activeRequestKind = contactRequestNone
+	v.requestCancel = nil
+	v.loading = false
+}
+
+func (v *contactsView) cancelRequest() {
+	if v.requestCancel != nil {
+		v.requestCancel()
+	}
+	v.activeRequestID++
+	v.activeRequestKind = contactRequestNone
+	v.requestCancel = nil
+	v.loading = false
+}
+
+func (v *contactsView) requestContacts(page int) tea.Cmd {
+	requestID, ctx := v.beginRequest(contactRequestList)
+	return v.fetchContacts(ctx, requestID, max(page, 1))
+}
+
+func (v *contactsView) requestContactDetail(contactID int64) tea.Cmd {
+	requestID, ctx := v.beginRequest(contactRequestDetail)
+	return v.fetchContactDetail(ctx, requestID, contactID)
+}
+
+func (v *contactsView) startAddContact() tea.Cmd {
+	v.contactForm = newContactForm(contactFormAdd, models.Contact{}, v.vc.styles)
+	v.contactForm.resize(v.vc.width, v.vc.height)
+	return v.contactForm.init()
+}
+
+func (v *contactsView) startEditContact() tea.Cmd {
+	v.contactForm = newContactForm(contactFormEdit, v.detail, v.vc.styles)
+	v.contactForm.resize(v.vc.width, v.vc.height)
+	return v.contactForm.init()
+}
+
+func (v *contactsView) startNote() tea.Cmd {
+	v.noteForm = newContactNoteForm(v.detail.ID, v.note, v.vc.styles)
+	v.noteForm.resize(v.vc.width, v.vc.height)
+	return v.noteForm.init()
+}
+
+func (v *contactsView) saveContact() tea.Cmd {
+	form := v.contactForm
+	name, email, aliases := form.values()
+	requestID, ctx := v.beginRequest(contactRequestMutation)
+	return func() tea.Msg {
+		params := hey.ContactParams{Name: name, EmailAddress: email, AliasEmailAddresses: aliases}
+		var contact *generated.Contact
+		var err error
+		created := form.mode == contactFormAdd
+		if created {
+			contact, err = v.vc.sdk.Contacts().Create(ctx, params)
+		} else {
+			contact, err = v.vc.sdk.Contacts().Update(ctx, form.contactID, params)
+		}
+		if err != nil {
+			return contactSavedMsg{requestID: requestID, originalID: form.contactID, created: created, err: err}
+		}
+		if contact == nil {
+			return contactSavedMsg{requestID: requestID, originalID: form.contactID, created: created, err: fmt.Errorf("contact save returned no data")}
+		}
+		return contactSavedMsg{requestID: requestID, originalID: form.contactID, contact: sdkContactToModel(*contact), created: created}
+	}
+}
+
+func (v *contactsView) hideContact() tea.Cmd {
+	contact := v.detail
+	requestID, ctx := v.beginRequest(contactRequestMutation)
+	return func() tea.Msg {
+		err := v.vc.sdk.Contacts().Hide(ctx, contact.ID)
+		return contactHiddenMsg{requestID: requestID, contact: contact, err: err}
+	}
+}
+
+func (v *contactsView) revealContact(contactID int64) tea.Cmd {
+	requestID, ctx := v.beginRequest(contactRequestMutation)
+	return func() tea.Msg {
+		contact, err := v.vc.sdk.Contacts().Reveal(ctx, contactID)
+		if err != nil {
+			return contactRevealedMsg{requestID: requestID, err: err}
+		}
+		if contact == nil {
+			return contactRevealedMsg{requestID: requestID, err: fmt.Errorf("contact reveal returned no data")}
+		}
+		return contactRevealedMsg{requestID: requestID, contact: sdkContactToModel(*contact)}
+	}
+}
+
+func (v *contactsView) saveNote() tea.Cmd {
+	form := v.noteForm
+	content := strings.TrimSpace(form.input.Value())
+	requestID, ctx := v.beginRequest(contactRequestMutation)
+	return func() tea.Msg {
+		note, err := v.vc.sdk.Contacts().SetNote(ctx, form.contactID, content)
+		if err != nil {
+			return contactNoteSavedMsg{requestID: requestID, err: err}
+		}
+		if note == nil {
+			return contactNoteSavedMsg{requestID: requestID, err: fmt.Errorf("contact note save returned no data")}
+		}
+		return contactNoteSavedMsg{requestID: requestID, note: note.Note}
+	}
+}
+
+func (v *contactsView) deleteNote() tea.Cmd {
+	contactID := v.detail.ID
+	requestID, ctx := v.beginRequest(contactRequestMutation)
+	return func() tea.Msg {
+		err := v.vc.sdk.Contacts().DeleteNote(ctx, contactID)
+		return contactNoteSavedMsg{requestID: requestID, deleted: true, err: err}
+	}
+}
+
+func (v *contactsView) updateContactInList(contact models.Contact) {
+	for i := range v.list.contacts {
+		if v.list.contacts[i].ID == contact.ID {
+			v.list.contacts[i] = contact
+			return
+		}
+	}
+	v.list.contacts = append([]models.Contact{contact}, v.list.contacts...)
+}
+
+func (v *contactsView) refreshDetailView() {
+	v.detailView.SetContent(v.renderContactDetail())
+	v.detailView.GotoTop()
+}
+
+func (v *contactsView) renderContactDetail() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n", v.vc.styles.title.Render(v.detail.Name))
+	fmt.Fprintf(&b, "%s\n", v.detail.EmailAddress)
+	if len(v.detail.Aliases) > 0 {
+		aliases := make([]string, 0, len(v.detail.Aliases))
+		for _, alias := range v.detail.Aliases {
+			aliases = append(aliases, alias.EmailAddress)
+		}
+		fmt.Fprintf(&b, "Aliases: %s\n", strings.Join(aliases, ", "))
+	}
+	fmt.Fprintf(&b, "Contact ID: %d\n", v.detail.ID)
+	b.WriteString("\n")
+	b.WriteString(v.vc.styles.entryFrom.Render("Private note"))
+	b.WriteString("\n")
+	if v.note == "" {
+		b.WriteString(v.vc.styles.entryDate.Render("(empty)"))
+	} else {
+		b.WriteString(v.note)
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func (v *contactsView) fetchContacts(ctx context.Context, requestID uint64, page int) tea.Cmd {
+	return func() tea.Msg {
+		pageValue := fmt.Sprintf("%d", page)
+		params := &generated.ListContactsParams{Page: &pageValue}
+		result, err := v.vc.sdk.Contacts().List(ctx, params)
+		if err != nil {
+			return contactsLoadedMsg{requestID: requestID, page: page, err: err}
+		}
+		var sdkContacts []generated.Contact
+		if result != nil {
+			sdkContacts = *result
+		}
+		contacts := make([]models.Contact, 0, len(sdkContacts))
+		for _, contact := range sdkContacts {
+			contacts = append(contacts, sdkContactToModel(contact))
+		}
+		return contactsLoadedMsg{requestID: requestID, page: page, contacts: contacts}
+	}
+}
+
+func (v *contactsView) fetchContactDetail(ctx context.Context, requestID uint64, contactID int64) tea.Cmd {
+	return func() tea.Msg {
+		var detail *generated.ContactDetail
+		var note *generated.ContactNote
+		group, groupCtx := errgroup.WithContext(ctx)
+		group.Go(func() error {
+			var err error
+			detail, err = v.vc.sdk.Contacts().Get(groupCtx, contactID)
+			return err
+		})
+		group.Go(func() error {
+			var err error
+			note, err = v.vc.sdk.Contacts().Note(groupCtx, contactID)
+			return err
+		})
+		if err := group.Wait(); err != nil {
+			return contactDetailLoadedMsg{requestID: requestID, err: err}
+		}
+		if detail == nil {
+			return contactDetailLoadedMsg{requestID: requestID, err: fmt.Errorf("contact %d returned no data", contactID)}
+		}
+		content := ""
+		if note != nil {
+			content = note.Note
+		}
+		return contactDetailLoadedMsg{requestID: requestID, contact: sdkContactDetailToModel(*detail), note: content}
+	}
+}
+
+func contactSaveFailure(err error) string {
+	var conflict *hey.ContactConflictError
+	if errors.As(err, &conflict) {
+		message := fmt.Sprintf("Contact %d was saved but conflicts with existing contact IDs", conflict.ContactID)
+		for _, id := range conflict.ConflictingContactIDs {
+			message += fmt.Sprintf(" %d", id)
+		}
+		return message
+	}
+	return "Save failed: " + err.Error()
+}
+
+func sdkContactToModel(contact generated.Contact) models.Contact {
+	return models.Contact{
+		ID:           contact.Id,
+		AccountID:    contact.AccountId,
+		Name:         contact.Name,
+		EmailAddress: contact.EmailAddress,
+		Avatar:       contact.AvatarUrl,
+		UpdatedAt:    formatTimestamp(contact.UpdatedAt),
+	}
+}
+
+func sdkContactDetailToModel(contact generated.ContactDetail) models.Contact {
+	result := models.Contact{
+		ID:           contact.Id,
+		AccountID:    contact.AccountId,
+		Name:         contact.Name,
+		EmailAddress: contact.EmailAddress,
+		Avatar:       contact.AvatarUrl,
+		UpdatedAt:    formatTimestamp(contact.UpdatedAt),
+		Aliases:      make([]models.Contact, 0, len(contact.Aliases)),
+	}
+	for _, alias := range contact.Aliases {
+		result.Aliases = append(result.Aliases, sdkContactToModel(alias))
+	}
+	return result
+}

--- a/internal/tui/contacts.go
+++ b/internal/tui/contacts.go
@@ -69,19 +69,21 @@ type contactNoteSavedMsg struct {
 type contactsView struct {
 	vc *viewContext
 
-	list              contactList
-	loaded            bool
-	page              int
-	detail            models.Contact
-	note              string
-	inDetail          bool
-	detailView        viewport.Model
-	contactForm       *contactForm
-	noteForm          *contactNoteForm
-	lastHiddenID      int64
-	confirmNoteDelete bool
-	notice            string
-	loading           bool
+	list                contactList
+	loaded              bool
+	page                int
+	detail              models.Contact
+	note                string
+	inDetail            bool
+	detailView          viewport.Model
+	contactForm         *contactForm
+	noteForm            *contactNoteForm
+	lastHiddenID        int64
+	pendingSavedContact bool
+	pendingOriginalID   int64
+	confirmNoteDelete   bool
+	notice              string
+	loading             bool
 
 	activeRequestID   uint64
 	activeRequestKind contactRequestKind
@@ -128,7 +130,17 @@ func (v *contactsView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		}
 		v.finishRequest(msg.requestID)
 		if msg.err != nil {
+			v.pendingSavedContact = false
+			v.pendingOriginalID = 0
 			return func() tea.Msg { return errMsg{msg.err} }, true
+		}
+		if v.pendingSavedContact {
+			if v.pendingOriginalID != 0 && v.pendingOriginalID != msg.contact.ID {
+				v.list.remove(v.pendingOriginalID)
+			}
+			v.updateContactInList(msg.contact)
+			v.pendingSavedContact = false
+			v.pendingOriginalID = 0
 		}
 		v.detail = msg.contact
 		v.note = msg.note
@@ -146,6 +158,8 @@ func (v *contactsView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			if errors.As(msg.err, &conflict) && conflict.ContactID != 0 {
 				v.contactForm = nil
 				v.notice = contactSaveFailure(msg.err)
+				v.pendingSavedContact = true
+				v.pendingOriginalID = msg.originalID
 				return v.requestContactDetail(conflict.ContactID), true
 			}
 			if v.contactForm != nil {
@@ -381,6 +395,8 @@ func (v *contactsView) ExitDetail(_ string) {
 
 func (v *contactsView) ExitThread() {
 	v.inDetail = false
+	v.pendingSavedContact = false
+	v.pendingOriginalID = 0
 	v.contactForm = nil
 	v.noteForm = nil
 	v.detail = models.Contact{}
@@ -393,6 +409,8 @@ func (v *contactsView) CancelPendingDetail() bool {
 	if v.activeRequestKind != contactRequestDetail {
 		return false
 	}
+	v.pendingSavedContact = false
+	v.pendingOriginalID = 0
 	v.cancelRequest()
 	return true
 }

--- a/internal/tui/contacts_list.go
+++ b/internal/tui/contacts_list.go
@@ -1,0 +1,109 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/basecamp/hey-cli/internal/models"
+)
+
+type contactList struct {
+	contacts  []models.Contact
+	cursor    int
+	scrollOff int
+	width     int
+	height    int
+}
+
+func (l *contactList) setContacts(contacts []models.Contact) {
+	l.contacts = contacts
+	l.cursor = 0
+	l.scrollOff = 0
+}
+
+func (l *contactList) setSize(width, height int) {
+	l.width = width
+	l.height = height
+}
+
+func (l *contactList) moveUp() {
+	if l.cursor > 0 {
+		l.cursor--
+		l.ensureVisible()
+	}
+}
+
+func (l *contactList) moveDown() {
+	if l.cursor < len(l.contacts)-1 {
+		l.cursor++
+		l.ensureVisible()
+	}
+}
+
+func (l *contactList) ensureVisible() {
+	visible := max(l.height/2, 1)
+	if l.cursor < l.scrollOff {
+		l.scrollOff = l.cursor
+	}
+	if l.cursor >= l.scrollOff+visible {
+		l.scrollOff = l.cursor - visible + 1
+	}
+}
+
+func (l *contactList) selected() *models.Contact {
+	if l.cursor < 0 || l.cursor >= len(l.contacts) {
+		return nil
+	}
+	return &l.contacts[l.cursor]
+}
+
+func (l *contactList) remove(id int64) {
+	for i := range l.contacts {
+		if l.contacts[i].ID != id {
+			continue
+		}
+		l.contacts = append(l.contacts[:i], l.contacts[i+1:]...)
+		if l.cursor > i {
+			l.cursor--
+		}
+		if l.cursor >= len(l.contacts) && l.cursor > 0 {
+			l.cursor--
+		}
+		l.ensureVisible()
+		return
+	}
+}
+
+func (l *contactList) view() string {
+	if len(l.contacts) == 0 {
+		return lipgloss.NewStyle().Foreground(colorMuted).Render("  (no contacts)")
+	}
+	visible := max(l.height/2, 1)
+	end := min(l.scrollOff+visible, len(l.contacts))
+	selected := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
+	normal := lipgloss.NewStyle().Foreground(colorBright)
+	muted := lipgloss.NewStyle().Foreground(colorMuted)
+
+	var b strings.Builder
+	for i := l.scrollOff; i < end; i++ {
+		contact := l.contacts[i]
+		cursor := i == l.cursor
+		prefix := "  "
+		if cursor {
+			prefix = selected.Render("│") + " "
+		}
+		name := truncateStr(contact.Name, max(l.width-4, 10))
+		email := truncateStr(contact.EmailAddress, max(l.width-18, 10))
+		line2 := fmt.Sprintf("#%d  %s", contact.ID, email)
+		if cursor {
+			fmt.Fprintf(&b, "%s%s\n", prefix, selected.Render(name))
+			fmt.Fprintf(&b, "%s  %s\n", selected.Render("│"), selected.Render(line2))
+		} else {
+			fmt.Fprintf(&b, "%s%s\n", prefix, normal.Render(name))
+			fmt.Fprintf(&b, "    %s\n", muted.Render(line2))
+		}
+	}
+	return b.String()
+}

--- a/internal/tui/contacts_test.go
+++ b/internal/tui/contacts_test.go
@@ -220,6 +220,9 @@ func TestContactsViewCreateConflictLoadsWrittenContact(t *testing.T) {
 	if !view.inDetail || view.detail.ID != 9 {
 		t.Errorf("written conflict contact was not loaded: %+v", view.detail)
 	}
+	if len(view.list.contacts) != 2 || view.list.contacts[0].ID != 9 {
+		t.Errorf("written conflict contact was not added to the list: %+v", view.list.contacts)
+	}
 }
 
 func TestContactsViewEditsContact(t *testing.T) {

--- a/internal/tui/contacts_test.go
+++ b/internal/tui/contacts_test.go
@@ -1,0 +1,405 @@
+package tui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/models"
+)
+
+type recordedTUIContacts struct {
+	mu       sync.Mutex
+	requests []string
+	bodies   [][]byte
+}
+
+func (r *recordedTUIContacts) snapshot() ([]string, [][]byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.requests...), append([][]byte(nil), r.bodies...)
+}
+
+func contactsWithTestServer(t *testing.T) (*contactsView, *recordedTUIContacts) {
+	t.Helper()
+	recorded := &recordedTUIContacts{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var raw json.RawMessage
+		if req.Body != nil {
+			_ = json.NewDecoder(req.Body).Decode(&raw)
+		}
+		recorded.mu.Lock()
+		recorded.requests = append(recorded.requests, req.Method+" "+req.URL.RequestURI())
+		recorded.bodies = append(recorded.bodies, append([]byte(nil), raw...))
+		recorded.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/contacts.json":
+			if req.URL.Query().Get("page") == "2" {
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			_, _ = w.Write([]byte(`[{"id":7,"name":"Jane Doe","email_address":"jane@example.com"}]`))
+		case req.Method == http.MethodPost && req.URL.Path == "/contacts.json":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":8,"name":"Sam Rivera","email_address":"sam@example.org"}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/contacts/7.json":
+			_, _ = w.Write([]byte(`{"id":7,"name":"Jane Doe","email_address":"jane@example.com","aliases":[{"id":17,"name":"Jane Doe","email_address":"jane.doe@example.org"}]}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/contacts/8.json":
+			_, _ = w.Write([]byte(`{"id":8,"name":"Sam Rivera","email_address":"sam@example.org","aliases":[]}`))
+		case req.Method == http.MethodPatch && req.URL.Path == "/contacts/7.json":
+			_, _ = w.Write([]byte(`{"id":7,"name":"Jane Dawson","email_address":"jane@example.com"}`))
+		case req.Method == http.MethodDelete && req.URL.Path == "/contacts/7.json":
+			w.WriteHeader(http.StatusNoContent)
+		case req.Method == http.MethodPost && req.URL.Path == "/contacts/7/reveal.json":
+			_, _ = w.Write([]byte(`{"id":7,"name":"Jane Doe","email_address":"jane@example.com"}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/contacts/7/note.json":
+			_, _ = w.Write([]byte(`{"contact_id":7,"note":"Prefers email","note_html":"<p>Prefers email</p>"}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/contacts/8/note.json":
+			_, _ = w.Write([]byte(`{"contact_id":8,"note":"","note_html":""}`))
+		case req.Method == http.MethodPatch && req.URL.Path == "/contacts/7/note.json":
+			_, _ = w.Write([]byte(`{"contact_id":7,"note":"Prefers a call","note_html":"<p>Prefers a call</p>"}`))
+		case req.Method == http.MethodDelete && req.URL.Path == "/contacts/7/note.json":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "test-token"}, hey.WithMaxRetries(0))
+	vc := testVC()
+	vc.sdk = client
+	view := newContactsView(vc)
+	view.Resize(vc.width, vc.height)
+	return view, recorded
+}
+
+func loadTUIContacts(t *testing.T, view *contactsView) {
+	t.Helper()
+	cmd := view.Init()
+	if cmd == nil {
+		t.Fatal("contacts init returned no command")
+	}
+	msg := cmd()
+	if _, ok := msg.(contactsLoadedMsg); !ok {
+		t.Fatalf("contacts init returned %T", msg)
+	}
+	view.Update(msg)
+}
+
+func openTUIContact(t *testing.T, view *contactsView) {
+	t.Helper()
+	cmd := view.HandleContentKey(keyPress("enter"))
+	if cmd == nil {
+		t.Fatal("opening selected contact returned no command")
+	}
+	view.Update(cmd())
+}
+
+func TestContactsViewLoadsListsAndPages(t *testing.T) {
+	view, recorded := contactsWithTestServer(t)
+	loadTUIContacts(t, view)
+	if view.loading || !view.loaded || len(view.list.contacts) != 1 || view.list.contacts[0].ID != 7 {
+		t.Errorf("list state = loading:%v loaded:%v contacts:%+v", view.loading, view.loaded, view.list.contacts)
+	}
+
+	next := view.HandleContentKey(keyPress("n"))
+	if next == nil {
+		t.Fatal("next page returned no command")
+	}
+	view.Update(next())
+	if view.page != 1 || len(view.list.contacts) != 1 || view.notice != "No more contacts" {
+		t.Errorf("empty next page changed results: page=%d contacts=%+v notice=%q", view.page, view.list.contacts, view.notice)
+	}
+	requests, _ := recorded.snapshot()
+	if !strings.Contains(strings.Join(requests, "\n"), "page=2") {
+		t.Errorf("requests = %v", requests)
+	}
+}
+
+func TestContactsViewOpensDetailWithAliasesAndNote(t *testing.T) {
+	view, _ := contactsWithTestServer(t)
+	loadTUIContacts(t, view)
+	openTUIContact(t, view)
+	if !view.inDetail || view.detail.ID != 7 || len(view.detail.Aliases) != 1 || view.note != "Prefers email" {
+		t.Errorf("detail = open:%v contact:%+v note:%q", view.inDetail, view.detail, view.note)
+	}
+	rendered := view.View()
+	for _, want := range []string{"Jane Doe", "jane@example.com", "jane.doe@example.org", "Prefers email"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("detail omitted %q: %q", want, rendered)
+		}
+	}
+}
+
+func TestContactsViewIgnoresStaleResponses(t *testing.T) {
+	view, _ := contactsWithTestServer(t)
+	view.activeRequestID = 2
+	view.Update(contactsLoadedMsg{requestID: 1, page: 1, contacts: []models.Contact{{ID: 99}}})
+	if len(view.list.contacts) != 0 {
+		t.Error("stale contacts changed the list")
+	}
+	view.Update(contactDetailLoadedMsg{requestID: 1, contact: models.Contact{ID: 99}})
+	if view.inDetail {
+		t.Error("stale detail opened")
+	}
+}
+
+func TestContactsViewAddsContact(t *testing.T) {
+	view, recorded := contactsWithTestServer(t)
+	loadTUIContacts(t, view)
+	if cmd := view.HandleContentKey(keyPress("a")); cmd == nil || view.contactForm == nil || !view.CapturingInput() {
+		t.Fatal("a should open and focus the contact form")
+	}
+	view.contactForm.inputs[contactFieldName].SetValue("Sam Rivera")
+	view.contactForm.inputs[contactFieldEmail].SetValue("sam@example.org")
+	view.contactForm.inputs[contactFieldAliases].SetValue("sam.rivera@example.com")
+
+	save := view.HandleContentKey(keyPress("ctrl+s"))
+	if save == nil {
+		t.Fatal("ctrl+s should save the contact")
+	}
+	detail, _ := view.Update(save())
+	if detail == nil {
+		t.Fatal("successful create should load contact detail")
+	}
+	view.Update(detail())
+	if view.contactForm != nil || !view.inDetail || view.detail.ID != 8 {
+		t.Errorf("create state = form:%v detail:%+v", view.contactForm, view.detail)
+	}
+	requests, bodies := recorded.snapshot()
+	var found bool
+	for i, request := range requests {
+		if request == "POST /contacts.json" {
+			found = true
+			if !strings.Contains(string(bodies[i]), "sam.rivera@example.com") {
+				t.Errorf("create body = %s", bodies[i])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("requests = %v", requests)
+	}
+}
+
+func TestContactsViewEditsContact(t *testing.T) {
+	view, recorded := contactsWithTestServer(t)
+	loadTUIContacts(t, view)
+	openTUIContact(t, view)
+	view.HandleContentKey(keyPress("e"))
+	if view.contactForm == nil || view.contactForm.inputs[contactFieldAliases].Value() != "jane.doe@example.org" {
+		t.Fatal("edit form should include current aliases")
+	}
+	view.contactForm.inputs[contactFieldName].SetValue("Jane Dawson")
+	save := view.HandleContentKey(keyPress("ctrl+s"))
+	detail, _ := view.Update(save())
+	if detail == nil {
+		t.Fatal("successful update should reload contact detail")
+	}
+	view.Update(detail())
+	if view.detail.Name != "Jane Doe" {
+		// The detail fixture is intentionally stable; the PATCH response itself verifies the edit.
+		t.Errorf("detail fixture = %+v", view.detail)
+	}
+	requests, bodies := recorded.snapshot()
+	var patchBody string
+	for i, request := range requests {
+		if request == "PATCH /contacts/7.json" {
+			patchBody = string(bodies[i])
+		}
+	}
+	if !strings.Contains(patchBody, "Jane Dawson") || !strings.Contains(patchBody, "jane.doe@example.org") {
+		t.Errorf("patch body = %s", patchBody)
+	}
+}
+
+func TestContactsViewReplacesPromotedAliasContactID(t *testing.T) {
+	view, _ := contactsWithTestServer(t)
+	view.list.setContacts([]models.Contact{{ID: 7, Name: "Jane Doe"}})
+	view.activeRequestID = 3
+	view.loading = true
+
+	cmd, _ := view.Update(contactSavedMsg{
+		requestID:  3,
+		originalID: 7,
+		contact:    models.Contact{ID: 17, Name: "Jane Doe"},
+	})
+	if cmd == nil {
+		t.Fatal("saved contact should load returned contact detail")
+	}
+	if len(view.list.contacts) != 1 || view.list.contacts[0].ID != 17 {
+		t.Errorf("promoted alias left stale contact in list: %+v", view.list.contacts)
+	}
+}
+
+func TestContactsViewValidatesFormBeforeSaving(t *testing.T) {
+	view, recorded := contactsWithTestServer(t)
+	loadTUIContacts(t, view)
+	view.HandleContentKey(keyPress("a"))
+	if cmd := view.HandleContentKey(keyPress("ctrl+s")); cmd != nil {
+		t.Fatal("invalid form should not save")
+	}
+	if view.contactForm == nil || view.contactForm.status != "Name is required" {
+		t.Errorf("form status = %q", view.contactForm.status)
+	}
+	requests, _ := recorded.snapshot()
+	if len(requests) != 1 {
+		t.Errorf("validation made requests: %v", requests)
+	}
+}
+
+func TestContactsViewHidesAndShowsAgain(t *testing.T) {
+	view, recorded := contactsWithTestServer(t)
+	loadTUIContacts(t, view)
+	openTUIContact(t, view)
+	hide := view.HandleContentKey(keyPress("h"))
+	view.Update(hide())
+	if view.inDetail || len(view.list.contacts) != 0 || view.lastHiddenID != 7 || view.notice != "Contact hidden" {
+		t.Errorf("hide state = detail:%v contacts:%+v hidden:%d notice:%q", view.inDetail, view.list.contacts, view.lastHiddenID, view.notice)
+	}
+	reveal := view.HandleContentKey(keyPress("u"))
+	refresh, _ := view.Update(reveal())
+	if refresh == nil {
+		t.Fatal("successful reveal should refresh contacts")
+	}
+	view.Update(refresh())
+	if view.lastHiddenID != 0 || len(view.list.contacts) != 1 || view.notice != "Contact shown again" {
+		t.Errorf("reveal state = contacts:%+v hidden:%d notice:%q", view.list.contacts, view.lastHiddenID, view.notice)
+	}
+	requests, _ := recorded.snapshot()
+	joined := strings.Join(requests, "\n")
+	if !strings.Contains(joined, "DELETE /contacts/7.json") || !strings.Contains(joined, "POST /contacts/7/reveal.json") {
+		t.Errorf("requests = %v", requests)
+	}
+}
+
+func TestContactsViewEditsAndDeletesNote(t *testing.T) {
+	view, recorded := contactsWithTestServer(t)
+	loadTUIContacts(t, view)
+	openTUIContact(t, view)
+	view.HandleContentKey(keyPress("n"))
+	if view.noteForm == nil || view.noteForm.input.Value() != "Prefers email" {
+		t.Fatal("note form should contain existing note")
+	}
+	view.noteForm.input.SetValue("Prefers a call")
+	save := view.HandleContentKey(keyPress("ctrl+s"))
+	view.Update(save())
+	if view.noteForm != nil || view.note != "Prefers a call" || view.notice != "Private note saved" {
+		t.Errorf("note save state = form:%v note:%q notice:%q", view.noteForm, view.note, view.notice)
+	}
+	if deleteCmd := view.HandleContentKey(keyPress("x")); deleteCmd != nil || !view.confirmNoteDelete || !strings.Contains(view.notice, "permanently delete") {
+		t.Fatal("first x should request note deletion confirmation")
+	}
+	deleteCmd := view.HandleContentKey(keyPress("x"))
+	if deleteCmd == nil {
+		t.Fatal("second x should delete the note")
+	}
+	view.Update(deleteCmd())
+	if view.note != "" || view.notice != "Private note deleted" {
+		t.Errorf("note delete state = note:%q notice:%q", view.note, view.notice)
+	}
+	requests, _ := recorded.snapshot()
+	joined := strings.Join(requests, "\n")
+	if !strings.Contains(joined, "PATCH /contacts/7/note.json") || !strings.Contains(joined, "DELETE /contacts/7/note.json") {
+		t.Errorf("requests = %v", requests)
+	}
+}
+
+func TestContactsViewCancelsPendingDetail(t *testing.T) {
+	view, _ := contactsWithTestServer(t)
+	loadTUIContacts(t, view)
+	cmd := view.HandleContentKey(keyPress("enter"))
+	if cmd == nil || !view.loading || view.activeRequestKind != contactRequestDetail {
+		t.Fatal("opening should start detail request")
+	}
+	if !view.CancelPendingDetail() || view.loading || view.activeRequestKind != contactRequestNone {
+		t.Error("pending detail was not canceled")
+	}
+	view.Update(cmd())
+	if view.inDetail {
+		t.Error("canceled detail response opened the contact")
+	}
+}
+
+func TestContactsListNavigationAndRendering(t *testing.T) {
+	list := contactList{}
+	list.setSize(80, 10)
+	list.setContacts([]models.Contact{
+		{ID: 1, Name: "Jane Doe", EmailAddress: "jane@example.com"},
+		{ID: 2, Name: "Sam Rivera", EmailAddress: "sam@example.org"},
+	})
+	list.moveDown()
+	if selected := list.selected(); selected == nil || selected.ID != 2 {
+		t.Errorf("selected = %+v", selected)
+	}
+	view := list.view()
+	for _, want := range []string{"Jane Doe", "jane@example.com", "Sam Rivera", "#2"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("list omitted %q: %q", want, view)
+		}
+	}
+	list.remove(2)
+	if len(list.contacts) != 1 || list.cursor != 0 {
+		t.Errorf("remove state = contacts:%+v cursor:%d", list.contacts, list.cursor)
+	}
+}
+
+func TestContactsViewHelpBindings(t *testing.T) {
+	view, _ := contactsWithTestServer(t)
+	view.loaded = true
+	view.list.setContacts([]models.Contact{{ID: 7}})
+	keys := map[string]bool{}
+	for _, binding := range view.HelpBindings() {
+		keys[binding.key] = true
+	}
+	for _, want := range []string{"a", "r", "n/p"} {
+		if !keys[want] {
+			t.Errorf("list help missing %q: %v", want, view.HelpBindings())
+		}
+	}
+	view.inDetail = true
+	view.note = "Private"
+	view.confirmNoteDelete = true
+	keys = map[string]bool{}
+	for _, binding := range view.HelpBindings() {
+		keys[binding.key] = true
+	}
+	for _, want := range []string{"e", "n", "h", "x"} {
+		if !keys[want] {
+			t.Errorf("detail help missing %q: %v", want, view.HelpBindings())
+		}
+	}
+	for _, binding := range view.HelpBindings() {
+		if binding.key == "x" && binding.desc != "confirm delete" {
+			t.Errorf("delete confirmation help = %v", view.HelpBindings())
+		}
+	}
+}
+
+func TestContactsViewConverterPreservesAliases(t *testing.T) {
+	contact := sdkContactDetailToModel(generatedContactDetailFixture())
+	if contact.ID != 7 || len(contact.Aliases) != 1 || contact.Aliases[0].EmailAddress != "jane.doe@example.org" {
+		t.Errorf("contact = %+v", contact)
+	}
+}
+
+func generatedContactDetailFixture() generated.ContactDetail {
+	return generated.ContactDetail{
+		Id:           7,
+		Name:         "Jane Doe",
+		EmailAddress: "jane@example.com",
+		Aliases: []generated.Contact{{
+			Id:           17,
+			Name:         "Jane Doe",
+			EmailAddress: "jane.doe@example.org",
+		}},
+	}
+}

--- a/internal/tui/contacts_test.go
+++ b/internal/tui/contacts_test.go
@@ -18,6 +18,7 @@ type recordedTUIContacts struct {
 	mu       sync.Mutex
 	requests []string
 	bodies   [][]byte
+	conflict bool
 }
 
 func (r *recordedTUIContacts) snapshot() ([]string, [][]byte) {
@@ -37,6 +38,7 @@ func contactsWithTestServer(t *testing.T) (*contactsView, *recordedTUIContacts) 
 		recorded.mu.Lock()
 		recorded.requests = append(recorded.requests, req.Method+" "+req.URL.RequestURI())
 		recorded.bodies = append(recorded.bodies, append([]byte(nil), raw...))
+		conflict := recorded.conflict
 		recorded.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
@@ -48,12 +50,19 @@ func contactsWithTestServer(t *testing.T) (*contactsView, *recordedTUIContacts) 
 			}
 			_, _ = w.Write([]byte(`[{"id":7,"name":"Jane Doe","email_address":"jane@example.com"}]`))
 		case req.Method == http.MethodPost && req.URL.Path == "/contacts.json":
+			if conflict {
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"errors":["Some email addresses are already in use for other contacts"],"contact_id":9,"conflicting_contact_ids":[4,5]}`))
+				return
+			}
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"id":8,"name":"Sam Rivera","email_address":"sam@example.org"}`))
 		case req.Method == http.MethodGet && req.URL.Path == "/contacts/7.json":
 			_, _ = w.Write([]byte(`{"id":7,"name":"Jane Doe","email_address":"jane@example.com","aliases":[{"id":17,"name":"Jane Doe","email_address":"jane.doe@example.org"}]}`))
 		case req.Method == http.MethodGet && req.URL.Path == "/contacts/8.json":
 			_, _ = w.Write([]byte(`{"id":8,"name":"Sam Rivera","email_address":"sam@example.org","aliases":[]}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/contacts/9.json":
+			_, _ = w.Write([]byte(`{"id":9,"name":"Sam Rivera","email_address":"sam@example.org","aliases":[]}`))
 		case req.Method == http.MethodPatch && req.URL.Path == "/contacts/7.json":
 			_, _ = w.Write([]byte(`{"id":7,"name":"Jane Dawson","email_address":"jane@example.com"}`))
 		case req.Method == http.MethodDelete && req.URL.Path == "/contacts/7.json":
@@ -64,6 +73,8 @@ func contactsWithTestServer(t *testing.T) (*contactsView, *recordedTUIContacts) 
 			_, _ = w.Write([]byte(`{"contact_id":7,"note":"Prefers email","note_html":"<p>Prefers email</p>"}`))
 		case req.Method == http.MethodGet && req.URL.Path == "/contacts/8/note.json":
 			_, _ = w.Write([]byte(`{"contact_id":8,"note":"","note_html":""}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/contacts/9/note.json":
+			_, _ = w.Write([]byte(`{"contact_id":9,"note":"","note_html":""}`))
 		case req.Method == http.MethodPatch && req.URL.Path == "/contacts/7/note.json":
 			_, _ = w.Write([]byte(`{"contact_id":7,"note":"Prefers a call","note_html":"<p>Prefers a call</p>"}`))
 		case req.Method == http.MethodDelete && req.URL.Path == "/contacts/7/note.json":
@@ -190,6 +201,27 @@ func TestContactsViewAddsContact(t *testing.T) {
 	}
 }
 
+func TestContactsViewCreateConflictLoadsWrittenContact(t *testing.T) {
+	view, recorded := contactsWithTestServer(t)
+	loadTUIContacts(t, view)
+	view.HandleContentKey(keyPress("a"))
+	view.contactForm.inputs[contactFieldName].SetValue("Sam Rivera")
+	view.contactForm.inputs[contactFieldEmail].SetValue("sam@example.org")
+	recorded.mu.Lock()
+	recorded.conflict = true
+	recorded.mu.Unlock()
+
+	save := view.HandleContentKey(keyPress("ctrl+s"))
+	detail, _ := view.Update(save())
+	if detail == nil || view.contactForm != nil || !strings.Contains(view.notice, "Contact 9 was saved") {
+		t.Fatalf("conflict state = detail:%v form:%v notice:%q", detail != nil, view.contactForm, view.notice)
+	}
+	view.Update(detail())
+	if !view.inDetail || view.detail.ID != 9 {
+		t.Errorf("written conflict contact was not loaded: %+v", view.detail)
+	}
+}
+
 func TestContactsViewEditsContact(t *testing.T) {
 	view, recorded := contactsWithTestServer(t)
 	loadTUIContacts(t, view)
@@ -237,6 +269,20 @@ func TestContactsViewReplacesPromotedAliasContactID(t *testing.T) {
 	}
 	if len(view.list.contacts) != 1 || view.list.contacts[0].ID != 17 {
 		t.Errorf("promoted alias left stale contact in list: %+v", view.list.contacts)
+	}
+}
+
+func TestContactFormBlankAliasesCreatesExplicitEmptyReplacement(t *testing.T) {
+	form := newContactForm(contactFormEdit, models.Contact{
+		ID:           7,
+		Name:         "Jane Doe",
+		EmailAddress: "jane@example.com",
+		Aliases:      []models.Contact{{EmailAddress: "jane.doe@example.org"}},
+	}, newStyles())
+	form.inputs[contactFieldAliases].SetValue("")
+	_, _, aliases := form.values()
+	if aliases == nil || len(aliases) != 0 {
+		t.Errorf("aliases = %#v, want non-nil empty replacement", aliases)
 	}
 }
 
@@ -310,6 +356,17 @@ func TestContactsViewEditsAndDeletesNote(t *testing.T) {
 	joined := strings.Join(requests, "\n")
 	if !strings.Contains(joined, "PATCH /contacts/7/note.json") || !strings.Contains(joined, "DELETE /contacts/7/note.json") {
 		t.Errorf("requests = %v", requests)
+	}
+}
+
+func TestContactsViewCannotExitDuringMutation(t *testing.T) {
+	view, _ := contactsWithTestServer(t)
+	view.inDetail = true
+	view.loading = true
+	view.activeRequestKind = contactRequestMutation
+	view.ExitDetail("q")
+	if !view.inDetail || !view.loading || view.activeRequestKind != contactRequestMutation {
+		t.Error("detail exited while a contact mutation was pending")
 	}
 }
 

--- a/internal/tui/nav.go
+++ b/internal/tui/nav.go
@@ -13,6 +13,7 @@ type section int
 
 const (
 	sectionMail section = iota
+	sectionContacts
 	sectionCalendar
 	sectionJournal
 )
@@ -21,7 +22,7 @@ const (
 type focusRow int
 
 const (
-	rowSection focusRow = iota // row 1: Mail / Calendar / Journal
+	rowSection focusRow = iota // row 1: Mail / Contacts / Calendar / Journal
 	rowSubnav                  // row 2: boxes / calendars / dates
 	rowContent                 // content area
 )
@@ -36,6 +37,7 @@ type navItem struct {
 
 var sectionItems = []navItem{
 	{"🄼", "Mail"},
+	{"🄾", "Contacts"},
 	{"🄲", "Calendar"},
 	{"🄹", "Journal"},
 }
@@ -45,6 +47,8 @@ func sectionForShortcut(key string) section {
 	switch key {
 	case "M":
 		return sectionMail
+	case "O":
+		return sectionContacts
 	case "C":
 		return sectionCalendar
 	case "J":

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -38,6 +38,7 @@ type model struct {
 
 	// Section views (kept alive for state preservation)
 	mailView     *mailView
+	contactsView *contactsView
 	calendarView *calendarView
 	journalView  *journalView
 
@@ -54,6 +55,7 @@ func newModel(sdk *hey.Client) model {
 	vc := &viewContext{sdk: sdk, ctx: ctx, styles: s}
 
 	mv := newMailView(vc)
+	ov := newContactsView(vc)
 	cv := newCalendarView(vc)
 	jv := newJournalView(vc)
 
@@ -66,6 +68,7 @@ func newModel(sdk *hey.Client) model {
 		focus:        rowContent,
 		activeView:   mv,
 		mailView:     mv,
+		contactsView: ov,
 		calendarView: cv,
 		journalView:  jv,
 		loading:      true,
@@ -115,13 +118,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleKey(msg)
 	}
 
-	// Delegate to active section view
+	// Delegate to the active section first. Responses owned by an inactive
+	// section still update that section so switching views cannot drop a request.
 	cmd, consumed := m.activeView.Update(msg)
 	if consumed {
 		cmd = m.syncLoading(cmd)
 		m.updateHelpBindings()
+		return m, cmd
 	}
-	return m, cmd
+	for _, view := range []sectionView{m.mailView, m.contactsView, m.calendarView, m.journalView} {
+		if view == m.activeView {
+			continue
+		}
+		if cmd, consumed = view.Update(msg); consumed {
+			return m, cmd
+		}
+	}
+	return m, nil
 }
 
 // syncLoading synchronizes the main loading state with the active section view.
@@ -206,7 +219,7 @@ func (m *model) updateHelpBindings() {
 			bindings = []helpBinding{
 				{"←→", "section"},
 				{"tab", "next row"},
-				{"shift+M/C/J", "jump"},
+				{"shift+M/O/C/J", "jump"},
 				quitHint,
 			}
 		case rowSubnav:
@@ -322,6 +335,8 @@ func (m model) switchSection(sec section) (tea.Model, tea.Cmd) {
 	switch sec {
 	case sectionMail:
 		m.activeView = m.mailView
+	case sectionContacts:
+		m.activeView = m.contactsView
 	case sectionCalendar:
 		m.activeView = m.calendarView
 	case sectionJournal:

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -118,23 +118,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleKey(msg)
 	}
 
-	// Delegate to the active section first. Responses owned by an inactive
-	// section still update that section so switching views cannot drop a request.
+	// Delegate to the active section view.
 	cmd, consumed := m.activeView.Update(msg)
 	if consumed {
 		cmd = m.syncLoading(cmd)
 		m.updateHelpBindings()
-		return m, cmd
 	}
-	for _, view := range []sectionView{m.mailView, m.contactsView, m.calendarView, m.journalView} {
-		if view == m.activeView {
-			continue
-		}
-		if cmd, consumed = view.Update(msg); consumed {
-			return m, cmd
-		}
-	}
-	return m, nil
+	return m, cmd
 }
 
 // syncLoading synchronizes the main loading state with the active section view.
@@ -287,6 +277,10 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.updateHelpBindings()
 			return m, m.syncLoading(nil)
 		}
+		return m, nil
+	}
+
+	if m.loading {
 		return m, nil
 	}
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -199,22 +199,18 @@ func TestSingleCtrlCDoesNotQuit(t *testing.T) {
 	}
 }
 
-func TestInactiveSectionReceivesItsResponse(t *testing.T) {
+func TestLoadingViewKeepsItsSectionUntilResponse(t *testing.T) {
 	m := modelWithBoxes()
-	m.contactsView.loading = true
-	m.contactsView.activeRequestID = 4
+	m.loading = true
+	m.mailView.loading = true
 
-	updated, _ := m.Update(contactsLoadedMsg{
-		requestID: 4,
-		page:      1,
-		contacts:  []models.Contact{{ID: 7, Name: "Jane Doe"}},
-	})
+	updated, cmd := m.Update(keyPress("O"))
 	result := updated.(model)
 	if result.activeView != result.mailView || result.section != sectionMail {
-		t.Error("inactive response changed the active section")
+		t.Error("section changed while the active view was loading")
 	}
-	if result.contactsView.loading || !result.contactsView.loaded || len(result.contactsView.list.contacts) != 1 {
-		t.Errorf("inactive Contacts response was dropped: %+v", result.contactsView.list.contacts)
+	if cmd != nil {
+		t.Error("section shortcut should not start another request while loading")
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -199,6 +199,47 @@ func TestSingleCtrlCDoesNotQuit(t *testing.T) {
 	}
 }
 
+func TestInactiveSectionReceivesItsResponse(t *testing.T) {
+	m := modelWithBoxes()
+	m.contactsView.loading = true
+	m.contactsView.activeRequestID = 4
+
+	updated, _ := m.Update(contactsLoadedMsg{
+		requestID: 4,
+		page:      1,
+		contacts:  []models.Contact{{ID: 7, Name: "Jane Doe"}},
+	})
+	result := updated.(model)
+	if result.activeView != result.mailView || result.section != sectionMail {
+		t.Error("inactive response changed the active section")
+	}
+	if result.contactsView.loading || !result.contactsView.loaded || len(result.contactsView.list.contacts) != 1 {
+		t.Errorf("inactive Contacts response was dropped: %+v", result.contactsView.list.contacts)
+	}
+}
+
+func TestContactsSectionShortcut(t *testing.T) {
+	m := modelWithBoxes()
+	updated, cmd := m.Update(keyPress("O"))
+	result := updated.(model)
+	if result.section != sectionContacts || result.activeView != result.contactsView {
+		t.Errorf("O shortcut selected section %d and view %T", result.section, result.activeView)
+	}
+	if cmd == nil || !result.loading {
+		t.Error("opening Contacts should start its initial list request")
+	}
+}
+
+func TestSectionNavigationIncludesContacts(t *testing.T) {
+	m := modelWithBoxes()
+	m.focus = rowSection
+	updated, _ := m.Update(keyPress("right"))
+	result := updated.(model)
+	if result.section != sectionContacts {
+		t.Errorf("right from Mail selected section %d, want Contacts", result.section)
+	}
+}
+
 // --- Navigation: Esc/q in thread goes back ---
 
 func TestThreadHelpIncludesMailActions(t *testing.T) {

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: hey
 description: |
-  Interact with HEY email via the HEY CLI. Read and send emails, manage boxes,
-  calendars, todos, habits, time tracking, and journal entries. Use for ANY
+  Interact with HEY via the HEY CLI. Read and send emails, manage contacts,
+  boxes, calendars, todos, habits, time tracking, and journal entries. Use for ANY
   HEY-related question or action.
 triggers:
   # Direct invocations
@@ -12,6 +12,7 @@ triggers:
   - hey boxes
   - hey box
   - hey search
+  - hey contacts
   - hey threads
   - hey reply
   - hey forward
@@ -57,6 +58,11 @@ triggers:
   - list mailboxes
   - search email
   - find email
+  - list contacts
+  - add contact
+  - edit contact
+  - hide contact
+  - contact note
   - check calendar
   - add todo
   - complete todo
@@ -83,7 +89,7 @@ argument-hint: "[command] [args...]"
 
 # /hey - HEY Email Workflow Command
 
-CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos, habits, time tracking, and journal entries.
+CLI for HEY: mailboxes, email threads, contacts, replies, compose, calendars, todos, habits, time tracking, and journal entries.
 
 ## Agent Invariants
 
@@ -101,6 +107,15 @@ CLI for HEY email: mailboxes, email threads, replies, compose, calendars, todos,
 | List emails in a box | `hey box imbox --json` |
 | Search email | `hey search "quarterly planning" --json` |
 | List search filters | `hey search filters --json` |
+| List contacts | `hey contacts list --json` |
+| View contact | `hey contacts show <id> --json` |
+| Add contact | `hey contacts add --name "Jane Doe" --email jane@example.com` |
+| Edit contact | `hey contacts update <id> --name "Jane Dawson"` |
+| Hide contact | `hey contacts hide <id>` |
+| Show contact again | `hey contacts show-again <id>` |
+| Read private contact note | `hey contacts note show <id> --json` |
+| Set private contact note | `hey contacts note set <id> "Prefers email"` |
+| Delete private contact note | `hey contacts note delete <id>` |
 | Read email thread | `hey threads <topic_id> --json` |
 | Reply to email | `hey reply <topic_id> -m "Thanks!"` |
 | Forward email | `hey forward <topic_id> --to alice@example.com -m "For your review"` |
@@ -144,6 +159,7 @@ Want to read email?
 ├── List emails in box? → hey box <name|id> --json
 ├── Search threads and messages? → hey search <query> --json
 ├── Need available refinements? → hey search filters --json
+├── List or view contacts? → hey contacts list --json / hey contacts show <id> --json
 ├── Read full thread? → hey threads <topic_id> --json
 ├── Mark as seen? → hey seen <id>
 ├── Mark as unseen? → hey unseen <id>
@@ -207,6 +223,28 @@ hey search filters --json                      # Available box, date, label, and
 Search refinements are `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. `--page` selects one result page; `--all` fetches up to 100 pages from that point onward. When the cap is reached, the response notice provides the next `--page` value for continuation.
 
 **Response format:** `data` contains one item per matching thread. Each result has `id` (box item ID for organization actions), `topic_id` (thread ID for `hey threads`, `hey reply`, and `hey forward`), `subject`, `updated_at`, and `messages` containing the matching message IDs, senders, dates, and summaries. A result can omit `id` when the thread has no active box item.
+
+### Contacts
+
+```bash
+hey contacts list --json                       # List contacts
+hey contacts list --page 2 --json              # List another page
+hey contacts show 12345 --json                 # View details, aliases, and private note
+hey contacts add --name "Jane Doe" --email jane@example.com
+hey contacts add --name "Jane Doe" --email jane@example.com --alias jane.doe@example.org
+hey contacts update 12345 --name "Jane Dawson"
+hey contacts update 12345 --alias=              # Clear aliases
+hey contacts hide 12345                         # Hide from lists and autocomplete
+hey contacts show-again 12345                   # Reverse hiding
+hey contacts note show 12345 --json
+hey contacts note set 12345 "Prefers email"
+echo "Multiline private note" | hey contacts note set 12345
+hey contacts note delete 12345
+```
+
+`hey contacts list` returns contact IDs, names, email addresses, and update timestamps. `hey contacts show` adds aliases, screening status, and the private note. Contact updates preserve omitted fields. Supplying `--alias` replaces the complete alias list, and `--alias=` clears it.
+
+HEY hides contacts instead of permanently deleting them. A hidden contact leaves contact lists, autocomplete, and search results while remaining available by ID; `show-again` reverses the action. Contact notes are private and support positional content, `--note`, stdin, or `$EDITOR`. Deleting a note leaves the contact unchanged.
 
 ### Email - Threads
 

--- a/tests/smoke/contacts_test.go
+++ b/tests/smoke/contacts_test.go
@@ -1,6 +1,7 @@
 package smoke_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -30,14 +31,14 @@ func TestContactLifecycleAndPrivateNote(t *testing.T) {
 	email := "sam.rivera+" + unique + "@example.com"
 	alias := "samuel.rivera+" + unique + "@example.org"
 
-	created := dataAs[smokeContact](t, heyJSON(t, "contacts", "add", "--name", "Sam Rivera", "--email", email))
+	created := dataAs[smokeContact](t, contactWriteJSON(t, "contacts", "add", "--name", "Sam Rivera", "--email", email))
 	if created.ID == 0 || created.EmailAddress != email {
 		t.Fatalf("created contact is incomplete: id=%d email_matches=%v", created.ID, created.EmailAddress == email)
 	}
 	id := intStr(created.ID)
 	t.Cleanup(func() { _, _, _ = hey(t, "contacts", "hide", id) })
 
-	updated := dataAs[smokeContact](t, heyJSON(t, "contacts", "update", id, "--name", "Samuel Rivera", "--alias", alias))
+	updated := dataAs[smokeContact](t, contactWriteJSON(t, "contacts", "update", id, "--name", "Samuel Rivera", "--alias", alias))
 	if updated.ID == 0 || updated.Name != "Samuel Rivera" {
 		t.Errorf("contact update was not returned")
 	}
@@ -49,7 +50,7 @@ func TestContactLifecycleAndPrivateNote(t *testing.T) {
 	noteText := "Prefers email follow-ups for project planning."
 	note := dataAs[struct {
 		Note string `json:"note"`
-	}](t, heyJSON(t, "contacts", "note", "set", id, noteText))
+	}](t, contactWriteJSON(t, "contacts", "note", "set", id, noteText))
 	if note.Note != noteText {
 		t.Error("private note was not saved")
 	}
@@ -59,7 +60,7 @@ func TestContactLifecycleAndPrivateNote(t *testing.T) {
 	if shownNote.Note != noteText {
 		t.Error("private note read did not match the saved note")
 	}
-	heyJSON(t, "contacts", "note", "delete", id)
+	contactWriteJSON(t, "contacts", "note", "delete", id)
 	deletedNote := dataAs[struct {
 		Note string `json:"note"`
 	}](t, heyJSON(t, "contacts", "note", "show", id))
@@ -67,12 +68,29 @@ func TestContactLifecycleAndPrivateNote(t *testing.T) {
 		t.Error("private note was not deleted")
 	}
 
-	heyJSON(t, "contacts", "hide", id)
-	shownAgain := dataAs[smokeContact](t, heyJSON(t, "contacts", "show-again", id))
+	contactWriteJSON(t, "contacts", "hide", id)
+	shownAgain := dataAs[smokeContact](t, contactWriteJSON(t, "contacts", "show-again", id))
 	if shownAgain.ID != created.ID {
 		t.Error("hidden contact was not shown again")
 	}
-	heyJSON(t, "contacts", "hide", id)
+	contactWriteJSON(t, "contacts", "hide", id)
+}
+
+func contactWriteJSON(t *testing.T, args ...string) Response {
+	t.Helper()
+	args = append(args, "--json")
+	stdout, stderr, code := hey(t, args...)
+	if code != 0 {
+		t.Skipf("contact write unavailable (exit %d): %s", code, stderr)
+	}
+	var response Response
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("failed to parse contact write response: %v", err)
+	}
+	if !response.OK {
+		t.Fatalf("contact write returned ok=false: %s", stdout)
+	}
+	return response
 }
 
 func TestContactCommandsValidateInput(t *testing.T) {

--- a/tests/smoke/contacts_test.go
+++ b/tests/smoke/contacts_test.go
@@ -1,0 +1,82 @@
+package smoke_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+type smokeContact struct {
+	ID           int            `json:"id"`
+	Name         string         `json:"name"`
+	EmailAddress string         `json:"email_address"`
+	Aliases      []smokeContact `json:"aliases"`
+	Note         string         `json:"note"`
+}
+
+func TestContactsListAndShow(t *testing.T) {
+	contacts := dataAs[[]smokeContact](t, heyJSON(t, "contacts", "list"))
+	if len(contacts) == 0 {
+		t.Skip("no contacts available for read-only detail validation")
+	}
+	contact := dataAs[smokeContact](t, heyJSON(t, "contacts", "show", intStr(contacts[0].ID)))
+	if contact.ID != contacts[0].ID || contact.EmailAddress == "" {
+		t.Errorf("contact detail is incomplete: id=%d email_present=%v", contact.ID, contact.EmailAddress != "")
+	}
+}
+
+func TestContactLifecycleAndPrivateNote(t *testing.T) {
+	unique := fmt.Sprintf("%d", time.Now().UnixNano())
+	email := "sam.rivera+" + unique + "@example.com"
+	alias := "samuel.rivera+" + unique + "@example.org"
+
+	created := dataAs[smokeContact](t, heyJSON(t, "contacts", "add", "--name", "Sam Rivera", "--email", email))
+	if created.ID == 0 || created.EmailAddress != email {
+		t.Fatalf("created contact is incomplete: id=%d email_matches=%v", created.ID, created.EmailAddress == email)
+	}
+	id := intStr(created.ID)
+	t.Cleanup(func() { _, _, _ = hey(t, "contacts", "hide", id) })
+
+	updated := dataAs[smokeContact](t, heyJSON(t, "contacts", "update", id, "--name", "Samuel Rivera", "--alias", alias))
+	if updated.ID == 0 || updated.Name != "Samuel Rivera" {
+		t.Errorf("contact update was not returned")
+	}
+	detail := dataAs[smokeContact](t, heyJSON(t, "contacts", "show", id))
+	if len(detail.Aliases) != 1 || detail.Aliases[0].EmailAddress != alias {
+		t.Errorf("contact aliases were not updated")
+	}
+
+	noteText := "Prefers email follow-ups for project planning."
+	note := dataAs[struct {
+		Note string `json:"note"`
+	}](t, heyJSON(t, "contacts", "note", "set", id, noteText))
+	if note.Note != noteText {
+		t.Error("private note was not saved")
+	}
+	shownNote := dataAs[struct {
+		Note string `json:"note"`
+	}](t, heyJSON(t, "contacts", "note", "show", id))
+	if shownNote.Note != noteText {
+		t.Error("private note read did not match the saved note")
+	}
+	heyJSON(t, "contacts", "note", "delete", id)
+	deletedNote := dataAs[struct {
+		Note string `json:"note"`
+	}](t, heyJSON(t, "contacts", "note", "show", id))
+	if deletedNote.Note != "" {
+		t.Error("private note was not deleted")
+	}
+
+	heyJSON(t, "contacts", "hide", id)
+	shownAgain := dataAs[smokeContact](t, heyJSON(t, "contacts", "show-again", id))
+	if shownAgain.ID != created.ID {
+		t.Error("hidden contact was not shown again")
+	}
+	heyJSON(t, "contacts", "hide", id)
+}
+
+func TestContactCommandsValidateInput(t *testing.T) {
+	heyFail(t, "contacts", "add", "--name", "Sam Rivera")
+	heyFail(t, "contacts", "update", "12345")
+	heyFail(t, "contacts", "show", "not-an-id")
+}


### PR DESCRIPTION
## Summary

Delivers all three contact cards in one PR across CLI and TUI:

- add paginated `hey contacts list` and combined `hey contacts show <id>` details, aliases, screening status, and private note
- add `contacts add` and partial `contacts update`, including repeatable aliases, alias clearing, account selection, validation, and conflict IDs
- match HEY’s visible terminology with reversible `contacts hide` and `contacts show-again` commands rather than permanent contact deletion
- add `contacts note show/set/delete`, with positional content, `--note`, stdin, `$EDITOR`, multiline preservation, and explicit note deletion
- add a Contacts TUI section on Shift+O with list/detail navigation, add/edit forms, private-note editing, two-key note deletion confirmation, hide, and show-again undo
- preserve inactive-section responses so switching TUI sections cannot drop completed reads or mutations
- add pagination caps and continuation notices across output formats
- update help, command metadata, surface compatibility, README, embedded skill, API coverage, smoke coverage, and root product description

## Validation

- `GOWORK=off make check`
- `GOWORK=off make race-test`
- smoke test package compilation
- local build, rendered command help, command catalog, and TUI rendering
- authenticated CLI validation: list, detail, add, edit, alias replacement, private-note set/read/delete with multiline content, hide, show again, and final hidden cleanup
- authenticated TUI validation: Contacts section/list, add form, detail, edit with alias preservation, private-note edit/delete, hide, show-again undo, and final hidden cleanup

Authenticated validation used disposable `example.com`/`example.org` contacts and left them hidden. No real contact details are included in this report.

Contact search is intentionally excluded: Haystack’s contact index currently ignores the generated `q` parameter, so the CLI and TUI do not promise an ineffective filter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CLI and TUI contact management with reversible hide/show-again and private notes. Previously contacts were not exposed; now `hey contacts` and a Contacts TUI (Shift+O) provide lifecycle operations with pagination, HTML-aware detail output, and conflict-aware updates.

- **Highlights**
  - CLI: `hey contacts list [--page N | --all]` (caps with continuation notices), `show <id>` (honors `--html`), `add --name --email [--alias ...] [--account-user-id]`, `update <id> [--name] [--email] [--alias ...]` (`--alias` replaces; `--alias=` clears; validates aliases against preserved fields), `hide <id>`, `show-again <id>`, and `note show|set|delete` (accepts `--note`, positional, stdin, `$EDITOR`; empty input to `note set` is not deletion). Maps SDK validation and conflict errors to user-facing codes.
  - TUI: Contacts section (Shift+O) with list/detail, add/edit forms, private-note editing with two-key delete confirm, hide with undo. Requests use per-request IDs; the current view stays while loading; state and responses persist across section switches; conflicted updates remain visible with surfaced errors. Contact search is intentionally excluded.
  - Output/docs/tests: contact JSON adds `account_id`, `updated_at`, and `aliases`. Updates help text, `.surface`, README, `skills/hey/SKILL.md`, and tests (API coverage, unit, smoke).

- **Migration**
  - Use `hey contacts hide` and `hey contacts show-again` instead of deleting contacts.
  - To clear aliases, pass `--alias=` on `hey contacts update`.
  - To clear a private note, use `hey contacts note delete`.

<sup>Written for commit 7c94df91c89c1a0c798e28e140dca4f243cc04f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

