### PR TITLE
Restrict TUI image downloads to trusted sources

### DIFF
--- a/internal/htmlutil/htmlutil.go
+++ b/internal/htmlutil/htmlutil.go
@@ -190,6 +190,11 @@ func findAttachments(n *html.Node, attachments *[]Attachment) {
 	}
 }
 
+func isImageContentType(contentType string) bool {
+	contentType = strings.ToLower(strings.TrimSpace(contentType))
+	return contentType == "image" || strings.HasPrefix(contentType, "image/")
+}
+
 func parseAttachmentByteSize(value string) *int64 {
 	if value == "" {
 		return nil
@@ -218,12 +223,11 @@ func findImages(n *html.Node, urls *[]string) {
 				}
 			}
 		case "action-text-attachment":
-			contentType := strings.ToLower(strings.TrimSpace(getAttr(n, "content-type")))
-			if imageURL := getAttr(n, "url"); strings.HasPrefix(contentType, "image/") && imageURL != "" {
+			if imageURL := getAttr(n, "url"); isImageContentType(getAttr(n, "content-type")) && imageURL != "" {
 				*urls = append(*urls, imageURL)
 			}
 		case "figure":
-			if att := parseTrixAttachment(n); att != nil && att.URL != "" {
+			if att := parseTrixAttachment(n); att != nil && att.URL != "" && isImageContentType(att.ContentType) {
 				*urls = append(*urls, att.URL)
 			}
 		}

--- a/internal/htmlutil/htmlutil_test.go
+++ b/internal/htmlutil/htmlutil_test.go
@@ -180,18 +180,23 @@ func TestExtractImageURLsEmptySrc(t *testing.T) {
 
 func TestExtractImageURLsActionTextImage(t *testing.T) {
 	h := `<action-text-attachment url="/rails/blobs/photo.png" filename="photo.png" content-type="image/png"></action-text-attachment>
+<action-text-attachment url="https://gopher.hey.com/signed/photo.jpg" content-type="image"></action-text-attachment>
 <action-text-attachment url="/rails/blobs/report.pdf" filename="report.pdf" content-type="application/pdf"></action-text-attachment>`
 	urls := ExtractImageURLs(h)
-	if len(urls) != 1 {
-		t.Fatalf("ExtractImageURLs Action Text got %d urls, want 1", len(urls))
+	if len(urls) != 2 {
+		t.Fatalf("ExtractImageURLs Action Text got %d urls, want 2", len(urls))
 	}
 	if urls[0] != "/rails/blobs/photo.png" {
 		t.Errorf("url[0] = %q, want %q", urls[0], "/rails/blobs/photo.png")
 	}
+	if urls[1] != "https://gopher.hey.com/signed/photo.jpg" {
+		t.Errorf("url[1] = %q, want Gopher image", urls[1])
+	}
 }
 
 func TestExtractImageURLsTrixFigure(t *testing.T) {
-	h := `<figure data-trix-attachment='{"url":"/rails/blobs/abc/image.png","filename":"image.png","contentType":"image/png"}'></figure>`
+	h := `<figure data-trix-attachment='{"url":"/rails/blobs/abc/image.png","filename":"image.png","contentType":"image/png"}'></figure>
+<figure data-trix-attachment='{"url":"/rails/blobs/abc/report.pdf","filename":"report.pdf","contentType":"application/pdf"}'></figure>`
 	urls := ExtractImageURLs(h)
 	if len(urls) != 1 {
 		t.Fatalf("ExtractImageURLs trix got %d urls, want 1", len(urls))

--- a/internal/tui/image_fetcher.go
+++ b/internal/tui/image_fetcher.go
@@ -1,0 +1,215 @@
+package tui
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/gif"  // register GIF decoder for image.DecodeConfig
+	_ "image/jpeg" // register JPEG decoder
+	_ "image/png"  // register PNG decoder
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+)
+
+type imageBlobDownloader interface {
+	DownloadBlob(context.Context, string, io.Writer) (int64, http.Header, error)
+}
+
+type imageFetcher interface {
+	Fetch(context.Context, string) ([]byte, error)
+}
+
+const (
+	maxInlineImageBytes  int64 = 20 * 1024 * 1024
+	maxInlineImagePixels int64 = 100 * 1000 * 1000
+)
+
+type trustedImageFetcher struct {
+	heyOrigin     *url.URL
+	hey           imageBlobDownloader
+	gopherOrigins map[string]struct{}
+	gopherClient  *http.Client
+	maxBytes      int64
+}
+
+func newTrustedImageFetcher(client *hey.Client) *trustedImageFetcher {
+	if client == nil {
+		return nil
+	}
+
+	baseURL := client.Config().BaseURL
+	return newTrustedImageFetcherWithOrigins(client, baseURL, gopherOriginForHEY(baseURL))
+}
+
+func gopherOriginForHEY(heyOrigin string) string {
+	parsed, err := url.Parse(heyOrigin)
+	if err != nil {
+		return "https://gopher.hey.com"
+	}
+	hostname := strings.ToLower(parsed.Hostname())
+	address := net.ParseIP(hostname)
+	switch {
+	case hostname == "localhost", strings.HasSuffix(hostname, ".localhost"), address != nil && address.IsLoopback():
+		return "http://127.0.0.1:8888"
+	case hostname == "hey-staging.com", strings.HasSuffix(hostname, ".hey-staging.com"):
+		return "https://gopher.hey-staging.com"
+	default:
+		return "https://gopher.hey.com"
+	}
+}
+
+func newTrustedImageFetcherWithOrigins(client imageBlobDownloader, heyOrigin string, gopherOrigins ...string) *trustedImageFetcher {
+	parsedHEYOrigin, _ := url.Parse(heyOrigin)
+	trustedOrigins := make(map[string]struct{}, len(gopherOrigins))
+	for _, origin := range gopherOrigins {
+		parsed, err := url.Parse(origin)
+		if err == nil && parsed.Scheme != "" && parsed.Host != "" {
+			trustedOrigins[urlOrigin(parsed)] = struct{}{}
+		}
+	}
+
+	return &trustedImageFetcher{
+		heyOrigin:     parsedHEYOrigin,
+		hey:           client,
+		gopherOrigins: trustedOrigins,
+		maxBytes:      maxInlineImageBytes,
+		gopherClient: &http.Client{
+			Timeout: 10 * time.Second,
+			CheckRedirect: func(request *http.Request, via []*http.Request) error {
+				if len(via) >= 10 {
+					return fmt.Errorf("stopped after 10 Gopher redirects")
+				}
+				if _, trusted := trustedOrigins[urlOrigin(request.URL)]; !trusted {
+					return fmt.Errorf("gopher redirected outside its trusted origin")
+				}
+				return nil
+			},
+		},
+	}
+}
+
+func (f *trustedImageFetcher) Fetch(ctx context.Context, source string) ([]byte, error) {
+	parsed, err := url.Parse(source)
+	if err != nil {
+		return nil, fmt.Errorf("invalid image URL: %w", err)
+	}
+
+	if parsed.User != nil {
+		return nil, fmt.Errorf("image URL must not contain credentials")
+	}
+	if !parsed.IsAbs() && parsed.Host != "" {
+		return nil, fmt.Errorf("image URL must be relative or use an explicit trusted origin")
+	}
+
+	if !parsed.IsAbs() || sameURLOrigin(parsed, f.heyOrigin) {
+		destination := &limitedImageBuffer{limit: f.maxBytes}
+		_, headers, downloadErr := f.hey.DownloadBlob(ctx, source, destination)
+		if downloadErr != nil {
+			if errors.Is(downloadErr, errImageTooLarge) {
+				return nil, fmt.Errorf("HEY image exceeds the %d byte limit", f.maxBytes)
+			}
+			return nil, downloadErr
+		}
+		data := destination.Bytes()
+		if validationErr := validateImageData(data, headers); validationErr != nil {
+			return nil, validationErr
+		}
+		return data, nil
+	}
+
+	if _, trusted := f.gopherOrigins[urlOrigin(parsed)]; !trusted {
+		return nil, fmt.Errorf("image URL is not from HEY or Gopher")
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := f.gopherClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gopher returned HTTP %d", response.StatusCode)
+	}
+	if response.ContentLength > f.maxBytes {
+		return nil, fmt.Errorf("gopher image exceeds the %d byte limit", f.maxBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(response.Body, f.maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > f.maxBytes {
+		return nil, fmt.Errorf("gopher image exceeds the %d byte limit", f.maxBytes)
+	}
+	if err := validateImageData(data, response.Header); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func validateImageData(data []byte, headers http.Header) error {
+	declaredType, _, err := mime.ParseMediaType(headers.Get("Content-Type"))
+	if err != nil {
+		return fmt.Errorf("image has an invalid media type: %w", err)
+	}
+	if declaredType != "" && !strings.HasPrefix(declaredType, "image/") && declaredType != "application/octet-stream" {
+		return fmt.Errorf("image response has media type %s", declaredType)
+	}
+
+	detectedType := http.DetectContentType(data)
+	switch detectedType {
+	case "image/gif", "image/jpeg", "image/png":
+	default:
+		return fmt.Errorf("response content is not a supported image: %s", detectedType)
+	}
+
+	config, _, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil || config.Width <= 0 || config.Height <= 0 {
+		return fmt.Errorf("response content is not a valid image")
+	}
+	if int64(config.Width)*int64(config.Height) > maxInlineImagePixels {
+		return fmt.Errorf("image exceeds the %d pixel limit", maxInlineImagePixels)
+	}
+	return nil
+}
+
+var errImageTooLarge = errors.New("image exceeds size limit")
+
+type limitedImageBuffer struct {
+	bytes.Buffer
+	limit int64
+}
+
+func (b *limitedImageBuffer) Write(data []byte) (int, error) {
+	remaining := b.limit - int64(b.Len())
+	if remaining <= 0 {
+		return 0, errImageTooLarge
+	}
+	if int64(len(data)) > remaining {
+		written, _ := b.Buffer.Write(data[:int(remaining)])
+		return written, errImageTooLarge
+	}
+	return b.Buffer.Write(data)
+}
+
+func sameURLOrigin(left, right *url.URL) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	return strings.EqualFold(left.Scheme, right.Scheme) && strings.EqualFold(left.Host, right.Host)
+}
+
+func urlOrigin(parsed *url.URL) string {
+	return strings.ToLower(parsed.Scheme + "://" + parsed.Host)
+}

--- a/internal/tui/image_fetcher_test.go
+++ b/internal/tui/image_fetcher_test.go
@@ -1,0 +1,293 @@
+package tui
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+)
+
+type imageBlobDownloaderFunc func(context.Context, string, io.Writer) (int64, http.Header, error)
+
+func (f imageBlobDownloaderFunc) DownloadBlob(ctx context.Context, source string, destination io.Writer) (int64, http.Header, error) {
+	return f(ctx, source, destination)
+}
+
+func rejectingImageBlobDownloader(t *testing.T) imageBlobDownloaderFunc {
+	t.Helper()
+	return func(context.Context, string, io.Writer) (int64, http.Header, error) {
+		t.Fatal("unexpected HEY image request")
+		return 0, nil, errors.New("unexpected HEY image request")
+	}
+}
+
+func TestTrustedImageFetcherSelectsEnvironmentGopherOrigin(t *testing.T) {
+	tests := []struct {
+		name       string
+		heyOrigin  string
+		wantGopher string
+	}{
+		{"production", "https://app.hey.com", "https://gopher.hey.com"},
+		{"staging", "https://app.hey-staging.com", "https://gopher.hey-staging.com"},
+		{"local development", "http://app.hey.localhost:3003", "http://127.0.0.1:8888"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := hey.NewClient(
+				&hey.Config{BaseURL: test.heyOrigin},
+				&hey.StaticTokenProvider{Token: "test-token"},
+				hey.WithMaxRetries(0),
+			)
+			fetcher := newTrustedImageFetcher(client)
+
+			if len(fetcher.gopherOrigins) != 1 {
+				t.Fatalf("trusted Gopher origins = %v, want one", fetcher.gopherOrigins)
+			}
+			if _, ok := fetcher.gopherOrigins[test.wantGopher]; !ok {
+				t.Fatalf("trusted Gopher origins = %v, want %s", fetcher.gopherOrigins, test.wantGopher)
+			}
+		})
+	}
+}
+
+func TestTrustedImageFetcherRejectsLookalikeAndUnsafeOrigins(t *testing.T) {
+	fetcher := newTrustedImageFetcherWithOrigins(
+		rejectingImageBlobDownloader(t),
+		"https://app.hey.com",
+		"https://gopher.hey.com",
+	)
+
+	for _, source := range []string{
+		"http://gopher.hey.com/image.png",
+		"https://gopher.hey.com.evil.example/image.png",
+		"https://gopher.hey.com:444/image.png",
+		"http://127.0.0.1/image.png",
+		"data:image/png;base64,AAAA",
+		"file:///etc/passwd",
+	} {
+		t.Run(source, func(t *testing.T) {
+			if _, err := fetcher.Fetch(context.Background(), source); err == nil {
+				t.Fatalf("unsafe image URL succeeded: %s", source)
+			}
+		})
+	}
+}
+
+func TestTrustedImageFetcherRejectsURLCredentialsBeforeRequest(t *testing.T) {
+	var requests atomic.Int64
+	imageData := testPNG(t)
+	gopher := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(imageData)
+	}))
+	t.Cleanup(gopher.Close)
+
+	parsed, err := url.Parse(gopher.URL + "/image.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed.User = url.UserPassword("user", "password")
+	fetcher := newTrustedImageFetcherWithOrigins(rejectingImageBlobDownloader(t), "https://app.hey.com", gopher.URL)
+
+	if _, err := fetcher.Fetch(context.Background(), parsed.String()); err == nil {
+		t.Fatal("image URL containing credentials succeeded")
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("credential-bearing image URL made %d request(s)", got)
+	}
+}
+
+func TestTrustedImageFetcherRejectsNetworkPathURL(t *testing.T) {
+	fetcher := newTrustedImageFetcherWithOrigins(
+		rejectingImageBlobDownloader(t),
+		"https://app.hey.com",
+		"https://gopher.hey.com",
+	)
+
+	if _, err := fetcher.Fetch(context.Background(), "//127.0.0.1/internal.png"); err == nil {
+		t.Fatal("network-path image URL succeeded")
+	}
+}
+
+func TestTrustedImageFetcherLoadsRelativeAndSameOriginHEYImages(t *testing.T) {
+	imageData := testPNG(t)
+	for _, source := range []string{
+		"/rails/active_storage/blobs/redirect/image.png",
+		"https://app.hey.com/rails/active_storage/blobs/redirect/image.png",
+	} {
+		t.Run(source, func(t *testing.T) {
+			var requested string
+			downloader := imageBlobDownloaderFunc(func(_ context.Context, got string, destination io.Writer) (int64, http.Header, error) {
+				requested = got
+				written, err := destination.Write(imageData)
+				return int64(written), http.Header{"Content-Type": []string{"image/png"}}, err
+			})
+			fetcher := newTrustedImageFetcherWithOrigins(downloader, "https://app.hey.com", "https://gopher.hey.com")
+
+			got, err := fetcher.Fetch(context.Background(), source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if requested != source || string(got) != string(imageData) {
+				t.Fatalf("HEY image request = %q, data length = %d", requested, len(got))
+			}
+		})
+	}
+}
+
+func TestTrustedImageFetcherRejectsOversizedHEYImage(t *testing.T) {
+	downloader := imageBlobDownloaderFunc(func(_ context.Context, _ string, destination io.Writer) (int64, http.Header, error) {
+		written, err := destination.Write([]byte("123456789"))
+		return int64(written), http.Header{"Content-Type": []string{"image/png"}}, err
+	})
+	fetcher := newTrustedImageFetcherWithOrigins(downloader, "https://app.hey.com", "https://gopher.hey.com")
+	fetcher.maxBytes = 8
+
+	if _, err := fetcher.Fetch(context.Background(), "/image.png"); err == nil {
+		t.Fatal("oversized HEY image succeeded")
+	}
+}
+
+func TestTrustedImageFetcherLoadsImageFromGopherWithoutHEYCredentials(t *testing.T) {
+	imageData := testPNG(t)
+	var authorization string
+	gopher := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(imageData)
+	}))
+	t.Cleanup(gopher.Close)
+
+	fetcher := newTrustedImageFetcherWithOrigins(
+		rejectingImageBlobDownloader(t),
+		"https://app.hey.com",
+		gopher.URL,
+	)
+
+	got, err := fetcher.Fetch(context.Background(), gopher.URL+"/signed/image.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(imageData) {
+		t.Fatal("Gopher image data changed")
+	}
+	if authorization != "" {
+		t.Fatalf("Gopher received Authorization %q", authorization)
+	}
+}
+
+func TestTrustedImageFetcherRejectsNonImageContent(t *testing.T) {
+	gopher := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<script>alert(1)</script>"))
+	}))
+	t.Cleanup(gopher.Close)
+
+	fetcher := newTrustedImageFetcherWithOrigins(
+		rejectingImageBlobDownloader(t),
+		"https://app.hey.com",
+		gopher.URL,
+	)
+
+	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png"); err == nil {
+		t.Fatal("non-image Gopher response succeeded")
+	}
+}
+
+func TestTrustedImageFetcherRejectsExcessivePixelDimensions(t *testing.T) {
+	imageData := testPNG(t)
+	binary.BigEndian.PutUint32(imageData[16:20], 20_000)
+	binary.BigEndian.PutUint32(imageData[20:24], 20_000)
+	binary.BigEndian.PutUint32(imageData[29:33], crc32.ChecksumIEEE(imageData[12:29]))
+
+	gopher := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(imageData)
+	}))
+	t.Cleanup(gopher.Close)
+
+	fetcher := newTrustedImageFetcherWithOrigins(
+		rejectingImageBlobDownloader(t),
+		"https://app.hey.com",
+		gopher.URL,
+	)
+
+	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png"); err == nil {
+		t.Fatal("image with excessive pixel dimensions succeeded")
+	}
+}
+
+func TestTrustedImageFetcherRejectsMalformedImage(t *testing.T) {
+	gopher := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("\x89PNG\r\n\x1a\nmalformed"))
+	}))
+	t.Cleanup(gopher.Close)
+
+	fetcher := newTrustedImageFetcherWithOrigins(
+		rejectingImageBlobDownloader(t),
+		"https://app.hey.com",
+		gopher.URL,
+	)
+
+	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png"); err == nil {
+		t.Fatal("malformed image succeeded")
+	}
+}
+
+func TestTrustedImageFetcherRejectsOversizedGopherImage(t *testing.T) {
+	gopher := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("123456789"))
+	}))
+	t.Cleanup(gopher.Close)
+
+	fetcher := newTrustedImageFetcherWithOrigins(
+		rejectingImageBlobDownloader(t),
+		"https://app.hey.com",
+		gopher.URL,
+	)
+	fetcher.maxBytes = 8
+
+	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png"); err == nil {
+		t.Fatal("oversized Gopher image succeeded")
+	}
+}
+
+func TestTrustedImageFetcherRejectsGopherRedirectOutsideTrustedOrigin(t *testing.T) {
+	var untrustedRequests atomic.Int64
+	untrusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		untrustedRequests.Add(1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("untrusted image"))
+	}))
+	t.Cleanup(untrusted.Close)
+
+	gopher := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, untrusted.URL+"/image.png", http.StatusFound)
+	}))
+	t.Cleanup(gopher.Close)
+
+	fetcher := newTrustedImageFetcherWithOrigins(
+		rejectingImageBlobDownloader(t),
+		"https://app.hey.com",
+		gopher.URL,
+	)
+
+	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/signed/image.png"); err == nil {
+		t.Fatal("Gopher redirect to an untrusted origin succeeded")
+	}
+	if got := untrustedRequests.Load(); got != 0 {
+		t.Fatalf("Gopher redirect reached an untrusted origin %d time(s)", got)
+	}
+}

--- a/internal/tui/journal.go
+++ b/internal/tui/journal.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/viewport"
@@ -142,18 +141,12 @@ func (v *journalView) fetchJournalEntry(date string) tea.Cmd {
 		body := htmlToText(content)
 
 		var images [][]byte
-		for _, imgURL := range extractImageURLs(content) {
-			var data []byte
-			if strings.HasPrefix(imgURL, "http://") || strings.HasPrefix(imgURL, "https://") {
-				data = fetchImageData(v.vc.ctx, imgURL)
-			} else {
-				sdkResp, getErr := v.vc.sdk.Get(v.vc.ctx, imgURL)
-				if getErr == nil && sdkResp != nil {
-					data = sdkResp.Data
+		if v.vc.imageRenderer.protocol() == imageProtocolKitty && v.vc.imageFetcher != nil {
+			for _, imageURL := range extractImageURLs(content) {
+				data, fetchErr := v.vc.imageFetcher.Fetch(v.vc.ctx, imageURL)
+				if fetchErr == nil && len(data) > 0 {
+					images = append(images, data)
 				}
-			}
-			if len(data) > 0 {
-				images = append(images, data)
 			}
 		}
 

--- a/internal/tui/journal_test.go
+++ b/internal/tui/journal_test.go
@@ -1,8 +1,16 @@
 package tui
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 )
 
 func journalWithEntry() *journalView {
@@ -39,6 +47,47 @@ func TestJournalViewInitSelectsToday(t *testing.T) {
 }
 
 // --- Update: message routing ---
+
+func TestJournalTextFallbackDoesNotFetchImages(t *testing.T) {
+	var imageRequests atomic.Int64
+	imageData := testPNG(t)
+	untrusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		imageRequests.Add(1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(imageData)
+	}))
+	t.Cleanup(untrusted.Close)
+
+	heyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      1,
+			"content": fmt.Sprintf(`<img src=%q>`, untrusted.URL+"/tracking.png"),
+			"type":    "Calendar::JournalEntry",
+		})
+	}))
+	t.Cleanup(heyServer.Close)
+
+	client := hey.NewClient(
+		&hey.Config{BaseURL: heyServer.URL},
+		&hey.StaticTokenProvider{Token: "test-token"},
+		hey.WithMaxRetries(0),
+	)
+	vc := testVC()
+	vc.ctx = context.Background()
+	vc.sdk = client
+	vc.imageFetcher = newTrustedImageFetcher(client)
+	v := newJournalView(vc)
+
+	loaded := v.fetchJournalEntry("2026-08-19")().(journalDetailMsg)
+
+	if got := imageRequests.Load(); got != 0 {
+		t.Fatalf("text journal fetched an image %d time(s)", got)
+	}
+	if len(loaded.images) != 0 {
+		t.Fatalf("text journal returned %d images", len(loaded.images))
+	}
+}
 
 func TestJournalViewHandlesDetailLoaded(t *testing.T) {
 	v := newJournalView(testVC())

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -1143,19 +1143,11 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 		}
 
 		var images [][]byte
-		if v.vc.imageRenderer.protocol() == imageProtocolKitty {
+		if v.vc.imageRenderer.protocol() == imageProtocolKitty && v.vc.imageFetcher != nil {
 			for _, entry := range entries {
-				for _, imgURL := range extractImageURLs(entry.Body) {
-					var data []byte
-					if strings.HasPrefix(imgURL, "http://") || strings.HasPrefix(imgURL, "https://") {
-						data = fetchImageData(ctx, imgURL)
-					} else {
-						sdkResp, getErr := v.vc.sdk.Get(ctx, imgURL)
-						if getErr == nil && sdkResp != nil {
-							data = sdkResp.Data
-						}
-					}
-					if len(data) > 0 {
+				for _, imageURL := range extractImageURLs(entry.Body) {
+					data, fetchErr := v.vc.imageFetcher.Fetch(ctx, imageURL)
+					if fetchErr == nil && len(data) > 0 {
 						images = append(images, data)
 					}
 				}

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -1,9 +1,13 @@
 package tui
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"image"
+	"image/color"
+	"image/png"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -20,6 +24,17 @@ import (
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/models"
 )
+
+func testPNG(t *testing.T) []byte {
+	t.Helper()
+	var encoded bytes.Buffer
+	pixels := image.NewNRGBA(image.Rect(0, 0, 1, 1))
+	pixels.Set(0, 0, color.NRGBA{R: 0x22, G: 0x66, B: 0xAA, A: 0xFF})
+	if err := png.Encode(&encoded, pixels); err != nil {
+		t.Fatal(err)
+	}
+	return encoded.Bytes()
+}
 
 func testVC() *viewContext {
 	return &viewContext{
@@ -712,16 +727,19 @@ func TestMailViewEnterOpensSelectedThread(t *testing.T) {
 
 func TestMailViewDownloadsImageDataOnlyForKittyRenderer(t *testing.T) {
 	var imageRequests atomic.Int64
+	imageData := testPNG(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/topics/100.json":
+			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":100,"name":"Latest image","entries":[{"id":501,"kind":"message"}]}`))
 		case "/messages/501.json":
+			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":501,"content":"<action-text-attachment url=\"/rails/blobs/chart.png\" filename=\"chart.png\" content-type=\"image/png\"></action-text-attachment>"}`))
 		case "/rails/blobs/chart.png":
 			imageRequests.Add(1)
-			_, _ = w.Write([]byte("image data"))
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(imageData)
 		default:
 			http.NotFound(w, r)
 		}
@@ -735,6 +753,7 @@ func TestMailViewDownloadsImageDataOnlyForKittyRenderer(t *testing.T) {
 	)
 	vc := testVC()
 	vc.sdk = client
+	vc.imageFetcher = newTrustedImageFetcher(client)
 	v := newMailView(vc)
 	loaded := v.fetchTopic(context.Background(), 1, 1, 100, "Latest image")().(topicLoadedMsg)
 
@@ -750,6 +769,55 @@ func TestMailViewDownloadsImageDataOnlyForKittyRenderer(t *testing.T) {
 	loaded = v.fetchTopic(context.Background(), 2, 1, 100, "Latest image")().(topicLoadedMsg)
 	if loaded.err != nil || len(loaded.images) != 1 || imageRequests.Load() != 1 {
 		t.Errorf("Kitty topic = images:%d requests:%d error:%v", len(loaded.images), imageRequests.Load(), loaded.err)
+	}
+}
+
+func TestMailViewDoesNotFetchImagesOutsideHEYOrGopher(t *testing.T) {
+	var untrustedRequests atomic.Int64
+	untrusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		untrustedRequests.Add(1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("untrusted image"))
+	}))
+	t.Cleanup(untrusted.Close)
+
+	heyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/topics/100.json":
+			_, _ = w.Write([]byte(`{"id":100,"name":"Untrusted image","entries":[{"id":501,"kind":"message"}]}`))
+		case "/messages/501.json":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      501,
+				"content": fmt.Sprintf(`<img src=%q>`, untrusted.URL+"/tracking.png"),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(heyServer.Close)
+
+	client := hey.NewClient(
+		&hey.Config{BaseURL: heyServer.URL},
+		&hey.StaticTokenProvider{Token: "test-token"},
+		hey.WithMaxRetries(0),
+	)
+	vc := testVC()
+	vc.sdk = client
+	vc.imageRenderer = kittyImageRenderer{}
+	vc.imageFetcher = newTrustedImageFetcher(client)
+	v := newMailView(vc)
+
+	loaded := v.fetchTopic(context.Background(), 1, 1, 100, "Untrusted image")().(topicLoadedMsg)
+
+	if loaded.err != nil {
+		t.Fatalf("fetch topic: %v", loaded.err)
+	}
+	if got := untrustedRequests.Load(); got != 0 {
+		t.Fatalf("opening a message fetched an untrusted image %d time(s)", got)
+	}
+	if len(loaded.images) != 0 {
+		t.Fatalf("topic returned %d untrusted images", len(loaded.images))
 	}
 }
 

--- a/internal/tui/section_view.go
+++ b/internal/tui/section_view.go
@@ -17,6 +17,7 @@ type viewContext struct {
 	ctx                  context.Context
 	styles               styles
 	imageRenderer        imageRenderer
+	imageFetcher         imageFetcher
 	saveAttachment       attachmentSaveFunc
 	openAttachment       attachmentOpenFunc
 	newAttachmentTempDir func() (string, error)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2,8 +2,6 @@ package tui
 
 import (
 	"context"
-	"io"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -60,6 +58,7 @@ func newModel(sdk *hey.Client) model {
 		ctx:           ctx,
 		styles:        s,
 		imageRenderer: environmentImageRenderer(),
+		imageFetcher:  newTrustedImageFetcher(sdk),
 		saveAttachment: func(ctx context.Context, destination, sourceURL string, force bool) (int64, error) {
 			return attachmentfiles.Save(ctx, sdk, destination, sourceURL, force)
 		},
@@ -397,28 +396,6 @@ func formatTimestamp(ts time.Time) string {
 		return ""
 	}
 	return ts.UTC().Format("2006-01-02T15:04:05Z")
-}
-
-var imageHTTPClient = &http.Client{Timeout: 10 * time.Second}
-
-func fetchImageData(ctx context.Context, imgURL string) []byte {
-	req, err := http.NewRequestWithContext(ctx, "GET", imgURL, nil)
-	if err != nil {
-		return nil
-	}
-	resp, err := imageHTTPClient.Do(req)
-	if err != nil {
-		return nil
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return nil
-	}
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil
-	}
-	return data
 }
 
 // Run starts the TUI program.


### PR DESCRIPTION
## Summary

Restrict automatic TUI image downloads to sources controlled by HEY.

- route relative and current-origin images through the authenticated SDK blob downloader
- allow only the environment-specific Gopher origin for direct image requests
- reject arbitrary hosts, unsafe schemes, network-path URLs, URL credentials, lookalike hosts, and cross-origin Gopher redirects before access
- never send HEY credentials to Gopher
- cap inline images at 20 MB and 100 megapixels
- require valid PNG, JPEG, or GIF data before sending bytes to the terminal image protocol
- avoid all image downloads when the active renderer uses text fallback
- keep non-image Trix attachments out of the image renderer

Rejected images keep their visible text marker or attachment panel. They do not make the thread unreadable.

## Root cause

Mail and Journal extracted image URLs from rich-text content. Absolute HTTP URLs bypassed the SDK and went through an unrestricted HTTP client. That client followed redirects and read response bodies without a limit. A remote sender could therefore make a Kitty-compatible TUI request an arbitrary network URL when the user opened a thread.

## Tests

The regression test first reproduced a request to an untrusted local server through the real mail thread-loading path. Coverage now includes:

- untrusted image URLs are never requested
- relative and same-origin HEY images remain available
- production, staging, and local Gopher origin selection
- Gopher receives no authorization header
- lookalike origins, unsafe schemes, URL credentials, and network-path URLs
- cross-origin Gopher redirects
- response byte limits and pixel limits
- invalid media types and malformed images
- text-only Mail and Journal rendering makes no image request
- Action Text and Trix image classification

## Validation

- `make check`
- `make race-test`
- `make build`
- Windows amd64 and macOS arm64 TUI cross-compilation
- production Ghostty validation with a HEY-hosted PNG attachment

## Tracking

Basecamp card 10218120137


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts TUI image downloads to trusted HEY sources and validates image content. Previously, absolute HTTP URLs were fetched by an unrestricted client that followed redirects and read unbounded bodies; now only HEY blobs or the environment-specific Gopher origin are allowed with strict origin checks, size/pixel caps, and format validation. Rejected images keep their visible text marker and do not break threads.

- Review notes
  - Adds `trustedImageFetcher` (`internal/tui/image_fetcher.go`): uses SDK `DownloadBlob` for relative/same-origin HEY URLs; allows only the selected Gopher origin; blocks credentials in URLs, network-path URLs, lookalike hosts, and cross-origin redirects; never sends Authorization to Gopher.
  - Enforces caps: 20 MB and 100 megapixels; accepts PNG/JPEG/GIF only; checks declared media type and validates image decoding.
  - Mail and Journal use the fetcher only when the Kitty image renderer is active; text fallback performs no image downloads.
  - HTML extraction now includes only images: `isImageContentType` filters Action Text and Trix attachments (`internal/htmlutil`). Non-image Trix attachments no longer enter the image renderer.
  - Removes the old raw HTTP fetch path; wires `imageFetcher` in `newModel` and passes it through `viewContext`. Tests cover untrusted URLs, URL credentials, redirects, limits, invalid media types, malformed images, and text-only fallbacks.

- Rollout
  - Gopher origin is selected per environment (production, staging, local); no configuration or migrations required.

<sup>Written for commit a62ef3bba319061d6399575e806732e1ee9854ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

