### PR TITLE
Send and save email attachments

### DIFF
--- a/.surface
+++ b/.surface
@@ -10,6 +10,10 @@ hey --quiet
 hey --stats
 hey --styled
 hey --verbose
+hey attachments
+hey attachments save
+hey attachments save --force
+hey attachments save --output
 hey auth
 hey auth login
 hey auth login --cookie
@@ -30,6 +34,7 @@ hey calendars
 hey commands
 hey completion
 hey compose
+hey compose --attach
 hey compose --bcc
 hey compose --cc
 hey compose --message
@@ -90,6 +95,7 @@ hey recordings --ends-on
 hey recordings --limit
 hey recordings --starts-on
 hey reply
+hey reply --attach
 hey reply --message
 hey search
 hey search --all

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -1,7 +1,7 @@
 # API Coverage
 
-Mapping of HEY API endpoints used by the CLI. Most endpoints use the HEY SDK (`hey-sdk/go`).
-The legacy `internal/client/` is used only for HTML-scraping gap operations marked below.
+Mapping of HEY API endpoints used by the CLI. API interactions use the HEY SDK (`hey-sdk/go`).
+The remaining HTML-reading gaps use the SDK's authenticated HTML helper and are marked below.
 
 | Endpoint | Method | Client | CLI Command | Status |
 |----------|--------|--------|-------------|--------|
@@ -26,8 +26,13 @@ The legacy `internal/client/` is used only for HTML-scraping gap operations mark
 | `/contacts/{id}/note.json` | DELETE | SDK `Contacts().DeleteNote` | `hey contacts note delete`, Contacts TUI | covered |
 | `/calendars.json` | GET | SDK `Calendars().List` | `hey calendars` | covered |
 | `/calendars/{id}/recordings.json` | GET | SDK `Calendars().GetRecordings` | `hey recordings <calendar-id>`, `hey todo list`, `hey timetrack list`, `hey journal list` | covered |
-| `/topics/{id}/entries` | GET (HTML) | Legacy `GetTopicEntries` | `hey threads <id>` | gap: SDK Entry lacks body |
+| `/topics/{id}/entries` | GET (HTML) | SDK `GetHTML` | `hey threads <id>` | gap: SDK Entry lacks body |
+| `/topics/{id}/entries.json` | GET | SDK `Topics().GetEntries` | `hey attachments <topic-id>` | covered |
+| `/messages/{id}.json` | GET | SDK `Messages().Get` | `hey attachments <topic-id>`, `hey attachments save <id>` | covered |
 | `/entries/drafts.json` | GET | SDK `Entries().ListDrafts` | `hey drafts` | covered |
+| `/rails/active_storage/direct_uploads.json` | POST | SDK `Attachments().Upload` | `hey compose --attach`, `hey reply --attach` | covered |
+| signed Active Storage upload URL | PUT | SDK `Attachments().Upload` | `hey compose --attach`, `hey reply --attach` | covered |
+| signed Active Storage blob URL | GET | SDK `DownloadBlob` | `hey attachments save <id>` | covered |
 | `/messages.json` | POST | SDK `Messages().Create` | `hey compose`, `hey forward <topic-id>` | covered |
 | `/entries/{id}/replies` | POST | SDK `Entries().CreateReply` | `hey reply <topic-id>` | covered |
 | `/topics/{id}.json` | GET | SDK `Topics().Get` | `hey forward <topic-id>` | covered |

--- a/README.md
+++ b/README.md
@@ -83,9 +83,13 @@ hey contacts show-again 12345      # show a hidden contact again
 hey contacts note set 12345 "Prefers email"
 hey contacts note delete 12345
 hey threads 123                    # read a full email thread
+hey attachments 123                # list files attached to the thread
+hey attachments save 456:1         # save a file using its attachment ID
 hey reply 123 -m "Thanks!"        # reply to a thread (or omit -m to open $EDITOR)
+hey reply 123 -m "Attached." --attach ./diagram.png
 hey forward 123 --to alice@example.com -m "For your review"  # forward the latest message
 hey compose --to user@example.com --subject "Hello"  # compose a new message
+hey compose --to user@example.com --subject "Report" -m "Attached." --attach ./report.pdf
 hey compose --to user@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello"  # with CC/BCC
 hey drafts                         # list drafts
 hey move 12345 --to feed           # move a thread to another box
@@ -99,6 +103,8 @@ hey stop-ignoring 12345            # resume attention for a thread
 Search accepts free text plus `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. Use `--page` for one page or `--all` to fetch up to 100 pages; capped searches report the next page for continuation. Search results include `topic_id` for reading the thread and the matching message summaries. Results with an active box item also include `id` for organization actions.
 
 Contact updates preserve omitted name, email, and alias fields. Supplying `--alias` replaces the complete alias list; `--alias=` clears it. Contact notes accept positional content, `--note`, stdin, or `$EDITOR`. HEY hides contacts rather than permanently deleting them; hidden contacts leave lists, autocomplete, and search, and can be shown again by ID.
+
+`--attach` is repeatable on `hey compose` and `hey reply`, and attachment-only messages are supported. The CLI validates and uploads every file before sending the email. `hey attachments <topic_id>` returns stable message-and-position IDs such as `456:1`; pass an ID to `hey attachments save`. Saving uses the original filename by default, accepts `--output` for a file or directory, and preserves existing files unless `--force` is set.
 
 Organization actions take the `id` values returned by `hey box --json` or `hey search --json`. Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.6
-	github.com/basecamp/hey-sdk/go v0.4.0
+	github.com/basecamp/hey-sdk/go v0.5.0
 	github.com/mattn/go-runewidth v0.0.27
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/net v0.58.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 )
 
@@ -36,5 +37,4 @@ require (
 	github.com/oapi-codegen/runtime v1.6.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.47.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
-github.com/basecamp/hey-sdk/go v0.4.0 h1:5tngAdT7eucUp53wn9qXHY6Z3GJ1pKM7fQycaOnVvsM=
-github.com/basecamp/hey-sdk/go v0.4.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
+github.com/basecamp/hey-sdk/go v0.5.0 h1:h7FX/E/ci+TYEk6rfd8cV3o+e2rlO47F4NrhE3IeovY=
+github.com/basecamp/hey-sdk/go v0.5.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=

--- a/internal/cmd/attachment_upload.go
+++ b/internal/cmd/attachment_upload.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	stdhtml "html"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type uploadedAttachment struct {
+	Filename    string
+	ContentType string
+	ByteSize    int64
+	SGID        string
+}
+
+func attachFiles(ctx context.Context, content string, paths []string) (string, error) {
+	if len(paths) == 0 {
+		return content, nil
+	}
+
+	if err := validateAttachmentPaths(paths); err != nil {
+		return "", err
+	}
+
+	uploads := make([]uploadedAttachment, 0, len(paths))
+	for _, path := range paths {
+		upload, err := uploadAttachment(ctx, path)
+		if err != nil {
+			return "", err
+		}
+		uploads = append(uploads, upload)
+	}
+	return appendUploadedAttachments(content, uploads), nil
+}
+
+func validateAttachmentPaths(paths []string) error {
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return output.ErrUsage(fmt.Sprintf("could not read attachment %q: %v", path, err))
+		}
+		if !info.Mode().IsRegular() {
+			return output.ErrUsage(fmt.Sprintf("attachment %q is not a regular file", path))
+		}
+	}
+	return nil
+}
+
+func uploadAttachment(ctx context.Context, path string) (uploadedAttachment, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return uploadedAttachment{}, output.ErrUsage(fmt.Sprintf("could not open attachment %q: %v", path, err))
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return uploadedAttachment{}, output.ErrUsage(fmt.Sprintf("could not inspect attachment %q: %v", path, err))
+	}
+	if !info.Mode().IsRegular() {
+		return uploadedAttachment{}, output.ErrUsage(fmt.Sprintf("attachment %q is not a regular file", path))
+	}
+
+	contentType, err := attachmentContentType(file, path)
+	if err != nil {
+		return uploadedAttachment{}, err
+	}
+	upload, err := sdk.Attachments().Upload(ctx, filepath.Base(path), contentType, file)
+	if err != nil {
+		return uploadedAttachment{}, convertSDKError(err)
+	}
+	if upload == nil || upload.AttachableSgid == "" {
+		return uploadedAttachment{}, fmt.Errorf("HEY returned an empty attachment reference for %q", path)
+	}
+	return uploadedAttachment{
+		Filename:    filepath.Base(path),
+		ContentType: contentType,
+		ByteSize:    info.Size(),
+		SGID:        upload.AttachableSgid,
+	}, nil
+}
+
+func attachmentContentType(file io.ReadSeeker, path string) (string, error) {
+	if contentType := mime.TypeByExtension(strings.ToLower(filepath.Ext(path))); contentType != "" {
+		return attachmentMediaType(contentType), nil
+	}
+
+	buffer := make([]byte, 512)
+	read, err := file.Read(buffer)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("inspect attachment content %q: %w", path, err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", fmt.Errorf("rewind attachment %q: %w", path, err)
+	}
+	return attachmentMediaType(http.DetectContentType(buffer[:read])), nil
+}
+
+func attachmentMediaType(contentType string) string {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return contentType
+	}
+	return mediaType
+}
+
+func sentWithAttachmentsSummary(summary string, count int) string {
+	if count == 0 {
+		return summary
+	}
+	noun := "attachments"
+	if count == 1 {
+		noun = "attachment"
+	}
+	return fmt.Sprintf("%s with %d %s", summary, count, noun)
+}
+
+func appendUploadedAttachments(content string, attachments []uploadedAttachment) string {
+	var builder strings.Builder
+	builder.WriteString(content)
+	if content != "" && len(attachments) > 0 {
+		builder.WriteString("<br>")
+	}
+	for _, attachment := range attachments {
+		fmt.Fprintf(&builder,
+			`<action-text-attachment sgid="%s" content-type="%s" filename="%s" filesize="%d"></action-text-attachment>`,
+			stdhtml.EscapeString(attachment.SGID),
+			stdhtml.EscapeString(attachment.ContentType),
+			stdhtml.EscapeString(attachment.Filename),
+			attachment.ByteSize,
+		)
+	}
+	return builder.String()
+}

--- a/internal/cmd/attachment_upload.go
+++ b/internal/cmd/attachment_upload.go
@@ -55,6 +55,15 @@ func attachFiles(ctx context.Context, content string, paths []string) (string, e
 func prepareAttachments(paths []string) ([]preparedAttachment, error) {
 	attachments := make([]preparedAttachment, 0, len(paths))
 	for _, path := range paths {
+		pathInfo, err := os.Stat(path)
+		if err != nil {
+			closePreparedAttachments(attachments)
+			return nil, output.ErrUsage(fmt.Sprintf("could not inspect attachment %q: %v", path, err))
+		}
+		if !pathInfo.Mode().IsRegular() {
+			closePreparedAttachments(attachments)
+			return nil, output.ErrUsage(fmt.Sprintf("attachment %q is not a regular file", path))
+		}
 		file, err := os.Open(path)
 		if err != nil {
 			closePreparedAttachments(attachments)

--- a/internal/cmd/attachment_upload.go
+++ b/internal/cmd/attachment_upload.go
@@ -22,18 +22,28 @@ type uploadedAttachment struct {
 	SGID        string
 }
 
+type preparedAttachment struct {
+	path        string
+	filename    string
+	contentType string
+	byteSize    int64
+	file        *os.File
+}
+
 func attachFiles(ctx context.Context, content string, paths []string) (string, error) {
 	if len(paths) == 0 {
 		return content, nil
 	}
 
-	if err := validateAttachmentPaths(paths); err != nil {
+	attachments, err := prepareAttachments(paths)
+	if err != nil {
 		return "", err
 	}
+	defer closePreparedAttachments(attachments)
 
-	uploads := make([]uploadedAttachment, 0, len(paths))
-	for _, path := range paths {
-		upload, err := uploadAttachment(ctx, path)
+	uploads := make([]uploadedAttachment, 0, len(attachments))
+	for _, attachment := range attachments {
+		upload, err := uploadAttachment(ctx, attachment)
 		if err != nil {
 			return "", err
 		}
@@ -42,49 +52,60 @@ func attachFiles(ctx context.Context, content string, paths []string) (string, e
 	return appendUploadedAttachments(content, uploads), nil
 }
 
-func validateAttachmentPaths(paths []string) error {
+func prepareAttachments(paths []string) ([]preparedAttachment, error) {
+	attachments := make([]preparedAttachment, 0, len(paths))
 	for _, path := range paths {
-		info, err := os.Stat(path)
+		file, err := os.Open(path)
 		if err != nil {
-			return output.ErrUsage(fmt.Sprintf("could not read attachment %q: %v", path, err))
+			closePreparedAttachments(attachments)
+			return nil, output.ErrUsage(fmt.Sprintf("could not open attachment %q: %v", path, err))
+		}
+		info, err := file.Stat()
+		if err != nil {
+			_ = file.Close()
+			closePreparedAttachments(attachments)
+			return nil, output.ErrUsage(fmt.Sprintf("could not inspect attachment %q: %v", path, err))
 		}
 		if !info.Mode().IsRegular() {
-			return output.ErrUsage(fmt.Sprintf("attachment %q is not a regular file", path))
+			_ = file.Close()
+			closePreparedAttachments(attachments)
+			return nil, output.ErrUsage(fmt.Sprintf("attachment %q is not a regular file", path))
 		}
+		contentType, err := attachmentContentType(file, path)
+		if err != nil {
+			_ = file.Close()
+			closePreparedAttachments(attachments)
+			return nil, err
+		}
+		attachments = append(attachments, preparedAttachment{
+			path:        path,
+			filename:    filepath.Base(path),
+			contentType: contentType,
+			byteSize:    info.Size(),
+			file:        file,
+		})
 	}
-	return nil
+	return attachments, nil
 }
 
-func uploadAttachment(ctx context.Context, path string) (uploadedAttachment, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return uploadedAttachment{}, output.ErrUsage(fmt.Sprintf("could not open attachment %q: %v", path, err))
+func closePreparedAttachments(attachments []preparedAttachment) {
+	for _, attachment := range attachments {
+		_ = attachment.file.Close()
 	}
-	defer func() { _ = file.Close() }()
+}
 
-	info, err := file.Stat()
-	if err != nil {
-		return uploadedAttachment{}, output.ErrUsage(fmt.Sprintf("could not inspect attachment %q: %v", path, err))
-	}
-	if !info.Mode().IsRegular() {
-		return uploadedAttachment{}, output.ErrUsage(fmt.Sprintf("attachment %q is not a regular file", path))
-	}
-
-	contentType, err := attachmentContentType(file, path)
-	if err != nil {
-		return uploadedAttachment{}, err
-	}
-	upload, err := sdk.Attachments().Upload(ctx, filepath.Base(path), contentType, file)
+func uploadAttachment(ctx context.Context, attachment preparedAttachment) (uploadedAttachment, error) {
+	upload, err := sdk.Attachments().Upload(ctx, attachment.filename, attachment.contentType, attachment.file)
 	if err != nil {
 		return uploadedAttachment{}, convertSDKError(err)
 	}
 	if upload == nil || upload.AttachableSgid == "" {
-		return uploadedAttachment{}, fmt.Errorf("HEY returned an empty attachment reference for %q", path)
+		return uploadedAttachment{}, fmt.Errorf("HEY returned an empty attachment reference for %q", attachment.path)
 	}
 	return uploadedAttachment{
-		Filename:    filepath.Base(path),
-		ContentType: contentType,
-		ByteSize:    info.Size(),
+		Filename:    attachment.filename,
+		ContentType: attachment.contentType,
+		ByteSize:    attachment.byteSize,
 		SGID:        upload.AttachableSgid,
 	}, nil
 }

--- a/internal/cmd/attachment_upload_unix_test.go
+++ b/internal/cmd/attachment_upload_unix_test.go
@@ -1,0 +1,20 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestPrepareAttachmentsRejectsFIFOWithoutOpeningIt(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "attachment.fifo")
+	if err := unix.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareAttachments([]string{fifo}); err == nil {
+		t.Fatal("FIFO attachment should be rejected")
+	}
+}

--- a/internal/cmd/attachments.go
+++ b/internal/cmd/attachments.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -121,10 +120,9 @@ func (c *attachmentsCommand) run(cmd *cobra.Command, args []string) error {
 func attachmentsForMarkdown(attachments []threadAttachment) []threadAttachment {
 	safe := make([]threadAttachment, len(attachments))
 	copy(safe, attachments)
-	replacer := strings.NewReplacer(`\`, `\\`, `|`, `\|`)
 	for index := range safe {
-		safe[index].Filename = replacer.Replace(terminalSafeText(safe[index].Filename))
-		safe[index].ContentType = replacer.Replace(terminalSafeText(safe[index].ContentType))
+		safe[index].Filename = markdownSafeText(safe[index].Filename)
+		safe[index].ContentType = markdownSafeText(safe[index].ContentType)
 	}
 	return safe
 }

--- a/internal/cmd/attachments.go
+++ b/internal/cmd/attachments.go
@@ -135,6 +135,9 @@ func attachmentsInThread(ctx context.Context, threadID int64) ([]threadAttachmen
 				if getErr != nil {
 					return getErr
 				}
+				if message == nil {
+					return fmt.Errorf("message %d returned no data", entry.Id)
+				}
 				messages[index] = message
 				return nil
 			})
@@ -145,9 +148,6 @@ func attachmentsInThread(ctx context.Context, threadID int64) ([]threadAttachmen
 
 		for entryIndex, entry := range *entries {
 			message := messages[entryIndex]
-			if message == nil {
-				continue
-			}
 			for attachmentIndex, attachment := range htmlutil.ExtractAttachments(message.Content) {
 				attachments = append(attachments, threadAttachment{
 					ID:          attachmentID(entry.Id, attachmentIndex+1),

--- a/internal/cmd/attachments.go
+++ b/internal/cmd/attachments.go
@@ -78,7 +78,12 @@ func (c *attachmentsCommand) run(cmd *cobra.Command, args []string) error {
 			table := newTable(cmd.OutOrStdout())
 			table.addRow([]string{"ID", "Filename", "Type", "Size"})
 			for _, attachment := range attachments {
-				table.addRow([]string{attachment.ID, attachment.Filename, attachment.ContentType, formatByteSize(attachment.ByteSize)})
+				table.addRow([]string{
+					attachment.ID,
+					terminalSafeText(attachment.Filename),
+					terminalSafeText(attachment.ContentType),
+					formatByteSize(attachment.ByteSize),
+				})
 			}
 			table.print()
 		}

--- a/internal/cmd/attachments.go
+++ b/internal/cmd/attachments.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -111,7 +112,21 @@ func (c *attachmentsCommand) run(cmd *cobra.Command, args []string) error {
 			Description: "Save an attachment",
 		}))
 	}
+	if writer.EffectiveFormat() == output.FormatMarkdown {
+		attachments = attachmentsForMarkdown(attachments)
+	}
 	return writeOK(attachments, options...)
+}
+
+func attachmentsForMarkdown(attachments []threadAttachment) []threadAttachment {
+	safe := make([]threadAttachment, len(attachments))
+	copy(safe, attachments)
+	replacer := strings.NewReplacer(`\`, `\\`, `|`, `\|`)
+	for index := range safe {
+		safe[index].Filename = replacer.Replace(terminalSafeText(safe[index].Filename))
+		safe[index].ContentType = replacer.Replace(terminalSafeText(safe[index].ContentType))
+	}
+	return safe
 }
 
 func attachmentsInThread(ctx context.Context, threadID int64) ([]threadAttachment, bool, error) {

--- a/internal/cmd/attachments.go
+++ b/internal/cmd/attachments.go
@@ -28,7 +28,7 @@ type threadAttachment struct {
 	MessageID   int64  `json:"message_id"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type,omitempty"`
-	ByteSize    int64  `json:"byte_size,omitempty"`
+	ByteSize    *int64 `json:"byte_size,omitempty"`
 	URL         string `json:"-"`
 }
 
@@ -82,7 +82,7 @@ func (c *attachmentsCommand) run(cmd *cobra.Command, args []string) error {
 					attachment.ID,
 					terminalSafeText(attachment.Filename),
 					terminalSafeText(attachment.ContentType),
-					formatByteSize(attachment.ByteSize),
+					formatOptionalByteSize(attachment.ByteSize),
 				})
 			}
 			table.print()
@@ -180,9 +180,16 @@ func attachmentID(messageID int64, position int) string {
 	return fmt.Sprintf("%d:%d", messageID, position)
 }
 
+func formatOptionalByteSize(size *int64) string {
+	if size == nil {
+		return "—"
+	}
+	return formatByteSize(*size)
+}
+
 func formatByteSize(size int64) string {
 	switch {
-	case size <= 0:
+	case size < 0:
 		return "—"
 	case size < 1024:
 		return fmt.Sprintf("%d B", size)

--- a/internal/cmd/attachments.go
+++ b/internal/cmd/attachments.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 
@@ -13,7 +14,10 @@ import (
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
-const maxAttachmentThreadPages = 100
+const (
+	maxAttachmentThreadPages              = 100
+	maxConcurrentAttachmentMessageFetches = 8
+)
 
 type attachmentsCommand struct {
 	cmd *cobra.Command
@@ -117,17 +121,31 @@ func attachmentsInThread(ctx context.Context, threadID int64) ([]threadAttachmen
 			return attachments, false, nil
 		}
 
-		for _, entry := range *entries {
-			message, err := sdk.Messages().Get(ctx, entry.Id)
-			if err != nil {
-				return nil, false, convertSDKError(err)
-			}
+		messages := make([]*generated.Message, len(*entries))
+		group, groupCtx := errgroup.WithContext(ctx)
+		group.SetLimit(maxConcurrentAttachmentMessageFetches)
+		for index, entry := range *entries {
+			group.Go(func() error {
+				message, getErr := sdk.Messages().Get(groupCtx, entry.Id)
+				if getErr != nil {
+					return getErr
+				}
+				messages[index] = message
+				return nil
+			})
+		}
+		if err := group.Wait(); err != nil {
+			return nil, false, convertSDKError(err)
+		}
+
+		for entryIndex, entry := range *entries {
+			message := messages[entryIndex]
 			if message == nil {
 				continue
 			}
-			for index, attachment := range htmlutil.ExtractAttachments(message.Content) {
+			for attachmentIndex, attachment := range htmlutil.ExtractAttachments(message.Content) {
 				attachments = append(attachments, threadAttachment{
-					ID:          attachmentID(entry.Id, index+1),
+					ID:          attachmentID(entry.Id, attachmentIndex+1),
 					MessageID:   entry.Id,
 					Filename:    attachment.Filename,
 					ContentType: attachment.ContentType,

--- a/internal/cmd/attachments.go
+++ b/internal/cmd/attachments.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+
+	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+const maxAttachmentThreadPages = 100
+
+type attachmentsCommand struct {
+	cmd *cobra.Command
+}
+
+type threadAttachment struct {
+	ID          string `json:"id"`
+	MessageID   int64  `json:"message_id"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type,omitempty"`
+	ByteSize    int64  `json:"byte_size,omitempty"`
+	URL         string `json:"-"`
+}
+
+func newAttachmentsCommand() *attachmentsCommand {
+	attachmentsCommand := &attachmentsCommand{}
+	attachmentsCommand.cmd = &cobra.Command{
+		Use:   "attachments <thread-id>",
+		Short: "List and save files from a thread",
+		Annotations: map[string]string{
+			"agent_notes": "Lists downloadable attachments from every message in a known thread. Pass a returned ID to `hey attachments save <id>`.",
+		},
+		Example: `  hey attachments 12345
+  hey attachments 12345 --json
+  hey attachments save 67890:1
+  hey attachments save 67890:1 --output ./quarterly-report.pdf`,
+		RunE: attachmentsCommand.run,
+		Args: usageExactOneArg(),
+	}
+
+	attachmentsCommand.cmd.AddCommand(newAttachmentsSaveCommand().cmd)
+	return attachmentsCommand
+}
+
+func (c *attachmentsCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	threadID, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil || threadID <= 0 {
+		return output.ErrUsage(fmt.Sprintf("invalid thread ID: %s", args[0]))
+	}
+
+	attachments, truncated, err := attachmentsInThread(cmd.Context(), threadID)
+	if err != nil {
+		return err
+	}
+
+	notice := ""
+	if truncated {
+		notice = fmt.Sprintf("Attachment discovery stopped after %d pages of thread messages", maxAttachmentThreadPages)
+	}
+	if writer.IsStyled() {
+		if len(attachments) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No attachments found.")
+		} else {
+			table := newTable(cmd.OutOrStdout())
+			table.addRow([]string{"ID", "Filename", "Type", "Size"})
+			for _, attachment := range attachments {
+				table.addRow([]string{attachment.ID, attachment.Filename, attachment.ContentType, formatByteSize(attachment.ByteSize)})
+			}
+			table.print()
+		}
+		if notice != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n", notice)
+		}
+		return nil
+	}
+	if stderrNotice := paginationNoticeForStderr(writer.EffectiveFormat(), notice); stderrNotice != "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), stderrNotice)
+	}
+
+	noun := "attachments"
+	if len(attachments) == 1 {
+		noun = "attachment"
+	}
+	options := []output.ResponseOption{
+		output.WithSummary(fmt.Sprintf("%d %s in thread %d", len(attachments), noun, threadID)),
+		output.WithNotice(notice),
+	}
+	if len(attachments) > 0 {
+		options = append(options, output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "save",
+			Command:     fmt.Sprintf("hey attachments save %s", attachments[0].ID),
+			Description: "Save an attachment",
+		}))
+	}
+	return writeOK(attachments, options...)
+}
+
+func attachmentsInThread(ctx context.Context, threadID int64) ([]threadAttachment, bool, error) {
+	var attachments []threadAttachment
+	for page := 1; page <= maxAttachmentThreadPages; page++ {
+		pageValue := strconv.Itoa(page)
+		entries, err := sdk.Topics().GetEntries(ctx, threadID, &generated.GetTopicEntriesParams{Page: &pageValue})
+		if err != nil {
+			return nil, false, convertSDKError(err)
+		}
+		if entries == nil || len(*entries) == 0 {
+			return attachments, false, nil
+		}
+
+		for _, entry := range *entries {
+			message, err := sdk.Messages().Get(ctx, entry.Id)
+			if err != nil {
+				return nil, false, convertSDKError(err)
+			}
+			if message == nil {
+				continue
+			}
+			for index, attachment := range htmlutil.ExtractAttachments(message.Content) {
+				attachments = append(attachments, threadAttachment{
+					ID:          attachmentID(entry.Id, index+1),
+					MessageID:   entry.Id,
+					Filename:    attachment.Filename,
+					ContentType: attachment.ContentType,
+					ByteSize:    attachment.ByteSize,
+					URL:         attachment.URL,
+				})
+			}
+		}
+	}
+	return attachments, true, nil
+}
+
+func attachmentID(messageID int64, position int) string {
+	return fmt.Sprintf("%d:%d", messageID, position)
+}
+
+func formatByteSize(size int64) string {
+	switch {
+	case size <= 0:
+		return "—"
+	case size < 1024:
+		return fmt.Sprintf("%d B", size)
+	case size < 1024*1024:
+		return fmt.Sprintf("%.1f KB", float64(size)/1024)
+	default:
+		return fmt.Sprintf("%.1f MB", float64(size)/(1024*1024))
+	}
+}

--- a/internal/cmd/attachments_save.go
+++ b/internal/cmd/attachments_save.go
@@ -107,16 +107,16 @@ func parseAttachmentID(id string) (int64, int, error) {
 }
 
 func attachmentDestination(outputPath, filename string) (string, error) {
-	filename, err := portableAttachmentFilename(filename)
-	if err != nil {
-		return "", err
-	}
 	if outputPath == "" {
-		return filename, nil
+		return portableAttachmentFilename(filename)
 	}
 	info, err := os.Stat(outputPath)
 	if err == nil && info.IsDir() {
-		return filepath.Join(outputPath, filename), nil
+		safeFilename, filenameErr := portableAttachmentFilename(filename)
+		if filenameErr != nil {
+			return "", filenameErr
+		}
+		return filepath.Join(outputPath, safeFilename), nil
 	}
 	if err != nil && !os.IsNotExist(err) {
 		return "", output.ErrAPI(0, fmt.Sprintf("could not inspect output path: %v", err))

--- a/internal/cmd/attachments_save.go
+++ b/internal/cmd/attachments_save.go
@@ -207,7 +207,7 @@ func downloadAttachmentFile(ctx context.Context, destination, sourceURL string, 
 		}
 		return written, nil
 	}
-	if err := os.Link(temporaryPath, destination); os.IsExist(err) {
+	if err := commitFileNoReplace(temporaryPath, destination); os.IsExist(err) {
 		return written, output.ErrUsage(fmt.Sprintf("destination already exists: %s (use --force to replace it)", destination))
 	} else if err != nil {
 		return written, output.ErrAPI(0, fmt.Sprintf("could not save attachment file: %v", err))

--- a/internal/cmd/attachments_save.go
+++ b/internal/cmd/attachments_save.go
@@ -152,13 +152,17 @@ func windowsReservedFilename(filename string) bool {
 		stem = stem[:dot]
 	}
 	stem = strings.ToUpper(stem)
-	if stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL" {
+	if stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL" || stem == "CONIN$" || stem == "CONOUT$" {
 		return true
 	}
-	if len(stem) == 4 && (strings.HasPrefix(stem, "COM") || strings.HasPrefix(stem, "LPT")) {
-		return stem[3] >= '1' && stem[3] <= '9'
+	runes := []rune(stem)
+	if len(runes) != 4 || (string(runes[:3]) != "COM" && string(runes[:3]) != "LPT") {
+		return false
 	}
-	return false
+	if runes[3] == '¹' || runes[3] == '²' || runes[3] == '³' {
+		return true
+	}
+	return runes[3] >= '1' && runes[3] <= '9'
 }
 
 func downloadAttachmentFile(ctx context.Context, destination, sourceURL string, force bool) (int64, error) {

--- a/internal/cmd/attachments_save.go
+++ b/internal/cmd/attachments_save.go
@@ -149,7 +149,7 @@ func downloadAttachmentFile(ctx context.Context, destination, sourceURL string, 
 	}
 
 	if force {
-		if err := os.Rename(temporaryPath, destination); err != nil {
+		if err := replaceFile(temporaryPath, destination); err != nil {
 			return written, output.ErrAPI(0, fmt.Sprintf("could not replace attachment file: %v", err))
 		}
 		return written, nil

--- a/internal/cmd/attachments_save.go
+++ b/internal/cmd/attachments_save.go
@@ -90,7 +90,17 @@ func (c *attachmentsSaveCommand) run(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "Saved %s (%s)\n", destination, formatByteSize(result.ByteSize))
 		return nil
 	}
-	return writeOK(result, output.WithSummary(fmt.Sprintf("Attachment saved to %s", destination)))
+	outputResult := result
+	if writer.EffectiveFormat() == output.FormatMarkdown {
+		outputResult = savedAttachmentForMarkdown(outputResult)
+	}
+	return writeOK(outputResult, output.WithSummary(fmt.Sprintf("Attachment saved to %s", destination)))
+}
+
+func savedAttachmentForMarkdown(attachment savedAttachment) savedAttachment {
+	attachment.Filename = markdownSafeText(attachment.Filename)
+	attachment.Path = markdownSafeText(attachment.Path)
+	return attachment
 }
 
 func parseAttachmentID(id string) (int64, int, error) {

--- a/internal/cmd/attachments_save.go
+++ b/internal/cmd/attachments_save.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type attachmentsSaveCommand struct {
+	cmd    *cobra.Command
+	output string
+	force  bool
+}
+
+type savedAttachment struct {
+	ID       string `json:"id"`
+	Filename string `json:"filename"`
+	Path     string `json:"path"`
+	ByteSize int64  `json:"byte_size"`
+}
+
+func newAttachmentsSaveCommand() *attachmentsSaveCommand {
+	attachmentsSaveCommand := &attachmentsSaveCommand{}
+	attachmentsSaveCommand.cmd = &cobra.Command{
+		Use:   "save <id>",
+		Short: "Save an attachment to disk",
+		Annotations: map[string]string{
+			"agent_notes": "Saves the attachment identified by an ID from `hey attachments <thread-id>`. Existing files are preserved unless --force is set.",
+		},
+		Example: `  hey attachments save 67890:1
+  hey attachments save 67890:1 --output ./quarterly-report.pdf
+  hey attachments save 67890:1 --output ./downloads --force`,
+		RunE: attachmentsSaveCommand.run,
+		Args: usageExactOneArg(),
+	}
+
+	attachmentsSaveCommand.cmd.Flags().StringVarP(&attachmentsSaveCommand.output, "output", "o", "", "Destination file or directory")
+	attachmentsSaveCommand.cmd.Flags().BoolVar(&attachmentsSaveCommand.force, "force", false, "Replace an existing destination file")
+	return attachmentsSaveCommand
+}
+
+func (c *attachmentsSaveCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	messageID, position, err := parseAttachmentID(args[0])
+	if err != nil {
+		return err
+	}
+	message, err := sdk.Messages().Get(cmd.Context(), messageID)
+	if err != nil {
+		return convertSDKError(err)
+	}
+	if message == nil {
+		return output.ErrNotFound("message", strconv.FormatInt(messageID, 10))
+	}
+	attachments := htmlutil.ExtractAttachments(message.Content)
+	if position > len(attachments) {
+		return output.ErrNotFound("attachment", args[0])
+	}
+	attachment := attachments[position-1]
+
+	destination, err := attachmentDestination(c.output, attachment.Filename)
+	if err != nil {
+		return err
+	}
+	byteSize, err := downloadAttachmentFile(cmd.Context(), destination, attachment.URL, c.force)
+	if err != nil {
+		return err
+	}
+
+	result := savedAttachment{
+		ID:       args[0],
+		Filename: attachment.Filename,
+		Path:     destination,
+		ByteSize: byteSize,
+	}
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Saved %s (%s)\n", destination, formatByteSize(result.ByteSize))
+		return nil
+	}
+	return writeOK(result, output.WithSummary(fmt.Sprintf("Attachment saved to %s", destination)))
+}
+
+func parseAttachmentID(id string) (int64, int, error) {
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		return 0, 0, output.ErrUsage(fmt.Sprintf("invalid attachment ID: %s", id))
+	}
+	messageID, messageErr := strconv.ParseInt(parts[0], 10, 64)
+	position, positionErr := strconv.Atoi(parts[1])
+	if messageErr != nil || positionErr != nil || messageID <= 0 || position <= 0 {
+		return 0, 0, output.ErrUsage(fmt.Sprintf("invalid attachment ID: %s", id))
+	}
+	return messageID, position, nil
+}
+
+func attachmentDestination(outputPath, filename string) (string, error) {
+	filename = filepath.Base(strings.TrimSpace(filename))
+	if filename == "" || filename == "." || filename == ".." || filename == string(filepath.Separator) {
+		return "", output.ErrUsage("attachment has no safe filename")
+	}
+	if outputPath == "" {
+		return filename, nil
+	}
+	info, err := os.Stat(outputPath)
+	if err == nil && info.IsDir() {
+		return filepath.Join(outputPath, filename), nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return "", output.ErrAPI(0, fmt.Sprintf("could not inspect output path: %v", err))
+	}
+	return filepath.Clean(outputPath), nil
+}
+
+func downloadAttachmentFile(ctx context.Context, destination, sourceURL string, force bool) (int64, error) {
+	if !force {
+		if _, err := os.Lstat(destination); err == nil {
+			return 0, output.ErrUsage(fmt.Sprintf("destination already exists: %s (use --force to replace it)", destination))
+		} else if !os.IsNotExist(err) {
+			return 0, output.ErrAPI(0, fmt.Sprintf("could not inspect attachment destination: %v", err))
+		}
+	}
+
+	directory := filepath.Dir(destination)
+	temporary, err := os.CreateTemp(directory, ".hey-attachment-*")
+	if err != nil {
+		return 0, output.ErrAPI(0, fmt.Sprintf("could not create temporary attachment file: %v", err))
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+
+	written, _, err := sdk.DownloadBlob(ctx, sourceURL, temporary)
+	if err != nil {
+		_ = temporary.Close()
+		return written, convertSDKError(err)
+	}
+	if err := temporary.Close(); err != nil {
+		return written, output.ErrAPI(0, fmt.Sprintf("could not close attachment file: %v", err))
+	}
+
+	if force {
+		if err := os.Rename(temporaryPath, destination); err != nil {
+			return written, output.ErrAPI(0, fmt.Sprintf("could not replace attachment file: %v", err))
+		}
+		return written, nil
+	}
+	if err := os.Link(temporaryPath, destination); os.IsExist(err) {
+		return written, output.ErrUsage(fmt.Sprintf("destination already exists: %s (use --force to replace it)", destination))
+	} else if err != nil {
+		return written, output.ErrAPI(0, fmt.Sprintf("could not save attachment file: %v", err))
+	}
+	return written, nil
+}

--- a/internal/cmd/attachments_save.go
+++ b/internal/cmd/attachments_save.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -105,9 +107,9 @@ func parseAttachmentID(id string) (int64, int, error) {
 }
 
 func attachmentDestination(outputPath, filename string) (string, error) {
-	filename = filepath.Base(strings.TrimSpace(filename))
-	if filename == "" || filename == "." || filename == ".." || filename == string(filepath.Separator) {
-		return "", output.ErrUsage("attachment has no safe filename")
+	filename, err := portableAttachmentFilename(filename)
+	if err != nil {
+		return "", err
 	}
 	if outputPath == "" {
 		return filename, nil
@@ -120,6 +122,43 @@ func attachmentDestination(outputPath, filename string) (string, error) {
 		return "", output.ErrAPI(0, fmt.Sprintf("could not inspect output path: %v", err))
 	}
 	return filepath.Clean(outputPath), nil
+}
+
+func portableAttachmentFilename(filename string) (string, error) {
+	filename = strings.TrimSpace(filename)
+	filename = path.Base(strings.ReplaceAll(filename, `\`, "/"))
+	if filename == "" || filename == "." || filename == ".." || filename == "/" {
+		return "", output.ErrUsage("attachment has no safe filename")
+	}
+	filename = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || strings.ContainsRune(`<>:"/\|?*`, r) {
+			return '_'
+		}
+		return r
+	}, filename)
+	filename = strings.TrimRight(filename, ". ")
+	if filename == "" {
+		filename = "attachment"
+	}
+	if windowsReservedFilename(filename) {
+		filename = "_" + filename
+	}
+	return filename, nil
+}
+
+func windowsReservedFilename(filename string) bool {
+	stem := filename
+	if dot := strings.IndexByte(stem, '.'); dot >= 0 {
+		stem = stem[:dot]
+	}
+	stem = strings.ToUpper(stem)
+	if stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL" {
+		return true
+	}
+	if len(stem) == 4 && (strings.HasPrefix(stem, "COM") || strings.HasPrefix(stem, "LPT")) {
+		return stem[3] >= '1' && stem[3] <= '9'
+	}
+	return false
 }
 
 func downloadAttachmentFile(ctx context.Context, destination, sourceURL string, force bool) (int64, error) {

--- a/internal/cmd/attachments_test.go
+++ b/internal/cmd/attachments_test.go
@@ -312,6 +312,23 @@ func TestReplyUploadsAttachmentsBeforeSending(t *testing.T) {
 	}
 }
 
+func TestReplySupportsAttachmentOnlyMessages(t *testing.T) {
+	server, state := attachmentServer(t)
+	path := filepath.Join(t.TempDir(), "quarterly-report.pdf")
+	if err := os.WriteFile(path, []byte("report contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runAttachmentCommand(t, server, "reply", "7", "--attach", path); err != nil {
+		t.Fatal(err)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.sentContents) != 1 || !strings.HasPrefix(state.sentContents[0], `<action-text-attachment`) {
+		t.Errorf("attachment-only reply content = %q", state.sentContents)
+	}
+}
+
 func TestReplyReadsPipedBodyWithAttachments(t *testing.T) {
 	server, state := attachmentServer(t)
 	path := filepath.Join(t.TempDir(), "quarterly-report.pdf")
@@ -370,17 +387,34 @@ func TestAttachmentContentTypeUsesBrowserCompatibleMediaType(t *testing.T) {
 
 func TestAttachmentDestinationUsesSafeFilename(t *testing.T) {
 	directory := t.TempDir()
-	destination, err := attachmentDestination(directory, "../../quarterly-report.pdf")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if destination != filepath.Join(directory, "quarterly-report.pdf") {
-		t.Errorf("destination = %q", destination)
+	for filename, want := range map[string]string{
+		"../../quarterly-report.pdf": `quarterly-report.pdf`,
+		`..\..\project-notes.txt`:    `project-notes.txt`,
+		`CON.pdf`:                    `_CON.pdf`,
+		`notes?.txt`:                 `notes_.txt`,
+		"line\nbreak.txt":            `line_break.txt`,
+		`quarterly-report. `:         `quarterly-report`,
+	} {
+		destination, err := attachmentDestination(directory, filename)
+		if err != nil {
+			t.Errorf("attachmentDestination(%q): %v", filename, err)
+			continue
+		}
+		if destination != filepath.Join(directory, want) {
+			t.Errorf("attachmentDestination(%q) = %q, want %q", filename, destination, filepath.Join(directory, want))
+		}
 	}
 	for _, filename := range []string{"", ".", ".."} {
 		if _, err := attachmentDestination("", filename); err == nil {
 			t.Errorf("unsafe filename %q was accepted", filename)
 		}
+	}
+}
+
+func TestTerminalSafeTextReplacesControls(t *testing.T) {
+	safe := terminalSafeText("report\x1b[31m\r\n.pdf")
+	if strings.ContainsAny(safe, "\x1b\r\n") {
+		t.Errorf("terminal-safe text still contains controls: %q", safe)
 	}
 }
 

--- a/internal/cmd/attachments_test.go
+++ b/internal/cmd/attachments_test.go
@@ -1,0 +1,355 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+)
+
+type attachmentServerState struct {
+	mu             sync.Mutex
+	directUploads  int
+	storageUploads int
+	sentContents   []string
+	events         []string
+	blobStatus     int
+}
+
+func attachmentServer(t *testing.T) (*httptest.Server, *attachmentServerState) {
+	t.Helper()
+	state := &attachmentServerState{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/topics/42/entries.json":
+			if r.URL.Query().Get("page") == "1" {
+				_, _ = w.Write([]byte(`[{"id":101,"kind":"message"},{"id":102,"kind":"message"}]`))
+			} else {
+				_, _ = w.Write([]byte(`[]`))
+			}
+		case r.Method == http.MethodGet && r.URL.Path == "/messages/101.json":
+			_, _ = w.Write([]byte(`{
+				"id":101,
+				"content":"<figure data-trix-attachment='{\"sgid\":\"sgid-pdf\",\"url\":\"/rails/active_storage/blobs/report.pdf\",\"filename\":\"quarterly-report.pdf\",\"contentType\":\"application/pdf\",\"filesize\":23}'></figure>"
+			}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/messages/102.json":
+			_, _ = w.Write([]byte(`{"id":102,"content":"<p>No files here</p>"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/rails/active_storage/blobs/report.pdf":
+			state.mu.Lock()
+			blobStatus := state.blobStatus
+			state.mu.Unlock()
+			if blobStatus != 0 {
+				http.Error(w, "download failed", blobStatus)
+				return
+			}
+			w.Header().Set("Content-Type", "application/pdf")
+			_, _ = w.Write([]byte("downloaded report bytes"))
+		case r.Method == http.MethodPost && r.URL.Path == "/rails/active_storage/direct_uploads.json":
+			state.mu.Lock()
+			state.directUploads++
+			state.events = append(state.events, "reserve")
+			state.mu.Unlock()
+			_, _ = fmt.Fprintf(w, `{
+				"signed_id":"signed-upload",
+				"attachable_sgid":"sgid-upload",
+				"direct_upload":{"url":%q,"headers":{"Content-Type":"application/pdf"}}
+			}`, server.URL+"/storage/upload")
+		case r.Method == http.MethodPut && r.URL.Path == "/storage/upload":
+			state.mu.Lock()
+			state.storageUploads++
+			state.events = append(state.events, "upload")
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/identity.json":
+			_, _ = w.Write([]byte(`{"id":1,"senders":[{"id":42,"default":true}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/topics/7":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(topicWithRecipients))
+		case r.Method == http.MethodGet && r.URL.Path == "/topics/7/entries":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(topicEntries))
+		case r.Method == http.MethodPost && r.URL.Path == "/entries/12/replies.json":
+			var body struct {
+				Message struct {
+					Content string `json:"content"`
+				} `json:"message"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			state.mu.Lock()
+			state.sentContents = append(state.sentContents, body.Message.Content)
+			state.events = append(state.events, "send")
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/messages.json":
+			var body struct {
+				Message struct {
+					Content string `json:"content"`
+				} `json:"message"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			state.mu.Lock()
+			state.sentContents = append(state.sentContents, body.Message.Content)
+			state.events = append(state.events, "send")
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Logf("unhandled attachment test request: %s %s", r.Method, r.URL.RequestURI())
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, state
+}
+
+func runAttachmentCommand(t *testing.T, server *httptest.Server, args ...string) (string, error) {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	root := newRootCmd()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	root.SetArgs(append([]string{"--json", "--base-url", server.URL}, args...))
+	err := root.Execute()
+	return output.String(), err
+}
+
+func TestAttachmentsListsFilesFromKnownThread(t *testing.T) {
+	server, _ := attachmentServer(t)
+	stdout, err := runAttachmentCommand(t, server, "attachments", "42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response struct {
+		OK   bool               `json:"ok"`
+		Data []threadAttachment `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, stdout)
+	}
+	if !response.OK || len(response.Data) != 1 {
+		t.Fatalf("response = %+v", response)
+	}
+	attachment := response.Data[0]
+	if attachment.ID != "101:1" || attachment.MessageID != 101 || attachment.Filename != "quarterly-report.pdf" || attachment.ByteSize != 23 {
+		t.Errorf("attachment = %+v", attachment)
+	}
+}
+
+func TestAttachmentsSavePreservesExistingFilesUnlessForced(t *testing.T) {
+	server, _ := attachmentServer(t)
+	destination := filepath.Join(t.TempDir(), "saved-report.pdf")
+	if _, err := runAttachmentCommand(t, server, "attachments", "save", "101:1", "--output", destination); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil || string(data) != "downloaded report bytes" {
+		t.Fatalf("saved data = %q, error = %v", data, err)
+	}
+
+	if err := os.WriteFile(destination, []byte("keep me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = runAttachmentCommand(t, server, "attachments", "save", "101:1", "--output", destination)
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "usage" || !strings.Contains(cliErr.Message, "use --force") {
+		t.Fatalf("existing destination error = %v", err)
+	}
+	data, _ = os.ReadFile(destination)
+	if string(data) != "keep me" {
+		t.Errorf("existing destination was changed to %q", data)
+	}
+
+	if _, err := runAttachmentCommand(t, server, "attachments", "save", "101:1", "--output", destination, "--force"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ = os.ReadFile(destination)
+	if string(data) != "downloaded report bytes" {
+		t.Errorf("forced destination = %q", data)
+	}
+}
+
+func TestAttachmentsSaveRemovesPartialFileOnDownloadFailure(t *testing.T) {
+	server, state := attachmentServer(t)
+	state.mu.Lock()
+	state.blobStatus = http.StatusInternalServerError
+	state.mu.Unlock()
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "saved-report.pdf")
+
+	if _, err := runAttachmentCommand(t, server, "attachments", "save", "101:1", "--output", destination); err == nil {
+		t.Fatal("failed download should return an error")
+	}
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Errorf("failed download left destination behind: %v", err)
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("failed download left temporary files: %v", entries)
+	}
+}
+
+func TestComposeUploadsAttachmentsBeforeSending(t *testing.T) {
+	server, state := attachmentServer(t)
+	path := filepath.Join(t.TempDir(), "quarterly-report.pdf")
+	if err := os.WriteFile(path, []byte("report contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runAttachmentCommand(t, server,
+		"compose", "--to", "alice@example.com", "--subject", "Quarterly report", "-m", "Attached.", "--attach", path,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.directUploads != 1 || state.storageUploads != 1 || len(state.sentContents) != 1 {
+		t.Fatalf("state = %+v", state)
+	}
+	if strings.Join(state.events, ",") != "reserve,upload,send" {
+		t.Errorf("events = %v", state.events)
+	}
+	content := state.sentContents[0]
+	if !strings.Contains(content, "Attached.<br>") || !strings.Contains(content, `action-text-attachment sgid="sgid-upload"`) || !strings.Contains(content, `filename="quarterly-report.pdf"`) {
+		t.Errorf("sent content = %q", content)
+	}
+}
+
+func TestComposeSupportsAttachmentOnlyMessages(t *testing.T) {
+	server, state := attachmentServer(t)
+	path := filepath.Join(t.TempDir(), "quarterly-report.pdf")
+	if err := os.WriteFile(path, []byte("report contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runAttachmentCommand(t, server,
+		"compose", "--to", "alice@example.com", "--subject", "Quarterly report", "--attach", path,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.sentContents) != 1 || !strings.HasPrefix(state.sentContents[0], `<action-text-attachment`) {
+		t.Errorf("attachment-only content = %q", state.sentContents)
+	}
+}
+
+func TestReplyUploadsAttachmentsBeforeSending(t *testing.T) {
+	server, state := attachmentServer(t)
+	path := filepath.Join(t.TempDir(), "quarterly-report.pdf")
+	if err := os.WriteFile(path, []byte("report contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runAttachmentCommand(t, server, "reply", "7", "-m", "Attached.", "--attach", path); err != nil {
+		t.Fatal(err)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if strings.Join(state.events, ",") != "reserve,upload,send" || len(state.sentContents) != 1 || !strings.Contains(state.sentContents[0], `sgid="sgid-upload"`) {
+		t.Errorf("reply attachment state = %+v", state)
+	}
+}
+
+func TestComposeValidatesEveryAttachmentBeforeUploading(t *testing.T) {
+	server, state := attachmentServer(t)
+	path := filepath.Join(t.TempDir(), "quarterly-report.pdf")
+	if err := os.WriteFile(path, []byte("report contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runAttachmentCommand(t, server,
+		"compose", "--to", "alice@example.com", "--subject", "Quarterly report", "-m", "Attached.",
+		"--attach", path, "--attach", filepath.Join(t.TempDir(), "missing.pdf"),
+	)
+	if err == nil {
+		t.Fatal("missing attachment should fail")
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.directUploads != 0 || state.storageUploads != 0 || len(state.sentContents) != 0 {
+		t.Errorf("invalid attachment performed writes: %+v", state)
+	}
+}
+
+func TestAttachmentContentTypeUsesBrowserCompatibleMediaType(t *testing.T) {
+	contentType, err := attachmentContentType(strings.NewReader("plain text"), "notes.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contentType != "text/plain" {
+		t.Errorf("content type = %q, want text/plain", contentType)
+	}
+	contentType, err = attachmentContentType(strings.NewReader("plain text"), "notes.unknown")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contentType != "text/plain" {
+		t.Errorf("sniffed content type = %q, want text/plain", contentType)
+	}
+}
+
+func TestAttachmentDestinationUsesSafeFilename(t *testing.T) {
+	directory := t.TempDir()
+	destination, err := attachmentDestination(directory, "../../quarterly-report.pdf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if destination != filepath.Join(directory, "quarterly-report.pdf") {
+		t.Errorf("destination = %q", destination)
+	}
+	for _, filename := range []string{"", ".", ".."} {
+		if _, err := attachmentDestination("", filename); err == nil {
+			t.Errorf("unsafe filename %q was accepted", filename)
+		}
+	}
+}
+
+func TestAppendUploadedAttachmentsSupportsAttachmentOnlyMessages(t *testing.T) {
+	content := appendUploadedAttachments("", []uploadedAttachment{{
+		Filename:    `report & "notes".pdf`,
+		ContentType: "application/pdf",
+		ByteSize:    128,
+		SGID:        `sgid&1`,
+	}})
+	if strings.HasPrefix(content, "<br>") {
+		t.Errorf("attachment-only content starts with a break: %q", content)
+	}
+	for _, want := range []string{`sgid="sgid&amp;1"`, `filename="report &amp; &#34;notes&#34;.pdf"`, `filesize="128"`} {
+		if !strings.Contains(content, want) {
+			t.Errorf("content %q does not contain %q", content, want)
+		}
+	}
+}
+
+func TestParseAttachmentID(t *testing.T) {
+	messageID, position, err := parseAttachmentID("101:2")
+	if err != nil || messageID != 101 || position != 2 {
+		t.Fatalf("parseAttachmentID = %d, %d, %v", messageID, position, err)
+	}
+	for _, id := range []string{"", "101", "101:0", "x:1", "1:2:3"} {
+		if _, _, err := parseAttachmentID(id); err == nil {
+			t.Errorf("parseAttachmentID(%q) succeeded", id)
+		}
+	}
+}

--- a/internal/cmd/attachments_test.go
+++ b/internal/cmd/attachments_test.go
@@ -444,13 +444,30 @@ func TestTerminalSafeTextReplacesControls(t *testing.T) {
 }
 
 func TestAttachmentsForMarkdownEscapesUntrustedFields(t *testing.T) {
-	attachments := []threadAttachment{{Filename: "report|draft\n.pdf", ContentType: "text/plain|preview"}}
+	attachments := []threadAttachment{{
+		Filename:    "[report](https://example.invalid)|draft\n<img>.pdf",
+		ContentType: "text/plain|preview",
+	}}
 	safe := attachmentsForMarkdown(attachments)
-	if strings.ContainsAny(safe[0].Filename, "\r\n\x1b") || !strings.Contains(safe[0].Filename, `\|`) || !strings.Contains(safe[0].ContentType, `\|`) {
+	if strings.ContainsAny(safe[0].Filename, "\r\n\x1b") ||
+		!strings.Contains(safe[0].Filename, `\[report\]\(`) ||
+		!strings.Contains(safe[0].Filename, `\<img\>`) ||
+		!strings.Contains(safe[0].ContentType, `\|`) {
 		t.Errorf("Markdown attachment = %+v", safe[0])
 	}
-	if attachments[0].Filename != "report|draft\n.pdf" {
+	if attachments[0].Filename != "[report](https://example.invalid)|draft\n<img>.pdf" {
 		t.Errorf("JSON attachment data was changed to %q", attachments[0].Filename)
+	}
+}
+
+func TestSavedAttachmentForMarkdownEscapesFilenameAndPath(t *testing.T) {
+	attachment := savedAttachment{Filename: "[report](https://example.invalid)", Path: "<download>/report.pdf"}
+	safe := savedAttachmentForMarkdown(attachment)
+	if !strings.Contains(safe.Filename, `\[report\]\(`) || !strings.Contains(safe.Path, `\<download\>`) {
+		t.Errorf("Markdown saved attachment = %+v", safe)
+	}
+	if attachment.Filename != "[report](https://example.invalid)" {
+		t.Errorf("JSON saved attachment data was changed to %q", attachment.Filename)
 	}
 }
 

--- a/internal/cmd/attachments_test.go
+++ b/internal/cmd/attachments_test.go
@@ -132,6 +132,27 @@ func runAttachmentCommand(t *testing.T, server *httptest.Server, args ...string)
 	return output.String(), err
 }
 
+func runAttachmentCommandWithStdin(t *testing.T, server *httptest.Server, input string, args ...string) (string, error) {
+	t.Helper()
+	stdin, err := os.CreateTemp(t.TempDir(), "stdin-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stdin.WriteString(input); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stdin.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	oldStdin := os.Stdin
+	os.Stdin = stdin
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = stdin.Close()
+	})
+	return runAttachmentCommand(t, server, args...)
+}
+
 func TestAttachmentsListsFilesFromKnownThread(t *testing.T) {
 	server, _ := attachmentServer(t)
 	stdout, err := runAttachmentCommand(t, server, "attachments", "42")
@@ -236,6 +257,25 @@ func TestComposeUploadsAttachmentsBeforeSending(t *testing.T) {
 	}
 }
 
+func TestComposeReadsPipedBodyWithAttachments(t *testing.T) {
+	server, state := attachmentServer(t)
+	path := filepath.Join(t.TempDir(), "quarterly-report.pdf")
+	if err := os.WriteFile(path, []byte("report contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runAttachmentCommandWithStdin(t, server, "Piped compose body\n",
+		"compose", "--to", "alice@example.com", "--subject", "Quarterly report", "--attach", path,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.sentContents) != 1 || !strings.HasPrefix(state.sentContents[0], "Piped compose body<br>") {
+		t.Errorf("sent content = %q", state.sentContents)
+	}
+}
+
 func TestComposeSupportsAttachmentOnlyMessages(t *testing.T) {
 	server, state := attachmentServer(t)
 	path := filepath.Join(t.TempDir(), "quarterly-report.pdf")
@@ -269,6 +309,25 @@ func TestReplyUploadsAttachmentsBeforeSending(t *testing.T) {
 	defer state.mu.Unlock()
 	if strings.Join(state.events, ",") != "reserve,upload,send" || len(state.sentContents) != 1 || !strings.Contains(state.sentContents[0], `sgid="sgid-upload"`) {
 		t.Errorf("reply attachment state = %+v", state)
+	}
+}
+
+func TestReplyReadsPipedBodyWithAttachments(t *testing.T) {
+	server, state := attachmentServer(t)
+	path := filepath.Join(t.TempDir(), "quarterly-report.pdf")
+	if err := os.WriteFile(path, []byte("report contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runAttachmentCommandWithStdin(t, server, "Piped reply body\n",
+		"reply", "7", "--attach", path,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.sentContents) != 1 || !strings.HasPrefix(state.sentContents[0], "Piped reply body<br>") {
+		t.Errorf("sent content = %q", state.sentContents)
 	}
 }
 

--- a/internal/cmd/attachments_test.go
+++ b/internal/cmd/attachments_test.go
@@ -430,6 +430,10 @@ func TestAttachmentDestinationUsesSafeFilename(t *testing.T) {
 			t.Errorf("unsafe filename %q was accepted", filename)
 		}
 	}
+	explicit := filepath.Join(t.TempDir(), "chosen-name.pdf")
+	if destination, err := attachmentDestination(explicit, ".."); err != nil || destination != explicit {
+		t.Errorf("explicit destination = %q, %v", destination, err)
+	}
 }
 
 func TestTerminalSafeTextReplacesControls(t *testing.T) {

--- a/internal/cmd/attachments_test.go
+++ b/internal/cmd/attachments_test.go
@@ -23,6 +23,7 @@ type attachmentServerState struct {
 	sentContents   []string
 	events         []string
 	blobStatus     int
+	nilMessage     bool
 }
 
 func attachmentServer(t *testing.T) (*httptest.Server, *attachmentServerState) {
@@ -44,6 +45,13 @@ func attachmentServer(t *testing.T) (*httptest.Server, *attachmentServerState) {
 				"content":"<figure data-trix-attachment='{\"sgid\":\"sgid-pdf\",\"url\":\"/rails/active_storage/blobs/report.pdf\",\"filename\":\"quarterly-report.pdf\",\"contentType\":\"application/pdf\",\"filesize\":23}'></figure>"
 			}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/messages/102.json":
+			state.mu.Lock()
+			nilMessage := state.nilMessage
+			state.mu.Unlock()
+			if nilMessage {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
 			_, _ = w.Write([]byte(`{"id":102,"content":"<p>No files here</p>"}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/rails/active_storage/blobs/report.pdf":
 			state.mu.Lock()
@@ -172,6 +180,17 @@ func TestAttachmentsListsFilesFromKnownThread(t *testing.T) {
 	attachment := response.Data[0]
 	if attachment.ID != "101:1" || attachment.MessageID != 101 || attachment.Filename != "quarterly-report.pdf" || attachment.ByteSize != 23 {
 		t.Errorf("attachment = %+v", attachment)
+	}
+}
+
+func TestAttachmentsRejectsAnEmptyMessageResponse(t *testing.T) {
+	server, state := attachmentServer(t)
+	state.mu.Lock()
+	state.nilMessage = true
+	state.mu.Unlock()
+
+	if _, err := runAttachmentCommand(t, server, "attachments", "42"); err == nil {
+		t.Fatal("empty message response should fail attachment discovery")
 	}
 }
 
@@ -391,6 +410,8 @@ func TestAttachmentDestinationUsesSafeFilename(t *testing.T) {
 		"../../quarterly-report.pdf": `quarterly-report.pdf`,
 		`..\..\project-notes.txt`:    `project-notes.txt`,
 		`CON.pdf`:                    `_CON.pdf`,
+		`CONIN$`:                     `_CONIN$`,
+		`LPT².log`:                   `_LPT².log`,
 		`notes?.txt`:                 `notes_.txt`,
 		"line\nbreak.txt":            `line_break.txt`,
 		`quarterly-report. `:         `quarterly-report`,

--- a/internal/cmd/attachments_test.go
+++ b/internal/cmd/attachments_test.go
@@ -439,6 +439,17 @@ func TestTerminalSafeTextReplacesControls(t *testing.T) {
 	}
 }
 
+func TestAttachmentsForMarkdownEscapesUntrustedFields(t *testing.T) {
+	attachments := []threadAttachment{{Filename: "report|draft\n.pdf", ContentType: "text/plain|preview"}}
+	safe := attachmentsForMarkdown(attachments)
+	if strings.ContainsAny(safe[0].Filename, "\r\n\x1b") || !strings.Contains(safe[0].Filename, `\|`) || !strings.Contains(safe[0].ContentType, `\|`) {
+		t.Errorf("Markdown attachment = %+v", safe[0])
+	}
+	if attachments[0].Filename != "report|draft\n.pdf" {
+		t.Errorf("JSON attachment data was changed to %q", attachments[0].Filename)
+	}
+}
+
 func TestAppendUploadedAttachmentsSupportsAttachmentOnlyMessages(t *testing.T) {
 	content := appendUploadedAttachments("", []uploadedAttachment{{
 		Filename:    `report & "notes".pdf`,

--- a/internal/cmd/attachments_test.go
+++ b/internal/cmd/attachments_test.go
@@ -178,7 +178,7 @@ func TestAttachmentsListsFilesFromKnownThread(t *testing.T) {
 		t.Fatalf("response = %+v", response)
 	}
 	attachment := response.Data[0]
-	if attachment.ID != "101:1" || attachment.MessageID != 101 || attachment.Filename != "quarterly-report.pdf" || attachment.ByteSize != 23 {
+	if attachment.ID != "101:1" || attachment.MessageID != 101 || attachment.Filename != "quarterly-report.pdf" || attachment.ByteSize == nil || *attachment.ByteSize != 23 {
 		t.Errorf("attachment = %+v", attachment)
 	}
 }
@@ -433,6 +433,21 @@ func TestAttachmentDestinationUsesSafeFilename(t *testing.T) {
 	explicit := filepath.Join(t.TempDir(), "chosen-name.pdf")
 	if destination, err := attachmentDestination(explicit, ".."); err != nil || destination != explicit {
 		t.Errorf("explicit destination = %q, %v", destination, err)
+	}
+}
+
+func TestAttachmentByteSizeDistinguishesEmptyFromUnknown(t *testing.T) {
+	zero := int64(0)
+	attachment := threadAttachment{ID: "101:1", ByteSize: &zero}
+	encoded, err := json.Marshal(attachment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), `"byte_size":0`) || formatOptionalByteSize(attachment.ByteSize) != "0 B" {
+		t.Errorf("empty attachment = %s, %q", encoded, formatOptionalByteSize(attachment.ByteSize))
+	}
+	if formatOptionalByteSize(nil) != "—" {
+		t.Errorf("unknown attachment size = %q", formatOptionalByteSize(nil))
 	}
 }
 

--- a/internal/cmd/commit_file_darwin.go
+++ b/internal/cmd/commit_file_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func commitFileNoReplace(source, destination string) error {
+	err := unix.RenamexNp(source, destination, unix.RENAME_EXCL)
+	if err == nil || (!errors.Is(err, unix.ENOSYS) && !errors.Is(err, unix.EINVAL) && !errors.Is(err, unix.EOPNOTSUPP)) {
+		return err
+	}
+	return os.Link(source, destination)
+}

--- a/internal/cmd/commit_file_linux.go
+++ b/internal/cmd/commit_file_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func commitFileNoReplace(source, destination string) error {
+	err := unix.Renameat2(unix.AT_FDCWD, source, unix.AT_FDCWD, destination, unix.RENAME_NOREPLACE)
+	if err == nil || (!errors.Is(err, unix.ENOSYS) && !errors.Is(err, unix.EINVAL) && !errors.Is(err, unix.EOPNOTSUPP)) {
+		return err
+	}
+	return os.Link(source, destination)
+}

--- a/internal/cmd/commit_file_other.go
+++ b/internal/cmd/commit_file_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux && !windows
+
+package cmd
+
+import "os"
+
+func commitFileNoReplace(source, destination string) error {
+	return os.Link(source, destination)
+}

--- a/internal/cmd/commit_file_windows.go
+++ b/internal/cmd/commit_file_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package cmd
+
+import "golang.org/x/sys/windows"
+
+func commitFileNoReplace(source, destination string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFile(from, to)
+}

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -60,25 +60,23 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	message := c.message
-	if message == "" && len(c.attachments) == 0 {
-		if !stdinIsTerminal() {
-			var err error
-			message, err = readStdin()
-			if err != nil {
-				return err
-			}
-			if message == "" {
-				return output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
-			}
-		} else {
-			var err error
-			message, err = editor.Open("")
-			if err != nil {
-				return output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
-			}
-			if message == "" {
-				return output.ErrUsage("empty message, aborting")
-			}
+	if message == "" && !stdinIsTerminal() {
+		var err error
+		message, err = readStdin()
+		if err != nil {
+			return err
+		}
+		if message == "" && len(c.attachments) == 0 {
+			return output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
+		}
+	} else if message == "" && len(c.attachments) == 0 {
+		var err error
+		message, err = editor.Open("")
+		if err != nil {
+			return output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
+		}
+		if message == "" {
+			return output.ErrUsage("empty message, aborting")
 		}
 	}
 

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -12,13 +12,14 @@ import (
 )
 
 type composeCommand struct {
-	cmd      *cobra.Command
-	to       string
-	cc       string
-	bcc      string
-	subject  string
-	message  string
-	threadID string
+	cmd         *cobra.Command
+	to          string
+	cc          string
+	bcc         string
+	subject     string
+	message     string
+	threadID    string
+	attachments []string
 }
 
 func newComposeCommand() *composeCommand {
@@ -27,11 +28,12 @@ func newComposeCommand() *composeCommand {
 		Use:   "compose",
 		Short: "Write and send a new email",
 		Annotations: map[string]string{
-			"agent_notes": "Starts a new thread with --to (optionally --cc/--bcc), which requires --subject, or replies to an existing one with --thread-id, which does not: a reply carries the thread's subject and goes to that thread's recipients.",
+			"agent_notes": "Starts a new thread with --to (optionally --cc/--bcc), which requires --subject, or replies to an existing one with --thread-id, which does not. Repeatable --attach files are uploaded before sending and can be sent without body text.",
 		},
 		Example: `  hey compose --to alice@example.com --subject "Hello" -m "Hi there"
   hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Hello" -m "Hi"
-  hey compose --thread-id 12345 -m "Thread reply"
+  hey compose --to alice@example.com --subject "Report" -m "Attached." --attach ./report.pdf
+  hey compose --thread-id 12345 -m "Thread reply" --attach ./diagram.png
   echo "Long message" | hey compose --to bob@example.com --subject "Report"`,
 		RunE: composeCommand.run,
 	}
@@ -42,6 +44,7 @@ func newComposeCommand() *composeCommand {
 	composeCommand.cmd.Flags().StringVar(&composeCommand.subject, "subject", "", "Message subject (required for a new message)")
 	composeCommand.cmd.Flags().StringVarP(&composeCommand.message, "message", "m", "", "Message body (or opens $EDITOR)")
 	composeCommand.cmd.Flags().StringVar(&composeCommand.threadID, "thread-id", "", "Reply to this thread instead of starting a new one")
+	composeCommand.cmd.Flags().StringArrayVar(&composeCommand.attachments, "attach", nil, "File to attach (repeatable)")
 
 	return composeCommand
 }
@@ -57,7 +60,7 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	message := c.message
-	if message == "" {
+	if message == "" && len(c.attachments) == 0 {
 		if !stdinIsTerminal() {
 			var err error
 			message, err = readStdin()
@@ -82,15 +85,19 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
 	if c.threadID != "" {
-		topicID, err := strconv.ParseInt(c.threadID, 10, 64)
-		if err != nil {
+		topicID, parseErr := strconv.ParseInt(c.threadID, 10, 64)
+		if parseErr != nil {
 			return output.ErrUsage(fmt.Sprintf("invalid thread ID: %s", c.threadID))
 		}
-		target, err := resolveThreadReply(ctx, topicID)
-		if err != nil {
-			return err
+		target, resolveErr := resolveThreadReply(ctx, topicID)
+		if resolveErr != nil {
+			return resolveErr
 		}
-		if err := sdk.Entries().CreateReply(ctx, target.EntryID, message,
+		messageWithAttachments, attachErr := attachFiles(ctx, message, c.attachments)
+		if attachErr != nil {
+			return attachErr
+		}
+		if err := sdk.Entries().CreateReply(ctx, target.EntryID, messageWithAttachments,
 			target.Addressed.To, target.Addressed.CC, target.Addressed.BCC); err != nil {
 			return convertSDKError(err)
 		}
@@ -98,17 +105,25 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		to := parseAddresses(c.to)
 		cc := parseAddresses(c.cc)
 		bcc := parseAddresses(c.bcc)
-		if err := sdk.Messages().Create(ctx, c.subject, message, to, cc, bcc); err != nil {
+		if len(to)+len(cc)+len(bcc) == 0 {
+			return output.ErrUsage("a message needs at least one recipient (to, cc or bcc)")
+		}
+		messageWithAttachments, attachErr := attachFiles(ctx, message, c.attachments)
+		if attachErr != nil {
+			return attachErr
+		}
+		if err := sdk.Messages().Create(ctx, c.subject, messageWithAttachments, to, cc, bcc); err != nil {
 			return convertSDKError(err)
 		}
 	}
 
+	summary := sentWithAttachmentsSummary("Message sent", len(c.attachments))
 	if writer.IsStyled() {
-		fmt.Fprintln(cmd.OutOrStdout(), "Message sent.")
+		fmt.Fprintln(cmd.OutOrStdout(), summary+".")
 		return nil
 	}
 
-	return writeOK(nil, output.WithSummary("Message sent"))
+	return writeOK(nil, output.WithSummary(summary))
 }
 
 func parseAddresses(s string) []string {

--- a/internal/cmd/formatting.go
+++ b/internal/cmd/formatting.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/mattn/go-runewidth"
 	"golang.org/x/term"
@@ -80,6 +81,15 @@ func (s style) format(value string) string {
 		return value
 	}
 	return "\033[" + string(s) + "m" + value + "\033[0m"
+}
+
+func terminalSafeText(value string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return '�'
+		}
+		return r
+	}, value)
 }
 
 func truncate(s string, maxWidth int) string {

--- a/internal/cmd/formatting.go
+++ b/internal/cmd/formatting.go
@@ -92,6 +92,18 @@ func terminalSafeText(value string) string {
 	}, value)
 }
 
+func markdownSafeText(value string) string {
+	const punctuation = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+	var safe strings.Builder
+	for _, r := range terminalSafeText(value) {
+		if strings.ContainsRune(punctuation, r) {
+			safe.WriteByte('\\')
+		}
+		safe.WriteRune(r)
+	}
+	return safe.String()
+}
+
 func truncate(s string, maxWidth int) string {
 	if runewidth.StringWidth(s) <= maxWidth {
 		return s

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -17,7 +17,7 @@ var curatedCategories = []struct {
 }{
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "search", "contacts", "threads", "compose", "reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
+		names:   []string{"boxes", "box", "search", "contacts", "threads", "attachments", "compose", "reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -97,6 +97,7 @@ EMAIL
   search         Search email threads and messages
   contacts       Manage contacts
   threads        Read a thread
+  attachments    List and save files from a thread
   compose        Write and send a new email
   reply          Reply to a thread
   forward        Forward the latest message in a thread

--- a/internal/cmd/replace_file_unix.go
+++ b/internal/cmd/replace_file_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package cmd
+
+import "os"
+
+func replaceFile(source, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/internal/cmd/replace_file_windows.go
+++ b/internal/cmd/replace_file_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package cmd
+
+import "golang.org/x/sys/windows"
+
+func replaceFile(source, destination string) error {
+	return windows.Rename(source, destination)
+}

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -55,23 +55,21 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	message := c.message
-	if message == "" && len(c.attachments) == 0 {
-		if !stdinIsTerminal() {
-			message, err = readStdin()
-			if err != nil {
-				return err
-			}
-			if message == "" {
-				return output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
-			}
-		} else {
-			message, err = editor.Open("")
-			if err != nil {
-				return output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
-			}
-			if message == "" {
-				return output.ErrUsage("empty message, aborting")
-			}
+	if message == "" && !stdinIsTerminal() {
+		message, err = readStdin()
+		if err != nil {
+			return err
+		}
+		if message == "" && len(c.attachments) == 0 {
+			return output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
+		}
+	} else if message == "" && len(c.attachments) == 0 {
+		message, err = editor.Open("")
+		if err != nil {
+			return output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
+		}
+		if message == "" {
+			return output.ErrUsage("empty message, aborting")
 		}
 	}
 

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -11,8 +11,9 @@ import (
 )
 
 type replyCommand struct {
-	cmd     *cobra.Command
-	message string
+	cmd         *cobra.Command
+	message     string
+	attachments []string
 }
 
 func newReplyCommand() *replyCommand {
@@ -21,15 +22,17 @@ func newReplyCommand() *replyCommand {
 		Use:   "reply <thread-id>",
 		Short: "Reply to a thread",
 		Annotations: map[string]string{
-			"agent_notes": "Replies to the latest entry in a thread. Accepts message via -m, stdin, or $EDITOR.",
+			"agent_notes": "Replies to the latest entry in a thread. Accepts message via -m, stdin, or $EDITOR, plus repeatable --attach files; an attachment can be sent without body text.",
 		},
 		Example: `  hey reply 12345 -m "Thanks!"
+  hey reply 12345 -m "Attached is the report." --attach ./report.pdf
   echo "Detailed reply" | hey reply 12345`,
 		RunE: replyCommand.run,
 		Args: usageExactOneArg(),
 	}
 
 	replyCommand.cmd.Flags().StringVarP(&replyCommand.message, "message", "m", "", "Reply message (or opens $EDITOR)")
+	replyCommand.cmd.Flags().StringArrayVar(&replyCommand.attachments, "attach", nil, "File to attach (repeatable)")
 
 	return replyCommand
 }
@@ -52,7 +55,7 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	message := c.message
-	if message == "" {
+	if message == "" && len(c.attachments) == 0 {
 		if !stdinIsTerminal() {
 			message, err = readStdin()
 			if err != nil {
@@ -72,17 +75,22 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	message, err = attachFiles(ctx, message, c.attachments)
+	if err != nil {
+		return err
+	}
 	if err = sdk.Entries().CreateReply(ctx, target.EntryID, message, target.Addressed.To, target.Addressed.CC, target.Addressed.BCC); err != nil {
 		return convertSDKError(err)
 	}
 
+	summary := sentWithAttachmentsSummary("Reply sent", len(c.attachments))
 	if writer.IsStyled() {
-		fmt.Fprintln(cmd.OutOrStdout(), "Reply sent.")
+		fmt.Fprintln(cmd.OutOrStdout(), summary+".")
 		return nil
 	}
 
 	return writeOK(nil,
-		output.WithSummary("Reply sent"),
+		output.WithSummary(summary),
 		output.WithBreadcrumbs(output.Breadcrumb{
 			Action:      "view",
 			Command:     fmt.Sprintf("hey threads %d", threadID),

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -122,6 +122,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newSearchCommand().cmd)
 	root.AddCommand(newContactsCommand().cmd)
 	root.AddCommand(newThreadsCommand().cmd)
+	root.AddCommand(newAttachmentsCommand().cmd)
 	root.AddCommand(newReplyCommand().cmd)
 	root.AddCommand(newForwardCommand().cmd)
 	root.AddCommand(newComposeCommand().cmd)

--- a/internal/htmlutil/htmlutil.go
+++ b/internal/htmlutil/htmlutil.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	stdhtml "html"
+	"strconv"
 	"strings"
 
 	"golang.org/x/net/html"
@@ -46,6 +47,26 @@ func ExtractImageURLs(s string) []string {
 	var urls []string
 	findImages(doc, &urls)
 	return urls
+}
+
+// Attachment describes a downloadable file embedded in rich-text content.
+type Attachment struct {
+	URL         string
+	Filename    string
+	ContentType string
+	ByteSize    int64
+	SGID        string
+}
+
+// ExtractAttachments returns downloadable files in their document order.
+func ExtractAttachments(s string) []Attachment {
+	doc, err := html.Parse(strings.NewReader(s))
+	if err != nil {
+		return nil
+	}
+	var attachments []Attachment
+	findAttachments(doc, &attachments)
+	return attachments
 }
 
 func walkNode(b *strings.Builder, n *html.Node) {
@@ -103,6 +124,8 @@ type trixAttachment struct {
 	URL         string `json:"url"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"contentType"`
+	Filesize    int64  `json:"filesize"`
+	SGID        string `json:"sgid"`
 }
 
 func parseTrixAttachment(n *html.Node) *trixAttachment {
@@ -132,6 +155,38 @@ func getAttr(n *html.Node, key string) string {
 func walkChildren(b *strings.Builder, n *html.Node) {
 	for c := n.FirstChild; c != nil; c = c.NextSibling {
 		walkNode(b, c)
+	}
+}
+
+func findAttachments(n *html.Node, attachments *[]Attachment) {
+	if n.Type == html.ElementNode {
+		switch n.Data {
+		case "action-text-attachment":
+			byteSize, _ := strconv.ParseInt(getAttr(n, "filesize"), 10, 64)
+			attachment := Attachment{
+				URL:         getAttr(n, "url"),
+				Filename:    getAttr(n, "filename"),
+				ContentType: getAttr(n, "content-type"),
+				ByteSize:    byteSize,
+				SGID:        getAttr(n, "sgid"),
+			}
+			if attachment.URL != "" && attachment.Filename != "" {
+				*attachments = append(*attachments, attachment)
+			}
+		case "figure":
+			if trix := parseTrixAttachment(n); trix != nil && trix.URL != "" {
+				*attachments = append(*attachments, Attachment{
+					URL:         trix.URL,
+					Filename:    trix.Filename,
+					ContentType: trix.ContentType,
+					ByteSize:    trix.Filesize,
+					SGID:        trix.SGID,
+				})
+			}
+		}
+	}
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		findAttachments(child, attachments)
 	}
 }
 

--- a/internal/htmlutil/htmlutil.go
+++ b/internal/htmlutil/htmlutil.go
@@ -54,7 +54,7 @@ type Attachment struct {
 	URL         string
 	Filename    string
 	ContentType string
-	ByteSize    int64
+	ByteSize    *int64
 	SGID        string
 }
 
@@ -124,7 +124,7 @@ type trixAttachment struct {
 	URL         string `json:"url"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"contentType"`
-	Filesize    int64  `json:"filesize"`
+	Filesize    *int64 `json:"filesize"`
 	SGID        string `json:"sgid"`
 }
 
@@ -162,7 +162,7 @@ func findAttachments(n *html.Node, attachments *[]Attachment) {
 	if n.Type == html.ElementNode {
 		switch n.Data {
 		case "action-text-attachment":
-			byteSize, _ := strconv.ParseInt(getAttr(n, "filesize"), 10, 64)
+			byteSize := parseAttachmentByteSize(getAttr(n, "filesize"))
 			attachment := Attachment{
 				URL:         getAttr(n, "url"),
 				Filename:    getAttr(n, "filename"),
@@ -179,7 +179,7 @@ func findAttachments(n *html.Node, attachments *[]Attachment) {
 					URL:         trix.URL,
 					Filename:    trix.Filename,
 					ContentType: trix.ContentType,
-					ByteSize:    trix.Filesize,
+					ByteSize:    nonnegativeAttachmentByteSize(trix.Filesize),
 					SGID:        trix.SGID,
 				})
 			}
@@ -188,6 +188,24 @@ func findAttachments(n *html.Node, attachments *[]Attachment) {
 	for child := n.FirstChild; child != nil; child = child.NextSibling {
 		findAttachments(child, attachments)
 	}
+}
+
+func parseAttachmentByteSize(value string) *int64 {
+	if value == "" {
+		return nil
+	}
+	size, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || size < 0 {
+		return nil
+	}
+	return &size
+}
+
+func nonnegativeAttachmentByteSize(size *int64) *int64 {
+	if size == nil || *size < 0 {
+		return nil
+	}
+	return size
 }
 
 func findImages(n *html.Node, urls *[]string) {

--- a/internal/htmlutil/htmlutil.go
+++ b/internal/htmlutil/htmlutil.go
@@ -217,6 +217,11 @@ func findImages(n *html.Node, urls *[]string) {
 					*urls = append(*urls, a.Val)
 				}
 			}
+		case "action-text-attachment":
+			contentType := strings.ToLower(strings.TrimSpace(getAttr(n, "content-type")))
+			if imageURL := getAttr(n, "url"); strings.HasPrefix(contentType, "image/") && imageURL != "" {
+				*urls = append(*urls, imageURL)
+			}
 		case "figure":
 			if att := parseTrixAttachment(n); att != nil && att.URL != "" {
 				*urls = append(*urls, att.URL)

--- a/internal/htmlutil/htmlutil_test.go
+++ b/internal/htmlutil/htmlutil_test.go
@@ -112,6 +112,29 @@ func TestPrependTextWithoutNote(t *testing.T) {
 	}
 }
 
+func TestExtractAttachments(t *testing.T) {
+	h := `<action-text-attachment sgid="sgid-1" url="/rails/blobs/report.pdf" filename="quarterly-report.pdf" content-type="application/pdf" filesize="128"></action-text-attachment>
+<figure data-trix-attachment='{"sgid":"sgid-2","url":"/rails/blobs/photo.png","filename":"photo.png","contentType":"image/png","filesize":256}'></figure>`
+	attachments := ExtractAttachments(h)
+	if len(attachments) != 2 {
+		t.Fatalf("ExtractAttachments got %d attachments, want 2", len(attachments))
+	}
+	if attachments[0].Filename != "quarterly-report.pdf" || attachments[0].ContentType != "application/pdf" || attachments[0].ByteSize != 128 || attachments[0].SGID != "sgid-1" {
+		t.Errorf("canonical attachment = %+v", attachments[0])
+	}
+	if attachments[1].Filename != "photo.png" || attachments[1].URL != "/rails/blobs/photo.png" || attachments[1].ByteSize != 256 || attachments[1].SGID != "sgid-2" {
+		t.Errorf("Trix attachment = %+v", attachments[1])
+	}
+}
+
+func TestExtractAttachmentsSkipsIncompleteElements(t *testing.T) {
+	h := `<action-text-attachment sgid="sgid-1" filename="missing-url.pdf"></action-text-attachment>
+<figure data-trix-attachment='{"url":"/rails/blobs/missing-name"}'></figure>`
+	if attachments := ExtractAttachments(h); len(attachments) != 0 {
+		t.Errorf("ExtractAttachments = %+v, want none", attachments)
+	}
+}
+
 func TestExtractImageURLs(t *testing.T) {
 	h := `<p>Hello</p><img src="https://example.com/a.png"><img src="https://example.com/b.jpg">`
 	urls := ExtractImageURLs(h)

--- a/internal/htmlutil/htmlutil_test.go
+++ b/internal/htmlutil/htmlutil_test.go
@@ -178,6 +178,18 @@ func TestExtractImageURLsEmptySrc(t *testing.T) {
 	}
 }
 
+func TestExtractImageURLsActionTextImage(t *testing.T) {
+	h := `<action-text-attachment url="/rails/blobs/photo.png" filename="photo.png" content-type="image/png"></action-text-attachment>
+<action-text-attachment url="/rails/blobs/report.pdf" filename="report.pdf" content-type="application/pdf"></action-text-attachment>`
+	urls := ExtractImageURLs(h)
+	if len(urls) != 1 {
+		t.Fatalf("ExtractImageURLs Action Text got %d urls, want 1", len(urls))
+	}
+	if urls[0] != "/rails/blobs/photo.png" {
+		t.Errorf("url[0] = %q, want %q", urls[0], "/rails/blobs/photo.png")
+	}
+}
+
 func TestExtractImageURLsTrixFigure(t *testing.T) {
 	h := `<figure data-trix-attachment='{"url":"/rails/blobs/abc/image.png","filename":"image.png","contentType":"image/png"}'></figure>`
 	urls := ExtractImageURLs(h)

--- a/internal/htmlutil/htmlutil_test.go
+++ b/internal/htmlutil/htmlutil_test.go
@@ -119,11 +119,26 @@ func TestExtractAttachments(t *testing.T) {
 	if len(attachments) != 2 {
 		t.Fatalf("ExtractAttachments got %d attachments, want 2", len(attachments))
 	}
-	if attachments[0].Filename != "quarterly-report.pdf" || attachments[0].ContentType != "application/pdf" || attachments[0].ByteSize != 128 || attachments[0].SGID != "sgid-1" {
+	if attachments[0].Filename != "quarterly-report.pdf" || attachments[0].ContentType != "application/pdf" || attachments[0].ByteSize == nil || *attachments[0].ByteSize != 128 || attachments[0].SGID != "sgid-1" {
 		t.Errorf("canonical attachment = %+v", attachments[0])
 	}
-	if attachments[1].Filename != "photo.png" || attachments[1].URL != "/rails/blobs/photo.png" || attachments[1].ByteSize != 256 || attachments[1].SGID != "sgid-2" {
+	if attachments[1].Filename != "photo.png" || attachments[1].URL != "/rails/blobs/photo.png" || attachments[1].ByteSize == nil || *attachments[1].ByteSize != 256 || attachments[1].SGID != "sgid-2" {
 		t.Errorf("Trix attachment = %+v", attachments[1])
+	}
+}
+
+func TestExtractAttachmentsDistinguishesEmptyFromUnknownSize(t *testing.T) {
+	h := `<action-text-attachment url="/rails/blobs/empty.txt" filename="empty.txt" filesize="0"></action-text-attachment>
+<figure data-trix-attachment='{"url":"/rails/blobs/unknown.txt","filename":"unknown.txt"}'></figure>`
+	attachments := ExtractAttachments(h)
+	if len(attachments) != 2 {
+		t.Fatalf("ExtractAttachments got %d attachments, want 2", len(attachments))
+	}
+	if attachments[0].ByteSize == nil || *attachments[0].ByteSize != 0 {
+		t.Errorf("empty attachment size = %v", attachments[0].ByteSize)
+	}
+	if attachments[1].ByteSize != nil {
+		t.Errorf("unknown attachment size = %v", *attachments[1].ByteSize)
 	}
 }
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -176,13 +176,17 @@ Want to read email?
 ```
 Want to send email?
 ├── Reply to thread? → hey reply <topic_id> -m "message"
-│   └── Open editor? → hey reply <topic_id> (omit -m to open $EDITOR)
+│   ├── Open editor? → hey reply <topic_id> (omit -m to open $EDITOR)
+│   └── Attach files? → add --attach ./report.pdf (repeatable)
 ├── Forward latest message? → hey forward <topic_id> --to <email>
 │   └── Add a note? → add -m "note"
 ├── Compose new? → hey compose --to <email> --subject "Subject"
 │   ├── With body? → hey compose --to <email> --subject "Subject" -m "Body"
+│   ├── With files? → add --attach ./report.pdf (repeatable; body is optional)
 │   ├── With CC? → add --cc <email>
 │   └── With BCC? → add --bcc <email>
+├── List files in a thread? → hey attachments <topic_id> --json
+│   └── Save one? → hey attachments save <attachment_id> [--output <path>]
 └── Check drafts? → hey drafts --json
 ```
 
@@ -253,17 +257,31 @@ hey threads <topic_id> --json                 # Read full email thread
 hey threads <topic_id> --html                 # Read with raw HTML content
 ```
 
-**ID note:** Every email thread returned by `hey box` has an `id` (its box item ID) and a `topic_id` (its thread ID). `hey seen`, `hey unseen`, `hey move`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring` expect `id`. `hey threads`, `hey reply`, and `hey forward` expect `topic_id`. The `app_url` field also contains the thread ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
+**ID note:** Every email thread returned by `hey box` has an `id` (its box item ID) and a `topic_id` (its thread ID). `hey seen`, `hey unseen`, `hey move`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring` expect `id`. `hey threads`, `hey attachments`, `hey reply`, and `hey forward` expect `topic_id`. The `app_url` field also contains the thread ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
+
+### Email - Attachments
+
+```bash
+hey attachments <topic_id> --json               # List files in every message
+hey attachments save 67890:1                    # Save using a returned ID
+hey attachments save 67890:1 --output ./reports # Save into a directory
+hey attachments save 67890:1 --output ./report.pdf --force
+```
+
+An attachment ID combines its message ID and position, so `67890:1` identifies the first attachment in message `67890`. Saving uses the original filename unless `--output` names a destination. Existing files are preserved unless `--force` is set.
 
 ### Email - Reply, Forward & Compose
 
 ```bash
 hey reply <topic_id> -m "Thanks!"             # Reply with inline message
 hey reply <topic_id>                          # Reply via $EDITOR
+hey reply <topic_id> -m "Attached." --attach ./diagram.png
 hey forward <topic_id> --to alice@example.com                 # Forward the latest message
 hey forward <topic_id> --to alice@example.com -m "Please review"  # Forward with a note
 hey compose --to user@example.com --subject "Hello"         # Compose new (opens $EDITOR)
 hey compose --to user@example.com --subject "Hi" -m "Body"  # With inline body
+hey compose --to user@example.com --subject "Report" --attach ./report.pdf  # Attachment-only message
+hey compose --to user@example.com --subject "Report" -m "Attached." --attach ./report.pdf --attach ./chart.png
 hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Project update" -m "Body"  # With CC/BCC
 hey compose --thread-id 12345 -m "msg"                       # Reply to an existing thread (no subject: it carries the thread's)
 ```

--- a/tests/smoke/attachments_test.go
+++ b/tests/smoke/attachments_test.go
@@ -1,0 +1,93 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAttachmentSendListAndSave(t *testing.T) {
+	uid := uniqueID()
+	subject := fmt.Sprintf("Attachment delivery %s", uid)
+	filename := "project-notes.txt"
+	contents := []byte("Agenda notes for the quarterly planning meeting.\n")
+	attachmentPath := filepath.Join(t.TempDir(), filename)
+	if err := os.WriteFile(attachmentPath, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := hey(t, "compose",
+		"--to", "david@basecamp.com",
+		"--subject", subject,
+		"-m", "Attached are the planning notes.",
+		"--attach", attachmentPath,
+		"--json",
+	)
+	if code != 0 {
+		t.Skipf("attachment sending is unavailable (exit %d): %s", code, stderr)
+	}
+	var composeResponse Response
+	if err := json.Unmarshal([]byte(stdout), &composeResponse); err != nil || !composeResponse.OK {
+		t.Fatalf("invalid compose response: %v, %s", err, stdout)
+	}
+
+	var result smokeSearchResult
+	for attempt := 0; attempt < 10 && result.TopicID == 0; attempt++ {
+		searchOut, _, searchCode := hey(t, "search", "--subject", subject, "--all", "--json")
+		if searchCode == 0 {
+			var response Response
+			if err := json.Unmarshal([]byte(searchOut), &response); err == nil {
+				for _, candidate := range dataAs[[]smokeSearchResult](t, response) {
+					if candidate.Subject == subject {
+						result = candidate
+						break
+					}
+				}
+			}
+		}
+		if result.TopicID == 0 {
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+	if result.TopicID == 0 {
+		t.Skip("sent attachment thread was not searchable yet")
+	}
+	if result.ID != 0 {
+		t.Cleanup(func() { _, _, _ = hey(t, "trash", fmt.Sprint(result.ID), "--json") })
+	}
+
+	attachments := dataAs[[]struct {
+		Ref      string `json:"ref"`
+		Filename string `json:"filename"`
+	}](t, heyJSON(t, "attachments", fmt.Sprint(result.TopicID)))
+	var ref string
+	for _, attachment := range attachments {
+		if attachment.Filename == filename {
+			ref = attachment.Ref
+			break
+		}
+	}
+	if ref == "" {
+		t.Fatalf("sent thread did not list %s", filename)
+	}
+
+	destination := filepath.Join(t.TempDir(), "saved-project-notes.txt")
+	heysaveOut, saveErr, saveCode := hey(t, "attachments", "save", ref, "--output", destination, "--json")
+	if saveCode != 0 {
+		t.Fatalf("attachment save failed (exit %d): %s", saveCode, saveErr)
+	}
+	var saveResponse Response
+	if err := json.Unmarshal([]byte(heysaveOut), &saveResponse); err != nil || !saveResponse.OK {
+		t.Fatalf("invalid save response: %v, %s", err, heysaveOut)
+	}
+	saved, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(saved) != string(contents) {
+		t.Errorf("saved attachment content differs: %q", saved)
+	}
+}

--- a/tests/smoke/attachments_test.go
+++ b/tests/smoke/attachments_test.go
@@ -60,13 +60,13 @@ func TestAttachmentSendListAndSave(t *testing.T) {
 	}
 
 	attachments := dataAs[[]struct {
-		Ref      string `json:"ref"`
+		ID       string `json:"id"`
 		Filename string `json:"filename"`
 	}](t, heyJSON(t, "attachments", fmt.Sprint(result.TopicID)))
 	var ref string
 	for _, attachment := range attachments {
 		if attachment.Filename == filename {
-			ref = attachment.Ref
+			ref = attachment.ID
 			break
 		}
 	}


### PR DESCRIPTION
## Summary

Add the CLI workflows needed to send attachments with email and save attachments from known threads.

- make `--attach <path>` repeatable for `hey compose` and `hey reply`
- validate every path and upload every file before sending the email
- support attachment-only messages
- add `hey attachments <topic-id>` with stable `<message-id>:<position>` identifiers
- add `hey attachments save <id>` with safe filenames, atomic writes, `--output`, and explicit `--force` replacement
- extract Action Text/Trix attachment metadata from message content
- document the commands and update API/surface coverage

Global attachment browsing remains deferred until HEY provides the required typed JSON endpoints.

## Safety and compatibility

- uses released [hey-sdk v0.5.0](https://github.com/basecamp/hey-sdk/releases/tag/v0.5.0) for direct uploads and streaming downloads
- preserves existing files unless `--force` is supplied
- sanitizes server-provided filenames and commits downloads atomically
- starts downloads on the configured HEY origin; the SDK strips Authorization before cross-origin redirects
- remains compatible with emails that have no attachments

## Validation

- `GOWORK=off make check`
- `GOWORK=off make build`
- `cd tests/smoke && GOWORK=off go test -c -o /tmp/hey-cli-smoke.test .`
- authenticated production validation for compose uploads, reply uploads, attachment discovery, streaming saves, and byte-for-byte file integrity
- moved the disposable validation thread to Trash after verification

## Reviewer focus

- the upload-before-send ordering in `internal/cmd/attachment_upload.go`
- attachment identifier resolution and safe atomic replacement in `internal/cmd/attachments*.go`
- Action Text attachment extraction in `internal/htmlutil/htmlutil.go`

## Tracking

- [Basecamp card 10217261957](https://3.basecamp.com/2914079/buckets/48521764/card_tables/cards/10217261957)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send and save email attachments from the CLI. Previously unsupported; now `--attach` uploads files before send, `hey attachments` lists per-thread files, and `hey attachments save` writes them with portable filenames and atomic replacement.

- Send: repeatable `--attach`, reject non-regular files (e.g., FIFOs) before opening, infer content type, upload before send, support attachment-only messages, inject Action Text attachments, and include attachment counts in send summaries.
- Discover: stable `<message-id>:<position>` IDs across thread messages, bounded pagination (100 pages) and concurrency, hard-fail on incomplete results (e.g., empty message responses), emit a truncation notice when discovery stops early, and preserve empty sizes (0) while omitting unknown sizes (rendered as "—").
- Save: safe cross-platform filenames (incl. Windows reserved names), `--output` supports file or directory, preserve existing files unless `--force`, atomic replacement on `--force`, and cleanup on download errors; downloads stream via the SDK and drop Authorization on cross-origin redirects.
- Output/docs: filter terminal control characters and escape Markdown for untrusted filenames, types, and paths; TUI image extraction now recognizes Action Text image attachments; help and README include `attachments` examples.
- Uses `github.com/basecamp/hey-sdk/go v0.5.0` for direct uploads, streaming downloads, and authenticated HTML reads.

<sup>Written for commit b76ac4f2170f7e4f6db7a068f67d01d9e1fe7140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

