### PR TITLE
Add resilient TUI attachment fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Run `hey` to launch the interactive terminal UI.
 
 Navigate between Mail, Contacts, Calendar, and Journal. In Mail, use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
 
+Thread attachments always appear with their filename, media type, and size. Use `[` and `]` to select an attachment, `s` to save it without replacing an existing file, and `o` to download and open it in an external application. Attachments never open automatically. Kitty and Ghostty can show inline images. Foot and other terminals use visible text markers.
+
 Press Shift+O to open Contacts. Use Enter to view a contact, `a` to add, `e` to edit, `n` to edit the private note, `x` twice to delete a note, `h` to hide, and `u` to show the most recently hidden contact again. Escape or `q` goes back.
 
 ## CLI Commands

--- a/internal/attachments/commit_file_darwin.go
+++ b/internal/attachments/commit_file_darwin.go
@@ -1,6 +1,6 @@
-//go:build linux
+//go:build darwin
 
-package cmd
+package attachments
 
 import (
 	"errors"
@@ -10,7 +10,7 @@ import (
 )
 
 func commitFileNoReplace(source, destination string) error {
-	err := unix.Renameat2(unix.AT_FDCWD, source, unix.AT_FDCWD, destination, unix.RENAME_NOREPLACE)
+	err := unix.RenamexNp(source, destination, unix.RENAME_EXCL)
 	if err == nil || (!errors.Is(err, unix.ENOSYS) && !errors.Is(err, unix.EINVAL) && !errors.Is(err, unix.EOPNOTSUPP)) {
 		return err
 	}

--- a/internal/attachments/commit_file_linux.go
+++ b/internal/attachments/commit_file_linux.go
@@ -1,6 +1,6 @@
-//go:build darwin
+//go:build linux
 
-package cmd
+package attachments
 
 import (
 	"errors"
@@ -10,7 +10,7 @@ import (
 )
 
 func commitFileNoReplace(source, destination string) error {
-	err := unix.RenamexNp(source, destination, unix.RENAME_EXCL)
+	err := unix.Renameat2(unix.AT_FDCWD, source, unix.AT_FDCWD, destination, unix.RENAME_NOREPLACE)
 	if err == nil || (!errors.Is(err, unix.ENOSYS) && !errors.Is(err, unix.EINVAL) && !errors.Is(err, unix.EOPNOTSUPP)) {
 		return err
 	}

--- a/internal/attachments/commit_file_other.go
+++ b/internal/attachments/commit_file_other.go
@@ -1,6 +1,6 @@
 //go:build !darwin && !linux && !windows
 
-package cmd
+package attachments
 
 import "os"
 

--- a/internal/attachments/commit_file_windows.go
+++ b/internal/attachments/commit_file_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package cmd
+package attachments
 
 import "golang.org/x/sys/windows"
 

--- a/internal/attachments/replace_file_unix.go
+++ b/internal/attachments/replace_file_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package cmd
+package attachments
 
 import "os"
 

--- a/internal/attachments/replace_file_windows.go
+++ b/internal/attachments/replace_file_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package cmd
+package attachments
 
 import "golang.org/x/sys/windows"
 

--- a/internal/attachments/save.go
+++ b/internal/attachments/save.go
@@ -1,0 +1,118 @@
+package attachments
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+)
+
+type Downloader interface {
+	DownloadBlob(context.Context, string, io.Writer) (int64, http.Header, error)
+}
+
+func Destination(outputPath, filename string) (string, error) {
+	if outputPath == "" {
+		return PortableFilename(filename)
+	}
+	info, err := os.Stat(outputPath)
+	if err == nil && info.IsDir() {
+		safeFilename, filenameErr := PortableFilename(filename)
+		if filenameErr != nil {
+			return "", filenameErr
+		}
+		return filepath.Join(outputPath, safeFilename), nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return "", apierr.ErrAPI(0, fmt.Sprintf("could not inspect output path: %v", err))
+	}
+	return filepath.Clean(outputPath), nil
+}
+
+func PortableFilename(filename string) (string, error) {
+	filename = strings.TrimSpace(filename)
+	filename = path.Base(strings.ReplaceAll(filename, `\`, "/"))
+	if filename == "" || filename == "." || filename == ".." || filename == "/" {
+		return "", apierr.ErrUsage("attachment has no safe filename")
+	}
+	filename = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || strings.ContainsRune(`<>:"/\|?*`, r) {
+			return '_'
+		}
+		return r
+	}, filename)
+	filename = strings.TrimRight(filename, ". ")
+	if filename == "" {
+		filename = "attachment"
+	}
+	if windowsReservedFilename(filename) {
+		filename = "_" + filename
+	}
+	return filename, nil
+}
+
+func Save(ctx context.Context, downloader Downloader, destination, sourceURL string, force bool) (int64, error) {
+	if !force {
+		if _, err := os.Lstat(destination); err == nil {
+			return 0, apierr.ErrUsage(fmt.Sprintf("destination already exists: %s (use --force to replace it)", destination))
+		} else if !os.IsNotExist(err) {
+			return 0, apierr.ErrAPI(0, fmt.Sprintf("could not inspect attachment destination: %v", err))
+		}
+	}
+
+	directory := filepath.Dir(destination)
+	temporary, err := os.CreateTemp(directory, ".hey-attachment-*")
+	if err != nil {
+		return 0, apierr.ErrAPI(0, fmt.Sprintf("could not create temporary attachment file: %v", err))
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+
+	written, _, err := downloader.DownloadBlob(ctx, sourceURL, temporary)
+	if err != nil {
+		_ = temporary.Close()
+		return written, err
+	}
+	if err := temporary.Close(); err != nil {
+		return written, apierr.ErrAPI(0, fmt.Sprintf("could not close attachment file: %v", err))
+	}
+
+	if force {
+		if err := replaceFile(temporaryPath, destination); err != nil {
+			return written, apierr.ErrAPI(0, fmt.Sprintf("could not replace attachment file: %v", err))
+		}
+		return written, nil
+	}
+	if err := commitFileNoReplace(temporaryPath, destination); os.IsExist(err) {
+		return written, apierr.ErrUsage(fmt.Sprintf("destination already exists: %s (use --force to replace it)", destination))
+	} else if err != nil {
+		return written, apierr.ErrAPI(0, fmt.Sprintf("could not save attachment file: %v", err))
+	}
+	return written, nil
+}
+
+func windowsReservedFilename(filename string) bool {
+	stem := filename
+	if dot := strings.IndexByte(stem, '.'); dot >= 0 {
+		stem = stem[:dot]
+	}
+	stem = strings.ToUpper(stem)
+	if stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL" || stem == "CONIN$" || stem == "CONOUT$" {
+		return true
+	}
+	runes := []rune(stem)
+	if len(runes) != 4 || (string(runes[:3]) != "COM" && string(runes[:3]) != "LPT") {
+		return false
+	}
+	if runes[3] == '¹' || runes[3] == '²' || runes[3] == '³' {
+		return true
+	}
+	return runes[3] >= '1' && runes[3] <= '9'
+}

--- a/internal/attachments/save_test.go
+++ b/internal/attachments/save_test.go
@@ -1,0 +1,156 @@
+package attachments
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+)
+
+type downloadFunc func(context.Context, string, io.Writer) (int64, http.Header, error)
+
+func (f downloadFunc) DownloadBlob(ctx context.Context, sourceURL string, destination io.Writer) (int64, http.Header, error) {
+	return f(ctx, sourceURL, destination)
+}
+
+func writeDownload(data string) downloadFunc {
+	return func(_ context.Context, _ string, destination io.Writer) (int64, http.Header, error) {
+		written, err := io.WriteString(destination, data)
+		return int64(written), nil, err
+	}
+}
+
+func TestDestinationPreservesPortableFilenameBehavior(t *testing.T) {
+	directory := t.TempDir()
+	for filename, want := range map[string]string{
+		"../../quarterly-report.pdf": "quarterly-report.pdf",
+		`..\..\project-notes.txt`:    "project-notes.txt",
+		"CON.pdf":                    "_CON.pdf",
+		"CONIN$":                     "_CONIN$",
+		"LPT².log":                   "_LPT².log",
+		"notes?.txt":                 "notes_.txt",
+		"line\nbreak.txt":            "line_break.txt",
+		"quarterly-report. ":         "quarterly-report",
+	} {
+		destination, err := Destination(directory, filename)
+		if err != nil {
+			t.Errorf("Destination(%q): %v", filename, err)
+			continue
+		}
+		if destination != filepath.Join(directory, want) {
+			t.Errorf("Destination(%q) = %q, want %q", filename, destination, filepath.Join(directory, want))
+		}
+	}
+
+	for _, filename := range []string{"", ".", ".."} {
+		if _, err := Destination("", filename); err == nil {
+			t.Errorf("unsafe filename %q was accepted", filename)
+		}
+	}
+
+	explicit := filepath.Join(t.TempDir(), "chosen-name.pdf")
+	if destination, err := Destination(explicit, ".."); err != nil || destination != explicit {
+		t.Errorf("explicit destination = %q, %v", destination, err)
+	}
+}
+
+func TestSavePreservesExistingFileUnlessForced(t *testing.T) {
+	destination := filepath.Join(t.TempDir(), "quarterly-report.pdf")
+	if err := os.WriteFile(destination, []byte("keep me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Save(context.Background(), writeDownload("new report"), destination, "/report.pdf", false)
+	var saveErr *apierr.Error
+	if !errors.As(err, &saveErr) || saveErr.Code != "usage" || !strings.Contains(saveErr.Message, "use --force") {
+		t.Fatalf("existing destination error = %v", err)
+	}
+	assertFileContent(t, destination, "keep me")
+
+	written, err := Save(context.Background(), writeDownload("new report"), destination, "/report.pdf", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != int64(len("new report")) {
+		t.Errorf("written = %d, want %d", written, len("new report"))
+	}
+	assertFileContent(t, destination, "new report")
+}
+
+func TestSaveDoesNotReplaceFileCreatedDuringDownload(t *testing.T) {
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "quarterly-report.pdf")
+	downloader := func(_ context.Context, _ string, temporary io.Writer) (int64, http.Header, error) {
+		written, err := io.WriteString(temporary, "downloaded report")
+		if err != nil {
+			return int64(written), nil, err
+		}
+		if err := os.WriteFile(destination, []byte("created concurrently"), 0o600); err != nil {
+			return int64(written), nil, err
+		}
+		return int64(written), nil, nil
+	}
+
+	_, err := Save(context.Background(), downloadFunc(downloader), destination, "/report.pdf", false)
+	var saveErr *apierr.Error
+	if !errors.As(err, &saveErr) || saveErr.Code != "usage" {
+		t.Fatalf("concurrent destination error = %v", err)
+	}
+	assertFileContent(t, destination, "created concurrently")
+	assertNoTemporaryFiles(t, directory)
+}
+
+func TestSaveRemovesPartialFileAndPreservesDownloadError(t *testing.T) {
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "quarterly-report.pdf")
+	downloadErr := errors.New("download stopped")
+	downloader := func(_ context.Context, _ string, temporary io.Writer) (int64, http.Header, error) {
+		written, err := io.WriteString(temporary, "partial")
+		if err != nil {
+			return int64(written), nil, err
+		}
+		return int64(written), nil, downloadErr
+	}
+
+	written, err := Save(context.Background(), downloadFunc(downloader), destination, "/report.pdf", false)
+	if !errors.Is(err, downloadErr) {
+		t.Fatalf("download error = %v, want %v", err, downloadErr)
+	}
+	if written != int64(len("partial")) {
+		t.Errorf("written = %d, want %d", written, len("partial"))
+	}
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Errorf("failed download left destination behind: %v", err)
+	}
+	assertNoTemporaryFiles(t, directory)
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != want {
+		t.Errorf("file content = %q, want %q", data, want)
+	}
+}
+
+func assertNoTemporaryFiles(t *testing.T, directory string) {
+	t.Helper()
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".hey-attachment-") {
+			t.Errorf("temporary file was not removed: %s", entry.Name())
+		}
+	}
+}

--- a/internal/cmd/attachments_save.go
+++ b/internal/cmd/attachments_save.go
@@ -2,16 +2,14 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
-	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/spf13/cobra"
 
+	attachmentfiles "github.com/basecamp/hey-cli/internal/attachments"
 	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/output"
 )
@@ -117,100 +115,17 @@ func parseAttachmentID(id string) (int64, int, error) {
 }
 
 func attachmentDestination(outputPath, filename string) (string, error) {
-	if outputPath == "" {
-		return portableAttachmentFilename(filename)
-	}
-	info, err := os.Stat(outputPath)
-	if err == nil && info.IsDir() {
-		safeFilename, filenameErr := portableAttachmentFilename(filename)
-		if filenameErr != nil {
-			return "", filenameErr
-		}
-		return filepath.Join(outputPath, safeFilename), nil
-	}
-	if err != nil && !os.IsNotExist(err) {
-		return "", output.ErrAPI(0, fmt.Sprintf("could not inspect output path: %v", err))
-	}
-	return filepath.Clean(outputPath), nil
-}
-
-func portableAttachmentFilename(filename string) (string, error) {
-	filename = strings.TrimSpace(filename)
-	filename = path.Base(strings.ReplaceAll(filename, `\`, "/"))
-	if filename == "" || filename == "." || filename == ".." || filename == "/" {
-		return "", output.ErrUsage("attachment has no safe filename")
-	}
-	filename = strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) || strings.ContainsRune(`<>:"/\|?*`, r) {
-			return '_'
-		}
-		return r
-	}, filename)
-	filename = strings.TrimRight(filename, ". ")
-	if filename == "" {
-		filename = "attachment"
-	}
-	if windowsReservedFilename(filename) {
-		filename = "_" + filename
-	}
-	return filename, nil
-}
-
-func windowsReservedFilename(filename string) bool {
-	stem := filename
-	if dot := strings.IndexByte(stem, '.'); dot >= 0 {
-		stem = stem[:dot]
-	}
-	stem = strings.ToUpper(stem)
-	if stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL" || stem == "CONIN$" || stem == "CONOUT$" {
-		return true
-	}
-	runes := []rune(stem)
-	if len(runes) != 4 || (string(runes[:3]) != "COM" && string(runes[:3]) != "LPT") {
-		return false
-	}
-	if runes[3] == '¹' || runes[3] == '²' || runes[3] == '³' {
-		return true
-	}
-	return runes[3] >= '1' && runes[3] <= '9'
+	return attachmentfiles.Destination(outputPath, filename)
 }
 
 func downloadAttachmentFile(ctx context.Context, destination, sourceURL string, force bool) (int64, error) {
-	if !force {
-		if _, err := os.Lstat(destination); err == nil {
-			return 0, output.ErrUsage(fmt.Sprintf("destination already exists: %s (use --force to replace it)", destination))
-		} else if !os.IsNotExist(err) {
-			return 0, output.ErrAPI(0, fmt.Sprintf("could not inspect attachment destination: %v", err))
-		}
-	}
-
-	directory := filepath.Dir(destination)
-	temporary, err := os.CreateTemp(directory, ".hey-attachment-*")
-	if err != nil {
-		return 0, output.ErrAPI(0, fmt.Sprintf("could not create temporary attachment file: %v", err))
-	}
-	temporaryPath := temporary.Name()
-	defer func() { _ = os.Remove(temporaryPath) }()
-
-	written, _, err := sdk.DownloadBlob(ctx, sourceURL, temporary)
-	if err != nil {
-		_ = temporary.Close()
-		return written, convertSDKError(err)
-	}
-	if err := temporary.Close(); err != nil {
-		return written, output.ErrAPI(0, fmt.Sprintf("could not close attachment file: %v", err))
-	}
-
-	if force {
-		if err := replaceFile(temporaryPath, destination); err != nil {
-			return written, output.ErrAPI(0, fmt.Sprintf("could not replace attachment file: %v", err))
-		}
+	written, err := attachmentfiles.Save(ctx, sdk, destination, sourceURL, force)
+	if err == nil {
 		return written, nil
 	}
-	if err := commitFileNoReplace(temporaryPath, destination); os.IsExist(err) {
-		return written, output.ErrUsage(fmt.Sprintf("destination already exists: %s (use --force to replace it)", destination))
-	} else if err != nil {
-		return written, output.ErrAPI(0, fmt.Sprintf("could not save attachment file: %v", err))
+	var attachmentErr *output.Error
+	if errors.As(err, &attachmentErr) {
+		return written, err
 	}
-	return written, nil
+	return written, convertSDKError(err)
 }

--- a/internal/tui/attachments.go
+++ b/internal/tui/attachments.go
@@ -1,0 +1,85 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+type messageAttachment struct {
+	ID          string
+	MessageID   int64
+	Filename    string
+	ContentType string
+	ByteSize    *int64
+	URL         string
+}
+
+func attachmentsForMessage(attachments []messageAttachment, messageID int64) []messageAttachment {
+	var matches []messageAttachment
+	for _, attachment := range attachments {
+		if attachment.MessageID == messageID {
+			matches = append(matches, attachment)
+		}
+	}
+	return matches
+}
+
+func selectedAttachmentForMessage(attachments []messageAttachment, selected int, messageID int64) int {
+	if selected < 0 || selected >= len(attachments) || attachments[selected].MessageID != messageID {
+		return -1
+	}
+	localIndex := 0
+	for index := range selected {
+		if attachments[index].MessageID == messageID {
+			localIndex++
+		}
+	}
+	return localIndex
+}
+
+func renderAttachmentPanel(attachments []messageAttachment, selected int) string {
+	if len(attachments) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("╭─ Attachments\n")
+	for index, attachment := range attachments {
+		marker := " "
+		if index == selected {
+			marker = "›"
+		}
+		contentType := terminalSafeAttachmentText(attachment.ContentType)
+		if contentType == "" {
+			contentType = "unknown type"
+		}
+		fmt.Fprintf(&b, "│ %s %d. %s\n", marker, index+1, terminalSafeAttachmentText(attachment.Filename))
+		fmt.Fprintf(&b, "│     %s · %s\n", contentType, formatAttachmentSize(attachment.ByteSize))
+	}
+	b.WriteString("╰─")
+	return b.String()
+}
+
+func formatAttachmentSize(size *int64) string {
+	if size == nil || *size < 0 {
+		return "unknown size"
+	}
+	switch {
+	case *size < 1024:
+		return fmt.Sprintf("%d B", *size)
+	case *size < 1024*1024:
+		return fmt.Sprintf("%.1f KB", float64(*size)/1024)
+	default:
+		return fmt.Sprintf("%.1f MB", float64(*size)/(1024*1024))
+	}
+}
+
+func terminalSafeAttachmentText(value string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return '�'
+		}
+		return r
+	}, value)
+}

--- a/internal/tui/image_renderer.go
+++ b/internal/tui/image_renderer.go
@@ -1,0 +1,73 @@
+package tui
+
+import (
+	"os"
+	"strings"
+)
+
+type imageProtocol string
+
+const (
+	imageProtocolText  imageProtocol = "text"
+	imageProtocolKitty imageProtocol = "kitty"
+	imageProtocolSixel imageProtocol = "sixel"
+)
+
+type renderedImage struct {
+	content string
+	raw     string
+}
+
+type imageRenderer interface {
+	protocol() imageProtocol
+	render(data []byte, id, maxCols int) renderedImage
+}
+
+type textImageRenderer struct{}
+
+type kittyImageRenderer struct{}
+
+func selectImageRenderer(lookupEnv func(string) string) imageRenderer {
+	switch detectImageCapability(lookupEnv) {
+	case imageProtocolKitty:
+		return kittyImageRenderer{}
+	case imageProtocolSixel:
+		// Sixel graphics are cursor-positioned. Bubble Tea redraws the cell grid
+		// after raw output, so use the visible text marker until it has a stable
+		// Sixel placement integration.
+		return textImageRenderer{}
+	default:
+		return textImageRenderer{}
+	}
+}
+
+func detectImageCapability(lookupEnv func(string) string) imageProtocol {
+	term := strings.ToLower(lookupEnv("TERM"))
+	termProgram := strings.ToLower(lookupEnv("TERM_PROGRAM"))
+
+	if lookupEnv("KITTY_WINDOW_ID") != "" || strings.Contains(term, "kitty") || termProgram == "kitty" || termProgram == "ghostty" {
+		return imageProtocolKitty
+	}
+	if strings.HasPrefix(term, "foot") || termProgram == "foot" {
+		return imageProtocolSixel
+	}
+	return imageProtocolText
+}
+
+func environmentImageRenderer() imageRenderer {
+	return selectImageRenderer(os.Getenv)
+}
+
+func (textImageRenderer) protocol() imageProtocol { return imageProtocolText }
+
+func (textImageRenderer) render([]byte, int, int) renderedImage { return renderedImage{} }
+
+func (kittyImageRenderer) protocol() imageProtocol { return imageProtocolKitty }
+
+func (kittyImageRenderer) render(data []byte, id, maxCols int) renderedImage {
+	cols, rows := imageDimensions(data, maxCols)
+	return renderedImage{
+		content: renderImagePlaceholder(id, cols, rows),
+		raw:     kittyUploadAndPlace(data, id, cols, rows),
+	}
+}

--- a/internal/tui/image_renderer_test.go
+++ b/internal/tui/image_renderer_test.go
@@ -1,0 +1,52 @@
+package tui
+
+import "testing"
+
+func TestImageRendererSelection(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want imageProtocol
+	}{
+		{"Kitty window", map[string]string{"KITTY_WINDOW_ID": "1"}, imageProtocolKitty},
+		{"Kitty TERM", map[string]string{"TERM": "xterm-kitty"}, imageProtocolKitty},
+		{"Ghostty", map[string]string{"TERM_PROGRAM": "ghostty"}, imageProtocolKitty},
+		{"Foot uses text until Sixel renderer is available", map[string]string{"TERM": "foot"}, imageProtocolText},
+		{"unsupported terminal", map[string]string{"TERM": "xterm-256color"}, imageProtocolText},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			renderer := selectImageRenderer(func(key string) string { return tt.env[key] })
+			if got := renderer.protocol(); got != tt.want {
+				t.Errorf("selected protocol = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTerminalCapabilityRecognizesSixel(t *testing.T) {
+	capability := detectImageCapability(func(key string) string {
+		if key == "TERM" {
+			return "foot"
+		}
+		return ""
+	})
+	if capability != imageProtocolSixel {
+		t.Errorf("Foot capability = %q, want %q", capability, imageProtocolSixel)
+	}
+}
+
+func TestTextRendererDoesNotEmitInvisiblePlaceholders(t *testing.T) {
+	rendered := textImageRenderer{}.render([]byte("image"), 1, 40)
+	if rendered.content != "" || rendered.raw != "" {
+		t.Errorf("text renderer output = content %q raw %q, want visible message marker only", rendered.content, rendered.raw)
+	}
+}
+
+func TestKittyRendererPreservesUnicodePlaceholderBehavior(t *testing.T) {
+	rendered := kittyImageRenderer{}.render([]byte("not an image"), 1, 40)
+	if rendered.content == "" || rendered.raw == "" {
+		t.Fatalf("Kitty renderer output = content %q raw %q", rendered.content, rendered.raw)
+	}
+}

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"charm.land/bubbles/v2/viewport"
@@ -12,6 +13,8 @@ import (
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
+	"github.com/basecamp/hey-cli/internal/apierr"
+	attachmentfiles "github.com/basecamp/hey-cli/internal/attachments"
 	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/models"
 )
@@ -59,6 +62,20 @@ type searchResultsLoadedMsg struct {
 	err       error
 }
 
+type attachmentSavedMsg struct {
+	topicID      int64
+	attachmentID string
+	path         string
+	err          error
+}
+
+type attachmentOpenedMsg struct {
+	topicID      int64
+	attachmentID string
+	filename     string
+	err          error
+}
+
 type postingActionEffect int
 
 const (
@@ -90,8 +107,10 @@ type mailView struct {
 	topicContent     string
 	topicID          int64
 	topicName        string
+	entries          []models.Entry
 	attachments      []messageAttachment
 	attachmentCursor int
+	imageContent     string
 	inThread         bool
 	loading          bool
 
@@ -178,23 +197,25 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.inThread = true
 		v.topicID = msg.topicID
 		v.topicName = msg.title
+		v.entries = msg.entries
 		v.attachments = msg.attachments
 		v.attachmentCursor = 0
-		v.topicContent = v.renderEntries(msg.entries)
-		v.topicViewport.SetContent(v.topicContent)
-		v.topicViewport.GotoTop()
+		var imageContent strings.Builder
 		var uploadCmds []tea.Cmd
 		for i, imgData := range msg.images {
 			imageID := i + 1
 			rendered := v.vc.imageRenderer.render(imgData, imageID, v.vc.width-4)
 			if rendered.content != "" {
-				v.topicContent += "\n\n" + rendered.content
-				v.topicViewport.SetContent(v.topicContent)
+				imageContent.WriteString("\n\n")
+				imageContent.WriteString(rendered.content)
 			}
 			if rendered.raw != "" {
 				uploadCmds = append(uploadCmds, tea.Raw(rendered.raw))
 			}
 		}
+		v.imageContent = imageContent.String()
+		v.rebuildTopicContent()
+		v.topicViewport.GotoTop()
 		if len(uploadCmds) > 0 {
 			return tea.Batch(uploadCmds...), true
 		}
@@ -235,6 +256,33 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		}
 		v.compose = nil
 		v.notice = msg.label
+		return nil, true
+
+	case attachmentSavedMsg:
+		if !v.currentAttachmentAction(msg.topicID, msg.attachmentID) {
+			return nil, true
+		}
+		if msg.err != nil {
+			saveErr := apierr.AsError(msg.err)
+			if saveErr.Code == "usage" && strings.HasPrefix(saveErr.Message, "destination already exists:") {
+				v.notice = "Attachment already exists: " + terminalSafeAttachmentText(msg.path)
+			} else {
+				v.notice = "Could not save attachment: " + msg.err.Error()
+			}
+			return nil, true
+		}
+		v.notice = "Saved attachment to " + terminalSafeAttachmentText(msg.path)
+		return nil, true
+
+	case attachmentOpenedMsg:
+		if !v.currentAttachmentAction(msg.topicID, msg.attachmentID) {
+			return nil, true
+		}
+		if msg.err != nil {
+			v.notice = "Could not open attachment: " + msg.err.Error()
+			return nil, true
+		}
+		v.notice = "Opened attachment " + terminalSafeAttachmentText(msg.filename)
 		return nil, true
 
 	case postingActionDoneMsg:
@@ -335,7 +383,16 @@ func (v *mailView) HelpBindings() []helpBinding {
 		return v.movePicker.helpBindings()
 	}
 	if v.inThread {
-		return []helpBinding{{"r", "reply"}, {"f", "forward"}}
+		bindings := []helpBinding{{"r", "reply"}, {"f", "forward"}}
+		if len(v.attachments) > 0 {
+			bindings = append(bindings,
+				helpBinding{"[", "previous attachment"},
+				helpBinding{"]", "next attachment"},
+				helpBinding{"s", "save attachment"},
+				helpBinding{"o", "open attachment"},
+			)
+		}
+		return bindings
 	}
 	if v.searchActive {
 		return []helpBinding{{"enter", "open"}, {"/", "new search"}, {"n", "next page"}, {"p", "previous page"}}
@@ -437,11 +494,25 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	if v.inThread {
-		if msg.String() == "r" && v.topicID != 0 {
-			return v.loadReplyContext(v.topicID, v.topicName)
-		}
-		if msg.String() == "f" && v.topicID != 0 {
-			return v.loadForwardContext(v.topicID, v.topicName)
+		switch msg.String() {
+		case "r":
+			if v.topicID != 0 {
+				return v.loadReplyContext(v.topicID, v.topicName)
+			}
+		case "f":
+			if v.topicID != 0 {
+				return v.loadForwardContext(v.topicID, v.topicName)
+			}
+		case "[":
+			v.moveAttachmentCursor(-1)
+			return nil
+		case "]":
+			v.moveAttachmentCursor(1)
+			return nil
+		case "s":
+			return v.saveSelectedAttachment()
+		case "o":
+			return v.openSelectedAttachment()
 		}
 		var cmd tea.Cmd
 		v.topicViewport, cmd = v.topicViewport.Update(msg)
@@ -644,6 +715,81 @@ func (v *mailView) postingIndex(postingID int64) int {
 		}
 	}
 	return -1
+}
+
+func (v *mailView) moveAttachmentCursor(delta int) {
+	if len(v.attachments) == 0 {
+		return
+	}
+	v.attachmentCursor = max(0, min(v.attachmentCursor+delta, len(v.attachments)-1))
+	v.rebuildTopicContent()
+	if marker := strings.Index(v.topicContent, "│ › "); marker >= 0 {
+		v.topicViewport.EnsureVisible(strings.Count(v.topicContent[:marker], "\n"), 0, 0)
+	}
+}
+
+func (v *mailView) saveSelectedAttachment() tea.Cmd {
+	attachment := v.selectedAttachment()
+	if attachment == nil || v.vc.saveAttachment == nil {
+		return nil
+	}
+	topicID := v.topicID
+	return func() tea.Msg {
+		destination, err := attachmentfiles.Destination("", attachment.Filename)
+		if err == nil {
+			_, err = v.vc.saveAttachment(v.vc.ctx, destination, attachment.URL, false)
+		}
+		return attachmentSavedMsg{topicID: topicID, attachmentID: attachment.ID, path: destination, err: err}
+	}
+}
+
+func (v *mailView) openSelectedAttachment() tea.Cmd {
+	attachment := v.selectedAttachment()
+	if attachment == nil || v.vc.saveAttachment == nil || v.vc.openAttachment == nil || v.vc.newAttachmentTempDir == nil {
+		return nil
+	}
+	topicID := v.topicID
+	return func() tea.Msg {
+		directory, err := v.vc.newAttachmentTempDir()
+		if err != nil {
+			return attachmentOpenedMsg{topicID: topicID, attachmentID: attachment.ID, filename: attachment.Filename, err: err}
+		}
+		destination, err := attachmentfiles.Destination(directory, attachment.Filename)
+		if err == nil {
+			_, err = v.vc.saveAttachment(v.vc.ctx, destination, attachment.URL, false)
+		}
+		if err == nil {
+			err = v.vc.openAttachment(destination)
+		}
+		if err != nil {
+			_ = os.RemoveAll(directory)
+		}
+		return attachmentOpenedMsg{topicID: topicID, attachmentID: attachment.ID, filename: attachment.Filename, err: err}
+	}
+}
+
+func (v *mailView) selectedAttachment() *messageAttachment {
+	if v.attachmentCursor < 0 || v.attachmentCursor >= len(v.attachments) {
+		return nil
+	}
+	return &v.attachments[v.attachmentCursor]
+}
+
+func (v *mailView) currentAttachmentAction(topicID int64, attachmentID string) bool {
+	if !v.inThread || topicID != v.topicID {
+		return false
+	}
+	for _, attachment := range v.attachments {
+		if attachment.ID == attachmentID {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *mailView) rebuildTopicContent() {
+	v.topicContent = v.renderEntries(v.entries) + v.imageContent
+	v.topicViewport.SetContent(v.topicContent)
 }
 
 func (v *mailView) openSelected() tea.Cmd {
@@ -997,19 +1143,21 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 		}
 
 		var images [][]byte
-		for _, entry := range entries {
-			for _, imgURL := range extractImageURLs(entry.Body) {
-				var data []byte
-				if strings.HasPrefix(imgURL, "http://") || strings.HasPrefix(imgURL, "https://") {
-					data = fetchImageData(ctx, imgURL)
-				} else {
-					sdkResp, getErr := v.vc.sdk.Get(ctx, imgURL)
-					if getErr == nil && sdkResp != nil {
-						data = sdkResp.Data
+		if v.vc.imageRenderer.protocol() == imageProtocolKitty {
+			for _, entry := range entries {
+				for _, imgURL := range extractImageURLs(entry.Body) {
+					var data []byte
+					if strings.HasPrefix(imgURL, "http://") || strings.HasPrefix(imgURL, "https://") {
+						data = fetchImageData(ctx, imgURL)
+					} else {
+						sdkResp, getErr := v.vc.sdk.Get(ctx, imgURL)
+						if getErr == nil && sdkResp != nil {
+							data = sdkResp.Data
+						}
 					}
-				}
-				if len(data) > 0 {
-					images = append(images, data)
+					if len(data) > 0 {
+						images = append(images, data)
+					}
 				}
 			}
 		}

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -12,6 +12,7 @@ import (
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
+	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/models"
 )
 
@@ -40,13 +41,14 @@ type postingsLoadedMsg struct {
 }
 
 type topicLoadedMsg struct {
-	requestID uint64
-	boxID     int64
-	topicID   int64
-	title     string
-	entries   []models.Entry
-	images    [][]byte
-	err       error
+	requestID   uint64
+	boxID       int64
+	topicID     int64
+	title       string
+	entries     []models.Entry
+	attachments []messageAttachment
+	images      [][]byte
+	err         error
 }
 
 type searchResultsLoadedMsg struct {
@@ -83,13 +85,15 @@ type mailView struct {
 	boxes    []models.Box
 	boxIndex int
 
-	postingList   contentList
-	topicViewport viewport.Model
-	topicContent  string
-	topicID       int64
-	topicName     string
-	inThread      bool
-	loading       bool
+	postingList      contentList
+	topicViewport    viewport.Model
+	topicContent     string
+	topicID          int64
+	topicName        string
+	attachments      []messageAttachment
+	attachmentCursor int
+	inThread         bool
+	loading          bool
 
 	compose           *composeForm    // non-nil while a message, reply or forward is being written
 	movePicker        *movePicker     // non-nil while a destination box is being selected
@@ -174,17 +178,22 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.inThread = true
 		v.topicID = msg.topicID
 		v.topicName = msg.title
+		v.attachments = msg.attachments
+		v.attachmentCursor = 0
 		v.topicContent = v.renderEntries(msg.entries)
 		v.topicViewport.SetContent(v.topicContent)
 		v.topicViewport.GotoTop()
 		var uploadCmds []tea.Cmd
 		for i, imgData := range msg.images {
 			imageID := i + 1
-			cols, rows := imageDimensions(imgData, v.vc.width-4)
-			v.topicContent += "\n\n" + renderImagePlaceholder(imageID, cols, rows)
-			v.topicViewport.SetContent(v.topicContent)
-			seq := kittyUploadAndPlace(imgData, imageID, cols, rows)
-			uploadCmds = append(uploadCmds, tea.Raw(seq))
+			rendered := v.vc.imageRenderer.render(imgData, imageID, v.vc.width-4)
+			if rendered.content != "" {
+				v.topicContent += "\n\n" + rendered.content
+				v.topicViewport.SetContent(v.topicContent)
+			}
+			if rendered.raw != "" {
+				uploadCmds = append(uploadCmds, tea.Raw(rendered.raw))
+			}
 		}
 		if len(uploadCmds) > 0 {
 			return tea.Batch(uploadCmds...), true
@@ -972,8 +981,19 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 		}
 
 		entries := make([]models.Entry, len(topic.Entries))
+		var attachments []messageAttachment
 		for i, entry := range topic.Entries {
 			entries[i] = sdkMessageToEntry(entry, messages[i])
+			for position, attachment := range htmlutil.ExtractAttachments(messages[i].Content) {
+				attachments = append(attachments, messageAttachment{
+					ID:          fmt.Sprintf("%d:%d", entry.Id, position+1),
+					MessageID:   entry.Id,
+					Filename:    attachment.Filename,
+					ContentType: attachment.ContentType,
+					ByteSize:    attachment.ByteSize,
+					URL:         attachment.URL,
+				})
+			}
 		}
 
 		var images [][]byte
@@ -995,12 +1015,13 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 		}
 
 		return topicLoadedMsg{
-			requestID: requestID,
-			boxID:     boxID,
-			topicID:   topicID,
-			title:     title,
-			entries:   entries,
-			images:    images,
+			requestID:   requestID,
+			boxID:       boxID,
+			topicID:     topicID,
+			title:       title,
+			entries:     entries,
+			attachments: attachments,
+			images:      images,
 		}
 	}
 }
@@ -1036,6 +1057,10 @@ func (v *mailView) renderEntries(entries []models.Entry) string {
 		}
 		if e.Body != "" {
 			fmt.Fprintf(&b, "\n%s\n", v.vc.styles.entryBody.Render(htmlToText(e.Body)))
+		}
+		entryAttachments := attachmentsForMessage(v.attachments, e.ID)
+		if panel := renderAttachmentPanel(entryAttachments, selectedAttachmentForMessage(v.attachments, v.attachmentCursor, e.ID)); panel != "" {
+			fmt.Fprintf(&b, "\n%s\n", panel)
 		}
 		b.WriteString("\n")
 	}

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -16,6 +17,7 @@ import (
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
+	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/models"
 )
 
@@ -708,6 +710,49 @@ func TestMailViewEnterOpensSelectedThread(t *testing.T) {
 	}
 }
 
+func TestMailViewDownloadsImageDataOnlyForKittyRenderer(t *testing.T) {
+	var imageRequests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/topics/100.json":
+			_, _ = w.Write([]byte(`{"id":100,"name":"Latest image","entries":[{"id":501,"kind":"message"}]}`))
+		case "/messages/501.json":
+			_, _ = w.Write([]byte(`{"id":501,"content":"<action-text-attachment url=\"/rails/blobs/chart.png\" filename=\"chart.png\" content-type=\"image/png\"></action-text-attachment>"}`))
+		case "/rails/blobs/chart.png":
+			imageRequests.Add(1)
+			_, _ = w.Write([]byte("image data"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := hey.NewClient(
+		&hey.Config{BaseURL: server.URL},
+		&hey.StaticTokenProvider{Token: "test-token"},
+		hey.WithMaxRetries(0),
+	)
+	vc := testVC()
+	vc.sdk = client
+	v := newMailView(vc)
+	loaded := v.fetchTopic(context.Background(), 1, 1, 100, "Latest image")().(topicLoadedMsg)
+
+	if loaded.err != nil || len(loaded.attachments) != 1 {
+		t.Fatalf("text fallback topic = attachments:%d error:%v", len(loaded.attachments), loaded.err)
+	}
+	if len(loaded.images) != 0 || imageRequests.Load() != 0 {
+		t.Errorf("text fallback downloaded %d discarded images and returned %d", imageRequests.Load(), len(loaded.images))
+	}
+
+	vc.imageRenderer = kittyImageRenderer{}
+	v = newMailView(vc)
+	loaded = v.fetchTopic(context.Background(), 2, 1, 100, "Latest image")().(topicLoadedMsg)
+	if loaded.err != nil || len(loaded.images) != 1 || imageRequests.Load() != 1 {
+		t.Errorf("Kitty topic = images:%d requests:%d error:%v", len(loaded.images), imageRequests.Load(), loaded.err)
+	}
+}
+
 func TestMailViewFetchesThreadMessagesConcurrentlyInOrder(t *testing.T) {
 	const entryCount = 12
 
@@ -1128,6 +1173,186 @@ func TestMailViewRendersPostings(t *testing.T) {
 	view := v.View()
 	if !strings.Contains(view, "Hello world") {
 		t.Error("view should contain posting summary")
+	}
+}
+
+func TestMailViewAttachmentNavigationUpdatesSelectionAndHelp(t *testing.T) {
+	v := mailWithPostings()
+	v.Resize(80, 30)
+	v.Update(topicLoadedMsg{
+		boxID:   1,
+		topicID: 100,
+		title:   "Quarterly planning",
+		entries: []models.Entry{{ID: 501, Creator: models.Contact{Name: "Alice"}}, {ID: 502, Creator: models.Contact{Name: "Bob"}}},
+		attachments: []messageAttachment{
+			{ID: "501:1", MessageID: 501, Filename: "agenda.pdf"},
+			{ID: "502:1", MessageID: 502, Filename: "chart.png"},
+		},
+	})
+
+	if !strings.Contains(v.View(), "› 1. agenda.pdf") {
+		t.Fatalf("first attachment is not selected: %q", v.View())
+	}
+	if cmd := v.HandleContentKey(keyPress("]")); cmd != nil {
+		t.Fatal("attachment navigation should not start a command")
+	}
+	if v.attachmentCursor != 1 || !strings.Contains(v.View(), "› 1. chart.png") || strings.Contains(v.View(), "› 1. agenda.pdf") {
+		t.Errorf("next attachment state = cursor:%d view:%q", v.attachmentCursor, v.View())
+	}
+	v.HandleContentKey(keyPress("["))
+	if v.attachmentCursor != 0 || !strings.Contains(v.View(), "› 1. agenda.pdf") {
+		t.Errorf("previous attachment state = cursor:%d view:%q", v.attachmentCursor, v.View())
+	}
+
+	bindings := fmt.Sprint(v.HelpBindings())
+	for _, want := range []string{"previous attachment", "next attachment", "save attachment", "open attachment"} {
+		if !strings.Contains(bindings, want) {
+			t.Errorf("thread help does not contain %q: %s", want, bindings)
+		}
+	}
+}
+
+func TestMailViewSavesSelectedAttachmentOnlyAfterExplicitAction(t *testing.T) {
+	v := mailWithPostings()
+	var savedDestination, savedURL string
+	var savedForce bool
+	var saveCalls int
+	v.vc.saveAttachment = func(_ context.Context, destination, sourceURL string, force bool) (int64, error) {
+		saveCalls++
+		savedDestination = destination
+		savedURL = sourceURL
+		savedForce = force
+		return 128, nil
+	}
+	v.Update(topicLoadedMsg{
+		boxID:   1,
+		topicID: 100,
+		title:   "Quarterly planning",
+		entries: []models.Entry{{ID: 501, Creator: models.Contact{Name: "Alice"}}},
+		attachments: []messageAttachment{
+			{ID: "501:1", MessageID: 501, Filename: "agenda.pdf", URL: "/rails/blobs/agenda.pdf"},
+			{ID: "501:2", MessageID: 501, Filename: "chart.png", URL: "/rails/blobs/chart.png"},
+		},
+	})
+	if saveCalls != 0 {
+		t.Fatal("loading a thread must not save its attachment")
+	}
+	v.HandleContentKey(keyPress("]"))
+
+	save := v.HandleContentKey(keyPress("s"))
+	if save == nil {
+		t.Fatal("s should save the selected attachment")
+	}
+	if saveCalls != 0 {
+		t.Fatal("handling the key must defer file access to the command")
+	}
+	if _, consumed := v.Update(save()); !consumed {
+		t.Fatal("attachment save result was not consumed")
+	}
+	if saveCalls != 1 || savedDestination != "chart.png" || savedURL != "/rails/blobs/chart.png" || savedForce {
+		t.Errorf("save call = count:%d destination:%q URL:%q force:%v", saveCalls, savedDestination, savedURL, savedForce)
+	}
+	if v.notice != "Saved attachment to chart.png" {
+		t.Errorf("save notice = %q", v.notice)
+	}
+}
+
+func TestMailViewExplainsThatSaveWillNotReplaceExistingAttachment(t *testing.T) {
+	v := mailWithPostings()
+	v.vc.saveAttachment = func(context.Context, string, string, bool) (int64, error) {
+		return 0, apierr.ErrUsage("destination already exists: agenda.pdf (use --force to replace it)")
+	}
+	v.Update(topicLoadedMsg{
+		boxID:       1,
+		topicID:     100,
+		title:       "Quarterly planning",
+		entries:     []models.Entry{{ID: 501, Creator: models.Contact{Name: "Alice"}}},
+		attachments: []messageAttachment{{ID: "501:1", MessageID: 501, Filename: "agenda.pdf", URL: "/rails/blobs/agenda.pdf"}},
+	})
+
+	save := v.HandleContentKey(keyPress("s"))
+	v.Update(save())
+	if v.notice != "Attachment already exists: agenda.pdf" {
+		t.Errorf("existing attachment notice = %q", v.notice)
+	}
+}
+
+func TestMailViewDownloadsBeforeExplicitExternalOpen(t *testing.T) {
+	v := mailWithPostings()
+	temporaryDirectory := t.TempDir()
+	var events []string
+	var openedPath string
+	v.vc.newAttachmentTempDir = func() (string, error) { return temporaryDirectory, nil }
+	v.vc.saveAttachment = func(_ context.Context, destination, sourceURL string, force bool) (int64, error) {
+		events = append(events, "save")
+		if sourceURL != "/rails/blobs/chart.png" || force {
+			t.Errorf("save arguments = URL:%q force:%v", sourceURL, force)
+		}
+		return 256, nil
+	}
+	v.vc.openAttachment = func(path string) error {
+		events = append(events, "open")
+		openedPath = path
+		return nil
+	}
+	v.Update(topicLoadedMsg{
+		boxID:       1,
+		topicID:     100,
+		title:       "Quarterly planning",
+		entries:     []models.Entry{{ID: 501, Creator: models.Contact{Name: "Alice"}}},
+		attachments: []messageAttachment{{ID: "501:1", MessageID: 501, Filename: "chart.png", URL: "/rails/blobs/chart.png"}},
+	})
+	if len(events) != 0 {
+		t.Fatalf("loading a thread opened an attachment: %v", events)
+	}
+
+	open := v.HandleContentKey(keyPress("o"))
+	if open == nil {
+		t.Fatal("o should open the selected attachment")
+	}
+	if len(events) != 0 {
+		t.Fatalf("handling the key opened an attachment before the command ran: %v", events)
+	}
+	if _, consumed := v.Update(open()); !consumed {
+		t.Fatal("attachment open result was not consumed")
+	}
+	if fmt.Sprint(events) != "[save open]" {
+		t.Errorf("open events = %v", events)
+	}
+	if openedPath != filepath.Join(temporaryDirectory, "chart.png") {
+		t.Errorf("opened path = %q", openedPath)
+	}
+	if v.notice != "Opened attachment chart.png" {
+		t.Errorf("open notice = %q", v.notice)
+	}
+}
+
+func TestMailViewDoesNotOpenAttachmentWhenDownloadFails(t *testing.T) {
+	v := mailWithPostings()
+	v.vc.newAttachmentTempDir = func() (string, error) { return t.TempDir(), nil }
+	v.vc.saveAttachment = func(context.Context, string, string, bool) (int64, error) {
+		return 0, fmt.Errorf("download failed")
+	}
+	openCalls := 0
+	v.vc.openAttachment = func(string) error {
+		openCalls++
+		return nil
+	}
+	v.Update(topicLoadedMsg{
+		boxID:       1,
+		topicID:     100,
+		title:       "Quarterly planning",
+		entries:     []models.Entry{{ID: 501, Creator: models.Contact{Name: "Alice"}}},
+		attachments: []messageAttachment{{ID: "501:1", MessageID: 501, Filename: "chart.png", URL: "/rails/blobs/chart.png"}},
+	})
+
+	open := v.HandleContentKey(keyPress("o"))
+	v.Update(open())
+	if openCalls != 0 {
+		t.Errorf("opener was called %d times after download failure", openCalls)
+	}
+	if !strings.Contains(v.notice, "Could not open attachment: download failed") {
+		t.Errorf("open failure notice = %q", v.notice)
 	}
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -20,7 +20,13 @@ import (
 )
 
 func testVC() *viewContext {
-	return &viewContext{ctx: context.Background(), styles: newStyles(), width: 80, height: 30}
+	return &viewContext{
+		ctx:           context.Background(),
+		styles:        newStyles(),
+		imageRenderer: textImageRenderer{},
+		width:         80,
+		height:        30,
+	}
 }
 
 func mailWithPostings() *mailView {
@@ -1122,6 +1128,40 @@ func TestMailViewRendersPostings(t *testing.T) {
 	view := v.View()
 	if !strings.Contains(view, "Hello world") {
 		t.Error("view should contain posting summary")
+	}
+}
+
+func TestMailViewAlwaysRendersAttachmentPanelAndTextMarker(t *testing.T) {
+	size := int64(1536)
+	v := mailWithPostings()
+	v.Resize(80, 30)
+	v.Update(topicLoadedMsg{
+		boxID:   1,
+		topicID: 100,
+		title:   "Quarterly planning",
+		entries: []models.Entry{{
+			ID:      501,
+			Creator: models.Contact{Name: "Alice"},
+			Body:    `<p>Review this image:</p><action-text-attachment url="/rails/blobs/chart.png" filename="chart.png" content-type="image/png" filesize="1536"></action-text-attachment><p>Thank you.</p>`,
+		}},
+		attachments: []messageAttachment{{
+			ID:          "501:1",
+			MessageID:   501,
+			Filename:    "chart.png",
+			ContentType: "image/png",
+			ByteSize:    &size,
+			URL:         "/rails/blobs/chart.png",
+		}},
+	})
+
+	view := v.View()
+	for _, want := range []string{"[chart.png]", "Attachments", "chart.png", "image/png", "1.5 KB"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("thread view does not contain %q: %q", want, view)
+		}
+	}
+	if strings.ContainsRune(view, placeholder) {
+		t.Errorf("text fallback contains an invisible Kitty placeholder: %q", view)
 	}
 }
 

--- a/internal/tui/open_file.go
+++ b/internal/tui/open_file.go
@@ -1,0 +1,33 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+func openExternalFile(path string) error {
+	var name string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		name = "open"
+		args = []string{path}
+	case "linux":
+		name = "xdg-open"
+		args = []string{path}
+	case "windows":
+		name = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler", path}
+	default:
+		return fmt.Errorf("opening attachments is not supported on %s", runtime.GOOS)
+	}
+
+	command := exec.CommandContext(context.Background(), name, args...) //nolint:gosec // The user explicitly asks to open the selected local attachment.
+	if err := command.Start(); err != nil {
+		return err
+	}
+	go func() { _ = command.Wait() }()
+	return nil
+}

--- a/internal/tui/section_view.go
+++ b/internal/tui/section_view.go
@@ -10,11 +10,12 @@ import (
 
 // viewContext holds shared dependencies injected into every sectionView.
 type viewContext struct {
-	sdk    *hey.Client
-	ctx    context.Context
-	styles styles
-	width  int
-	height int // content area height
+	sdk           *hey.Client
+	ctx           context.Context
+	styles        styles
+	imageRenderer imageRenderer
+	width         int
+	height        int // content area height
 }
 
 // sectionView is the interface every top-level section must implement.

--- a/internal/tui/section_view.go
+++ b/internal/tui/section_view.go
@@ -9,13 +9,19 @@ import (
 )
 
 // viewContext holds shared dependencies injected into every sectionView.
+type attachmentSaveFunc func(context.Context, string, string, bool) (int64, error)
+type attachmentOpenFunc func(string) error
+
 type viewContext struct {
-	sdk           *hey.Client
-	ctx           context.Context
-	styles        styles
-	imageRenderer imageRenderer
-	width         int
-	height        int // content area height
+	sdk                  *hey.Client
+	ctx                  context.Context
+	styles               styles
+	imageRenderer        imageRenderer
+	saveAttachment       attachmentSaveFunc
+	openAttachment       attachmentOpenFunc
+	newAttachmentTempDir func() (string, error)
+	width                int
+	height               int // content area height
 }
 
 // sectionView is the interface every top-level section must implement.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	attachmentfiles "github.com/basecamp/hey-cli/internal/attachments"
 )
 
 // --- Shared messages ---
@@ -52,7 +55,19 @@ type model struct {
 func newModel(sdk *hey.Client) model {
 	s := newStyles()
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel stored, called on ctrl+c
-	vc := &viewContext{sdk: sdk, ctx: ctx, styles: s, imageRenderer: environmentImageRenderer()}
+	vc := &viewContext{
+		sdk:           sdk,
+		ctx:           ctx,
+		styles:        s,
+		imageRenderer: environmentImageRenderer(),
+		saveAttachment: func(ctx context.Context, destination, sourceURL string, force bool) (int64, error) {
+			return attachmentfiles.Save(ctx, sdk, destination, sourceURL, force)
+		},
+		openAttachment: openExternalFile,
+		newAttachmentTempDir: func() (string, error) {
+			return os.MkdirTemp("", "hey-cli-attachment-*")
+		},
+	}
 
 	mv := newMailView(vc)
 	ov := newContactsView(vc)
@@ -233,6 +248,14 @@ func (m *model) updateHelpBindings() {
 		}
 	}
 	m.help.setBindings(bindings)
+	contentHeight := m.height - headerHeight - m.help.height() - 3
+	if contentHeight < 1 {
+		contentHeight = 1
+	}
+	if contentHeight != m.vc.height {
+		m.vc.height = contentHeight
+		m.activeView.Resize(m.vc.width, contentHeight)
+	}
 }
 
 // --- Key handling ---

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -52,7 +52,7 @@ type model struct {
 func newModel(sdk *hey.Client) model {
 	s := newStyles()
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel stored, called on ctrl+c
-	vc := &viewContext{sdk: sdk, ctx: ctx, styles: s}
+	vc := &viewContext{sdk: sdk, ctx: ctx, styles: s, imageRenderer: environmentImageRenderer()}
 
 	mv := newMailView(vc)
 	ov := newContactsView(vc)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -104,6 +105,35 @@ func TestInitReturnsCmd(t *testing.T) {
 	cmd := m.Init()
 	if cmd == nil {
 		t.Fatal("Init should return a command")
+	}
+}
+
+func TestModelResizesContentWhenThreadHelpChangesHeight(t *testing.T) {
+	for _, width := range []int{32, 40, 48, 64, 80, 100} {
+		t.Run(strconv.Itoa(width), func(t *testing.T) {
+			m := modelWithBoxes()
+			updated, _ := m.Update(tea.WindowSizeMsg{Width: width, Height: 30})
+			m = updated.(model)
+			m.mailView.activeRequestID = 7
+			m.mailView.activeRequestKind = mailRequestTopic
+			updated, _ = m.Update(topicLoadedMsg{
+				requestID:   7,
+				boxID:       1,
+				topicID:     100,
+				title:       "Quarterly planning",
+				entries:     []models.Entry{{ID: 501, Creator: models.Contact{Name: "Alice"}}},
+				attachments: []messageAttachment{{ID: "501:1", MessageID: 501, Filename: "agenda.pdf"}},
+			})
+			m = updated.(model)
+
+			wantHeight := m.height - headerHeight - m.help.height() - 3
+			if wantHeight < 1 {
+				wantHeight = 1
+			}
+			if m.vc.height != wantHeight || m.mailView.topicViewport.Height() != wantHeight {
+				t.Errorf("thread content height = context:%d viewport:%d, want %d for help height %d", m.vc.height, m.mailView.topicViewport.Height(), wantHeight, m.help.height())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Add a resilient attachment experience to the mail TUI.

- always show attachment panels with filename, media type, and size
- keep image positions visible as text markers in every terminal
- preserve Kitty Unicode Placeholder rendering in Kitty and Ghostty
- use the visible text fallback in Foot and unsupported terminals
- select attachments with `[` and `]`
- save with `s` without replacing an existing file
- download and open externally only after an explicit `o` action
- share portable filename and atomic save behavior between the CLI and TUI

Open behavior and file saving are injected at the TUI boundary and covered without launching applications in tests. Text-only terminals do not download image data that they will discard.

## Safety

- attachments never open automatically
- save preserves existing files and reports the conflict clearly
- open downloads through the authenticated SDK into a private temporary directory before launching the platform file handler
- shared saves retain portable filenames, atomic commits, partial-file cleanup, and redirect credential stripping from the SDK

## Validation

- `make check`
- `make race-test`
- `make build`
- Windows amd64 and macOS arm64 cross-compilation for `internal/cmd` and `internal/tui`
- smoke-test package compilation
- real production TUI validation in Foot for text markers, panel metadata, selection, help, save, no-replace behavior, no automatic open, and explicit external open

## Follow-up

Foot advertises Sixel support, but raw cursor-positioned Sixel output does not yet have stable placement through Bubble Tea redraws. This PR keeps Foot on the visible text fallback. Sixel remains on Basecamp card 10217807944 for a later proven integration.

## Tracking

- Basecamp card 10217807944
- Stacked on #179

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Mail TUI attachments reliable across terminals and deduplicates save/open logic for safety and portability. Images render inline only where supported; attachments never auto-open.

- Behavior
  - Always show an Attachments panel with filename, media type, and size. Kitty/Ghostty render inline via Kitty placeholders; Foot/others show text markers (Sixel detected but not used). Use `[` and `]` to select, `s` to save without replacing, `o` to download to a private temp dir and open via the OS handler.
  - Text-only terminals do not download image data they will discard. Saves are atomic with portable filenames; partial downloads are cleaned up. Clear notice when a file already exists.

- Review notes
  - Shared attachment I/O moved to `internal/attachments` with `Destination` and `Save`; platform commit/replace helpers moved there. `internal/cmd/attachments_save` now delegates to `attachments.Save`.
  - TUI injects `imageRenderer`, `saveAttachment`, `openAttachment`, and `newAttachmentTempDir` via `viewContext`.
  - Tests cover renderer selection, panel rendering, key handling, save/open flow, and file safety. README documents keys.

<sup>Written for commit 01260f55c99e8b7ef6f1e5354675d847d553fced. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

