### PR TITLE
Publish prebuilt binaries to the AUR

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,0 +1,186 @@
+# Manual AUR publish, for when the release-time publish could not run.
+#
+# The AUR goes down for maintenance often enough that a release must not depend
+# on it being reachable — release.yml's aur-publish job is continue-on-error for
+# exactly that reason. This workflow is the recovery path: it republishes any
+# already-released version once the AUR is back, with no need to cut a new tag.
+#
+# scripts/publish-aur.sh derives the PKGBUILD entirely from the published GitHub
+# release assets and no-ops when the AUR copy is already current, so running this
+# against an already-published version is safe and idempotent.
+name: Publish to AUR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Released version to publish, without the v prefix (e.g. 0.8.0)'
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: aur-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to AUR
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: release
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '${VERSION}' — expected semver with no v prefix (e.g. 0.8.0)"
+            exit 1
+          fi
+          # Only publish versions that actually exist as a stable release, so a
+          # typo cannot push a PKGBUILD pointing at assets that were never built.
+          if ! gh release view "v${VERSION}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "::error::No published release found for v${VERSION}"
+            exit 1
+          fi
+          echo "Publishing v${VERSION} to the AUR"
+
+      - name: Refuse to downgrade the AUR package
+        id: aur-state
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # publish-aur.sh rewrites pkgver unconditionally, so dispatching an
+          # older-but-valid release would push every Arch user backwards. Being
+          # a published release is not enough — compare against what is actually
+          # in the AUR right now.
+          if ! body=$(curl -fsS --max-time 30 --retry 2 \
+                        'https://aur.archlinux.org/rpc/v5/info/hey-cli'); then
+            # Fail closed: proceeding blind here risks a silent downgrade, and a
+            # dispatch is cheap to repeat once the AUR is reachable again.
+            # Flag it so the notify step can tell an outage from a bad input.
+            echo "unreachable=true" >> "$GITHUB_OUTPUT"
+            echo "::error::Could not reach the AUR to check the published version. Retry when it is reachable."
+            exit 1
+          fi
+
+          # AUR reports version as pkgver-pkgrel (e.g. 0.7.2-1).
+          full=$(printf '%s' "$body" | jq -r '.results[0].Version // empty')
+          if [ -z "$full" ]; then
+            echo "hey-cli is not in the AUR yet — nothing to downgrade"
+            exit 0
+          fi
+          if [[ "$full" == *-* ]]; then
+            current="${full%-*}"
+            currel="${full##*-}"
+          else
+            current="$full"
+            currel=1
+          fi
+
+          if [ "$current" = "$VERSION" ]; then
+            # publish-aur.sh hardcodes pkgrel=1, so republishing over a higher
+            # revision would silently discard an AUR-side packaging fix.
+            #
+            # Compare with sort -V, not an arithmetic test: PKGBUILD(5) allows a
+            # dotted subrelease (1.1), which `[ -gt ]` rejects as a non-integer
+            # with status 2 — and a suppressed stderr would turn that error into
+            # a silent "not greater", letting the clobber through.
+            highest=$(printf '%s\n%s\n' "$currel" "1" | sort -V | tail -1)
+            if [ "$highest" != "1" ]; then
+              echo "::error::AUR has ${full}; publish-aur.sh would replace it with ${VERSION}-1 and discard that packaging revision"
+              exit 1
+            fi
+            echo "AUR already at ${full} — republish is a no-op unless the PKGBUILD drifted"
+            exit 0
+          fi
+
+          oldest=$(printf '%s\n%s\n' "$current" "$VERSION" | sort -V | head -1)
+          if [ "$oldest" = "$VERSION" ]; then
+            echo "::error::Refusing to downgrade the AUR from ${current} to ${VERSION}"
+            exit 1
+          fi
+          echo "AUR is at ${current}; publishing ${VERSION}"
+
+      - name: Verify AUR key is configured
+        env:
+          AUR_KEY: ${{ secrets.AUR_KEY }}
+        run: |
+          if [ -z "$AUR_KEY" ]; then
+            echo "::error::AUR_KEY is not configured for the release environment"
+            exit 1
+          fi
+
+      - name: Publish to AUR
+        id: publish
+        env:
+          AUR_KEY: ${{ secrets.AUR_KEY }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$AUR_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          echo -e "Host aur.archlinux.org\n  IdentityFile ~/.ssh/aur\n  User aur\n  StrictHostKeyChecking accept-new" >> ~/.ssh/config
+          git config --global user.name "37signals"
+          git config --global user.email "dev@37signals.com"
+          for attempt in 1 2 3; do
+            if scripts/publish-aur.sh "$VERSION"; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "AUR publish attempt ${attempt} failed; retrying in $((attempt * 60))s"
+              sleep $((attempt * 60))
+            fi
+          done
+          echo "::error::AUR publish failed after 3 attempts"
+          exit 1
+
+      # The recovery path needs this more than the release job does: a recovery
+      # run is dispatched by hand and then forgotten, and its whole reason for
+      # existing is that the AUR was unreachable — which is exactly the outage
+      # likely to still be going when the retries run out.
+      #
+      # Scoped to the two failures that actually mean "the AUR is unreachable":
+      # retries exhausted, or the RPC reachability check. A bare failure() would
+      # also catch a mistyped version, a version with no release, a refused
+      # downgrade and a missing AUR_KEY — none of which the issue's "retry once
+      # the AUR accepts pushes again" advice fits. Those are operator mistakes,
+      # visible in the run they just dispatched by hand, and because the issue
+      # dedupes on label they would otherwise land as misleading comments on the
+      # genuine outage issue.
+      - name: Notify on AUR publish failure
+        if: failure() && (steps.publish.outcome == 'failure' || steps.aur-state.outputs.unreachable == 'true')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_SLUG: ${{ github.repository }}
+          VERSION: ${{ inputs.version }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          RUN_URL="https://github.com/${REPO_SLUG}/actions/runs/${RUN_ID}"
+          BODY="Recovery publish of \`${VERSION}\` to the AUR [failed](${RUN_URL}). The GitHub release is unaffected — only the Arch package is stale. Re-run the \`Publish to AUR\` workflow with version \`${VERSION}\` once the AUR accepts pushes again."
+
+          # Dedup lives in notify-issue.sh, shared with release.yml, and keys on
+          # the aur-publish label rather than the title. A title lookup misses
+          # the moment someone retitles the issue while triaging it — which is
+          # the normal fate of an issue that stays open across an outage.
+          notify_status=0
+          scripts/notify-issue.sh \
+            --repo "$REPO_SLUG" \
+            --label aur-publish \
+            --title "AUR publish failure" \
+            --body "$BODY" || notify_status=$?
+
+          # The notifier fails closed, so on a lookup failure the annotation is
+          # the only record that this dispatch went nowhere.
+          echo "::error::AUR publish failed for ${VERSION}. See ${RUN_URL}"
+          exit "$notify_status"

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -60,10 +60,11 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          # publish-aur.sh rewrites pkgver unconditionally, so dispatching an
-          # older-but-valid release would push every Arch user backwards. Being
-          # a published release is not enough — compare against what is actually
-          # in the AUR right now.
+          # publish-aur.sh refuses downgrades itself, but silently — it exits 0
+          # so an out-of-order automatic run doesn't fail over a package that is
+          # already correct. A hand-dispatched run deserves the opposite: an
+          # operator asking for an older-but-valid version should get a hard
+          # error, not a quiet no-op they will mistake for a publish.
           if ! body=$(curl -fsS --max-time 30 --retry 2 \
                         'https://aur.archlinux.org/rpc/v5/info/hey-cli'); then
             # Fail closed: proceeding blind here risks a silent downgrade, and a
@@ -89,8 +90,9 @@ jobs:
           fi
 
           if [ "$current" = "$VERSION" ]; then
-            # publish-aur.sh hardcodes pkgrel=1, so republishing over a higher
-            # revision would silently discard an AUR-side packaging fix.
+            # publish-aur.sh hardcodes pkgrel=1 and would refuse this with a
+            # quiet no-op; fail the dispatch loudly instead so the operator
+            # learns the AUR carries a packaging revision to preserve.
             #
             # Compare with sort -V, not an arithmetic test: PKGBUILD(5) allows a
             # dotted subrelease (1.1), which `[ -gt ]` rejects as a non-integer

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -49,8 +49,19 @@ jobs:
           fi
           # Only publish versions that actually exist as a stable release, so a
           # typo cannot push a PKGBUILD pointing at assets that were never built.
-          if ! gh release view "v${VERSION}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          # gh release view also answers for drafts and prereleases, so check
+          # the flags explicitly — the semver regex above already rejects
+          # prerelease tags, but a plain-versioned release can still carry the
+          # prerelease flag, and a draft's assets are not downloadable anyway.
+          state=$(gh release view "v${VERSION}" --repo "${GITHUB_REPOSITORY}" \
+                    --json isDraft,isPrerelease \
+                    --jq 'if .isDraft then "draft" elif .isPrerelease then "prerelease" else "stable" end' \
+                    2>/dev/null) || {
             echo "::error::No published release found for v${VERSION}"
+            exit 1
+          }
+          if [ "$state" != "stable" ]; then
+            echo "::error::v${VERSION} is a ${state} release — only stable releases publish to the AUR"
             exit 1
           fi
           echo "Publishing v${VERSION} to the AUR"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,33 +167,92 @@ jobs:
             echo "First release — no baseline to compare against"
           fi
 
+  # The AUR goes down for maintenance often enough that a release must not
+  # depend on it being reachable — isolated and continue-on-error, an AUR outage
+  # cannot fail the release. Recover a missed publish with the aur-publish
+  # workflow (workflow_dispatch).
   aur-publish:
+    name: Publish to AUR
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    continue-on-error: true
     runs-on: ubuntu-latest
-    needs: release
+    timeout-minutes: 20
+    # Shared with the aur-publish workflow's recovery runs. Without this, a
+    # recovery that already passed its version check could clone after a newer
+    # automatic publish landed and push the older PKGBUILD as a fast-forward.
+    concurrency:
+      group: aur-publish
+      cancel-in-progress: false
     environment: release
     permissions:
       contents: read
-    if: startsWith(github.ref, 'refs/tags/v')
+      issues: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - name: Check AUR secret
-        id: check
+      - name: Check AUR publishing configuration
+        id: aur-config
         env:
           AUR_KEY: ${{ secrets.AUR_KEY }}
         run: |
           if [ -n "$AUR_KEY" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish to AUR
-        if: steps.check.outputs.available == 'true'
-        run: scripts/publish-aur.sh
+        if: steps.aur-config.outputs.enabled == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUR_KEY: ${{ secrets.AUR_KEY }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          mkdir -p ~/.ssh
+          echo "$AUR_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          echo -e "Host aur.archlinux.org\n  IdentityFile ~/.ssh/aur\n  User aur\n  StrictHostKeyChecking accept-new" >> ~/.ssh/config
+          git config --global user.name "37signals"
+          git config --global user.email "dev@37signals.com"
+          # publish-aur.sh derives everything from the published release assets
+          # and no-ops when the PKGBUILD is already current, so retrying is safe.
+          for attempt in 1 2 3; do
+            if scripts/publish-aur.sh "$VERSION"; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "AUR publish attempt ${attempt} failed; retrying in $((attempt * 60))s"
+              sleep $((attempt * 60))
+            fi
+          done
+          echo "AUR publish failed after 3 attempts"
+          exit 1
+
+      - name: Notify on AUR publish failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_SLUG: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          RUN_URL="https://github.com/${REPO_SLUG}/actions/runs/${RUN_ID}"
+          BODY="Publishing [${REF_NAME}](${RUN_URL}) to the AUR failed. The GitHub release is unaffected — only the Arch package is stale. Re-run the \`Publish to AUR\` workflow with version \`${REF_NAME#v}\` once the AUR is reachable."
+
+          # Dedup lives in notify-issue.sh, shared with aur-publish.yml, keyed
+          # on the aur-publish label rather than the title so a retitled issue
+          # does not spawn a duplicate.
+          notify_status=0
+          scripts/notify-issue.sh \
+            --repo "$REPO_SLUG" \
+            --label aur-publish \
+            --title "AUR publish failure" \
+            --body "$BODY" || notify_status=$?
+
+          echo "::error::AUR publish failed for ${REF_NAME}. See ${RUN_URL}"
+          exit "$notify_status"
 
   sync-skills:
     name: Sync skills

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,7 +22,7 @@ Pushing the tag triggers the GitHub Actions release workflow, which:
 9. Publishes Homebrew cask to `basecamp/homebrew-tap`
 10. Publishes Scoop manifest to `basecamp/homebrew-tap`
 11. Builds .deb and .rpm packages
-12. Publishes to AUR (if `AUR_KEY` configured)
+12. Publishes the binary package to AUR (if `AUR_KEY` configured; isolated and non-blocking — an AUR outage cannot fail the release)
 13. Checks CLI surface compatibility against previous release
 14. Syncs skills to `basecamp/skills`
 
@@ -76,6 +76,15 @@ goreleaser release --snapshot --clean
 1. Generate ed25519 SSH keypair: `ssh-keygen -t ed25519 -f aur_key`
 2. Add public key to your AUR account profile
 3. Add private key as `AUR_KEY` secret on the hey-cli repo
+
+The AUR package installs the prebuilt release binaries (with shell completions),
+not a source build — `publish-aur.sh` derives the PKGBUILD from the published
+release assets.
+
+If the release-time publish fails (the AUR is down for maintenance regularly),
+a labeled `aur-publish` issue is filed and the release itself is unaffected.
+Recover by dispatching the `Publish to AUR` workflow with the released version —
+it is idempotent and refuses downgrades.
 
 ## PGO (Profile-Guided Optimization)
 

--- a/scripts/notify-issue.sh
+++ b/scripts/notify-issue.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Files or updates the single open issue tracking a recurring failure.
+#
+# Usage:
+#   scripts/notify-issue.sh --repo OWNER/NAME --label LABEL --title TITLE --body BODY
+#
+# Dedupes by *label*, not by title. Titles get edited the moment a human triages
+# the issue, and a title-based lookup then misses and opens a duplicate. A label
+# survives retitling, reassignment and rewording.
+#
+# Fails closed. The lookup's failure and its empty result must never be the same
+# thing: `2>/dev/null || true` around the search turns a rate limit, a
+# permissions gap or a GitHub outage into "no match found", and the very next
+# line creates a duplicate. If we cannot see the issue list, we file nothing and
+# say so — the workflow annotation still makes the underlying failure visible.
+#
+# Shared by release.yml and aur-publish.yml so a fix to this logic reaches both.
+#
+# Exit codes:
+#   0 — commented on the existing issue, or created a new one
+#   1 — usage error, or the comment/create itself failed
+#   2 — the lookup failed; nothing was created
+#   3 — more than one open issue carries the label; nothing was created
+
+set -euo pipefail
+
+REPO=""
+LABEL=""
+TITLE=""
+BODY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)  REPO="${2:-}";  shift 2 ;;
+    --label) LABEL="${2:-}"; shift 2 ;;
+    --title) TITLE="${2:-}"; shift 2 ;;
+    --body)  BODY="${2:-}";  shift 2 ;;
+    *)
+      echo "notify-issue.sh: unknown argument '$1'" >&2
+      exit 1
+      ;;
+  esac
+done
+
+missing=""
+[[ -n "$REPO"  ]] || missing="$missing --repo"
+[[ -n "$LABEL" ]] || missing="$missing --label"
+[[ -n "$TITLE" ]] || missing="$missing --title"
+[[ -n "$BODY"  ]] || missing="$missing --body"
+if [[ -n "$missing" ]]; then
+  echo "notify-issue.sh: missing required argument(s):$missing" >&2
+  exit 1
+fi
+
+if ! matches=$(gh issue list --repo "$REPO" --state open --label "$LABEL" \
+                 --json number --jq '.[].number'); then
+  echo "::error::Could not list open '${LABEL}' issues in ${REPO}. Filing nothing rather than risk a duplicate — the failure is still annotated on this run."
+  exit 2
+fi
+
+issues=()
+while IFS= read -r number; do
+  if [[ "$number" =~ ^[0-9]+$ ]]; then
+    issues+=("$number")
+  fi
+done <<<"$matches"
+
+case "${#issues[@]}" in
+  0)
+    echo "No open '${LABEL}' issue; filing one."
+    gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" --label "$LABEL"
+    ;;
+  1)
+    echo "Commenting on existing '${LABEL}' issue #${issues[0]}."
+    gh issue comment --repo "$REPO" "${issues[0]}" --body "$BODY"
+    ;;
+  *)
+    # Picking one arbitrarily would scatter the history of a single outage
+    # across issues that a human already decided to keep separate.
+    echo "::error::${#issues[@]} open issues carry the '${LABEL}' label (${issues[*]}). Refusing to guess which one to update — consolidate them, then re-run."
+    exit 3
+    ;;
+esac

--- a/scripts/publish-aur.sh
+++ b/scripts/publish-aur.sh
@@ -1,110 +1,106 @@
 #!/usr/bin/env bash
+# Publish the binary package to AUR as hey-cli.
+# Called from the release workflow after GoReleaser uploads assets, and from
+# the aur-publish recovery workflow for versions whose release-time publish
+# could not run.
+#
+# Derives the PKGBUILD entirely from the published GitHub release assets and
+# no-ops when the AUR copy is already current, so re-running it against an
+# already-published version is safe and idempotent.
+#
+# Expects SSH access to aur.archlinux.org and a git identity to already be
+# configured by the caller.
+#
+# Usage: scripts/publish-aur.sh <version>
 set -euo pipefail
 
-# Publish hey-cli to AUR
-# Requires: GITHUB_REF_NAME (from GitHub Actions), AUR_KEY environment variables
+VERSION="${1:?usage: publish-aur.sh <version>}"
+PKGNAME="hey-cli"
+AUR_REPO="ssh://aur@aur.archlinux.org/${PKGNAME}.git"
 
-: "${GITHUB_REF_NAME:?GITHUB_REF_NAME is required (set by GitHub Actions)}"
-: "${AUR_KEY:?AUR_KEY is required for AUR publishing}"
+# Compute checksums from the GitHub release assets
+base_url="https://github.com/basecamp/hey-cli/releases/download/v${VERSION}"
+sha_x86=$(curl -sL "${base_url}/checksums.txt" | grep "linux_amd64\.tar\.gz$" | awk '{print $1}')
+sha_arm=$(curl -sL "${base_url}/checksums.txt" | grep "linux_arm64\.tar\.gz$" | awk '{print $1}')
 
-VERSION="${GITHUB_REF_NAME#v}"
-REPO="basecamp/hey-cli"
-
-echo "Publishing hey-cli $VERSION to AUR..."
-
-# Download source tarball and compute checksum
-SOURCE_URL="https://github.com/$REPO/archive/v${VERSION}.tar.gz"
-curl -fsSL "$SOURCE_URL" -o source.tar.gz
-SHA256=$(sha256sum source.tar.gz | cut -d' ' -f1)
-rm source.tar.gz
+if [ -z "$sha_x86" ] || [ -z "$sha_arm" ]; then
+  echo "ERROR: could not find linux checksums in release assets" >&2
+  exit 1
+fi
 
 # Generate PKGBUILD
-cat > PKGBUILD << EOF
+pkgbuild=$(cat <<PKGBUILD
 # Maintainer: 37signals <support@37signals.com>
-pkgname=hey-cli
-pkgver=$VERSION
+pkgname=${PKGNAME}
+pkgver=${VERSION}
 pkgrel=1
 pkgdesc="CLI for HEY email"
 arch=('x86_64' 'aarch64')
-url="https://github.com/$REPO"
+url="https://github.com/basecamp/hey-cli"
 license=('MIT')
-depends=('glibc')
-makedepends=('go')
 provides=('hey')
 conflicts=('hey' 'hey-bin')
-source=("\$pkgname-\$pkgver.tar.gz::https://github.com/$REPO/archive/v\$pkgver.tar.gz")
-sha256sums=('$SHA256')
-options=('!debug')
-
-build() {
-    cd "\$pkgname-\$pkgver"
-    export CGO_CPPFLAGS="\${CPPFLAGS}"
-    export CGO_CFLAGS="\${CFLAGS}"
-    export CGO_CXXFLAGS="\${CXXFLAGS}"
-    export CGO_LDFLAGS="\${LDFLAGS}"
-    export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
-    go build -ldflags "-s -w -X github.com/basecamp/hey-cli/internal/version.Version=\${pkgver}" -o hey ./cmd/hey
-
-    # Generate completions
-    ./hey completion bash > hey.bash
-    ./hey completion zsh > hey.zsh
-    ./hey completion fish > hey.fish
-}
+optdepends=(
+  'bash-completion: for bash shell completions'
+  'zsh: for zsh shell completions'
+  'fish: for fish shell completions'
+)
+source_x86_64=("${base_url}/hey_\${pkgver}_linux_amd64.tar.gz")
+source_aarch64=("${base_url}/hey_\${pkgver}_linux_arm64.tar.gz")
+sha256sums_x86_64=('${sha_x86}')
+sha256sums_aarch64=('${sha_arm}')
 
 package() {
-    cd "\$pkgname-\$pkgver"
-    install -Dm755 hey "\$pkgdir/usr/bin/hey"
-    install -Dm644 LICENSE.md "\$pkgdir/usr/share/licenses/\$pkgname/LICENSE.md"
-    install -Dm644 hey.bash "\$pkgdir/usr/share/bash-completion/completions/hey"
-    install -Dm644 hey.zsh "\$pkgdir/usr/share/zsh/site-functions/_hey"
-    install -Dm644 hey.fish "\$pkgdir/usr/share/fish/vendor_completions.d/hey.fish"
+  install -Dm755 "hey" "\${pkgdir}/usr/bin/hey"
+  install -Dm644 "LICENSE.md" "\${pkgdir}/usr/share/licenses/\${pkgname}/LICENSE.md"
+  install -Dm644 "completions/hey.bash" "\${pkgdir}/usr/share/bash-completion/completions/hey"
+  install -Dm644 "completions/hey.zsh" "\${pkgdir}/usr/share/zsh/site-functions/_hey"
+  install -Dm644 "completions/hey.fish" "\${pkgdir}/usr/share/fish/vendor_completions.d/hey.fish"
 }
-EOF
+PKGBUILD
+)
 
 # Generate .SRCINFO
-cat > .SRCINFO << EOF
-pkgbase = hey-cli
+srcinfo=$(cat <<SRCINFO
+pkgbase = ${PKGNAME}
 	pkgdesc = CLI for HEY email
-	pkgver = $VERSION
+	pkgver = ${VERSION}
 	pkgrel = 1
-	url = https://github.com/$REPO
+	url = https://github.com/basecamp/hey-cli
 	arch = x86_64
 	arch = aarch64
 	license = MIT
-	makedepends = go
-	depends = glibc
 	provides = hey
 	conflicts = hey
 	conflicts = hey-bin
-	options = !debug
-	source = hey-cli-$VERSION.tar.gz::https://github.com/$REPO/archive/v$VERSION.tar.gz
-	sha256sums = $SHA256
+	optdepends = bash-completion: for bash shell completions
+	optdepends = zsh: for zsh shell completions
+	optdepends = fish: for fish shell completions
+	source_x86_64 = ${base_url}/hey_${VERSION}_linux_amd64.tar.gz
+	sha256sums_x86_64 = ${sha_x86}
+	source_aarch64 = ${base_url}/hey_${VERSION}_linux_arm64.tar.gz
+	sha256sums_aarch64 = ${sha_arm}
 
-pkgname = hey-cli
-EOF
+pkgname = ${PKGNAME}
+SRCINFO
+)
 
-# Clone AUR repo and push
-mkdir -p ~/.ssh
-echo "$AUR_KEY" > ~/.ssh/aur
-chmod 600 ~/.ssh/aur
-cat >> ~/.ssh/config << SSHEOF
-Host aur.archlinux.org
-    IdentityFile ~/.ssh/aur
-    User aur
-    StrictHostKeyChecking accept-new
-SSHEOF
+# Clone, update, push
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
 
-git clone ssh://aur@aur.archlinux.org/hey-cli.git aur-repo
-cp PKGBUILD .SRCINFO aur-repo/
-cd aur-repo
-git config user.name "cli-release-bot"
-git config user.email "cli-release-bot@users.noreply.github.com"
+git clone "$AUR_REPO" "$workdir/aur"
+cd "$workdir/aur"
+
+echo "$pkgbuild" > PKGBUILD
+echo "$srcinfo" > .SRCINFO
+
 git add PKGBUILD .SRCINFO
 if git diff --cached --quiet; then
-  echo "AUR package already up to date for $VERSION"
-else
-  git commit -m "Update to $VERSION"
-  git push
+  echo "AUR already up to date"
+  exit 0
 fi
 
-echo "Published hey-cli $VERSION to AUR"
+git commit -m "Update to v${VERSION}"
+git push origin master
+echo "Published ${PKGNAME} v${VERSION} to AUR"

--- a/scripts/publish-aur.sh
+++ b/scripts/publish-aur.sh
@@ -92,6 +92,34 @@ trap 'rm -rf "$workdir"' EXIT
 git clone "$AUR_REPO" "$workdir/aur"
 cd "$workdir/aur"
 
+# Never move the AUR backwards. The release workflow's concurrency group
+# serializes publishes but does not order them by version, so a re-run of an
+# older release's job can land after a newer version shipped. The just-cloned
+# PKGBUILD is the authoritative current state — read it rather than the AUR
+# RPC, which can lag. Exiting 0 keeps an out-of-order automatic run from
+# failing loudly over a package that is already correct; the recovery workflow
+# still rejects a downgrade dispatch with a hard error before reaching here.
+if [ -f PKGBUILD ]; then
+  current=$(sed -n 's/^pkgver=//p' PKGBUILD)
+  currel=$(sed -n 's/^pkgrel=//p' PKGBUILD)
+  if [ -n "$current" ]; then
+    if [ "$current" = "$VERSION" ]; then
+      # pkgrel=1 is hardcoded below, so republishing over a higher revision
+      # would silently discard an AUR-side packaging fix.
+      if [ "${currel:-1}" != "1" ]; then
+        echo "AUR already has ${current}-${currel}; refusing to clobber the packaging revision"
+        exit 0
+      fi
+    else
+      newest=$(printf '%s\n%s\n' "$current" "$VERSION" | sort -V | tail -1)
+      if [ "$newest" != "$VERSION" ]; then
+        echo "AUR already at ${current}, newer than ${VERSION}; nothing to do"
+        exit 0
+      fi
+    fi
+  fi
+fi
+
 echo "$pkgbuild" > PKGBUILD
 echo "$srcinfo" > .SRCINFO
 


### PR DESCRIPTION
## What

Swaps the AUR package from a source build (`makedepends=('go')`, compiled on the user's machine from the tag tarball) to the prebuilt release binaries, porting the pattern from basecamp-cli. `yay -S hey-cli` becomes a download-and-extract install — no Go toolchain, no compile — which is what Omarchy's delayed installer wants to point at.

## Changes

- **`scripts/publish-aur.sh`** — rewritten to derive the PKGBUILD entirely from the published release assets: `source_x86_64`/`source_aarch64` point at the goreleaser tarballs, checksums come from the release's `checksums.txt`, and `package()` installs the prebuilt `hey`, `LICENSE.md`, and bash/zsh/fish completions. Keeps `provides=('hey')` / `conflicts=('hey' 'hey-bin')`. Takes the version as an explicit argument, no-ops when the AUR copy is already current, and leaves SSH/git-identity setup to the callers, so it is idempotent and safe to re-run.
- **`release.yml`** — the `aur-publish` job is now isolated and `continue-on-error`, so an AUR maintenance outage cannot fail a release. Skips prereleases, retries three times with backoff, and shares an `aur-publish` concurrency group with the recovery workflow so a stale recovery run cannot race a newer automatic publish.
- **`.github/workflows/aur-publish.yml`** (new) — `workflow_dispatch` recovery path for a missed publish: validates the version exists as a published release, refuses downgrades and pkgrel clobbers via the AUR RPC (failing closed when the AUR is unreachable), then reuses the same script and retry loop.
- **`scripts/notify-issue.sh`** (new) — shared failure notifier: files or updates a single `aur-publish`-labeled issue, deduping by label rather than title so a retitled issue does not spawn duplicates, and failing closed when the issue lookup itself fails.
- **`RELEASING.md`** — documents the binary package and the recovery path.

The `aur-publish` label already exists on the repo (created to match basecamp-cli's).

## Verification

- `bash -n`, shellcheck, actionlint, and zizmor all pass on the touched files.
- Dry-ran `publish-aur.sh` with stubbed `curl`/`git` and inspected the generated PKGBUILD and .SRCINFO; the `package()` paths match the goreleaser archive layout (binary at root, `completions/hey.*`, `LICENSE.md`).
- Not verifiable until the first tag: an end-to-end publish (no release exists yet). `AUR_KEY` must be present in the `release` environment; the first publish intentionally overwrites the source-build stub currently in the AUR at 0.0.1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `hey-cli` to the AUR as a binary package instead of a source build, so installs are download-and-extract and releases no longer fail when the AUR is down. Previously the AUR package compiled from source; now the PKGBUILD points to signed GoReleaser tarballs and checksums, removing the Go toolchain requirement.

- `scripts/publish-aur.sh`: derives PKGBUILD from release assets, sets `source_x86_64`/`source_aarch64` and checksums from `checksums.txt`, installs `hey`, `LICENSE.md`, and bash/zsh/fish completions; keeps `provides=('hey')`/`conflicts=('hey' 'hey-bin')`; takes an explicit version; refuses downgrades and preserves higher `pkgrel` by reading the cloned PKGBUILD and exiting cleanly, making re-runs idempotent.
- `.github/workflows/release.yml`: isolates the AUR job, marks it `continue-on-error`, runs only for stable tags, retries 3x with backoff, shares an `aur-publish` concurrency group, and on failure posts via `scripts/notify-issue.sh`.
- `.github/workflows/aur-publish.yml` (new): manual recovery workflow; requires the version be a stable GitHub release (rejects drafts/prereleases), validates it exists, refuses downgrades and `pkgrel` clobbers via the AUR RPC (failing closed when unreachable), reuses the same script and retry loop, and only notifies on outage-like failures.
- `scripts/notify-issue.sh` (new): files or updates a single `aur-publish`-labeled issue, deduped by label and failing closed on lookup errors.
- `RELEASING.md`: documents the binary package behavior and the non-blocking recovery path.
- Required: `AUR_KEY` must be configured for the `release` environment; the first publish will overwrite the existing source-build stub in the AUR.

<sup>Written for commit ab008bb2e3916b5b71086e35e803da089eeac3e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

