### PR TITLE
Add safe bulk replies to CLI and TUI

### DIFF
--- a/.surface
+++ b/.surface
@@ -30,6 +30,12 @@ hey box --limit
 hey boxes
 hey boxes --all
 hey boxes --limit
+hey bulk-reply
+hey bulk-reply preview
+hey bulk-reply send
+hey bulk-reply send --attach
+hey bulk-reply send --message
+hey bulk-reply undo
 hey calendars
 hey commands
 hey completion

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -30,13 +30,16 @@ The remaining HTML-reading gaps use the SDK's authenticated HTML helper and are 
 | `/topics/{id}/entries.json` | GET | SDK `Topics().GetEntries` | `hey attachments <topic-id>` | covered |
 | `/messages/{id}.json` | GET | SDK `Messages().Get` | `hey attachments <topic-id>`, `hey attachments save <id>` | covered |
 | `/entries/drafts.json` | GET | SDK `Entries().ListDrafts` | `hey drafts` | covered |
-| `/rails/active_storage/direct_uploads.json` | POST | SDK `Attachments().Upload` | `hey compose --attach`, `hey reply --attach` | covered |
-| signed Active Storage upload URL | PUT | SDK `Attachments().Upload` | `hey compose --attach`, `hey reply --attach` | covered |
+| `/rails/active_storage/direct_uploads.json` | POST | SDK `Attachments().Upload` | `hey compose --attach`, `hey reply --attach`, `hey bulk-reply send --attach` | covered |
+| signed Active Storage upload URL | PUT | SDK `Attachments().Upload` | `hey compose --attach`, `hey reply --attach`, `hey bulk-reply send --attach` | covered |
 | signed Active Storage blob URL | GET | SDK `DownloadBlob` | `hey attachments save <id>` | covered |
 | `/messages.json` | POST | SDK `Messages().Create` | `hey compose`, `hey forward <topic-id>` | covered |
 | `/entries/{id}/replies` | POST | SDK `Entries().CreateReply` | `hey reply <topic-id>` | covered |
 | `/topics/{id}.json` | GET | SDK `Topics().Get` | `hey forward <topic-id>` | covered |
 | `/entries/{id}/forwards/new.json` | GET | SDK `Entries().NewForward` | `hey forward <topic-id>` | covered |
+| `/bulk_replies/new.json` | GET | SDK `BulkReplies().Draft` | `hey bulk-reply preview`, `hey bulk-reply send`, TUI `b` | covered |
+| `/bulk_replies.json` | POST | SDK `BulkReplies().Send` | `hey bulk-reply send`, TUI bulk reply | covered |
+| `/bulk_replies/{id}/undo_send` | POST | SDK `BulkReplies().Undo` | `hey bulk-reply undo`, TUI `u` | covered |
 | `/postings/moves.json` | POST | SDK `Postings().Move` | `hey move <id> --to <box>`, TUI `m` | covered |
 | `/postings/trash.json` | POST | SDK `Postings().MoveToTrash` | `hey trash <id>`, TUI `t` | covered |
 | `/postings/spam.json` | POST | SDK `Postings().MarkSpam` | `hey spam <id>`, TUI `s` | covered |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ hey auth logout   # clear credentials
 
 Run `hey` to launch the interactive terminal UI.
 
-Navigate between Mail, Contacts, Calendar, and Journal. In Mail, use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
+Navigate between Mail, Contacts, Calendar, and Journal. In Mail, use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press `b` to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with `u` while HEY's undo window remains open. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
 
 Thread attachments always appear with their filename, media type, and size. Use `[` and `]` to select an attachment, `s` to save it without replacing an existing file, and `o` to download and open it in an external application. Attachments never open automatically. Kitty and Ghostty can show inline images. Foot and other terminals use visible text markers.
 
@@ -89,6 +89,9 @@ hey attachments 123                # list files attached to the thread
 hey attachments save 456:1         # save a file using its attachment ID
 hey reply 123 -m "Thanks!"        # reply to a thread (or omit -m to open $EDITOR)
 hey reply 123 -m "Attached." --attach ./diagram.png
+hey bulk-reply preview 12345 67890  # inspect threads and exact To/CC/BCC recipients
+hey bulk-reply send 12345 67890 -m "Thanks for the update."
+hey bulk-reply undo 98765            # recall a delayed bulk reply
 hey forward 123 --to alice@example.com -m "For your review"  # forward the latest message
 hey compose --to user@example.com --subject "Hello"  # compose a new message
 hey compose --to user@example.com --subject "Report" -m "Attached." --attach ./report.pdf
@@ -106,7 +109,9 @@ Search accepts free text plus `--required`, `--any`, `--none`, `--exact`, `--fro
 
 Contact updates preserve omitted name, email, and alias fields. Supplying `--alias` replaces the complete alias list; `--alias=` clears it. Contact notes accept positional content, `--note`, stdin, or `$EDITOR`. HEY hides contacts rather than permanently deleting them; hidden contacts leave lists, autocomplete, and search, and can be shown again by ID.
 
-`--attach` is repeatable on `hey compose` and `hey reply`, and attachment-only messages are supported. The CLI validates and uploads every file before sending the email. `hey attachments <topic_id>` returns stable message-and-position IDs such as `456:1`; pass an ID to `hey attachments save`. Saving uses the original filename by default, accepts `--output` for a file or directory, and preserves existing files unless `--force` is set.
+`hey bulk-reply preview` is read-only and resolves each posting to its latest replyable entry. `hey bulk-reply send` resolves the selection again, skips threads without a replyable entry, keeps HEY's server-provided name tag, and returns the exact reply count, delivery ID, delayed state, undo URL, and undo command. Posting IDs must be positive and unique. The message can come from `-m`, stdin, or `$EDITOR`; `--attach` is repeatable.
+
+`--attach` is repeatable on `hey compose`, `hey reply`, and `hey bulk-reply send`, and attachment-only messages are supported. The CLI validates and uploads every file before sending the email. `hey attachments <topic_id>` returns stable message-and-position IDs such as `456:1`; pass an ID to `hey attachments save`. Saving uses the original filename by default, accepts `--output` for a file or directory, and preserves existing files unless `--force` is set.
 
 Organization actions take the `id` values returned by `hey box --json` or `hey search --json`. Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 

--- a/internal/cmd/attachment_upload.go
+++ b/internal/cmd/attachment_upload.go
@@ -40,7 +40,10 @@ func attachFiles(ctx context.Context, content string, paths []string) (string, e
 		return "", err
 	}
 	defer closePreparedAttachments(attachments)
+	return attachPreparedFiles(ctx, content, attachments)
+}
 
+func attachPreparedFiles(ctx context.Context, content string, attachments []preparedAttachment) (string, error) {
 	uploads := make([]uploadedAttachment, 0, len(attachments))
 	for _, attachment := range attachments {
 		upload, err := uploadAttachment(ctx, attachment)

--- a/internal/cmd/bulk_reply.go
+++ b/internal/cmd/bulk_reply.go
@@ -1,0 +1,459 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/editor"
+	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type bulkReplyCommand struct {
+	cmd *cobra.Command
+}
+
+type bulkReplyPreviewCommand struct {
+	cmd *cobra.Command
+}
+
+type bulkReplySendCommand struct {
+	cmd         *cobra.Command
+	message     string
+	attachments []string
+}
+
+type bulkReplyUndoCommand struct {
+	cmd *cobra.Command
+}
+
+type bulkReplyRecipient struct {
+	ID           int64  `json:"id,omitempty"`
+	Name         string `json:"name,omitempty"`
+	EmailAddress string `json:"email_address,omitempty"`
+}
+
+type bulkReplyEntry struct {
+	ID        int64                `json:"id"`
+	TopicID   int64                `json:"topic_id"`
+	TopicName string               `json:"topic_name"`
+	To        []bulkReplyRecipient `json:"to"`
+	CC        []bulkReplyRecipient `json:"cc"`
+	BCC       []bulkReplyRecipient `json:"bcc"`
+}
+
+type bulkReplyMarkdownEntry struct {
+	ID        int64  `json:"id"`
+	TopicID   int64  `json:"topic_id"`
+	TopicName string `json:"topic_name"`
+	To        string `json:"to"`
+	CC        string `json:"cc"`
+	BCC       string `json:"bcc"`
+}
+
+func newBulkReplyCommand() *bulkReplyCommand {
+	bulkReplyCommand := &bulkReplyCommand{}
+	bulkReplyCommand.cmd = &cobra.Command{
+		Use:   "bulk-reply",
+		Short: "Reply to multiple email threads",
+		Long:  "Preview, send, and undo one reply across multiple HEY threads.",
+		Annotations: map[string]string{
+			"agent_notes": "Always run `hey bulk-reply preview <posting-id>...` before sending. Send resolves the postings again, keeps HEY's name-tag content, and returns the delivery ID and undo state.",
+		},
+	}
+	bulkReplyCommand.cmd.AddCommand(newBulkReplyPreviewCommand().cmd)
+	bulkReplyCommand.cmd.AddCommand(newBulkReplySendCommand().cmd)
+	bulkReplyCommand.cmd.AddCommand(newBulkReplyUndoCommand().cmd)
+	return bulkReplyCommand
+}
+
+func newBulkReplyPreviewCommand() *bulkReplyPreviewCommand {
+	previewCommand := &bulkReplyPreviewCommand{}
+	previewCommand.cmd = &cobra.Command{
+		Use:   "preview <posting-id>...",
+		Short: "Preview threads and recipients without sending",
+		Annotations: map[string]string{
+			"agent_notes": "Read-only. Posting IDs come from `hey box` or `hey search`. The result contains the latest replyable entry and exact To, CC, and BCC recipients for each thread.",
+		},
+		Example: `  hey bulk-reply preview 12345 67890
+  hey bulk-reply preview 12345 67890 --json`,
+		RunE: previewCommand.run,
+		Args: usageMinOneArg(),
+	}
+	return previewCommand
+}
+
+func (c *bulkReplyPreviewCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	postingIDs, err := parsePositiveUniqueIDs("posting", args)
+	if err != nil {
+		return err
+	}
+	draft, err := sdk.BulkReplies().Draft(cmd.Context(), postingIDs)
+	if err != nil {
+		if hey.AsError(err).Code != hey.CodeNotFound {
+			return convertSDKError(err)
+		}
+		draft = &generated.BulkReplyDraft{}
+	}
+	entries := makeBulkReplyEntries(draft)
+	skipped := len(postingIDs) - len(entries)
+	if skipped < 0 {
+		skipped = 0
+	}
+
+	if writer.IsStyled() {
+		printBulkReplyPreview(cmd, entries, draftContent(draft), skipped)
+		return nil
+	}
+	var data any = entries
+	if writer.EffectiveFormat() == output.FormatMarkdown {
+		data = makeBulkReplyMarkdownEntries(entries)
+	}
+	return writeOK(data,
+		output.WithSummary(bulkReplyPreviewSummary(len(entries), skipped)),
+		output.WithMeta("posting_ids", postingIDs),
+		output.WithMeta("replyable_count", len(entries)),
+		output.WithMeta("skipped_count", skipped),
+		output.WithMeta("prefilled_content", draftContent(draft)),
+		output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "send",
+			Command:     "hey bulk-reply send <posting-id>... -m <message>",
+			Description: "Send one reply to the previewed threads",
+		}),
+	)
+}
+
+func newBulkReplySendCommand() *bulkReplySendCommand {
+	sendCommand := &bulkReplySendCommand{}
+	sendCommand.cmd = &cobra.Command{
+		Use:   "send <posting-id>...",
+		Short: "Send one reply to multiple threads",
+		Annotations: map[string]string{
+			"agent_notes": "Mutating. Preview first. Accepts a message via -m, stdin, or $EDITOR and repeatable --attach files. HEY's server-provided name-tag content is preserved.",
+		},
+		Example: `  hey bulk-reply send 12345 67890 -m "Thanks for the update."
+  echo "Thanks for the update." | hey bulk-reply send 12345 67890
+  hey bulk-reply send 12345 67890 -m "The report is attached." --attach ./report.pdf`,
+		RunE: sendCommand.run,
+		Args: usageMinOneArg(),
+	}
+	sendCommand.cmd.Flags().StringVarP(&sendCommand.message, "message", "m", "", "Reply message (or opens $EDITOR)")
+	sendCommand.cmd.Flags().StringArrayVar(&sendCommand.attachments, "attach", nil, "File to attach (repeatable)")
+	return sendCommand
+}
+
+func (c *bulkReplySendCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	postingIDs, err := parsePositiveUniqueIDs("posting", args)
+	if err != nil {
+		return err
+	}
+	message, err := c.readMessage()
+	if err != nil {
+		return err
+	}
+	attachments, err := prepareAttachments(c.attachments)
+	if err != nil {
+		return err
+	}
+	defer closePreparedAttachments(attachments)
+
+	ctx := cmd.Context()
+	draft, err := sdk.BulkReplies().Draft(ctx, postingIDs)
+	if err != nil {
+		if hey.AsError(err).Code == hey.CodeNotFound {
+			return output.ErrUsage("no replyable threads resolved; no reply was sent")
+		}
+		return convertSDKError(err)
+	}
+	entries := makeBulkReplyEntries(draft)
+	if len(entries) == 0 {
+		return output.ErrUsage("no replyable threads resolved; no reply was sent")
+	}
+	entryIDs := make([]int64, len(entries))
+	for i, entry := range entries {
+		entryIDs[i] = entry.ID
+	}
+
+	content := htmlutil.PrependText(draftContent(draft), message)
+	content, err = attachPreparedFiles(ctx, content, attachments)
+	if err != nil {
+		return err
+	}
+	delivery, err := sdk.BulkReplies().Send(ctx, entryIDs, content)
+	if err != nil {
+		return convertSDKError(err)
+	}
+	if delivery == nil {
+		return output.ErrAPI(0, "HEY returned an empty bulk reply delivery")
+	}
+
+	skipped := len(postingIDs) - len(entries)
+	if skipped < 0 {
+		skipped = 0
+	}
+	summary := bulkReplyDeliverySummary(delivery, len(c.attachments), skipped)
+	if writer.IsStyled() {
+		printBulkReplyDelivery(cmd, delivery, summary)
+		return nil
+	}
+	switch writer.EffectiveFormat() {
+	case output.FormatIDs:
+		fmt.Fprintln(cmd.OutOrStdout(), delivery.Id)
+		return nil
+	case output.FormatCount:
+		fmt.Fprintln(cmd.OutOrStdout(), delivery.EntriesCount)
+		return nil
+	case output.FormatAuto, output.FormatJSON, output.FormatStyled, output.FormatQuiet, output.FormatMarkdown:
+	}
+
+	options := []output.ResponseOption{
+		output.WithSummary(summary),
+		output.WithMeta("posting_ids", postingIDs),
+		output.WithMeta("skipped_count", skipped),
+	}
+	if delivery.Delayed && delivery.Id > 0 {
+		options = append(options, output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "undo",
+			Command:     fmt.Sprintf("hey bulk-reply undo %d", delivery.Id),
+			Description: "Recall this bulk reply before HEY sends it",
+		}))
+	}
+	return writeOK(delivery, options...)
+}
+
+func (c *bulkReplySendCommand) readMessage() (string, error) {
+	return readBulkReplyMessage(c.message, len(c.attachments), stdinIsTerminal(), readStdin, editor.Open)
+}
+
+func readBulkReplyMessage(message string, attachmentCount int, stdinTerminal bool, readInput func() (string, error), openEditor func(string) (string, error)) (string, error) {
+	if message == "" && !stdinTerminal {
+		var err error
+		message, err = readInput()
+		if err != nil {
+			return "", err
+		}
+		if message == "" && attachmentCount == 0 {
+			return "", output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
+		}
+	} else if message == "" && attachmentCount == 0 {
+		var err error
+		message, err = openEditor("")
+		if err != nil {
+			return "", output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
+		}
+		message = strings.TrimSpace(message)
+		if message == "" {
+			return "", output.ErrUsage("empty message, aborting")
+		}
+	}
+	return message, nil
+}
+
+func newBulkReplyUndoCommand() *bulkReplyUndoCommand {
+	undoCommand := &bulkReplyUndoCommand{}
+	undoCommand.cmd = &cobra.Command{
+		Use:   "undo <bulk-reply-id>",
+		Short: "Recall a delayed bulk reply",
+		Annotations: map[string]string{
+			"agent_notes": "Mutating. Works only while HEY's undo window remains open. The bulk reply ID is returned by `hey bulk-reply send`.",
+		},
+		Example: `  hey bulk-reply undo 98765`,
+		RunE:    undoCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return undoCommand
+}
+
+func (c *bulkReplyUndoCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	ids, err := parsePositiveUniqueIDs("bulk reply", args)
+	if err != nil {
+		return err
+	}
+	if err := sdk.BulkReplies().Undo(cmd.Context(), ids[0]); err != nil {
+		return convertSDKError(err)
+	}
+	if writer.IsStyled() {
+		fmt.Fprintln(cmd.OutOrStdout(), "Bulk reply recalled.")
+		return nil
+	}
+	switch writer.EffectiveFormat() {
+	case output.FormatIDs:
+		fmt.Fprintln(cmd.OutOrStdout(), ids[0])
+		return nil
+	case output.FormatCount:
+		fmt.Fprintln(cmd.OutOrStdout(), 1)
+		return nil
+	case output.FormatAuto, output.FormatJSON, output.FormatStyled, output.FormatQuiet, output.FormatMarkdown:
+	}
+	return writeOK(map[string]any{"id": ids[0], "undone": true}, output.WithSummary("Bulk reply recalled"))
+}
+
+func parsePositiveUniqueIDs(kind string, values []string) ([]int64, error) {
+	ids := make([]int64, 0, len(values))
+	seen := make(map[int64]struct{}, len(values))
+	for _, value := range values {
+		id, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || id <= 0 {
+			return nil, output.ErrUsage(fmt.Sprintf("invalid %s ID: %s (must be a positive integer)", kind, value))
+		}
+		if _, exists := seen[id]; exists {
+			return nil, output.ErrUsage(fmt.Sprintf("duplicate %s ID: %d", kind, id))
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func makeBulkReplyEntries(draft *generated.BulkReplyDraft) []bulkReplyEntry {
+	if draft == nil {
+		return []bulkReplyEntry{}
+	}
+	entries := make([]bulkReplyEntry, 0, len(draft.Entries))
+	for _, entry := range draft.Entries {
+		entries = append(entries, bulkReplyEntry{
+			ID:        entry.Id,
+			TopicID:   entry.TopicId,
+			TopicName: entry.TopicName,
+			To:        makeBulkReplyRecipients(entry.Addressed.Directly),
+			CC:        makeBulkReplyRecipients(entry.Addressed.Copied),
+			BCC:       makeBulkReplyRecipients(entry.Addressed.Blindcopied),
+		})
+	}
+	return entries
+}
+
+func makeBulkReplyRecipients(contacts []generated.Contact) []bulkReplyRecipient {
+	recipients := make([]bulkReplyRecipient, 0, len(contacts))
+	for _, contact := range contacts {
+		recipients = append(recipients, bulkReplyRecipient{
+			ID:           contact.Id,
+			Name:         contact.Name,
+			EmailAddress: contact.EmailAddress,
+		})
+	}
+	return recipients
+}
+
+func makeBulkReplyMarkdownEntries(entries []bulkReplyEntry) []bulkReplyMarkdownEntry {
+	formatted := make([]bulkReplyMarkdownEntry, 0, len(entries))
+	for _, entry := range entries {
+		formatted = append(formatted, bulkReplyMarkdownEntry{
+			ID:        entry.ID,
+			TopicID:   entry.TopicID,
+			TopicName: markdownSafeText(entry.TopicName),
+			To:        markdownSafeText(formatBulkReplyRecipients(entry.To)),
+			CC:        markdownSafeText(formatBulkReplyRecipients(entry.CC)),
+			BCC:       markdownSafeText(formatBulkReplyRecipients(entry.BCC)),
+		})
+	}
+	return formatted
+}
+
+func draftContent(draft *generated.BulkReplyDraft) string {
+	if draft == nil {
+		return ""
+	}
+	return draft.Content
+}
+
+func printBulkReplyPreview(cmd *cobra.Command, entries []bulkReplyEntry, content string, skipped int) {
+	if len(entries) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No replyable threads found.")
+	} else {
+		table := newTable(cmd.OutOrStdout())
+		table.addRow([]string{"Entry", "Thread", "Subject", "To", "CC", "BCC"})
+		for _, entry := range entries {
+			table.addRow([]string{
+				fmt.Sprintf("%d", entry.ID),
+				fmt.Sprintf("%d", entry.TopicID),
+				truncate(terminalSafeText(entry.TopicName), 36),
+				truncate(formatBulkReplyRecipients(entry.To), 48),
+				truncate(formatBulkReplyRecipients(entry.CC), 48),
+				truncate(formatBulkReplyRecipients(entry.BCC), 48),
+			})
+		}
+		table.print()
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "\n%s.\n", bulkReplyPreviewSummary(len(entries), skipped))
+	if text := htmlutil.ToText(content); text != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "HEY will preserve this name tag: %s\n", terminalSafeText(text))
+	}
+}
+
+func formatBulkReplyRecipients(recipients []bulkReplyRecipient) string {
+	formatted := make([]string, 0, len(recipients))
+	for _, recipient := range recipients {
+		name := terminalSafeText(recipient.Name)
+		email := terminalSafeText(recipient.EmailAddress)
+		switch {
+		case name != "" && email != "":
+			formatted = append(formatted, fmt.Sprintf("%s <%s>", name, email))
+		case email != "":
+			formatted = append(formatted, email)
+		case name != "":
+			formatted = append(formatted, name)
+		}
+	}
+	return strings.Join(formatted, ", ")
+}
+
+func bulkReplyPreviewSummary(replyable, skipped int) string {
+	summary := fmt.Sprintf("%d replyable %s", replyable, threadNoun(replyable))
+	if skipped > 0 {
+		noun := "postings"
+		if skipped == 1 {
+			noun = "posting"
+		}
+		summary += fmt.Sprintf("; %d %s skipped", skipped, noun)
+	}
+	return summary
+}
+
+func bulkReplyDeliverySummary(delivery *generated.BulkReplyDelivery, attachmentCount, skipped int) string {
+	count := int(delivery.EntriesCount)
+	noun := "replies"
+	if count == 1 {
+		noun = "reply"
+	}
+	summary := fmt.Sprintf("%d %s sent", count, noun)
+	if delivery.Delayed {
+		summary = fmt.Sprintf("%d %s queued with undo available", count, noun)
+	}
+	if attachmentCount > 0 {
+		attachmentNoun := "attachments"
+		if attachmentCount == 1 {
+			attachmentNoun = "attachment"
+		}
+		summary += fmt.Sprintf(" with %d %s", attachmentCount, attachmentNoun)
+	}
+	if skipped > 0 {
+		summary += fmt.Sprintf("; %d skipped", skipped)
+	}
+	return summary
+}
+
+func printBulkReplyDelivery(cmd *cobra.Command, delivery *generated.BulkReplyDelivery, summary string) {
+	fmt.Fprintf(cmd.OutOrStdout(), "%s.\n", summary)
+	fmt.Fprintf(cmd.OutOrStdout(), "Delivery ID: %d\n", delivery.Id)
+	fmt.Fprintf(cmd.OutOrStdout(), "Delayed: %t\n", delivery.Delayed)
+	if delivery.UndoSendUrl != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Undo URL: %s\n", terminalSafeText(delivery.UndoSendUrl))
+		fmt.Fprintf(cmd.OutOrStdout(), "Undo: hey bulk-reply undo %d\n", delivery.Id)
+	}
+}

--- a/internal/cmd/bulk_reply_test.go
+++ b/internal/cmd/bulk_reply_test.go
@@ -1,0 +1,386 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+)
+
+type recordedBulkReplyRequest struct {
+	Method string
+	Path   string
+	Query  string
+	Body   []byte
+}
+
+type bulkReplyServerState struct {
+	mu            sync.Mutex
+	requests      []recordedBulkReplyRequest
+	draft         string
+	draftStatus   int
+	delivery      string
+	undoStatus    int
+	directUploads int
+	storage       int
+}
+
+func (s *bulkReplyServerState) snapshot() []recordedBulkReplyRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]recordedBulkReplyRequest(nil), s.requests...)
+}
+
+func bulkReplyServer(t *testing.T) (*httptest.Server, *bulkReplyServerState) {
+	t.Helper()
+	state := &bulkReplyServerState{
+		draft: `{
+			"content":"<div>Signing off with a tag!</div>",
+			"entries":[
+				{"id":11,"topic_id":21,"topic_name":"Quarterly planning","addressed":{"directly":[{"id":31,"name":"Jane Doe","email_address":"jane@example.com"}],"copied":[{"id":32,"name":"Bob Smith","email_address":"bob@example.org"}],"blindcopied":[{"id":33,"email_address":"audit@example.com"}]}},
+				{"id":12,"topic_id":22,"topic_name":"Design review","addressed":{"directly":[{"id":34,"name":"Alice Jones","email_address":"alice@example.com"}]}}
+			]
+		}`,
+		delivery: `{"id":900,"entries_count":2,"delayed":true,"undo_send_url":"https://app.hey.com/bulk_replies/900/undo_send"}`,
+	}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := new(bytes.Buffer)
+		_, _ = body.ReadFrom(r.Body)
+		state.mu.Lock()
+		state.requests = append(state.requests, recordedBulkReplyRequest{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery, Body: body.Bytes()})
+		draft := state.draft
+		draftStatus := state.draftStatus
+		delivery := state.delivery
+		undoStatus := state.undoStatus
+		state.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/bulk_replies/new.json":
+			if draftStatus != 0 {
+				w.WriteHeader(draftStatus)
+				_, _ = w.Write([]byte(`{"error":"No threads for replying were found"}`))
+				return
+			}
+			_, _ = w.Write([]byte(draft))
+		case r.Method == http.MethodPost && r.URL.Path == "/bulk_replies.json":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(delivery))
+		case r.Method == http.MethodPost && r.URL.Path == "/bulk_replies/900/undo_send":
+			if undoStatus != 0 {
+				w.WriteHeader(undoStatus)
+				_, _ = w.Write([]byte(`{"errors":["The undo window has expired"]}`))
+				return
+			}
+			w.Header().Set("Location", "/bulk_replies/900")
+			w.WriteHeader(http.StatusFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/bulk_replies/900":
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/rails/active_storage/direct_uploads.json":
+			state.mu.Lock()
+			state.directUploads++
+			state.mu.Unlock()
+			_, _ = fmt.Fprintf(w, `{"signed_id":"signed-upload","attachable_sgid":"sgid-upload","direct_upload":{"url":%q,"headers":{"Content-Type":"application/pdf"}}}`, server.URL+"/storage/upload")
+		case r.Method == http.MethodPut && r.URL.Path == "/storage/upload":
+			state.mu.Lock()
+			state.storage++
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, state
+}
+
+func runBulkReply(t *testing.T, server *httptest.Server, formatArgs, args []string) (string, error) {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	root := newRootCmd()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	commandArgs := append([]string{"bulk-reply", "--base-url", server.URL}, formatArgs...)
+	commandArgs = append(commandArgs, args...)
+	root.SetArgs(commandArgs)
+	err := root.Execute()
+	return output.String(), err
+}
+
+func TestBulkReplyPreviewShowsExactRecipientsInEveryFormat(t *testing.T) {
+	server, state := bulkReplyServer(t)
+	tests := []struct {
+		name       string
+		formatArgs []string
+		contains   []string
+	}{
+		{"json", []string{"--json"}, []string{`"topic_name": "Quarterly planning"`, `"email_address": "jane@example.com"`, `"skipped_count": 1`}},
+		{"quiet", []string{"--quiet"}, []string{`"topic_name": "Quarterly planning"`, `"email_address": "bob@example.org"`}},
+		{"markdown", []string{"--markdown"}, []string{"Quarterly planning", `jane\@example\.com`, `audit\@example\.com`}},
+		{"styled", []string{"--styled"}, []string{"Quarterly planning", "Jane Doe <jane@example.com>", "1 posting skipped", "Signing off with a tag!"}},
+		{"ids", []string{"--ids-only"}, []string{"11\n12\n"}},
+		{"count", []string{"--count"}, []string{"2\n"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := runBulkReply(t, server, tt.formatArgs, []string{"preview", "101", "202", "303"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, expected := range tt.contains {
+				if !strings.Contains(output, expected) {
+					t.Errorf("output does not contain %q:\n%s", expected, output)
+				}
+			}
+		})
+	}
+
+	requests := state.snapshot()
+	if len(requests) != len(tests) {
+		t.Fatalf("requests = %d, want %d", len(requests), len(tests))
+	}
+	for _, request := range requests {
+		if request.Method != http.MethodGet || request.Path != "/bulk_replies/new.json" || request.Query != "posting_ids=101%2C202%2C303" {
+			t.Errorf("preview request = %+v", request)
+		}
+	}
+}
+
+func TestBulkReplySendPreservesDraftAndReportsDelayedDelivery(t *testing.T) {
+	server, state := bulkReplyServer(t)
+	output, err := runBulkReply(t, server, []string{"--json"}, []string{"send", "101", "202", "303", "-m", "Thanks everyone"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, `"entries_count": 2`) || !strings.Contains(output, `"delayed": true`) || !strings.Contains(output, `"command": "hey bulk-reply undo 900"`) || !strings.Contains(output, `"skipped_count": 1`) {
+		t.Errorf("delivery output = %s", output)
+	}
+
+	requests := state.snapshot()
+	if len(requests) != 2 || requests[0].Method != http.MethodGet || requests[1].Method != http.MethodPost {
+		t.Fatalf("requests = %+v", requests)
+	}
+	var request struct {
+		EntryIDs []int64 `json:"entry_ids"`
+		Message  struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(requests[1].Body, &request); err != nil {
+		t.Fatal(err)
+	}
+	if fmt.Sprint(request.EntryIDs) != "[11 12]" {
+		t.Errorf("entry_ids = %v", request.EntryIDs)
+	}
+	want := "<div>Thanks everyone</div><br><div>Signing off with a tag!</div>"
+	if request.Message.Content != want {
+		t.Errorf("content = %q, want %q", request.Message.Content, want)
+	}
+}
+
+func TestBulkReplySendReportsImmediateDeliveryWithoutUndo(t *testing.T) {
+	server, state := bulkReplyServer(t)
+	state.delivery = `{"id":901,"entries_count":2,"delayed":false}`
+	output, err := runBulkReply(t, server, []string{"--json"}, []string{"send", "101", "202", "-m", "Thanks"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, `"summary": "2 replies sent"`) || strings.Contains(output, `"action": "undo"`) {
+		t.Errorf("immediate output = %s", output)
+	}
+}
+
+func TestBulkReplySendSupportsEveryOutputFormatWithoutPostSendErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		formatArgs []string
+		expected   string
+	}{
+		{"json", []string{"--json"}, `"id": 900`},
+		{"quiet", []string{"--quiet"}, `"id": 900`},
+		{"markdown", []string{"--markdown"}, "**id:** 900"},
+		{"styled", []string{"--styled"}, "Delivery ID: 900"},
+		{"ids", []string{"--ids-only"}, "900\n"},
+		{"count", []string{"--count"}, "2\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, state := bulkReplyServer(t)
+			output, err := runBulkReply(t, server, test.formatArgs, []string{"send", "101", "202", "-m", "Thanks"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(output, test.expected) {
+				t.Errorf("output does not contain %q: %s", test.expected, output)
+			}
+			requests := state.snapshot()
+			if len(requests) != 2 || requests[1].Path != "/bulk_replies.json" {
+				t.Errorf("send requests = %+v", requests)
+			}
+		})
+	}
+}
+
+func TestBulkReplySendSupportsAttachments(t *testing.T) {
+	server, state := bulkReplyServer(t)
+	attachment := filepath.Join(t.TempDir(), "report.pdf")
+	if err := os.WriteFile(attachment, []byte("quarterly report"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := runBulkReply(t, server, []string{"--json"}, []string{"send", "101", "202", "-m", "Attached", "--attach", attachment})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.mu.Lock()
+	if state.directUploads != 1 || state.storage != 1 {
+		t.Errorf("uploads = direct:%d storage:%d", state.directUploads, state.storage)
+	}
+	state.mu.Unlock()
+	requests := state.snapshot()
+	if len(requests) != 4 || requests[len(requests)-1].Path != "/bulk_replies.json" {
+		t.Fatalf("requests = %+v", requests)
+	}
+	if !strings.Contains(string(requests[len(requests)-1].Body), `action-text-attachment`) || !strings.Contains(string(requests[len(requests)-1].Body), `sgid-upload`) {
+		t.Errorf("send body did not include attachment: %s", requests[len(requests)-1].Body)
+	}
+}
+
+func TestBulkReplySendStopsWhenNoEntriesResolve(t *testing.T) {
+	for _, draftStatus := range []int{0, http.StatusNotFound} {
+		t.Run(fmt.Sprintf("status_%d", draftStatus), func(t *testing.T) {
+			server, state := bulkReplyServer(t)
+			state.draft = `{"content":"<div>Name tag</div>","entries":[]}`
+			state.draftStatus = draftStatus
+			attachment := filepath.Join(t.TempDir(), "report.pdf")
+			if err := os.WriteFile(attachment, []byte("report"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := runBulkReply(t, server, []string{"--json"}, []string{"send", "101", "-m", "This must not send", "--attach", attachment})
+			if err == nil || !strings.Contains(err.Error(), "no replyable threads") {
+				t.Fatalf("error = %v", err)
+			}
+			requests := state.snapshot()
+			if len(requests) != 1 || requests[0].Method != http.MethodGet {
+				t.Errorf("empty draft made mutation requests: %+v", requests)
+			}
+		})
+	}
+}
+
+func TestBulkReplyPreviewTurnsNoReplyableNotFoundIntoEmptyPreview(t *testing.T) {
+	server, state := bulkReplyServer(t)
+	state.draftStatus = http.StatusNotFound
+	output, err := runBulkReply(t, server, []string{"--json"}, []string{"preview", "101", "202"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, `"data": []`) || !strings.Contains(output, `"skipped_count": 2`) {
+		t.Errorf("empty preview = %s", output)
+	}
+}
+
+func TestBulkReplyValidatesPositiveUniqueIDsBeforeRequest(t *testing.T) {
+	tests := [][]string{
+		{"preview", "0"},
+		{"preview", "-1"},
+		{"preview", "not-an-id"},
+		{"send", "101", "101", "-m", "No"},
+		{"send", "101", "-m", ""},
+		{"send", "101", "-m", "No", "--attach", filepath.Join(t.TempDir(), "missing.pdf")},
+		{"undo", "0"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			server, state := bulkReplyServer(t)
+			if _, err := runBulkReply(t, server, []string{"--json"}, args); err == nil {
+				t.Fatal("expected validation error")
+			}
+			if requests := state.snapshot(); len(requests) != 0 {
+				t.Errorf("validation failure made requests: %+v", requests)
+			}
+		})
+	}
+}
+
+func TestReadBulkReplyMessageSupportsInlineStdinEditorAndAttachmentsOnly(t *testing.T) {
+	unused := func() (string, error) { return "", errors.New("should not read stdin") }
+	unusedEditor := func(string) (string, error) { return "", errors.New("should not open editor") }
+
+	message, err := readBulkReplyMessage("Inline", 0, true, unused, unusedEditor)
+	if err != nil || message != "Inline" {
+		t.Errorf("inline = %q, %v", message, err)
+	}
+	message, err = readBulkReplyMessage("", 0, false, func() (string, error) { return "From stdin", nil }, unusedEditor)
+	if err != nil || message != "From stdin" {
+		t.Errorf("stdin = %q, %v", message, err)
+	}
+	message, err = readBulkReplyMessage("", 0, true, unused, func(initial string) (string, error) {
+		if initial != "" {
+			t.Errorf("editor initial content = %q", initial)
+		}
+		return "  From editor\n", nil
+	})
+	if err != nil || message != "From editor" {
+		t.Errorf("editor = %q, %v", message, err)
+	}
+	message, err = readBulkReplyMessage("", 1, true, unused, unusedEditor)
+	if err != nil || message != "" {
+		t.Errorf("attachment-only = %q, %v", message, err)
+	}
+}
+
+func TestBulkReplyUndoSupportsDataOnlyFormats(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		formatArgs []string
+		expected   string
+	}{{"ids", []string{"--ids-only"}, "900\n"}, {"count", []string{"--count"}, "1\n"}} {
+		t.Run(test.name, func(t *testing.T) {
+			server, _ := bulkReplyServer(t)
+			output, err := runBulkReply(t, server, test.formatArgs, []string{"undo", "900"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if output != test.expected {
+				t.Errorf("output = %q, want %q", output, test.expected)
+			}
+		})
+	}
+}
+
+func TestBulkReplyUndoSuccessAndExpiredWindow(t *testing.T) {
+	server, _ := bulkReplyServer(t)
+	output, err := runBulkReply(t, server, []string{"--json"}, []string{"undo", "900"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, `"undone": true`) || !strings.Contains(output, `"id": 900`) {
+		t.Errorf("undo output = %s", output)
+	}
+
+	server, state := bulkReplyServer(t)
+	state.undoStatus = http.StatusUnprocessableEntity
+	_, err = runBulkReply(t, server, []string{"--json"}, []string{"undo", "900"})
+	if err == nil {
+		t.Fatal("expired undo should fail")
+	}
+	if converted := apierr.AsError(err); converted.Code != "api" {
+		t.Errorf("expired undo code = %q, want api (%v)", converted.Code, err)
+	}
+}

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -17,7 +17,7 @@ var curatedCategories = []struct {
 }{
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "search", "contacts", "threads", "attachments", "compose", "reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
+		names:   []string{"boxes", "box", "search", "contacts", "threads", "attachments", "compose", "reply", "bulk-reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -100,6 +100,7 @@ EMAIL
   attachments    List and save files from a thread
   compose        Write and send a new email
   reply          Reply to a thread
+  bulk-reply     Reply to multiple email threads
   forward        Forward the latest message in a thread
   drafts         List draft emails
   seen           Mark email threads as seen

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -124,6 +124,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newThreadsCommand().cmd)
 	root.AddCommand(newAttachmentsCommand().cmd)
 	root.AddCommand(newReplyCommand().cmd)
+	root.AddCommand(newBulkReplyCommand().cmd)
 	root.AddCommand(newForwardCommand().cmd)
 	root.AddCommand(newComposeCommand().cmd)
 	root.AddCommand(newDraftsCommand().cmd)

--- a/internal/tui/bulk_reply.go
+++ b/internal/tui/bulk_reply.go
@@ -1,0 +1,255 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/htmlutil"
+)
+
+type bulkReplyDraftLoadedMsg struct {
+	requestID  uint64
+	boxID      int64
+	postingIDs []int64
+	draft      *generated.BulkReplyDraft
+	err        error
+}
+
+type bulkReplySentMsg struct {
+	delivery *generated.BulkReplyDelivery
+	skipped  int
+	err      error
+}
+
+type bulkReplyUndoneMsg struct {
+	id  int64
+	err error
+}
+
+type bulkReplyForm struct {
+	postingIDs []int64
+	draft      generated.BulkReplyDraft
+	composing  bool
+	body       textarea.Model
+	status     string
+	isError    bool
+	sending    bool
+	styles     styles
+	width      int
+	height     int
+}
+
+func newBulkReplyForm(postingIDs []int64, draft *generated.BulkReplyDraft, s styles) *bulkReplyForm {
+	form := &bulkReplyForm{
+		postingIDs: append([]int64(nil), postingIDs...),
+		styles:     s,
+	}
+	if draft != nil {
+		form.draft = *draft
+	}
+	form.body = textarea.New()
+	form.body.Prompt = ""
+	form.body.ShowLineNumbers = false
+	form.body.Placeholder = "Write the reply that every selected thread will receive…"
+	return form
+}
+
+func (f *bulkReplyForm) init() tea.Cmd {
+	if !f.composing {
+		return nil
+	}
+	return f.body.Focus()
+}
+
+func (f *bulkReplyForm) resize(width, height int) {
+	f.width = width
+	f.height = height
+	f.body.SetWidth(max(width-4, 10))
+	f.body.SetHeight(max(height-8, 3))
+}
+
+func (f *bulkReplyForm) handleKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
+	if f.sending {
+		return nil, false
+	}
+	if !f.composing {
+		if msg.Key().Code == tea.KeyEnter {
+			f.composing = true
+			return f.body.Focus(), false
+		}
+		return nil, false
+	}
+	if msg.String() == "ctrl+s" {
+		if strings.TrimSpace(f.body.Value()) == "" {
+			f.status = "Message is empty"
+			f.isError = true
+			return nil, false
+		}
+		f.sending = true
+		f.status = "Sending…"
+		f.isError = false
+		return nil, true
+	}
+	var cmd tea.Cmd
+	f.body, cmd = f.body.Update(msg)
+	return cmd, false
+}
+
+func (f *bulkReplyForm) update(msg tea.Msg) tea.Cmd {
+	if !f.composing {
+		return nil
+	}
+	var cmd tea.Cmd
+	f.body, cmd = f.body.Update(msg)
+	return cmd
+}
+
+func (f *bulkReplyForm) helpBindings() []helpBinding {
+	if !f.composing {
+		return []helpBinding{{"enter", "write reply"}, {"esc", "cancel"}}
+	}
+	return []helpBinding{{"ctrl+s", "send to all"}, {"esc", "cancel"}}
+}
+
+func (f *bulkReplyForm) view() string {
+	if !f.composing {
+		return f.previewView()
+	}
+	return f.composeView()
+}
+
+func (f *bulkReplyForm) previewView() string {
+	var b strings.Builder
+	b.WriteString(f.styles.title.Render("Bulk reply preview"))
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "%d replyable %s", len(f.draft.Entries), tuiThreadNoun(len(f.draft.Entries)))
+	if skipped := len(f.postingIDs) - len(f.draft.Entries); skipped > 0 {
+		fmt.Fprintf(&b, " · %d skipped", skipped)
+	}
+	b.WriteString("\n\n")
+
+	labelStyle := lipgloss.NewStyle().Foreground(colorMuted)
+	for i, entry := range f.draft.Entries {
+		fmt.Fprintf(&b, "%d. %s\n", i+1, terminalSafeAttachmentText(entry.TopicName))
+		fmt.Fprintf(&b, "%s %s\n", labelStyle.Render("   To:"), formatBulkReplyContacts(entry.Addressed.Directly))
+		if len(entry.Addressed.Copied) > 0 {
+			fmt.Fprintf(&b, "%s %s\n", labelStyle.Render("   CC:"), formatBulkReplyContacts(entry.Addressed.Copied))
+		}
+		if len(entry.Addressed.Blindcopied) > 0 {
+			fmt.Fprintf(&b, "%s %s\n", labelStyle.Render("  BCC:"), formatBulkReplyContacts(entry.Addressed.Blindcopied))
+		}
+		b.WriteString("\n")
+	}
+	if nameTag := htmlutil.ToText(f.draft.Content); nameTag != "" {
+		b.WriteString(labelStyle.Render("HEY will preserve your name tag: "))
+		b.WriteString(terminalSafeAttachmentText(nameTag))
+		b.WriteString("\n\n")
+	}
+	b.WriteString(labelStyle.Render("Review every recipient, then press enter to write the reply."))
+	return b.String()
+}
+
+func (f *bulkReplyForm) composeView() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n", f.styles.title.Render(fmt.Sprintf("Bulk reply to %d %s", len(f.draft.Entries), tuiThreadNoun(len(f.draft.Entries)))))
+	b.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Render("The exact recipients from the preview and HEY's name tag will be preserved."))
+	b.WriteString("\n\n")
+	b.WriteString(f.body.View())
+	b.WriteString("\n")
+	if f.status != "" {
+		statusStyle := lipgloss.NewStyle().Foreground(colorMuted)
+		if f.isError {
+			statusStyle = lipgloss.NewStyle().Foreground(colorError)
+		}
+		b.WriteString(statusStyle.Render(f.status))
+	}
+	return b.String()
+}
+
+func formatBulkReplyContacts(contacts []generated.Contact) string {
+	formatted := make([]string, 0, len(contacts))
+	for _, contact := range contacts {
+		name := terminalSafeAttachmentText(contact.Name)
+		email := terminalSafeAttachmentText(contact.EmailAddress)
+		switch {
+		case name != "" && email != "":
+			formatted = append(formatted, fmt.Sprintf("%s <%s>", name, email))
+		case email != "":
+			formatted = append(formatted, email)
+		case name != "":
+			formatted = append(formatted, name)
+		}
+	}
+	return strings.Join(formatted, ", ")
+}
+
+func tuiThreadNoun(count int) string {
+	if count == 1 {
+		return "thread"
+	}
+	return "threads"
+}
+
+func replyNoun(count int) string {
+	if count == 1 {
+		return "reply"
+	}
+	return "replies"
+}
+
+func (v *mailView) startBulkReply() tea.Cmd {
+	postingIDs := v.postingList.selectedIDs()
+	if len(postingIDs) == 0 {
+		v.notice = "Select threads with space before starting a bulk reply"
+		return nil
+	}
+	requestID, ctx := v.beginRequest(mailRequestBulkReply)
+	boxID := v.currentBoxID()
+	return func() tea.Msg {
+		draft, err := v.vc.sdk.BulkReplies().Draft(ctx, postingIDs)
+		if err != nil && hey.AsError(err).Code == hey.CodeNotFound {
+			draft = &generated.BulkReplyDraft{}
+			err = nil
+		}
+		return bulkReplyDraftLoadedMsg{
+			requestID:  requestID,
+			boxID:      boxID,
+			postingIDs: postingIDs,
+			draft:      draft,
+			err:        err,
+		}
+	}
+}
+
+func (v *mailView) sendBulkReply() tea.Cmd {
+	form := v.bulkReply
+	entryIDs := make([]int64, len(form.draft.Entries))
+	for i, entry := range form.draft.Entries {
+		entryIDs[i] = entry.Id
+	}
+	content := htmlutil.PrependText(form.draft.Content, form.body.Value())
+	skipped := len(form.postingIDs) - len(entryIDs)
+	return func() tea.Msg {
+		delivery, err := v.vc.sdk.BulkReplies().Send(v.vc.ctx, entryIDs, content)
+		return bulkReplySentMsg{delivery: delivery, skipped: max(skipped, 0), err: err}
+	}
+}
+
+func (v *mailView) undoBulkReply() tea.Cmd {
+	id := v.lastBulkReplyID
+	if id == 0 {
+		v.notice = "No delayed bulk reply is available to undo"
+		return nil
+	}
+	return func() tea.Msg {
+		err := v.vc.sdk.BulkReplies().Undo(v.vc.ctx, id)
+		return bulkReplyUndoneMsg{id: id, err: err}
+	}
+}

--- a/internal/tui/bulk_reply_test.go
+++ b/internal/tui/bulk_reply_test.go
@@ -1,0 +1,331 @@
+package tui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+)
+
+type tuiBulkReplyRequest struct {
+	method string
+	path   string
+	query  string
+	body   []byte
+}
+
+type tuiBulkReplyServerState struct {
+	mu          sync.Mutex
+	requests    []tuiBulkReplyRequest
+	draft       string
+	draftStatus int
+	delivery    string
+	sendStatus  int
+	undoStatus  int
+}
+
+func (s *tuiBulkReplyServerState) snapshot() []tuiBulkReplyRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]tuiBulkReplyRequest(nil), s.requests...)
+}
+
+func tuiBulkReplyServer(t *testing.T) (*mailView, *tuiBulkReplyServerState) {
+	t.Helper()
+	state := &tuiBulkReplyServerState{
+		draft: `{
+			"content":"<div>Signing off with a tag!</div>",
+			"entries":[
+				{"id":501,"topic_id":700,"topic_name":"Quarterly planning","addressed":{"directly":[{"id":31,"name":"Jane Doe","email_address":"jane@example.com"}],"copied":[{"id":32,"name":"Bob Smith","email_address":"bob@example.org"}],"blindcopied":[{"id":33,"email_address":"audit@example.com"}]}},
+				{"id":502,"topic_id":701,"topic_name":"Design review","addressed":{"directly":[{"id":34,"name":"Alice Jones","email_address":"alice@example.com"}]}}
+			]
+		}`,
+		delivery: `{"id":900,"entries_count":2,"delayed":true,"undo_send_url":"https://app.hey.com/bulk_replies/900/undo_send"}`,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := new(bytes.Buffer)
+		_, _ = body.ReadFrom(r.Body)
+		state.mu.Lock()
+		state.requests = append(state.requests, tuiBulkReplyRequest{method: r.Method, path: r.URL.Path, query: r.URL.RawQuery, body: body.Bytes()})
+		draft := state.draft
+		draftStatus := state.draftStatus
+		delivery := state.delivery
+		sendStatus := state.sendStatus
+		undoStatus := state.undoStatus
+		state.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/bulk_replies/new.json":
+			if draftStatus != 0 {
+				w.WriteHeader(draftStatus)
+				_, _ = w.Write([]byte(`{"error":"No threads for replying were found"}`))
+				return
+			}
+			_, _ = w.Write([]byte(draft))
+		case r.Method == http.MethodPost && r.URL.Path == "/bulk_replies.json":
+			if sendStatus != 0 {
+				w.WriteHeader(sendStatus)
+				_, _ = w.Write([]byte(`{"errors":["Sending is unavailable"]}`))
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(delivery))
+		case r.Method == http.MethodPost && r.URL.Path == "/bulk_replies/900/undo_send":
+			if undoStatus != 0 {
+				w.WriteHeader(undoStatus)
+				_, _ = w.Write([]byte(`{"errors":["The undo window expired"]}`))
+				return
+			}
+			w.Header().Set("Location", "/bulk_replies/900")
+			w.WriteHeader(http.StatusFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/bulk_replies/900":
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "t"}, hey.WithMaxRetries(0))
+	vc := testVC()
+	vc.sdk = client
+	vc.ctx = context.Background()
+	view := newMailView(vc)
+	view.Resize(vc.width, vc.height)
+	view.boxes = orderBoxes(testBoxes())
+	view.Update(currentPostingsLoaded(view, testPostings()))
+	return view, state
+}
+
+func selectTwoThreads(view *mailView) {
+	space := tea.KeyPressMsg(tea.Key{Code: ' ', Text: " "})
+	view.HandleContentKey(space)
+	view.HandleContentKey(keyPress("down"))
+	view.HandleContentKey(space)
+}
+
+func TestTUIBulkReplyRequiresExplicitSelection(t *testing.T) {
+	view, state := tuiBulkReplyServer(t)
+	if cmd := view.HandleContentKey(keyPress("b")); cmd != nil {
+		t.Fatal("bulk reply without a selection should not make a request")
+	}
+	if view.notice != "Select threads with space before starting a bulk reply" {
+		t.Errorf("notice = %q", view.notice)
+	}
+	if requests := state.snapshot(); len(requests) != 0 {
+		t.Errorf("requests = %+v", requests)
+	}
+}
+
+func TestTUIBulkReplySelectionAndPreviewShowExactRecipients(t *testing.T) {
+	view, state := tuiBulkReplyServer(t)
+	selectTwoThreads(view)
+	if selected := view.postingList.selectedIDs(); len(selected) != 2 || selected[0] != 100 || selected[1] != 101 {
+		t.Fatalf("selected IDs = %v", selected)
+	}
+	if rendered := view.View(); strings.Count(rendered, "✓") != 2 {
+		t.Errorf("selected rows are not marked: %q", rendered)
+	}
+
+	msg := runCmd(view.HandleContentKey(keyPress("b")))
+	loaded, ok := msg.(bulkReplyDraftLoadedMsg)
+	if !ok || loaded.err != nil {
+		t.Fatalf("draft command returned %#v", msg)
+	}
+	view.Update(loaded)
+	if view.bulkReply == nil || !view.CapturingInput() {
+		t.Fatal("draft should open a capturing preview")
+	}
+	preview := view.View()
+	for _, expected := range []string{"Bulk reply preview", "Quarterly planning", "Jane Doe <jane@example.com>", "Bob Smith <bob@example.org>", "audit@example.com", "Signing off with a tag!"} {
+		if !strings.Contains(preview, expected) {
+			t.Errorf("preview does not contain %q: %q", expected, preview)
+		}
+	}
+	if help := view.HelpBindings(); len(help) == 0 || help[0].key != "enter" {
+		t.Errorf("preview help = %v", help)
+	}
+	requests := state.snapshot()
+	if len(requests) != 1 || requests[0].query != "posting_ids=100%2C101" {
+		t.Errorf("draft request = %+v", requests)
+	}
+}
+
+func TestTUIBulkReplyPreviewReportsSkippedThreads(t *testing.T) {
+	view, state := tuiBulkReplyServer(t)
+	state.draft = `{"content":"","entries":[{"id":501,"topic_id":700,"topic_name":"Quarterly planning","addressed":{"directly":[{"id":31,"email_address":"jane@example.com"}]}}]}`
+	selectTwoThreads(view)
+	loaded := runCmd(view.HandleContentKey(keyPress("b"))).(bulkReplyDraftLoadedMsg)
+	view.Update(loaded)
+	if !strings.Contains(view.View(), "1 replyable thread · 1 skipped") {
+		t.Errorf("preview = %q", view.View())
+	}
+}
+
+func TestTUIBulkReplyReviewsThenSendsAndOffersUndo(t *testing.T) {
+	view, state := tuiBulkReplyServer(t)
+	selectTwoThreads(view)
+	view.Update(runCmd(view.HandleContentKey(keyPress("b"))))
+
+	if cmd := view.HandleContentKey(keyPress("enter")); cmd == nil {
+		t.Error("enter should focus the bulk reply editor")
+	}
+	if view.bulkReply == nil || !view.bulkReply.composing {
+		t.Fatal("preview should advance to the editor")
+	}
+	typeText(view, "Thanks everyone")
+	cmd := view.HandleContentKey(ctrlS())
+	if cmd == nil || !view.bulkReply.sending {
+		t.Fatal("ctrl+s should submit the bulk reply")
+	}
+	sent, ok := runCmd(cmd).(bulkReplySentMsg)
+	if !ok || sent.err != nil {
+		t.Fatalf("send returned %#v", sent)
+	}
+	view.Update(sent)
+	if view.bulkReply != nil || len(view.postingList.selectedIDs()) != 0 {
+		t.Error("successful send should close the form and clear selection")
+	}
+	if view.lastBulkReplyID != 900 || !strings.Contains(view.notice, "2 bulk replies queued with undo available") || !strings.Contains(view.notice, "press u to undo") {
+		t.Errorf("delivery state = id:%d notice:%q", view.lastBulkReplyID, view.notice)
+	}
+	if help := view.HelpBindings(); help[len(help)-1].key != "u" {
+		t.Errorf("help does not offer undo: %v", help)
+	}
+
+	requests := state.snapshot()
+	if len(requests) != 2 || requests[1].path != "/bulk_replies.json" {
+		t.Fatalf("requests = %+v", requests)
+	}
+	var request struct {
+		EntryIDs []int64 `json:"entry_ids"`
+		Message  struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(requests[1].body, &request); err != nil {
+		t.Fatal(err)
+	}
+	if len(request.EntryIDs) != 2 || request.EntryIDs[0] != 501 || request.EntryIDs[1] != 502 {
+		t.Errorf("entry IDs = %v", request.EntryIDs)
+	}
+	want := "<div>Thanks everyone</div><br><div>Signing off with a tag!</div>"
+	if request.Message.Content != want {
+		t.Errorf("content = %q, want %q", request.Message.Content, want)
+	}
+}
+
+func TestTUIBulkReplyEmptyDraftNeverSends(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status int
+	}{{"empty", 0}, {"not_found", http.StatusNotFound}} {
+		t.Run(test.name, func(t *testing.T) {
+			view, state := tuiBulkReplyServer(t)
+			state.draft = `{"content":"","entries":[]}`
+			state.draftStatus = test.status
+			selectTwoThreads(view)
+			loaded := runCmd(view.HandleContentKey(keyPress("b"))).(bulkReplyDraftLoadedMsg)
+			view.Update(loaded)
+			if view.bulkReply != nil || !strings.Contains(view.notice, "nothing was sent") {
+				t.Errorf("empty draft state = form:%v notice:%q", view.bulkReply, view.notice)
+			}
+			if requests := state.snapshot(); len(requests) != 1 || requests[0].method != http.MethodGet {
+				t.Errorf("empty draft made a mutation request: %+v", requests)
+			}
+		})
+	}
+}
+
+func TestTUIBulkReplySendFailureKeepsEditor(t *testing.T) {
+	view, state := tuiBulkReplyServer(t)
+	state.sendStatus = http.StatusUnprocessableEntity
+	selectTwoThreads(view)
+	view.Update(runCmd(view.HandleContentKey(keyPress("b"))))
+	view.HandleContentKey(keyPress("enter"))
+	typeText(view, "Thanks everyone")
+	sent := runCmd(view.HandleContentKey(ctrlS())).(bulkReplySentMsg)
+	if sent.err == nil {
+		t.Fatal("send should fail")
+	}
+	view.Update(sent)
+	if view.bulkReply == nil || view.bulkReply.sending || !view.bulkReply.isError || !strings.Contains(view.bulkReply.status, "Send failed") {
+		t.Errorf("failed editor state = %#v", view.bulkReply)
+	}
+}
+
+func TestTUIBulkReplyImmediateDeliveryHasNoUndo(t *testing.T) {
+	view, state := tuiBulkReplyServer(t)
+	state.delivery = `{"id":901,"entries_count":2,"delayed":false}`
+	selectTwoThreads(view)
+	view.Update(runCmd(view.HandleContentKey(keyPress("b"))))
+	view.HandleContentKey(keyPress("enter"))
+	typeText(view, "Thanks")
+	view.Update(runCmd(view.HandleContentKey(ctrlS())))
+	if view.lastBulkReplyID != 0 || strings.Contains(view.notice, "undo") {
+		t.Errorf("immediate delivery state = id:%d notice:%q", view.lastBulkReplyID, view.notice)
+	}
+}
+
+func TestTUIBulkReplyUndoSuccessAndExpiry(t *testing.T) {
+	view, _ := tuiBulkReplyServer(t)
+	view.lastBulkReplyID = 900
+	undone, ok := runCmd(view.HandleContentKey(keyPress("u"))).(bulkReplyUndoneMsg)
+	if !ok || undone.err != nil {
+		t.Fatalf("undo returned %#v", undone)
+	}
+	view.Update(undone)
+	if view.lastBulkReplyID != 0 || view.notice != "Bulk reply recalled" {
+		t.Errorf("undo state = id:%d notice:%q", view.lastBulkReplyID, view.notice)
+	}
+
+	view, state := tuiBulkReplyServer(t)
+	state.undoStatus = http.StatusUnprocessableEntity
+	view.lastBulkReplyID = 900
+	undone = runCmd(view.HandleContentKey(keyPress("u"))).(bulkReplyUndoneMsg)
+	if undone.err == nil {
+		t.Fatal("expired undo should fail")
+	}
+	view.Update(undone)
+	if view.lastBulkReplyID != 900 || !strings.Contains(view.notice, "Could not undo") {
+		t.Errorf("expired undo state = id:%d notice:%q", view.lastBulkReplyID, view.notice)
+	}
+}
+
+func TestTUIBulkReplyCanCancelPreviewAndEditor(t *testing.T) {
+	for _, advance := range []bool{false, true} {
+		view, _ := tuiBulkReplyServer(t)
+		selectTwoThreads(view)
+		view.Update(runCmd(view.HandleContentKey(keyPress("b"))))
+		if advance {
+			view.HandleContentKey(keyPress("enter"))
+		}
+		if cmd := view.HandleContentKey(keyPress("esc")); cmd != nil {
+			t.Error("cancel should not start a command")
+		}
+		if view.bulkReply != nil || view.CapturingInput() {
+			t.Errorf("cancel did not close bulk reply (advance=%v)", advance)
+		}
+	}
+}
+
+func TestBulkReplyFormRequiresBodyBeforeSend(t *testing.T) {
+	form := newBulkReplyForm([]int64{100}, nil, newStyles())
+	form.draft.Entries = append(form.draft.Entries, generated.BulkReplyEntry{Id: 501})
+	form.composing = true
+	if _, submit := form.handleKey(tea.KeyPressMsg(tea.Key{Code: 's', Mod: tea.ModCtrl})); submit {
+		t.Fatal("empty bulk reply should not submit")
+	}
+	if !form.isError || form.status != "Message is empty" {
+		t.Errorf("validation state = error:%v status:%q", form.isError, form.status)
+	}
+}

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -34,12 +34,14 @@ type contentList struct {
 	width         int
 	height        int // visible rows (each posting takes 2 lines)
 	hideSeenState bool
+	selected      map[int64]struct{}
 }
 
 func (c *contentList) setPostings(postings []models.Posting) {
 	c.postings = postings
 	c.cursor = 0
 	c.scrollOff = 0
+	c.clearSelected()
 }
 
 func (c *contentList) setSize(w, h int) {
@@ -81,6 +83,36 @@ func (c *contentList) selectedPosting() *models.Posting {
 	return &c.postings[c.cursor]
 }
 
+func (c *contentList) toggleSelected() bool {
+	posting := c.selectedPosting()
+	if posting == nil {
+		return false
+	}
+	if c.selected == nil {
+		c.selected = make(map[int64]struct{})
+	}
+	if _, exists := c.selected[posting.ID]; exists {
+		delete(c.selected, posting.ID)
+		return false
+	}
+	c.selected[posting.ID] = struct{}{}
+	return true
+}
+
+func (c *contentList) selectedIDs() []int64 {
+	ids := make([]int64, 0, len(c.selected))
+	for _, posting := range c.postings {
+		if _, exists := c.selected[posting.ID]; exists {
+			ids = append(ids, posting.ID)
+		}
+	}
+	return ids
+}
+
+func (c *contentList) clearSelected() {
+	c.selected = nil
+}
+
 func (c *contentList) view() string {
 	if len(c.postings) == 0 {
 		return lipgloss.NewStyle().Foreground(colorMuted).Render("  (empty)")
@@ -98,6 +130,7 @@ func (c *contentList) view() string {
 	normal := lipgloss.NewStyle().Foreground(colorBright)
 	muted := lipgloss.NewStyle().Foreground(colorMuted)
 	unseenDot := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
+	selectedMark := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
 
 	for i := c.scrollOff; i < end; i++ {
 		p := c.postings[i]
@@ -110,7 +143,9 @@ func (c *contentList) view() string {
 		} else {
 			line1.WriteString("  ")
 		}
-		if !p.Seen && !c.hideSeenState {
+		if _, isSelected := c.selected[p.ID]; isSelected {
+			line1.WriteString(selectedMark.Render("✓") + " ")
+		} else if !p.Seen && !c.hideSeenState {
 			line1.WriteString(unseenDot.Render("●") + " ")
 		} else {
 			line1.WriteString("  ")

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -32,6 +32,7 @@ const (
 	mailRequestReply
 	mailRequestForward
 	mailRequestSearch
+	mailRequestBulkReply
 )
 
 type boxesLoadedMsg []models.Box
@@ -115,12 +116,14 @@ type mailView struct {
 	loading          bool
 
 	compose           *composeForm    // non-nil while a message, reply or forward is being written
+	bulkReply         *bulkReplyForm  // non-nil while a bulk reply is being previewed or written
 	movePicker        *movePicker     // non-nil while a destination box is being selected
 	searchForm        *mailSearchForm // non-nil while a search query is being entered
 	searchList        contentList
 	searchActive      bool
 	searchQuery       string
 	searchPage        int
+	lastBulkReplyID   int64  // delayed delivery currently available for undo
 	notice            string // one-shot confirmation shown above the posting list
 	activeRequestID   uint64 // identifies the only mail read allowed to update the view
 	activeRequestKind mailRequestKind
@@ -245,6 +248,68 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.compose.resize(v.vc.width, v.vc.height)
 		return v.compose.init(), true
 
+	case bulkReplyDraftLoadedMsg:
+		if msg.requestID != v.activeRequestID || msg.boxID != v.currentBoxID() {
+			return nil, true
+		}
+		v.finishRequest(msg.requestID)
+		if msg.err != nil {
+			v.notice = "Could not preview bulk reply: " + msg.err.Error()
+			return nil, true
+		}
+		if msg.draft == nil || len(msg.draft.Entries) == 0 {
+			v.notice = "No replyable threads found; nothing was sent"
+			return nil, true
+		}
+		v.bulkReply = newBulkReplyForm(msg.postingIDs, msg.draft, v.vc.styles)
+		v.bulkReply.resize(v.vc.width, v.vc.height)
+		return v.bulkReply.init(), true
+
+	case bulkReplySentMsg:
+		if v.bulkReply == nil {
+			return nil, true
+		}
+		if msg.err != nil {
+			v.bulkReply.sending = false
+			v.bulkReply.status = "Send failed: " + msg.err.Error()
+			v.bulkReply.isError = true
+			return nil, true
+		}
+		if msg.delivery == nil {
+			v.bulkReply.sending = false
+			v.bulkReply.status = "Send failed: HEY returned no delivery"
+			v.bulkReply.isError = true
+			return nil, true
+		}
+		v.bulkReply = nil
+		v.postingList.clearSelected()
+		count := int(msg.delivery.EntriesCount)
+		v.notice = fmt.Sprintf("%d bulk %s sent", count, replyNoun(count))
+		v.lastBulkReplyID = 0
+		if msg.delivery.Delayed {
+			v.notice = fmt.Sprintf("%d bulk %s queued with undo available", count, replyNoun(count))
+			if msg.delivery.Id > 0 {
+				v.lastBulkReplyID = msg.delivery.Id
+				v.notice += " — press u to undo"
+			}
+		}
+		if msg.skipped > 0 {
+			v.notice += fmt.Sprintf("; %d skipped", msg.skipped)
+		}
+		return nil, true
+
+	case bulkReplyUndoneMsg:
+		if msg.id != v.lastBulkReplyID {
+			return nil, true
+		}
+		if msg.err != nil {
+			v.notice = "Could not undo bulk reply: " + msg.err.Error()
+			return nil, true
+		}
+		v.lastBulkReplyID = 0
+		v.notice = "Bulk reply recalled"
+		return nil, true
+
 	case composeSentMsg:
 		if v.compose == nil {
 			return nil, true
@@ -325,6 +390,9 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 	if v.compose != nil {
 		return v.compose.update(msg), true
 	}
+	if v.bulkReply != nil {
+		return v.bulkReply.update(msg), true
+	}
 	if v.searchForm != nil {
 		return v.searchForm.update(msg), true
 	}
@@ -342,6 +410,9 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 func (v *mailView) View() string {
 	if v.compose != nil {
 		return v.compose.view()
+	}
+	if v.bulkReply != nil {
+		return v.bulkReply.view()
 	}
 	if v.searchForm != nil {
 		return v.searchForm.view()
@@ -369,12 +440,15 @@ func (v *mailView) View() string {
 
 // CapturingInput reports whether a form or picker is open and wants every key.
 func (v *mailView) CapturingInput() bool {
-	return v.compose != nil || v.movePicker != nil || v.searchForm != nil
+	return v.compose != nil || v.bulkReply != nil || v.movePicker != nil || v.searchForm != nil
 }
 
 func (v *mailView) HelpBindings() []helpBinding {
 	if v.compose != nil {
 		return v.compose.helpBindings()
+	}
+	if v.bulkReply != nil {
+		return v.bulkReply.helpBindings()
 	}
 	if v.searchForm != nil {
 		return v.searchForm.helpBindings()
@@ -401,9 +475,11 @@ func (v *mailView) HelpBindings() []helpBinding {
 	if selected := v.postingList.selectedPosting(); selected != nil && selected.Muted {
 		ignoreBinding = helpBinding{"+", "stop ignoring"}
 	}
-	return []helpBinding{
+	bindings := []helpBinding{
 		{"/", "search"},
 		{"c", "compose"},
+		{"space", "select"},
+		{"b", "bulk reply"},
 		{"r", "reply"},
 		{"f", "forward"},
 		{"m", "move"},
@@ -416,6 +492,10 @@ func (v *mailView) HelpBindings() []helpBinding {
 		{"s", "spam"},
 		ignoreBinding,
 	}
+	if v.lastBulkReplyID != 0 {
+		bindings = append(bindings, helpBinding{"u", "undo bulk reply"})
+	}
+	return bindings
 }
 
 func (v *mailView) SubnavItems() ([]navItem, int, string, bool) {
@@ -458,6 +538,18 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		cmd, submit := v.compose.handleKey(msg)
 		if submit {
 			return v.send()
+		}
+		return cmd
+	}
+
+	if v.bulkReply != nil {
+		if msg.Key().Code == tea.KeyEscape && !v.bulkReply.sending {
+			v.bulkReply = nil
+			return nil
+		}
+		cmd, submit := v.bulkReply.handleKey(msg)
+		if submit {
+			return v.sendBulkReply()
 		}
 		return cmd
 	}
@@ -556,6 +648,13 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 			return v.startSearch()
 		case "c":
 			return v.startCompose()
+		case " ", "space":
+			v.postingList.toggleSelected()
+			return nil
+		case "b":
+			return v.startBulkReply()
+		case "u":
+			return v.undoBulkReply()
 		case "m":
 			v.startMove()
 			return nil
@@ -603,7 +702,7 @@ func (v *mailView) clearSearch() {
 }
 
 func (v *mailView) CancelPendingDetail() bool {
-	if v.activeRequestKind != mailRequestTopic && v.activeRequestKind != mailRequestReply && v.activeRequestKind != mailRequestForward && v.activeRequestKind != mailRequestSearch {
+	if v.activeRequestKind != mailRequestTopic && v.activeRequestKind != mailRequestReply && v.activeRequestKind != mailRequestForward && v.activeRequestKind != mailRequestSearch && v.activeRequestKind != mailRequestBulkReply {
 		return false
 	}
 	v.cancelRequest()
@@ -615,6 +714,9 @@ func (v *mailView) Loading() bool { return v.loading }
 func (v *mailView) Resize(width, height int) {
 	if v.compose != nil {
 		v.compose.resize(width, height)
+	}
+	if v.bulkReply != nil {
+		v.bulkReply.resize(width, height)
 	}
 	if v.searchForm != nil {
 		v.searchForm.resize(width, height)

--- a/tests/smoke/bulk_reply_test.go
+++ b/tests/smoke/bulk_reply_test.go
@@ -1,0 +1,60 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Bulk reply smoke coverage exercises read-only preview and validation.
+// Mutation behavior runs against isolated HTTP servers in the unit suite.
+func TestBulkReplyPreview(t *testing.T) {
+	box := dataAs[struct {
+		Postings []struct {
+			ID int `json:"id"`
+		} `json:"postings"`
+	}](t, heyJSON(t, "box", "imbox", "--limit", "10"))
+	if len(box.Postings) == 0 {
+		t.Skip("no Imbox postings available for a read-only bulk reply preview")
+	}
+
+	args := []string{"bulk-reply", "preview"}
+	for i, posting := range box.Postings {
+		if i == 3 {
+			break
+		}
+		args = append(args, intStr(posting.ID))
+	}
+	stdout, stderr, code := hey(t, append(args, "--json")...)
+	if code != 0 {
+		t.Skipf("no replyable Imbox postings available (exit %d): %s", code, stderr)
+	}
+	var response Response
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("decode preview response: %v", err)
+	}
+	if !response.OK {
+		t.Fatalf("preview response was not OK: %s", stdout)
+	}
+	var entries []struct {
+		ID        int    `json:"id"`
+		TopicID   int    `json:"topic_id"`
+		TopicName string `json:"topic_name"`
+		To        []any  `json:"to"`
+		CC        []any  `json:"cc"`
+		BCC       []any  `json:"bcc"`
+	}
+	if err := json.Unmarshal(response.Data, &entries); err != nil {
+		t.Fatalf("decode preview entries: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.ID <= 0 || entry.TopicID <= 0 || entry.TopicName == "" {
+			t.Errorf("incomplete preview entry: %+v", entry)
+		}
+	}
+}
+
+func TestBulkReplyRejectsUnsafeSelections(t *testing.T) {
+	heyFail(t, "bulk-reply", "preview", "0", "--json")
+	heyFail(t, "bulk-reply", "send", "12345", "12345", "-m", "This must not send", "--json")
+	heyFail(t, "bulk-reply", "undo", "0", "--json")
+}


### PR DESCRIPTION
## Summary

- add `hey bulk-reply preview`, `send`, and `undo` using hey-sdk v0.5.0
- validate positive, unique posting IDs before any API request; resolve replyable entries before uploads or sends
- show exact thread and To/CC/BCC recipients, preserve HEY's server-provided name tag, support stdin/editor input and repeatable attachments, and report skipped threads plus delayed/undo delivery details
- add a TUI flow with Space selection, explicit recipient preview, bulk compose/send, and delayed-send undo
- update help, CLI surface, README, API coverage, and read-only smoke coverage

Card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892831

## Safety

- preview is read-only
- send is an explicit subcommand and never runs when validation fails or no replyable entries resolve
- TUI sending requires selection, recipient preview, and a separate compose/send step
- all implementation tests use isolated `httptest` servers; no HEY account was used for testing
- smoke coverage is read-only and mutation validation only

## Testing

- `GOWORK=off make check`
- `GOWORK=off go test -race ./internal/cmd ./internal/tui`
- `cd tests/smoke && GOWORK=off go test -run '^$' ./...`
- `GOWORK=off make build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds safe bulk replies to the CLI and TUI so users can preview exact recipients, send one reply to multiple threads, and undo while HEY’s delay window is open. Previously replies were per-thread only (`hey reply`, TUI `r`); now `hey bulk-reply preview|send|undo` and TUI selection (`Space`) + `b`/`u` enable batch replies while preserving HEY’s name tag and attachments.

- Implements CLI subcommands: `hey bulk-reply preview` (read-only), `send` (message via `-m`, stdin, or `$EDITOR`; repeatable `--attach`), and `undo <id>`; validates positive, unique posting IDs before any request; skips threads without a replyable entry.
- Adds TUI flow: select threads with `Space`, preview exact To/CC/BCC, compose/send with `ctrl+s`, and undo delayed sends with `u`; shows selection marks, recipient lists, and name-tag preservation.
- Preserves server-provided name tags by prepending draft content; reuses attachment upload path; returns delivery ID, delayed state, undo URL, and breadcrumbs; supports all output formats (`--json`, `--styled`, `--markdown`, `--ids-only`, `--count`).
- Updates help/README/surface and API coverage to include `BulkReplies().Draft|Send|Undo` in `hey-sdk` v0.5.0; adds comprehensive unit tests with isolated `httptest` servers and read-only smoke tests.

**Rollout and safety**
- No migrations required. Ensure the project uses `hey-sdk` v0.5.0.
- Preview is read-only; send never runs if validation fails or no replyable entries resolve.
- TUI requires explicit selection, recipient preview, and a separate compose/send step; undo succeeds only while HEY’s window remains open.

<sup>Written for commit 4e7973a4c9e232e5a0920506233741e04be67cd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

