### PR TITLE
Address bulk reply review findings

### DIFF
--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -40,6 +40,7 @@ The remaining HTML-reading gaps use the SDK's authenticated HTML helper and are 
 | `/bulk_replies/new.json` | GET | SDK `BulkReplies().Draft` | `hey bulk-reply preview`, `hey bulk-reply send`, TUI `b` | covered |
 | `/bulk_replies.json` | POST | SDK `BulkReplies().Send` | `hey bulk-reply send`, TUI bulk reply | covered |
 | `/bulk_replies/{id}/undo_send` | POST | SDK `BulkReplies().Undo` | `hey bulk-reply undo`, TUI `u` | covered |
+| `/bulk_replies/{id}` | GET (redirect target) | SDK `BulkReplies().Undo` redirect handling | `hey bulk-reply undo`, TUI `u` | covered |
 | `/postings/moves.json` | POST | SDK `Postings().Move` | `hey move <id> --to <box>`, TUI `m` | covered |
 | `/postings/trash.json` | POST | SDK `Postings().MoveToTrash` | `hey trash <id>`, TUI `t` | covered |
 | `/postings/spam.json` | POST | SDK `Postings().MarkSpam` | `hey spam <id>`, TUI `s` | covered |

--- a/internal/cmd/bulk_reply.go
+++ b/internal/cmd/bulk_reply.go
@@ -238,25 +238,29 @@ func (c *bulkReplySendCommand) readMessage() (string, error) {
 }
 
 func readBulkReplyMessage(message string, attachmentCount int, stdinTerminal bool, readInput func() (string, error), openEditor func(string) (string, error)) (string, error) {
+	inputSource := "inline"
 	if message == "" && !stdinTerminal {
+		inputSource = "stdin"
 		var err error
 		message, err = readInput()
 		if err != nil {
 			return "", err
 		}
-		if message == "" && attachmentCount == 0 {
-			return "", output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
-		}
 	} else if message == "" && attachmentCount == 0 {
+		inputSource = "editor"
 		var err error
 		message, err = openEditor("")
 		if err != nil {
 			return "", output.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
 		}
-		message = strings.TrimSpace(message)
-		if message == "" {
-			return "", output.ErrUsage("empty message, aborting")
+	}
+
+	message = strings.TrimSpace(message)
+	if message == "" && attachmentCount == 0 {
+		if inputSource == "stdin" {
+			return "", output.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
 		}
+		return "", output.ErrUsage("empty message, aborting")
 	}
 	return message, nil
 }
@@ -376,19 +380,17 @@ func printBulkReplyPreview(cmd *cobra.Command, entries []bulkReplyEntry, content
 	if len(entries) == 0 {
 		fmt.Fprintln(cmd.OutOrStdout(), "No replyable threads found.")
 	} else {
-		table := newTable(cmd.OutOrStdout())
-		table.addRow([]string{"Entry", "Thread", "Subject", "To", "CC", "BCC"})
-		for _, entry := range entries {
-			table.addRow([]string{
-				fmt.Sprintf("%d", entry.ID),
-				fmt.Sprintf("%d", entry.TopicID),
-				truncate(terminalSafeText(entry.TopicName), 36),
-				truncate(formatBulkReplyRecipients(entry.To), 48),
-				truncate(formatBulkReplyRecipients(entry.CC), 48),
-				truncate(formatBulkReplyRecipients(entry.BCC), 48),
-			})
+		for i, entry := range entries {
+			if i > 0 {
+				fmt.Fprintln(cmd.OutOrStdout())
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Entry: %d\n", entry.ID)
+			fmt.Fprintf(cmd.OutOrStdout(), "Thread: %d\n", entry.TopicID)
+			fmt.Fprintf(cmd.OutOrStdout(), "Subject: %s\n", terminalSafeText(entry.TopicName))
+			fmt.Fprintf(cmd.OutOrStdout(), "To: %s\n", formatBulkReplyRecipients(entry.To))
+			fmt.Fprintf(cmd.OutOrStdout(), "CC: %s\n", formatBulkReplyRecipients(entry.CC))
+			fmt.Fprintf(cmd.OutOrStdout(), "BCC: %s\n", formatBulkReplyRecipients(entry.BCC))
 		}
-		table.print()
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "\n%s.\n", bulkReplyPreviewSummary(len(entries), skipped))
 	if text := htmlutil.ToText(content); text != "" {

--- a/internal/cmd/bulk_reply_test.go
+++ b/internal/cmd/bulk_reply_test.go
@@ -161,6 +161,38 @@ func TestBulkReplyPreviewShowsExactRecipientsInEveryFormat(t *testing.T) {
 	}
 }
 
+func TestBulkReplyStyledPreviewNeverTruncatesSafetyDetails(t *testing.T) {
+	server, state := bulkReplyServer(t)
+	const subject = "Quarterly planning across every regional office and product team"
+	const finalRecipient = "final.recipient.with.a.long.address@example.com"
+	state.draft = `{
+		"content":"",
+		"entries":[{
+			"id":11,
+			"topic_id":21,
+			"topic_name":"` + subject + `",
+			"addressed":{"directly":[
+				{"id":31,"name":"Jane Doe","email_address":"jane@example.com"},
+				{"id":32,"name":"Bob Smith","email_address":"bob@example.org"},
+				{"id":33,"name":"Final Recipient","email_address":"` + finalRecipient + `"}
+			]}
+		}]
+	}`
+
+	preview, err := runBulkReply(t, server, []string{"--styled"}, []string{"preview", "101"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{subject, "Jane Doe <jane@example.com>", "Bob Smith <bob@example.org>", finalRecipient} {
+		if !strings.Contains(preview, expected) {
+			t.Errorf("styled preview omitted %q:\n%s", expected, preview)
+		}
+	}
+	if strings.Contains(preview, "...") {
+		t.Errorf("styled safety preview contains truncation: %s", preview)
+	}
+}
+
 func TestBulkReplySendPreservesDraftAndReportsDelayedDelivery(t *testing.T) {
 	server, state := bulkReplyServer(t)
 	output, err := runBulkReply(t, server, []string{"--json"}, []string{"send", "101", "202", "303", "-m", "Thanks everyone"})
@@ -302,6 +334,7 @@ func TestBulkReplyValidatesPositiveUniqueIDsBeforeRequest(t *testing.T) {
 		{"preview", "not-an-id"},
 		{"send", "101", "101", "-m", "No"},
 		{"send", "101", "-m", ""},
+		{"send", "101", "-m", "   \n\t"},
 		{"send", "101", "-m", "No", "--attach", filepath.Join(t.TempDir(), "missing.pdf")},
 		{"undo", "0"},
 	}
@@ -322,11 +355,11 @@ func TestReadBulkReplyMessageSupportsInlineStdinEditorAndAttachmentsOnly(t *test
 	unused := func() (string, error) { return "", errors.New("should not read stdin") }
 	unusedEditor := func(string) (string, error) { return "", errors.New("should not open editor") }
 
-	message, err := readBulkReplyMessage("Inline", 0, true, unused, unusedEditor)
+	message, err := readBulkReplyMessage("  Inline \n", 0, true, unused, unusedEditor)
 	if err != nil || message != "Inline" {
 		t.Errorf("inline = %q, %v", message, err)
 	}
-	message, err = readBulkReplyMessage("", 0, false, func() (string, error) { return "From stdin", nil }, unusedEditor)
+	message, err = readBulkReplyMessage("", 0, false, func() (string, error) { return "  From stdin\n", nil }, unusedEditor)
 	if err != nil || message != "From stdin" {
 		t.Errorf("stdin = %q, %v", message, err)
 	}
@@ -339,9 +372,12 @@ func TestReadBulkReplyMessageSupportsInlineStdinEditorAndAttachmentsOnly(t *test
 	if err != nil || message != "From editor" {
 		t.Errorf("editor = %q, %v", message, err)
 	}
-	message, err = readBulkReplyMessage("", 1, true, unused, unusedEditor)
+	message, err = readBulkReplyMessage(" \n\t", 1, true, unused, unusedEditor)
 	if err != nil || message != "" {
 		t.Errorf("attachment-only = %q, %v", message, err)
+	}
+	if message, err = readBulkReplyMessage(" \n\t", 0, true, unused, unusedEditor); err == nil || message != "" {
+		t.Errorf("whitespace-only inline message = %q, %v", message, err)
 	}
 }
 

--- a/internal/tui/bulk_reply.go
+++ b/internal/tui/bulk_reply.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/mattn/go-runewidth"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
@@ -37,6 +39,7 @@ type bulkReplyForm struct {
 	postingIDs []int64
 	draft      generated.BulkReplyDraft
 	composing  bool
+	preview    viewport.Model
 	body       textarea.Model
 	status     string
 	isError    bool
@@ -54,6 +57,8 @@ func newBulkReplyForm(postingIDs []int64, draft *generated.BulkReplyDraft, s sty
 	if draft != nil {
 		form.draft = *draft
 	}
+	form.preview = viewport.New(viewport.WithWidth(80), viewport.WithHeight(24))
+	form.preview.SetContent(form.previewContent(80))
 	form.body = textarea.New()
 	form.body.Prompt = ""
 	form.body.ShowLineNumbers = false
@@ -71,6 +76,11 @@ func (f *bulkReplyForm) init() tea.Cmd {
 func (f *bulkReplyForm) resize(width, height int) {
 	f.width = width
 	f.height = height
+	previewOffset := f.preview.YOffset()
+	f.preview.SetWidth(max(width, 1))
+	f.preview.SetHeight(max(height, 1))
+	f.preview.SetContent(f.previewContent(width))
+	f.preview.SetYOffset(previewOffset)
 	f.body.SetWidth(max(width-4, 10))
 	f.body.SetHeight(max(height-8, 3))
 }
@@ -84,7 +94,9 @@ func (f *bulkReplyForm) handleKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
 			f.composing = true
 			return f.body.Focus(), false
 		}
-		return nil, false
+		var cmd tea.Cmd
+		f.preview, cmd = f.preview.Update(msg)
+		return cmd, false
 	}
 	if msg.String() == "ctrl+s" {
 		if strings.TrimSpace(f.body.Value()) == "" {
@@ -103,29 +115,30 @@ func (f *bulkReplyForm) handleKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
 }
 
 func (f *bulkReplyForm) update(msg tea.Msg) tea.Cmd {
-	if !f.composing {
-		return nil
-	}
 	var cmd tea.Cmd
+	if !f.composing {
+		f.preview, cmd = f.preview.Update(msg)
+		return cmd
+	}
 	f.body, cmd = f.body.Update(msg)
 	return cmd
 }
 
 func (f *bulkReplyForm) helpBindings() []helpBinding {
 	if !f.composing {
-		return []helpBinding{{"enter", "write reply"}, {"esc", "cancel"}}
+		return []helpBinding{{"↑↓", "review recipients"}, {"enter", "write reply"}, {"esc", "cancel"}}
 	}
 	return []helpBinding{{"ctrl+s", "send to all"}, {"esc", "cancel"}}
 }
 
 func (f *bulkReplyForm) view() string {
 	if !f.composing {
-		return f.previewView()
+		return f.preview.View()
 	}
 	return f.composeView()
 }
 
-func (f *bulkReplyForm) previewView() string {
+func (f *bulkReplyForm) previewContent(width int) string {
 	var b strings.Builder
 	b.WriteString(f.styles.title.Render("Bulk reply preview"))
 	b.WriteString("\n")
@@ -137,20 +150,19 @@ func (f *bulkReplyForm) previewView() string {
 
 	labelStyle := lipgloss.NewStyle().Foreground(colorMuted)
 	for i, entry := range f.draft.Entries {
-		fmt.Fprintf(&b, "%d. %s\n", i+1, terminalSafeAttachmentText(entry.TopicName))
-		fmt.Fprintf(&b, "%s %s\n", labelStyle.Render("   To:"), formatBulkReplyContacts(entry.Addressed.Directly))
-		if len(entry.Addressed.Copied) > 0 {
-			fmt.Fprintf(&b, "%s %s\n", labelStyle.Render("   CC:"), formatBulkReplyContacts(entry.Addressed.Copied))
-		}
-		if len(entry.Addressed.Blindcopied) > 0 {
-			fmt.Fprintf(&b, "%s %s\n", labelStyle.Render("  BCC:"), formatBulkReplyContacts(entry.Addressed.Blindcopied))
-		}
+		writeBulkReplyWrappedLine(&b, fmt.Sprintf("%d. ", i+1), terminalSafeAttachmentText(entry.TopicName), width)
+		writeBulkReplyContacts(&b, "To", entry.Addressed.Directly, width, labelStyle)
+		writeBulkReplyContacts(&b, "CC", entry.Addressed.Copied, width, labelStyle)
+		writeBulkReplyContacts(&b, "BCC", entry.Addressed.Blindcopied, width, labelStyle)
 		b.WriteString("\n")
 	}
 	if nameTag := htmlutil.ToText(f.draft.Content); nameTag != "" {
-		b.WriteString(labelStyle.Render("HEY will preserve your name tag: "))
-		b.WriteString(terminalSafeAttachmentText(nameTag))
-		b.WriteString("\n\n")
+		b.WriteString(labelStyle.Render("HEY will preserve your name tag:"))
+		b.WriteString("\n")
+		for _, line := range wrapBulkReplyText(terminalSafeAttachmentText(nameTag), max(width-4, 10)) {
+			fmt.Fprintf(&b, "  %s\n", line)
+		}
+		b.WriteString("\n")
 	}
 	b.WriteString(labelStyle.Render("Review every recipient, then press enter to write the reply."))
 	return b.String()
@@ -173,21 +185,64 @@ func (f *bulkReplyForm) composeView() string {
 	return b.String()
 }
 
-func formatBulkReplyContacts(contacts []generated.Contact) string {
-	formatted := make([]string, 0, len(contacts))
+func writeBulkReplyContacts(b *strings.Builder, label string, contacts []generated.Contact, width int, labelStyle lipgloss.Style) {
+	fmt.Fprintf(b, "%s\n", labelStyle.Render(label+":"))
+	if len(contacts) == 0 {
+		fmt.Fprintln(b, "  (none)")
+		return
+	}
 	for _, contact := range contacts {
-		name := terminalSafeAttachmentText(contact.Name)
-		email := terminalSafeAttachmentText(contact.EmailAddress)
-		switch {
-		case name != "" && email != "":
-			formatted = append(formatted, fmt.Sprintf("%s <%s>", name, email))
-		case email != "":
-			formatted = append(formatted, email)
-		case name != "":
-			formatted = append(formatted, name)
+		writeBulkReplyWrappedLine(b, "  - ", formatBulkReplyContact(contact), width)
+	}
+}
+
+func formatBulkReplyContact(contact generated.Contact) string {
+	name := terminalSafeAttachmentText(contact.Name)
+	email := terminalSafeAttachmentText(contact.EmailAddress)
+	switch {
+	case name != "" && email != "":
+		return fmt.Sprintf("%s <%s>", name, email)
+	case email != "":
+		return email
+	default:
+		return name
+	}
+}
+
+func writeBulkReplyWrappedLine(b *strings.Builder, prefix, text string, width int) {
+	prefixWidth := runewidth.StringWidth(prefix)
+	lines := wrapBulkReplyText(text, max(width-prefixWidth, 1))
+	for i, line := range lines {
+		if i == 0 {
+			fmt.Fprintf(b, "%s%s\n", prefix, line)
+		} else {
+			fmt.Fprintf(b, "%s%s\n", strings.Repeat(" ", prefixWidth), line)
 		}
 	}
-	return strings.Join(formatted, ", ")
+}
+
+func wrapBulkReplyText(text string, width int) []string {
+	width = max(width, 1)
+	if text == "" {
+		return []string{""}
+	}
+	var lines []string
+	var line strings.Builder
+	lineWidth := 0
+	for _, r := range text {
+		runeWidth := runewidth.RuneWidth(r)
+		if line.Len() > 0 && lineWidth+runeWidth > width {
+			lines = append(lines, line.String())
+			line.Reset()
+			lineWidth = 0
+		}
+		line.WriteRune(r)
+		lineWidth += runeWidth
+	}
+	if line.Len() > 0 {
+		lines = append(lines, line.String())
+	}
+	return lines
 }
 
 func tuiThreadNoun(count int) string {

--- a/internal/tui/bulk_reply_test.go
+++ b/internal/tui/bulk_reply_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -151,12 +152,58 @@ func TestTUIBulkReplySelectionAndPreviewShowExactRecipients(t *testing.T) {
 			t.Errorf("preview does not contain %q: %q", expected, preview)
 		}
 	}
-	if help := view.HelpBindings(); len(help) == 0 || help[0].key != "enter" {
+	if help := view.HelpBindings(); len(help) < 2 || help[0].key != "↑↓" || help[1].key != "enter" {
 		t.Errorf("preview help = %v", help)
 	}
 	requests := state.snapshot()
 	if len(requests) != 1 || requests[0].query != "posting_ids=100%2C101" {
 		t.Errorf("draft request = %+v", requests)
+	}
+}
+
+func TestTUIBulkReplyPreviewScrollsThroughEveryRecipient(t *testing.T) {
+	entries := make([]generated.BulkReplyEntry, 12)
+	for i := range entries {
+		entries[i] = generated.BulkReplyEntry{
+			Id:        int64(500 + i),
+			TopicId:   int64(700 + i),
+			TopicName: fmt.Sprintf("Thread %02d", i+1),
+			Addressed: generated.Addressed{Directly: []generated.Contact{{
+				Id:           int64(900 + i),
+				EmailAddress: fmt.Sprintf("recipient-%02d@example.com", i+1),
+			}}},
+		}
+	}
+	form := newBulkReplyForm([]int64{100, 101}, &generated.BulkReplyDraft{Entries: entries}, newStyles())
+	form.resize(40, 8)
+
+	if strings.Contains(form.view(), "recipient-12@example.com") {
+		t.Fatal("last recipient should begin below the viewport")
+	}
+	for range 100 {
+		_, _ = form.handleKey(keyPress("down"))
+	}
+	if form.preview.YOffset() == 0 {
+		t.Fatal("down should scroll the recipient preview")
+	}
+	if !strings.Contains(form.view(), "recipient-12@example.com") {
+		t.Errorf("last recipient is not reviewable after scrolling: %q", form.view())
+	}
+}
+
+func TestTUIBulkReplyPreviewWrapsLongRecipientsWithoutDroppingText(t *testing.T) {
+	const email = "recipient-with-an-extraordinarily-long-address@example.com"
+	form := newBulkReplyForm([]int64{100}, &generated.BulkReplyDraft{Entries: []generated.BulkReplyEntry{{
+		Id:        501,
+		TopicId:   701,
+		TopicName: "A complete safety preview",
+		Addressed: generated.Addressed{Directly: []generated.Contact{{Id: 901, EmailAddress: email}}},
+	}}}, newStyles())
+
+	content := form.previewContent(24)
+	compacted := strings.NewReplacer("\n", "", " ", "").Replace(content)
+	if !strings.Contains(compacted, email) {
+		t.Errorf("wrapped preview dropped recipient text: %q", content)
 	}
 }
 

--- a/tests/smoke/bulk_reply_test.go
+++ b/tests/smoke/bulk_reply_test.go
@@ -26,7 +26,7 @@ func TestBulkReplyPreview(t *testing.T) {
 	}
 	stdout, stderr, code := hey(t, append(args, "--json")...)
 	if code != 0 {
-		t.Skipf("no replyable Imbox postings available (exit %d): %s", code, stderr)
+		t.Fatalf("bulk reply preview failed (exit %d): %s", code, stderr)
 	}
 	var response Response
 	if err := json.Unmarshal([]byte(stdout), &response); err != nil {


### PR DESCRIPTION
## Summary

Follow-up to #183 addressing every review finding that arrived after the original PR merged:

- render complete CLI subjects and To/CC/BCC recipient lists without truncation
- make the TUI safety preview vertically scrollable and wrap long recipient details without dropping text
- normalize every CLI message source and reject whitespace-only messages without attachments
- fail the read-only smoke test on preview regressions instead of skipping
- document the GET redirect target used by bulk-reply undo

## Testing

- `GOWORK=off go test ./internal/...`
- `GOWORK=off go test -race ./internal/cmd ./internal/tui`
- `GOWORK=off golangci-lint run ./...`
- `cd tests/smoke && GOWORK=off go test -run '^$' ./...`
- `GOWORK=off make build`

All tests use isolated servers or compile-only smoke validation; no real HEY account was used.

Follow-up to #183. This PR must not be merged without explicit approval.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses all bulk-reply review findings: removes preview truncation, adds a scrollable/wrapping TUI safety preview, normalizes message input, and tightens smoke testing. Old CLI output truncated Subject and recipients; new output shows full values. Old TUI preview could cut or hide recipients; new preview scrolls and wraps without losing text.

- CLI preview: replace the table with per-entry blocks; print full Subject/To/CC/BCC without truncation; keep text summary of HTML content.
- TUI preview: add vertical scrolling (↑↓) and width-aware wrapping for long recipients; show To/CC/BCC consistently; update help to include scrolling; preserve and show the name tag.
- Message input: trim inline/stdin/editor input; reject whitespace-only messages when no attachments; allow attachments-only; emit specific errors for empty stdin vs empty editor/inline.
- Smoke tests: fail the bulk-reply preview test on regression instead of skipping.
- API coverage: document the `GET /bulk_replies/{id}` redirect target used by undo.

Required action for scripts: ensure the bulk-reply message has non-whitespace content, or include at least one attachment.

<sup>Written for commit 64dbde929bf9fba0385f4ca9a077c0b5224646b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

