### PR TITLE
Add linked-account selection to the CLI

### DIFF
--- a/.surface
+++ b/.surface
@@ -1,4 +1,5 @@
 hey
+hey --account
 hey --agent
 hey --base-url
 hey --count
@@ -10,6 +11,9 @@ hey --quiet
 hey --stats
 hey --styled
 hey --verbose
+hey accounts
+hey accounts list
+hey accounts use
 hey attachments
 hey attachments save
 hey attachments save --force

--- a/.surface
+++ b/.surface
@@ -54,6 +54,9 @@ hey compose --to
 hey config
 hey config set
 hey config show
+hey config trust-local
+hey config trusted-locals
+hey config untrust-local
 hey contacts
 hey contacts add
 hey contacts add --account-user-id

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ tracking, and journal entries remain identity-wide.
 
 ## TUI
 
-Run `hey` to launch the interactive terminal UI.
+Run `hey` to launch the interactive terminal UI. For identities with multiple linked mail
+accounts, press Ctrl+A to switch between All Accounts and individual email addresses.
+Switching cancels requests from the previous account and reloads the active section;
+Calendar and Journal remain identity-wide.
 
 Navigate between Mail, Contacts, Calendar, and Journal. In Mail, use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press `b` to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with `u` while HEY's undo window remains open. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ hey auth refresh  # force token refresh
 hey auth logout   # clear credentials
 ```
 
+### Linked accounts
+
+One HEY login exposes every mail account linked to that identity. List the available
+filters, persist a default, or select one for a single invocation:
+
+```bash
+hey accounts list                 # list All Accounts and each linked account
+hey accounts use 12345            # persist a linked account as the default mail filter
+hey accounts use all              # return to All Accounts
+hey --account 12345 boxes         # override the default for one invocation
+HEY_ACCOUNT_ID=12345 hey search "quarterly planning"
+```
+
+The default is `all`. Selection precedence is `--account`, `HEY_ACCOUNT_ID`, local
+`.hey/config.json`, global `~/.config/hey-cli/config.json`, then All Accounts. Explicit
+and persisted IDs are validated against the signed-in identity before mail requests, so
+an unavailable account fails closed. Compose and contact creation use an individually
+selected account; replies and forwards use the thread's account. Calendars, todos, habits, time
+tracking, and journal entries remain identity-wide.
+
 ## TUI
 
 Run `hey` to launch the interactive terminal UI.
@@ -66,7 +86,8 @@ Press Shift+O to open Contacts. Use Enter to view a contact, `a` to add, `e` to 
 
 ## CLI Commands
 
-All commands support `--json` for raw JSON output and `--base-url` to override the server URL.
+All commands support `--json` for raw JSON output, `--base-url` to override the server URL,
+and `--account <id|all>` to select a linked mail account.
 
 ### Email
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,21 @@ hey --account 12345 boxes         # override the default for one invocation
 HEY_ACCOUNT_ID=12345 hey search "quarterly planning"
 ```
 
-The default is `all`. Selection precedence is `--account`, `HEY_ACCOUNT_ID`, local
-`.hey/config.json`, global `~/.config/hey-cli/config.json`, then All Accounts. Explicit
-and persisted IDs are validated against the signed-in identity before mail requests, so
-an unavailable account fails closed. Compose and contact creation use an individually
-selected account; replies and forwards use the thread's account. Calendars, todos, habits, time
-tracking, and journal entries remain identity-wide.
+The default is `all`. Selection precedence is `--account`, `HEY_ACCOUNT_ID`, trusted local
+`.hey/config.json`, the global default for the active server, then All Accounts. Global
+account defaults are stored separately for each server origin, so development and production
+selections cannot affect one another. Explicit and persisted IDs are validated against the
+signed-in identity before mail requests, so an unavailable account fails closed.
+
+The first command that would use a repository-local server or account setting asks whether to
+use it once, always trust its current values, or cancel. Non-interactive and JSON commands fail
+closed until you explicitly run `hey config trust-local` from that directory. Changes to the
+local server or account invalidate trust. Review trust with `hey config trusted-locals` and
+remove it with `hey config untrust-local`.
+
+Compose and contact creation use an individually selected account; replies and forwards use
+the thread's account. Calendars, todos, habits, time tracking, and journal entries remain
+identity-wide.
 
 ## TUI
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.6
-	github.com/basecamp/hey-sdk/go v0.5.0
+	github.com/basecamp/hey-sdk/go v0.6.0
 	github.com/mattn/go-runewidth v0.0.27
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
-github.com/basecamp/hey-sdk/go v0.5.0 h1:h7FX/E/ci+TYEk6rfd8cV3o+e2rlO47F4NrhE3IeovY=
-github.com/basecamp/hey-sdk/go v0.5.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
+github.com/basecamp/hey-sdk/go v0.6.0 h1:maoTjI41fb25L7d3KUbZq/CdzNTH96JGu8/oOukUnTs=
+github.com/basecamp/hey-sdk/go v0.6.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=

--- a/internal/cmd/accounts.go
+++ b/internal/cmd/accounts.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+
+	"github.com/basecamp/hey-cli/internal/config"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type accountsCommand struct {
+	cmd *cobra.Command
+}
+
+type accountListItem struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Email   string `json:"email,omitempty"`
+	Purpose string `json:"purpose,omitempty"`
+	Status  string `json:"status,omitempty"`
+	Active  bool   `json:"active"`
+}
+
+func newAccountsCommand() *accountsCommand {
+	accountsCommand := &accountsCommand{}
+	accountsCommand.cmd = &cobra.Command{
+		Use:   "accounts",
+		Short: "List and select linked mail accounts",
+		Long:  "List the mail accounts linked to the current HEY identity or choose the default mail filter.",
+		Annotations: map[string]string{
+			"agent_notes": "Linked accounts share the current login. Use list to discover IDs and use <id|all> to persist the default mail filter; --account overrides it for one invocation.",
+		},
+	}
+	accountsCommand.cmd.AddCommand(newAccountsListCommand())
+	accountsCommand.cmd.AddCommand(newAccountsUseCommand())
+	return accountsCommand
+}
+
+func newAccountsListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List linked mail accounts",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := requireAuth(); err != nil {
+				return err
+			}
+			identity, err := rootSDK.Identity().GetIdentity(cmd.Context())
+			if err != nil {
+				return convertSDKError(err)
+			}
+			if identity == nil {
+				return output.ErrAPI(0, "HEY returned no identity data")
+			}
+
+			accounts := linkedAccountList(identity, cfg.AccountID)
+			notice := unavailableAccountNotice(accounts, cfg.AccountID)
+			if writer.IsStyled() {
+				table := newTable(cmd.OutOrStdout())
+				table.addRow([]string{"ID", "Email", "Name", "Purpose", "Status", "Active"})
+				for _, account := range accounts {
+					active := ""
+					if account.Active {
+						active = "yes"
+					}
+					table.addRow([]string{
+						account.ID,
+						terminalSafeText(account.Email),
+						terminalSafeText(account.Name),
+						terminalSafeText(account.Purpose),
+						terminalSafeText(account.Status),
+						active,
+					})
+				}
+				table.print()
+				if notice != "" {
+					fmt.Fprintln(cmd.OutOrStdout(), notice)
+				}
+				return nil
+			}
+			return writeOK(accounts,
+				output.WithSummary(fmt.Sprintf("%d mail account filters", len(accounts))),
+				output.WithNotice(notice),
+			)
+		},
+	}
+}
+
+func newAccountsUseCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:     "use <id|all>",
+		Short:   "Set the default linked mail account",
+		Example: "  hey accounts use 12345\n  hey accounts use all",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			overrideSource := cfg.SourceOf("account_id")
+			if err := cfg.SetFromFlag("account_id", args[0]); err != nil {
+				return err
+			}
+			if cfg.AccountID != config.AllAccounts {
+				if err := requireAuth(); err != nil {
+					return err
+				}
+				id, _ := strconv.ParseInt(cfg.AccountID, 10, 64)
+				if _, err := rootSDK.ForAccount(cmd.Context(), id); err != nil {
+					return convertSDKError(err)
+				}
+			}
+			if err := cfg.SaveAccountID(cfg.AccountID); err != nil {
+				return err
+			}
+
+			label := cfg.AccountID
+			if label == config.AllAccounts {
+				label = "All Accounts"
+			}
+			notice := accountOverrideNotice(overrideSource)
+			if writer.IsStyled() {
+				fmt.Fprintf(cmd.OutOrStdout(), "Default mail account: %s\n", label)
+				if notice != "" {
+					fmt.Fprintln(cmd.OutOrStdout(), notice)
+				}
+				return nil
+			}
+			return writeOK(map[string]string{"account_id": cfg.AccountID},
+				output.WithSummary(fmt.Sprintf("Default mail account: %s", label)),
+				output.WithNotice(notice),
+			)
+		},
+	}
+}
+
+func unavailableAccountNotice(accounts []accountListItem, selected string) string {
+	if selected == config.AllAccounts {
+		return ""
+	}
+	for _, account := range accounts {
+		if account.Active {
+			return ""
+		}
+	}
+	return fmt.Sprintf("Configured account %s is unavailable; run `hey accounts use all` or select an available ID.", selected)
+}
+
+func accountOverrideNotice(source config.Source) string {
+	switch source {
+	case config.SourceLocal:
+		return "Saved the global default; local .hey/config.json remains higher precedence."
+	case config.SourceEnv:
+		return "Saved the global default; HEY_ACCOUNT_ID remains higher precedence."
+	case config.SourceFlag:
+		return "Saved the global default; --account controls only this invocation."
+	default:
+		return ""
+	}
+}
+
+func linkedAccountList(identity *generated.Identity, selected string) []accountListItem {
+	accounts := []accountListItem{{
+		ID:     config.AllAccounts,
+		Name:   "All Accounts",
+		Active: selected == config.AllAccounts,
+	}}
+	for _, account := range identity.Accounts {
+		if !linkedAccountAccessible(account) {
+			continue
+		}
+		id := strconv.FormatInt(account.Id, 10)
+		accounts = append(accounts, accountListItem{
+			ID:      id,
+			Name:    account.Name,
+			Email:   linkedAccountEmail(identity.AllUsers, account.Id),
+			Purpose: account.Purpose,
+			Status:  account.Status,
+			Active:  selected == id,
+		})
+	}
+	return accounts
+}
+
+func linkedAccountAccessible(account generated.Account) bool {
+	return account.Status == "active" ||
+		(account.Status == "inactive" && (account.Purpose == "work" || account.Purpose == "domains"))
+}
+
+func linkedAccountEmail(users []generated.User, accountID int64) string {
+	for _, user := range users {
+		if user.AccountId == accountID {
+			return user.Contact.EmailAddress
+		}
+	}
+	return ""
+}

--- a/internal/cmd/accounts_test.go
+++ b/internal/cmd/accounts_test.go
@@ -128,11 +128,13 @@ func TestPersistedAccountScopesMailRequests(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(configDir, "hey-cli"), 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(
-		filepath.Join(configDir, "hey-cli", "config.json"),
-		[]byte(`{"account_id":"2"}`),
-		0600,
-	); err != nil {
+	data, err := json.Marshal(map[string]any{
+		"account_defaults": map[string]string{server.URL: "2"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "hey-cli", "config.json"), data, 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -241,11 +243,15 @@ func TestConfigSetDoesNotPersistAccountOverride(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var file map[string]string
+	var file struct {
+		BaseURL         string            `json:"base_url"`
+		AccountID       string            `json:"account_id"`
+		AccountDefaults map[string]string `json:"account_defaults"`
+	}
 	if err := json.Unmarshal(data, &file); err != nil {
 		t.Fatal(err)
 	}
-	if file["base_url"] != "https://new.hey.com" || file["account_id"] != "1" {
+	if file.BaseURL != "https://new.hey.com" || file.AccountID != "" || file.AccountDefaults["https://old.hey.com"] != "1" {
 		t.Fatalf("saved config = %#v", file)
 	}
 }
@@ -264,12 +270,46 @@ func TestAccountsUseValidatesAndPersistsDefault(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var file map[string]any
+	var file struct {
+		AccountDefaults map[string]string `json:"account_defaults"`
+	}
 	if err := json.Unmarshal(data, &file); err != nil {
 		t.Fatal(err)
 	}
-	if file["account_id"] != "2" {
-		t.Fatalf("saved account = %#v", file["account_id"])
+	if file.AccountDefaults[server.URL] != "2" {
+		t.Fatalf("saved account defaults = %#v", file.AccountDefaults)
+	}
+}
+
+func TestBaseURLFlagDoesNotCarryGlobalAccountAcrossOrigins(t *testing.T) {
+	var boxesAccounts []string
+	server := linkedAccountServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/boxes.json" {
+			http.NotFound(w, r)
+			return
+		}
+		boxesAccounts = append(boxesAccounts, r.URL.Query().Get("filtered_account_id"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	})
+	configDir := t.TempDir()
+	dir := filepath.Join(configDir, "hey-cli")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	global := `{"base_url":"https://app.hey.com","account_defaults":{"https://app.hey.com":"1"}}`
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(global), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runAccountsCLIWithConfig(t, server, configDir, "boxes"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runAccountsCLIWithConfig(t, server, configDir, "--account", "2", "boxes"); err != nil {
+		t.Fatal(err)
+	}
+	if len(boxesAccounts) != 2 || boxesAccounts[0] != "" || boxesAccounts[1] != "2" {
+		t.Fatalf("boxes account filters = %#v, want [all, 2]", boxesAccounts)
 	}
 }
 

--- a/internal/cmd/accounts_test.go
+++ b/internal/cmd/accounts_test.go
@@ -1,0 +1,349 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/config"
+)
+
+func TestCommandAccountScopePolicy(t *testing.T) {
+	root := newRootCmd()
+	for _, test := range []struct {
+		args []string
+		want bool
+	}{
+		{args: []string{"boxes"}, want: true},
+		{args: []string{"calendars"}, want: true},
+		{args: []string{"tui"}, want: true},
+		{args: []string{"accounts", "list"}, want: false},
+		{args: []string{"auth", "status"}, want: false},
+		{args: []string{"config", "show"}, want: false},
+	} {
+		command, _, err := root.Find(test.args)
+		if err != nil {
+			t.Fatalf("Find(%v): %v", test.args, err)
+		}
+		if got := commandUsesAccountScope(command); got != test.want {
+			t.Errorf("commandUsesAccountScope(%v) = %v, want %v", test.args, got, test.want)
+		}
+	}
+}
+
+func TestUnavailableAccountNotice(t *testing.T) {
+	accounts := []accountListItem{{ID: "all"}, {ID: "1"}}
+	if unavailableAccountNotice(accounts, "all") != "" {
+		t.Fatal("All Accounts unexpectedly reported unavailable")
+	}
+	if unavailableAccountNotice(accounts, "1") == "" {
+		t.Fatal("unavailable selected account notice is empty")
+	}
+	accounts[1].Active = true
+	if unavailableAccountNotice(accounts, "1") != "" {
+		t.Fatal("available selected account unexpectedly reported unavailable")
+	}
+}
+
+func TestAccountOverrideNotice(t *testing.T) {
+	if accountOverrideNotice(config.SourceGlobal) != "" {
+		t.Fatal("global default unexpectedly reported an override")
+	}
+	if accountOverrideNotice(config.SourceEnv) == "" {
+		t.Fatal("environment override notice is empty")
+	}
+	if accountOverrideNotice(config.SourceLocal) == "" {
+		t.Fatal("local override notice is empty")
+	}
+}
+
+func TestLinkedAccountListIncludesAccessibleAccounts(t *testing.T) {
+	identity := &generated.Identity{
+		Accounts: []generated.Account{
+			{Id: 1, Name: "Personal", Purpose: "home", Status: "active"},
+			{Id: 2, Name: "Canceled", Purpose: "home", Status: "canceled"},
+			{Id: 3, Name: "Work", Purpose: "work", Status: "inactive"},
+			{Id: 4, Name: "Old home", Purpose: "home", Status: "inactive"},
+		},
+		AllUsers: []generated.User{
+			{Id: 11, AccountId: 1, Contact: generated.Contact{Id: 101, EmailAddress: "jane@example.com"}},
+			{Id: 33, AccountId: 3, Contact: generated.Contact{Id: 303, EmailAddress: "jane@company.example"}},
+		},
+	}
+
+	accounts := linkedAccountList(identity, "3")
+	if len(accounts) != 3 {
+		t.Fatalf("accounts = %#v, want All Accounts and two accessible accounts", accounts)
+	}
+	if accounts[0].ID != config.AllAccounts || accounts[0].Active {
+		t.Errorf("All Accounts row = %#v", accounts[0])
+	}
+	if accounts[1].ID != "1" || accounts[1].Email != "jane@example.com" || accounts[1].Active {
+		t.Errorf("personal row = %#v", accounts[1])
+	}
+	if accounts[2].ID != "3" || accounts[2].Email != "jane@company.example" || !accounts[2].Active {
+		t.Errorf("work row = %#v", accounts[2])
+	}
+}
+
+func TestAccountFlagScopesMailRequests(t *testing.T) {
+	var boxesAccount string
+	server := linkedAccountServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/boxes.json" {
+			boxesAccount = r.URL.Query().Get("filtered_account_id")
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	_, err := runAccountsCLI(t, server, "--account", "2", "boxes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if boxesAccount != "2" {
+		t.Fatalf("boxes account = %q, want 2", boxesAccount)
+	}
+}
+
+func TestPersistedAccountScopesMailRequests(t *testing.T) {
+	var boxesAccount string
+	server := linkedAccountServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/boxes.json" {
+			boxesAccount = r.URL.Query().Get("filtered_account_id")
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		http.NotFound(w, r)
+	})
+	configDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(configDir, "hey-cli"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(configDir, "hey-cli", "config.json"),
+		[]byte(`{"account_id":"2"}`),
+		0600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runAccountsCLIWithConfig(t, server, configDir, "boxes"); err != nil {
+		t.Fatal(err)
+	}
+	if boxesAccount != "2" {
+		t.Fatalf("boxes account = %q, want 2", boxesAccount)
+	}
+}
+
+func TestSelectedAccountUsesMatchingSenderAndUser(t *testing.T) {
+	var messageAccount, contactAccount string
+	var actingSenderID, actingUserID int64
+	server := linkedAccountServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/messages.json":
+			messageAccount = r.URL.Query().Get("filtered_account_id")
+			var body struct {
+				ActingSenderID int64 `json:"acting_sender_id"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			actingSenderID = body.ActingSenderID
+			w.WriteHeader(http.StatusCreated)
+		case "/contacts.json":
+			contactAccount = r.URL.Query().Get("filtered_account_id")
+			var body struct {
+				ActingUserID int64 `json:"acting_user_id"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			actingUserID = body.ActingUserID
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":77,"name":"Jane Doe","email_address":"jane@example.org"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	if _, err := runAccountsCLI(t, server,
+		"--account", "2", "compose",
+		"--to", "jane@example.org", "--subject", "Quarterly planning", "--message", "Agenda attached.",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runAccountsCLI(t, server,
+		"--account", "2", "contacts", "add",
+		"--name", "Jane Doe", "--email", "jane@example.org",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if messageAccount != "2" || actingSenderID != 222 {
+		t.Fatalf("message account/sender = %q/%d, want 2/222", messageAccount, actingSenderID)
+	}
+	if contactAccount != "2" || actingUserID != 22 {
+		t.Fatalf("contact account/user = %q/%d, want 2/22", contactAccount, actingUserID)
+	}
+}
+
+func TestThreadAccountIsRequiredForAccountSensitiveWrites(t *testing.T) {
+	_, err := clientForResourceAccount(t.Context(), 0)
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "api" {
+		t.Fatalf("error = %v, want api error", err)
+	}
+}
+
+func TestUnknownAccountFlagFailsClosed(t *testing.T) {
+	var boxesRequests int
+	server := linkedAccountServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/boxes.json" {
+			boxesRequests++
+		}
+		http.NotFound(w, r)
+	})
+
+	_, err := runAccountsCLI(t, server, "--account", "99", "boxes")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "not_found" {
+		t.Fatalf("error = %v, want not_found", err)
+	}
+	if boxesRequests != 0 {
+		t.Fatalf("boxes requests = %d, want 0", boxesRequests)
+	}
+}
+
+func TestConfigSetDoesNotPersistAccountOverride(t *testing.T) {
+	server := linkedAccountServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	configDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(configDir, "hey-cli"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(configDir, "hey-cli", "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"base_url":"https://old.hey.com","account_id":"1"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := runAccountsCLIWithConfig(t, server, configDir,
+		"--account", "2", "config", "set", "base_url", "https://new.hey.com",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var file map[string]string
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatal(err)
+	}
+	if file["base_url"] != "https://new.hey.com" || file["account_id"] != "1" {
+		t.Fatalf("saved config = %#v", file)
+	}
+}
+
+func TestAccountsUseValidatesAndPersistsDefault(t *testing.T) {
+	server := linkedAccountServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	tmp := t.TempDir()
+
+	_, err := runAccountsCLIWithConfig(t, server, tmp, "accounts", "use", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, "hey-cli", "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var file map[string]any
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatal(err)
+	}
+	if file["account_id"] != "2" {
+		t.Fatalf("saved account = %#v", file["account_id"])
+	}
+}
+
+func TestAccountsUseRejectsUnknownAccountWithoutSaving(t *testing.T) {
+	server := linkedAccountServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	configDir := t.TempDir()
+
+	_, err := runAccountsCLIWithConfig(t, server, configDir, "accounts", "use", "99")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "not_found" {
+		t.Fatalf("error = %v, want not_found", err)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "hey-cli", "config.json")); !os.IsNotExist(err) {
+		t.Fatalf("config was saved for unavailable account: %v", err)
+	}
+}
+
+func linkedAccountServer(t *testing.T, fallback http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/identity.json" {
+			if got := r.URL.Query().Get("filtered_account_id"); got != "" {
+				t.Errorf("identity validation account = %q, want unscoped", got)
+			}
+			_, _ = w.Write([]byte(`{
+				"id":1,
+				"accounts":[
+					{"id":1,"name":"Personal","purpose":"home","status":"active"},
+					{"id":2,"name":"Work","purpose":"work","status":"active"}
+				],
+				"all_users":[
+					{"id":11,"account_id":1,"contact":{"id":101,"email_address":"jane@example.com"}},
+					{"id":22,"account_id":2,"contact":{"id":202,"email_address":"jane@company.example"}}
+				],
+				"senders":[
+					{"id":111,"account_id":1,"default":true},
+					{"id":222,"account_id":2}
+				]
+			}`))
+			return
+		}
+		fallback(w, r)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func runAccountsCLI(t *testing.T, server *httptest.Server, args ...string) (string, error) {
+	t.Helper()
+	return runAccountsCLIWithConfig(t, server, t.TempDir(), args...)
+}
+
+func runAccountsCLIWithConfig(t *testing.T, server *httptest.Server, configDir string, args ...string) (string, error) {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("HEY_ACCOUNT_ID", "")
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	previousAccountFlag := accountFlag
+	accountFlag = ""
+	t.Cleanup(func() { accountFlag = previousAccountFlag })
+
+	root := newRootCmd()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	root.SetArgs(append([]string{"--json", "--base-url", server.URL}, args...))
+	err := root.Execute()
+	return output.String(), err
+}

--- a/internal/cmd/attachment_upload.go
+++ b/internal/cmd/attachment_upload.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
@@ -31,6 +33,10 @@ type preparedAttachment struct {
 }
 
 func attachFiles(ctx context.Context, content string, paths []string) (string, error) {
+	return attachFilesWithClient(ctx, sdk, content, paths)
+}
+
+func attachFilesWithClient(ctx context.Context, client *hey.Client, content string, paths []string) (string, error) {
 	if len(paths) == 0 {
 		return content, nil
 	}
@@ -40,13 +46,17 @@ func attachFiles(ctx context.Context, content string, paths []string) (string, e
 		return "", err
 	}
 	defer closePreparedAttachments(attachments)
-	return attachPreparedFiles(ctx, content, attachments)
+	return attachPreparedFilesWithClient(ctx, client, content, attachments)
 }
 
 func attachPreparedFiles(ctx context.Context, content string, attachments []preparedAttachment) (string, error) {
+	return attachPreparedFilesWithClient(ctx, sdk, content, attachments)
+}
+
+func attachPreparedFilesWithClient(ctx context.Context, client *hey.Client, content string, attachments []preparedAttachment) (string, error) {
 	uploads := make([]uploadedAttachment, 0, len(attachments))
 	for _, attachment := range attachments {
-		upload, err := uploadAttachment(ctx, attachment)
+		upload, err := uploadAttachment(ctx, client, attachment)
 		if err != nil {
 			return "", err
 		}
@@ -106,8 +116,8 @@ func closePreparedAttachments(attachments []preparedAttachment) {
 	}
 }
 
-func uploadAttachment(ctx context.Context, attachment preparedAttachment) (uploadedAttachment, error) {
-	upload, err := sdk.Attachments().Upload(ctx, attachment.filename, attachment.contentType, attachment.file)
+func uploadAttachment(ctx context.Context, client *hey.Client, attachment preparedAttachment) (uploadedAttachment, error) {
+	upload, err := client.Attachments().Upload(ctx, attachment.filename, attachment.contentType, attachment.file)
 	if err != nil {
 		return uploadedAttachment{}, convertSDKError(err)
 	}

--- a/internal/cmd/attachments_test.go
+++ b/internal/cmd/attachments_test.go
@@ -20,6 +20,7 @@ type attachmentServerState struct {
 	mu             sync.Mutex
 	directUploads  int
 	storageUploads int
+	uploadAccounts []string
 	sentContents   []string
 	events         []string
 	blobStatus     int
@@ -66,6 +67,7 @@ func attachmentServer(t *testing.T) (*httptest.Server, *attachmentServerState) {
 		case r.Method == http.MethodPost && r.URL.Path == "/rails/active_storage/direct_uploads.json":
 			state.mu.Lock()
 			state.directUploads++
+			state.uploadAccounts = append(state.uploadAccounts, r.URL.Query().Get("filtered_account_id"))
 			state.events = append(state.events, "reserve")
 			state.mu.Unlock()
 			_, _ = fmt.Fprintf(w, `{
@@ -80,14 +82,19 @@ func attachmentServer(t *testing.T) (*httptest.Server, *attachmentServerState) {
 			state.mu.Unlock()
 			w.WriteHeader(http.StatusNoContent)
 		case r.Method == http.MethodGet && r.URL.Path == "/identity.json":
-			_, _ = w.Write([]byte(`{"id":1,"senders":[{"id":42,"default":true}]}`))
+			if got := r.URL.Query().Get("filtered_account_id"); got != "" {
+				t.Errorf("identity account = %q, want unscoped", got)
+			}
+			_, _ = w.Write([]byte(`{"id":1,"accounts":[{"id":9,"status":"active"}],"senders":[{"id":42,"account_id":9,"default":true}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/topics/7.json":
+			_, _ = w.Write([]byte(`{"id":7,"account_id":9,"entries":[{"id":11},{"id":12}]}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/topics/7":
 			w.Header().Set("Content-Type", "text/html")
 			_, _ = w.Write([]byte(topicWithRecipients))
-		case r.Method == http.MethodGet && r.URL.Path == "/topics/7/entries":
-			w.Header().Set("Content-Type", "text/html")
-			_, _ = w.Write([]byte(topicEntries))
 		case r.Method == http.MethodPost && r.URL.Path == "/entries/12/replies.json":
+			if got := r.URL.Query().Get("filtered_account_id"); got != "9" {
+				t.Errorf("reply account = %q, want 9", got)
+			}
 			var body struct {
 				Message struct {
 					Content string `json:"content"`
@@ -328,6 +335,9 @@ func TestReplyUploadsAttachmentsBeforeSending(t *testing.T) {
 	defer state.mu.Unlock()
 	if strings.Join(state.events, ",") != "reserve,upload,send" || len(state.sentContents) != 1 || !strings.Contains(state.sentContents[0], `sgid="sgid-upload"`) {
 		t.Errorf("reply attachment state = %+v", state)
+	}
+	if len(state.uploadAccounts) != 1 || state.uploadAccounts[0] != "9" {
+		t.Errorf("reply upload accounts = %v, want [9]", state.uploadAccounts)
 	}
 }
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -127,8 +127,10 @@ func newAuthStatusCommand() *cobra.Command {
 		Short: "Show authentication status",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			status := map[string]any{
-				"base_url":      cfg.BaseURL,
-				"authenticated": false,
+				"base_url":       cfg.BaseURL,
+				"mail_account":   cfg.AccountID,
+				"account_source": cfg.SourceOf("account_id"),
+				"authenticated":  false,
 			}
 
 			if os.Getenv("HEY_TOKEN") != "" {
@@ -138,6 +140,7 @@ func newAuthStatusCommand() *cobra.Command {
 				if writer.IsStyled() {
 					w := cmd.OutOrStdout()
 					fmt.Fprintf(w, "Base URL:  %s\n", cfg.BaseURL)
+					fmt.Fprintf(w, "Mail:      %s (%s)\n", cfg.AccountID, cfg.SourceOf("account_id"))
 					fmt.Fprintln(w, "Status:    Logged in (via HEY_TOKEN env var)")
 					return nil
 				}
@@ -150,6 +153,7 @@ func newAuthStatusCommand() *cobra.Command {
 				if writer.IsStyled() {
 					w := cmd.OutOrStdout()
 					fmt.Fprintf(w, "Base URL:  %s\n", cfg.BaseURL)
+					fmt.Fprintf(w, "Mail:      %s (%s)\n", cfg.AccountID, cfg.SourceOf("account_id"))
 					fmt.Fprintln(w, "Status:    Not logged in")
 					return nil
 				}
@@ -183,6 +187,7 @@ func newAuthStatusCommand() *cobra.Command {
 			if writer.IsStyled() {
 				w := cmd.OutOrStdout()
 				fmt.Fprintf(w, "Base URL:  %s\n", cfg.BaseURL)
+				fmt.Fprintf(w, "Mail:      %s (%s)\n", cfg.AccountID, cfg.SourceOf("account_id"))
 				fmt.Fprintln(w, "Status:    Logged in")
 
 				if creds.OAuthType != "" {

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -91,10 +91,7 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		if resolveErr != nil {
 			return resolveErr
 		}
-		replySDK, resolveErr := clientForResourceAccount(ctx, target.AccountID)
-		if resolveErr != nil {
-			return resolveErr
-		}
+		replySDK := target.client
 		messageWithAttachments, attachErr := attachFilesWithClient(ctx, replySDK, message, c.attachments)
 		if attachErr != nil {
 			return attachErr

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -91,11 +91,15 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		if resolveErr != nil {
 			return resolveErr
 		}
-		messageWithAttachments, attachErr := attachFiles(ctx, message, c.attachments)
+		replySDK, resolveErr := clientForResourceAccount(ctx, target.AccountID)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		messageWithAttachments, attachErr := attachFilesWithClient(ctx, replySDK, message, c.attachments)
 		if attachErr != nil {
 			return attachErr
 		}
-		if err := sdk.Entries().CreateReply(ctx, target.EntryID, messageWithAttachments,
+		if err := replySDK.Entries().CreateReply(ctx, target.EntryID, messageWithAttachments,
 			target.Addressed.To, target.Addressed.CC, target.Addressed.BCC); err != nil {
 			return convertSDKError(err)
 		}

--- a/internal/cmd/compose_test.go
+++ b/internal/cmd/compose_test.go
@@ -85,6 +85,9 @@ func TestComposeSubjectRequiredOnlyForANewMessage(t *testing.T) {
 	if !strings.Contains(sent.Content, "the reply body") {
 		t.Errorf("content = %q", sent.Content)
 	}
+	if sent.ActingSenderID != 42 {
+		t.Errorf("acting sender = %d, want thread account sender 42", sent.ActingSenderID)
+	}
 	if len(sent.To) != 1 || sent.To[0] != "jane@example.com" {
 		t.Errorf("to = %v, want the thread's recipients", sent.To)
 	}

--- a/internal/cmd/compose_test.go
+++ b/internal/cmd/compose_test.go
@@ -76,7 +76,7 @@ func TestComposeSubjectRequiredOnlyForANewMessage(t *testing.T) {
 
 	// And the reply goes all the way out: --thread-id used to post a message to the
 	// topic, and now answers the thread's last entry with that entry's recipients.
-	if err := runCLI(t, server, "compose", "--thread-id", "7", "-m", "the reply body"); err != nil {
+	if err := runCLI(t, server, "--account", "8", "compose", "--thread-id", "7", "-m", "the reply body"); err != nil {
 		t.Fatalf("a reply should not need a subject, got %v", err)
 	}
 	if !strings.Contains(sent.Path, "/entries/12/replies") {
@@ -84,6 +84,12 @@ func TestComposeSubjectRequiredOnlyForANewMessage(t *testing.T) {
 	}
 	if !strings.Contains(sent.Content, "the reply body") {
 		t.Errorf("content = %q", sent.Content)
+	}
+	if sent.TopicAccountFilter != "" {
+		t.Errorf("topic account filter = %q, want unscoped discovery", sent.TopicAccountFilter)
+	}
+	if sent.HTMLAccountFilter != "9" {
+		t.Errorf("topic HTML account filter = %q, want thread account 9", sent.HTMLAccountFilter)
 	}
 	if sent.ActingSenderID != 42 {
 		t.Errorf("acting sender = %d, want thread account sender 42", sent.ActingSenderID)

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -44,7 +44,7 @@ func newConfigSetCommand() *cobra.Command {
 				return output.ErrUsage(fmt.Sprintf("unknown config key: %s (available: base_url)", key))
 			}
 
-			if err := cfg.Save(); err != nil {
+			if err := cfg.SaveBaseURL(cfg.BaseURL); err != nil {
 				return err
 			}
 
@@ -69,6 +69,11 @@ func newConfigShowCommand() *cobra.Command {
 					"key":    "base_url",
 					"value":  cfg.BaseURL,
 					"source": string(cfg.SourceOf("base_url")),
+				},
+				{
+					"key":    "account_id",
+					"value":  cfg.AccountID,
+					"source": string(cfg.SourceOf("account_id")),
 				},
 			}
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/basecamp/hey-cli/internal/config"
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
@@ -21,6 +22,9 @@ func newConfigCommand() *configCommand {
 
 	configCommand.cmd.AddCommand(newConfigShowCommand())
 	configCommand.cmd.AddCommand(newConfigSetCommand())
+	configCommand.cmd.AddCommand(newConfigTrustLocalCommand())
+	configCommand.cmd.AddCommand(newConfigUntrustLocalCommand())
+	configCommand.cmd.AddCommand(newConfigTrustedLocalsCommand())
 
 	return configCommand
 }
@@ -59,11 +63,88 @@ func newConfigSetCommand() *cobra.Command {
 	}
 }
 
+func newConfigTrustLocalCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "trust-local",
+		Short: "Trust this repository's local HEY settings",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			local := cfg.LocalConfig()
+			if local == nil {
+				return output.ErrUsage("no local .hey/config.json with a server or account setting was found")
+			}
+			if err := cfg.TrustLocalConfig(); err != nil {
+				return err
+			}
+			if writer.IsStyled() {
+				fmt.Fprintf(cmd.OutOrStdout(), "Trusted local HEY configuration: %s\n", terminalSafeText(local.Path))
+				return nil
+			}
+			return writeOK(cfg.LocalConfig(), output.WithSummary("Trusted local HEY configuration"))
+		},
+	}
+}
+
+func newConfigUntrustLocalCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "untrust-local",
+		Short: "Remove trust for this repository's local HEY settings",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			local := cfg.LocalConfig()
+			if local == nil {
+				return output.ErrUsage("no local .hey/config.json with a server or account setting was found")
+			}
+			if err := cfg.UntrustLocalConfig(); err != nil {
+				return err
+			}
+			if writer.IsStyled() {
+				fmt.Fprintf(cmd.OutOrStdout(), "Removed trust for local HEY configuration: %s\n", terminalSafeText(local.Path))
+				return nil
+			}
+			return writeOK(cfg.LocalConfig(), output.WithSummary("Removed trust for local HEY configuration"))
+		},
+	}
+}
+
+func newConfigTrustedLocalsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "trusted-locals",
+		Short: "List trusted repository-local HEY settings",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			trusted, err := config.TrustedLocalConfigs()
+			if err != nil {
+				return err
+			}
+			if writer.IsStyled() {
+				table := newTable(cmd.OutOrStdout())
+				table.addRow([]string{"Configuration", "Server", "Account", "Digest"})
+				for _, local := range trusted {
+					digest := local.Digest
+					if len(digest) > 12 {
+						digest = digest[:12]
+					}
+					table.addRow([]string{
+						terminalSafeText(local.Path),
+						terminalSafeText(local.ServerOrigin),
+						terminalSafeText(local.AccountID),
+						terminalSafeText(digest),
+					})
+				}
+				table.print()
+				return nil
+			}
+			return writeOK(trusted, output.WithSummary(fmt.Sprintf("%d trusted local configurations", len(trusted))))
+		},
+	}
+}
+
 func newConfigShowCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show",
 		Short: "Show current configuration with sources",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			entries := []map[string]string{
 				{
 					"key":    "base_url",
@@ -75,6 +156,17 @@ func newConfigShowCommand() *cobra.Command {
 					"value":  cfg.AccountID,
 					"source": string(cfg.SourceOf("account_id")),
 				},
+			}
+			if local := cfg.LocalConfig(); local != nil {
+				trust := "untrusted"
+				if local.Trusted {
+					trust = "trusted"
+				}
+				entries = append(entries, map[string]string{
+					"key":    "local_config_trust",
+					"value":  trust,
+					"source": "local",
+				})
 			}
 
 			if writer.IsStyled() {

--- a/internal/cmd/forward.go
+++ b/internal/cmd/forward.go
@@ -58,7 +58,7 @@ func (c *forwardCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := cmd.Context()
-	topic, err := sdk.Topics().Get(ctx, threadID)
+	topic, err := rootSDK.Topics().Get(ctx, threadID)
 	if err != nil {
 		return convertSDKError(err)
 	}

--- a/internal/cmd/forward.go
+++ b/internal/cmd/forward.go
@@ -65,9 +65,13 @@ func (c *forwardCommand) run(cmd *cobra.Command, args []string) error {
 	if topic == nil || len(topic.Entries) == 0 {
 		return output.ErrNotFound("entries for thread", args[0])
 	}
+	forwardSDK, err := clientForResourceAccount(ctx, topic.AccountId)
+	if err != nil {
+		return err
+	}
 	entryID := topic.Entries[len(topic.Entries)-1].Id
 
-	draft, err := sdk.Entries().NewForward(ctx, entryID)
+	draft, err := forwardSDK.Entries().NewForward(ctx, entryID)
 	if err != nil {
 		return convertSDKError(err)
 	}
@@ -76,7 +80,7 @@ func (c *forwardCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	content := htmlutil.PrependText(draft.Content, c.message)
-	if err := sdk.Messages().Create(ctx, draft.Subject, content, to, cc, bcc); err != nil {
+	if err := forwardSDK.Messages().Create(ctx, draft.Subject, content, to, cc, bcc); err != nil {
 		return convertSDKError(err)
 	}
 

--- a/internal/cmd/forward_test.go
+++ b/internal/cmd/forward_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 type sentForward struct {
-	Requests []string
-	Subject  string
-	Content  string
-	To       []string
-	CC       []string
-	BCC      []string
+	Requests       []string
+	ActingSenderID int64
+	Subject        string
+	Content        string
+	To             []string
+	CC             []string
+	BCC            []string
 }
 
 func forwardServer(t *testing.T, entriesJSON string) (*httptest.Server, *sentForward) {
@@ -29,14 +30,24 @@ func forwardServer(t *testing.T, entriesJSON string) (*httptest.Server, *sentFor
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/topics/7.json":
-			fmt.Fprintf(w, `{"id":7,"name":"Quarterly planning","entries":%s}`, entriesJSON)
+			fmt.Fprintf(w, `{"id":7,"account_id":9,"name":"Quarterly planning","entries":%s}`, entriesJSON)
 		case "/entries/12/forwards/new.json":
+			if got := r.URL.Query().Get("filtered_account_id"); got != "9" {
+				t.Errorf("forward draft account = %q, want 9", got)
+			}
 			fmt.Fprint(w, `{"subject":"Fwd: Quarterly planning","content":"<div>Quoted message</div>"}`)
 		case "/identity.json":
-			fmt.Fprint(w, `{"id":1,"senders":[{"id":42,"default":true}]}`)
+			if got := r.URL.Query().Get("filtered_account_id"); got != "" {
+				t.Errorf("identity account = %q, want unscoped", got)
+			}
+			fmt.Fprint(w, `{"id":1,"accounts":[{"id":9,"status":"active"}],"senders":[{"id":42,"account_id":9,"default":true}]}`)
 		case "/messages.json":
+			if got := r.URL.Query().Get("filtered_account_id"); got != "9" {
+				t.Errorf("forward message account = %q, want 9", got)
+			}
 			var body struct {
-				Message struct {
+				ActingSenderID int64 `json:"acting_sender_id"`
+				Message        struct {
 					Subject string `json:"subject"`
 					Content string `json:"content"`
 				} `json:"message"`
@@ -49,6 +60,7 @@ func forwardServer(t *testing.T, entriesJSON string) (*httptest.Server, *sentFor
 				} `json:"entry"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&body)
+			sent.ActingSenderID = body.ActingSenderID
 			sent.Subject = body.Message.Subject
 			sent.Content = body.Message.Content
 			sent.To = body.Entry.Addressed.Directly
@@ -79,12 +91,15 @@ func TestForwardSendsLatestEntryDraft(t *testing.T) {
 
 	wantRequests := []string{
 		"GET /topics/7.json",
-		"GET /entries/12/forwards/new.json",
 		"GET /identity.json",
+		"GET /entries/12/forwards/new.json",
 		"POST /messages.json",
 	}
 	if strings.Join(sent.Requests, ",") != strings.Join(wantRequests, ",") {
 		t.Errorf("requests = %v, want %v", sent.Requests, wantRequests)
+	}
+	if sent.ActingSenderID != 42 {
+		t.Errorf("acting sender = %d, want thread account sender 42", sent.ActingSenderID)
 	}
 	if sent.Subject != "Fwd: Quarterly planning" {
 		t.Errorf("subject = %q", sent.Subject)

--- a/internal/cmd/forward_test.go
+++ b/internal/cmd/forward_test.go
@@ -30,6 +30,9 @@ func forwardServer(t *testing.T, entriesJSON string) (*httptest.Server, *sentFor
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/topics/7.json":
+			if got := r.URL.Query().Get("filtered_account_id"); got != "" {
+				t.Errorf("topic account = %q, want unscoped discovery", got)
+			}
 			fmt.Fprintf(w, `{"id":7,"account_id":9,"name":"Quarterly planning","entries":%s}`, entriesJSON)
 		case "/entries/12/forwards/new.json":
 			if got := r.URL.Query().Get("filtered_account_id"); got != "9" {
@@ -40,7 +43,7 @@ func forwardServer(t *testing.T, entriesJSON string) (*httptest.Server, *sentFor
 			if got := r.URL.Query().Get("filtered_account_id"); got != "" {
 				t.Errorf("identity account = %q, want unscoped", got)
 			}
-			fmt.Fprint(w, `{"id":1,"accounts":[{"id":9,"status":"active"}],"senders":[{"id":42,"account_id":9,"default":true}]}`)
+			fmt.Fprint(w, `{"id":1,"accounts":[{"id":8,"status":"active"},{"id":9,"status":"active"}],"senders":[{"id":42,"account_id":9,"default":true}]}`)
 		case "/messages.json":
 			if got := r.URL.Query().Get("filtered_account_id"); got != "9" {
 				t.Errorf("forward message account = %q, want 9", got)
@@ -79,7 +82,7 @@ func forwardServer(t *testing.T, entriesJSON string) (*httptest.Server, *sentFor
 func TestForwardSendsLatestEntryDraft(t *testing.T) {
 	server, sent := forwardServer(t, `[{"id":11},{"id":12}]`)
 
-	err := runCLI(t, server, "forward", "7",
+	err := runCLI(t, server, "--account", "8", "forward", "7",
 		"--to", "alice@example.com",
 		"--cc", "bob@example.org",
 		"--bcc", "carol@example.com",
@@ -90,6 +93,7 @@ func TestForwardSendsLatestEntryDraft(t *testing.T) {
 	}
 
 	wantRequests := []string{
+		"GET /identity.json",
 		"GET /topics/7.json",
 		"GET /identity.json",
 		"GET /entries/12/forwards/new.json",

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -25,7 +25,7 @@ var curatedCategories = []struct {
 	},
 	{
 		heading: "AUTH & CONFIG",
-		names:   []string{"auth", "config", "setup", "doctor"},
+		names:   []string{"auth", "accounts", "config", "setup", "doctor"},
 	},
 }
 
@@ -102,6 +102,7 @@ func renderRootHelp(w io.Writer, cmd *cobra.Command) {
 		desc  string
 	}
 	flags := []flagEntry{
+		{"", "--account", "Select a linked mail account ID or all"},
 		{"", "--json", "Output JSON with metadata"},
 		{"", "--markdown", "Output as Markdown"},
 		{"", "--quiet", "Output result data only"},
@@ -244,6 +245,7 @@ func renderCommandHelp(cmd *cobra.Command) {
 // salientRootFlags is the curated set of root-level global flags shown in
 // INHERITED FLAGS for subcommands.
 var salientRootFlags = map[string]bool{
+	"account":  true,
 	"json":     true,
 	"markdown": true,
 	"quiet":    true,

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -120,12 +120,14 @@ CALENDAR & TASKS
   journal     Read and write journal entries
 
 AUTH & CONFIG
-  auth    Sign in, sign out, and check login status
-  config  View and change settings
-  setup   Set up HEY for first use
-  doctor  Find login and configuration problems
+  auth      Sign in, sign out, and check login status
+  accounts  List and select linked mail accounts
+  config    View and change settings
+  setup     Set up HEY for first use
+  doctor    Find login and configuration problems
 
 FLAGS
+      --account    Select a linked mail account ID or all
       --json       Output JSON with metadata
       --markdown   Output as Markdown
       --quiet      Output result data only

--- a/internal/cmd/local_config_trust.go
+++ b/internal/cmd/local_config_trust.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/config"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type localConfigTrustChoice int
+
+const (
+	localConfigTrustCancel localConfigTrustChoice = iota
+	localConfigTrustOnce
+	localConfigTrustAlways
+)
+
+var askLocalConfigTrust = promptForLocalConfigTrust
+
+func ensureLocalConfigTrusted(cmd *cobra.Command) error {
+	local := cfg.UntrustedLocalConfig()
+	if local == nil || !commandUsesRuntimeConfig(cmd) {
+		return nil
+	}
+	if machineReadableOutput() || !stdinIsTerminal() || !stdoutIsTerminal() {
+		return untrustedLocalConfigError(local)
+	}
+
+	choice, err := askLocalConfigTrust(cmd, local)
+	if err != nil {
+		return err
+	}
+	switch choice {
+	case localConfigTrustOnce:
+		return nil
+	case localConfigTrustAlways:
+		if err := cfg.TrustLocalConfig(); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return untrustedLocalConfigError(local)
+	}
+}
+
+func commandUsesRuntimeConfig(cmd *cobra.Command) bool {
+	parts := strings.Fields(cmd.CommandPath())
+	if len(parts) < 2 {
+		return true
+	}
+	switch parts[1] {
+	case "commands", "completion", "config", "skill":
+		return false
+	default:
+		return true
+	}
+}
+
+func machineReadableOutput() bool {
+	return jsonFlag || quietFlag || idsOnly || countFlag || markdownF || agentFlag
+}
+
+func promptForLocalConfigTrust(cmd *cobra.Command, local *config.LocalConfig) (localConfigTrustChoice, error) {
+	w := cmd.ErrOrStderr()
+	fmt.Fprintln(w, "This repository contains local HEY configuration:")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  Configuration:       %s\n", terminalSafeText(local.Path))
+	fmt.Fprintf(w, "  Local server:        %s\n", localTrustDisplayValue(local.BaseURL))
+	fmt.Fprintf(w, "  Local mail account:  %s\n", localTrustDisplayValue(local.AccountID))
+	fmt.Fprintf(w, "  Effective server:    %s\n", terminalSafeText(cfg.BaseURL))
+	fmt.Fprintf(w, "  Effective account:   %s\n", terminalSafeText(cfg.AccountID))
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Always trust approves the exact local values above for this effective server origin.")
+	fmt.Fprintln(w, "Commands run here may send credentials to that server and read or send mail using that account.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  [1] Use once")
+	fmt.Fprintln(w, "  [2] Always trust these settings")
+	fmt.Fprintln(w, "  [3] Cancel")
+	fmt.Fprint(w, "Selection [3]: ")
+
+	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && strings.TrimSpace(line) == "" {
+		return localConfigTrustCancel, fmt.Errorf("could not read local configuration trust choice: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "1", "once", "use once":
+		return localConfigTrustOnce, nil
+	case "2", "always", "trust", "always trust":
+		return localConfigTrustAlways, nil
+	default:
+		return localConfigTrustCancel, nil
+	}
+}
+
+func localTrustDisplayValue(value string) string {
+	if value == "" {
+		return "(not set)"
+	}
+	return terminalSafeText(value)
+}
+
+func untrustedLocalConfigError(local *config.LocalConfig) error {
+	path := terminalSafeText(local.Path)
+	return output.ErrUsageHint(
+		fmt.Sprintf("local HEY configuration is not trusted: %s", path),
+		"Review it, then run `hey config trust-local` from that directory.",
+	)
+}

--- a/internal/cmd/local_config_trust_test.go
+++ b/internal/cmd/local_config_trust_test.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/config"
+)
+
+func TestUntrustedLocalConfigFailsBeforeNetworkRequest(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1}`))
+	}))
+	t.Cleanup(server.Close)
+	setupLocalTrustTest(t, server.URL, "all")
+
+	err := runLocalTrustCLI(t, "--json", "boxes")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || !strings.Contains(cliErr.Message, "not trusted") {
+		t.Fatalf("error = %v, want untrusted local config", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestTrustLocalAllowsRequestsAndChangesRequireTrustAgain(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/identity.json":
+			_, _ = w.Write([]byte(`{"id":1,"accounts":[{"id":2,"status":"active"}]}`))
+		case "/boxes.json":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	path := setupLocalTrustTest(t, server.URL, "2")
+
+	if err := runLocalTrustCLI(t, "--json", "config", "trust-local"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runLocalTrustCLI(t, "--json", "boxes"); err != nil {
+		t.Fatal(err)
+	}
+	if requests == 0 {
+		t.Fatal("trusted local config made no request")
+	}
+	if err := runLocalTrustCLI(t, "--json", "config", "untrust-local"); err != nil {
+		t.Fatal(err)
+	}
+	requests = 0
+	if err := runLocalTrustCLI(t, "--json", "boxes"); err == nil {
+		t.Fatal("untrusted local config was used after trust removal")
+	}
+	if requests != 0 {
+		t.Fatalf("requests after trust removal = %d, want 0", requests)
+	}
+	if err := runLocalTrustCLI(t, "--json", "config", "trust-local"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(path, []byte(`{"base_url":"`+server.URL+`","account_id":"all"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	requests = 0
+	err := runLocalTrustCLI(t, "--json", "boxes")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || !strings.Contains(cliErr.Message, "not trusted") {
+		t.Fatalf("changed config error = %v, want untrusted", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests after local change = %d, want 0", requests)
+	}
+}
+
+func TestPromptForLocalConfigTrustChoices(t *testing.T) {
+	previousCfg := cfg
+	cfg = &config.Config{BaseURL: "https://app.hey.com", AccountID: "42"}
+	t.Cleanup(func() { cfg = previousCfg })
+
+	for _, test := range []struct {
+		input string
+		want  localConfigTrustChoice
+	}{
+		{"1\n", localConfigTrustOnce},
+		{"2\n", localConfigTrustAlways},
+		{"\n", localConfigTrustCancel},
+	} {
+		cmd := newRootCmd()
+		cmd.SetIn(strings.NewReader(test.input))
+		var output bytes.Buffer
+		cmd.SetErr(&output)
+		choice, err := promptForLocalConfigTrust(cmd, &config.LocalConfig{
+			Path:      "/workspace/.hey/config.json",
+			BaseURL:   "https://app.hey.com",
+			AccountID: "99",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if choice != test.want {
+			t.Errorf("choice for %q = %d, want %d", test.input, choice, test.want)
+		}
+		if !strings.Contains(output.String(), "/workspace/.hey/config.json") ||
+			!strings.Contains(output.String(), "Local mail account:  99") ||
+			!strings.Contains(output.String(), "Effective account:   42") {
+			t.Errorf("prompt omitted local or effective values: %q", output.String())
+		}
+	}
+}
+
+func setupLocalTrustTest(t *testing.T, baseURL, accountID string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmp, "state"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, "cache"))
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("HEY_ACCOUNT_ID", "")
+	workspace := filepath.Join(tmp, "workspace")
+	localDir := filepath.Join(workspace, ".hey")
+	if err := os.MkdirAll(localDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(workspace)
+	path := filepath.Join(localDir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"base_url":"`+baseURL+`","account_id":"`+accountID+`"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func runLocalTrustCLI(t *testing.T, args ...string) error {
+	t.Helper()
+	resetRootFlagsForTrustTest(t)
+	root := newRootCmd()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	root.SetArgs(args)
+	return root.Execute()
+}
+
+func resetRootFlagsForTrustTest(t *testing.T) {
+	t.Helper()
+	previousJSON := jsonFlag
+	previousAccount := accountFlag
+	previousBaseURL := baseURL
+	jsonFlag = false
+	accountFlag = ""
+	baseURL = ""
+	t.Cleanup(func() {
+		jsonFlag = previousJSON
+		accountFlag = previousAccount
+		baseURL = previousBaseURL
+	})
+}

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -53,10 +53,7 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	replySDK, err := clientForResourceAccount(ctx, target.AccountID)
-	if err != nil {
-		return err
-	}
+	replySDK := target.client
 
 	message := c.message
 	if message == "" && !stdinIsTerminal() {

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -53,6 +53,10 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	replySDK, err := clientForResourceAccount(ctx, target.AccountID)
+	if err != nil {
+		return err
+	}
 
 	message := c.message
 	if message == "" && !stdinIsTerminal() {
@@ -73,11 +77,11 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	message, err = attachFiles(ctx, message, c.attachments)
+	message, err = attachFilesWithClient(ctx, replySDK, message, c.attachments)
 	if err != nil {
 		return err
 	}
-	if err = sdk.Entries().CreateReply(ctx, target.EntryID, message, target.Addressed.To, target.Addressed.CC, target.Addressed.BCC); err != nil {
+	if err = replySDK.Entries().CreateReply(ctx, target.EntryID, message, target.Addressed.To, target.Addressed.CC, target.Addressed.BCC); err != nil {
 		return convertSDKError(err)
 	}
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -77,6 +77,10 @@ func newRootCmd() *cobra.Command {
 				}
 			}
 
+			if err := ensureLocalConfigTrusted(cmd); err != nil {
+				return err
+			}
+
 			if os.Getenv("HEY_DEBUG") != "" && verboseFlag == 0 {
 				verboseFlag = 1
 			}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -31,6 +31,7 @@ var (
 	statsFlag   bool
 	verboseFlag int
 	baseURL     string
+	accountFlag string
 	cfg         *config.Config
 	authMgr     *auth.Manager
 	writer      *output.Writer
@@ -70,6 +71,11 @@ func newRootCmd() *cobra.Command {
 					return err
 				}
 			}
+			if accountFlag != "" {
+				if err := cfg.SetFromFlag("account_id", accountFlag); err != nil {
+					return err
+				}
+			}
 
 			if os.Getenv("HEY_DEBUG") != "" && verboseFlag == 0 {
 				verboseFlag = 1
@@ -81,6 +87,12 @@ func newRootCmd() *cobra.Command {
 			initSDK(authMgr, cfg.BaseURL)
 
 			migrateOldCredentials(configDir)
+
+			if authMgr.IsAuthenticated() && commandUsesAccountScope(cmd) {
+				if err := selectConfiguredAccount(cmd.Context()); err != nil {
+					return err
+				}
+			}
 
 			return nil
 		},
@@ -107,6 +119,7 @@ func newRootCmd() *cobra.Command {
 	root.PersistentFlags().BoolVar(&agentFlag, "agent", false, "Agent mode (JSON envelope, no TTY formatting)")
 	root.PersistentFlags().MarkHidden("agent") //nolint:errcheck,gosec // flag exists
 	root.PersistentFlags().StringVar(&baseURL, "base-url", "", "Override server URL")
+	root.PersistentFlags().StringVar(&accountFlag, "account", "", "Select a linked mail account ID or all")
 	root.PersistentFlags().CountVarP(&verboseFlag, "verbose", "v", "Show request details")
 	root.PersistentFlags().BoolVar(&statsFlag, "stats", false, "Include request stats in response meta")
 
@@ -117,6 +130,7 @@ func newRootCmd() *cobra.Command {
 	root.SetHelpFunc(customHelpFunc(root.HelpFunc()))
 
 	root.AddCommand(newAuthCommand().cmd)
+	root.AddCommand(newAccountsCommand().cmd)
 	root.AddCommand(newBoxesCommand().cmd)
 	root.AddCommand(newBoxCommand().cmd)
 	root.AddCommand(newSearchCommand().cmd)
@@ -150,6 +164,19 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newConfigCommand().cmd)
 
 	return root
+}
+
+func commandUsesAccountScope(cmd *cobra.Command) bool {
+	parts := strings.Fields(cmd.CommandPath())
+	if len(parts) < 2 {
+		return true
+	}
+	switch parts[1] {
+	case "accounts", "auth", "commands", "completion", "config", "doctor", "setup", "skill":
+		return false
+	default:
+		return true
+	}
 }
 
 func Execute() {
@@ -214,7 +241,7 @@ func migrateOldCredentials(_ string) {
 		return
 	}
 
-	if err := cfg.Save(); err != nil {
+	if err := cfg.SaveBaseURL(old.BaseURL); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not update config after migration: %v\n", err)
 	}
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -103,7 +103,7 @@ func newRootCmd() *cobra.Command {
 			if err := requireAuth(); err != nil {
 				return err
 			}
-			return tui.Run(sdk)
+			return tui.Run(rootSDK, sdk, cfg.AccountID)
 		},
 	}
 

--- a/internal/cmd/sdk.go
+++ b/internal/cmd/sdk.go
@@ -16,11 +16,15 @@ import (
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/auth"
+	"github.com/basecamp/hey-cli/internal/config"
 	"github.com/basecamp/hey-cli/internal/output"
 	"github.com/basecamp/hey-cli/internal/version"
 )
 
-var sdk *hey.Client
+var (
+	rootSDK *hey.Client
+	sdk     *hey.Client
+)
 
 // cliAuthStrategy bridges the CLI's auth.Manager to the SDK's AuthStrategy interface.
 // This preserves session cookie support (which the SDK's BearerAuth doesn't have).
@@ -74,7 +78,44 @@ func initSDK(authMgr *auth.Manager, baseURL string) {
 	sdkStats = &statsHooks{}
 	opts = append(opts, hey.WithHooks(sdkStats))
 
-	sdk = hey.NewClient(sdkCfg, nil, opts...)
+	rootSDK = hey.NewClient(sdkCfg, nil, opts...)
+	sdk = rootSDK
+}
+
+func selectConfiguredAccount(ctx context.Context) error {
+	client, err := clientForAccountSelection(ctx, rootSDK, cfg.AccountID)
+	if err != nil {
+		return err
+	}
+	sdk = client
+	return nil
+}
+
+func clientForAccountSelection(ctx context.Context, client *hey.Client, accountID string) (*hey.Client, error) {
+	if accountID == "" || accountID == config.AllAccounts {
+		return client, nil
+	}
+
+	id, err := strconv.ParseInt(accountID, 10, 64)
+	if err != nil || id <= 0 {
+		return nil, output.ErrUsage(fmt.Sprintf("invalid account selection: %s", accountID))
+	}
+	scoped, err := client.ForAccount(ctx, id)
+	if err != nil {
+		return nil, convertSDKError(err)
+	}
+	return scoped, nil
+}
+
+func clientForResourceAccount(ctx context.Context, accountID int64) (*hey.Client, error) {
+	if accountID <= 0 {
+		return nil, output.ErrAPI(0, "thread did not identify its mail account")
+	}
+	scoped, err := sdk.ForAccount(ctx, accountID)
+	if err != nil {
+		return nil, convertSDKError(err)
+	}
+	return scoped, nil
 }
 
 // convertSDKError maps hey.Error to apierr.Error for CLI error display.

--- a/internal/cmd/sdk.go
+++ b/internal/cmd/sdk.go
@@ -111,7 +111,7 @@ func clientForResourceAccount(ctx context.Context, accountID int64) (*hey.Client
 	if accountID <= 0 {
 		return nil, output.ErrAPI(0, "thread did not identify its mail account")
 	}
-	scoped, err := sdk.ForAccount(ctx, accountID)
+	scoped, err := rootSDK.ForAccount(ctx, accountID)
 	if err != nil {
 		return nil, convertSDKError(err)
 	}

--- a/internal/cmd/thread_reply.go
+++ b/internal/cmd/thread_reply.go
@@ -4,24 +4,27 @@ import (
 	"context"
 	"fmt"
 
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
 	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
-// threadReplyTarget is what a reply to a thread needs: the entry it answers, and the
-// recipients that entry was addressed to. HEY saves an unaddressed reply as a draft, so
-// the recipients are not optional.
+// threadReplyTarget carries the entry a reply answers, its recipients, and an immutable
+// client bound to the thread's mail account. HEY saves an unaddressed reply as a draft,
+// so the recipients are not optional.
 type threadReplyTarget struct {
 	EntryID   int64
 	AccountID int64
 	Addressed *htmlutil.TopicAddressed
+	client    *hey.Client
 }
 
 // resolveThreadReply returns the thread's latest entry, linked account, and addressed
 // recipients. The typed topic carries entry and account data; the rendered topic header
 // carries the recipient groups HEY expects on a reply.
 func resolveThreadReply(ctx context.Context, threadID int64) (*threadReplyTarget, error) {
-	topic, err := sdk.Topics().Get(ctx, threadID)
+	topic, err := rootSDK.Topics().Get(ctx, threadID)
 	if err != nil {
 		return nil, convertSDKError(err)
 	}
@@ -29,7 +32,11 @@ func resolveThreadReply(ctx context.Context, threadID int64) (*threadReplyTarget
 		return nil, output.ErrNotFound("entries for thread", fmt.Sprintf("%d", threadID))
 	}
 
-	topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", threadID))
+	threadSDK, err := clientForResourceAccount(ctx, topic.AccountId)
+	if err != nil {
+		return nil, err
+	}
+	topicResp, err := threadSDK.GetHTML(ctx, fmt.Sprintf("/topics/%d", threadID))
 	if err != nil {
 		return nil, convertSDKError(err)
 	}
@@ -42,5 +49,6 @@ func resolveThreadReply(ctx context.Context, threadID int64) (*threadReplyTarget
 		EntryID:   topic.Entries[len(topic.Entries)-1].Id,
 		AccountID: topic.AccountId,
 		Addressed: addressed,
+		client:    threadSDK,
 	}, nil
 }

--- a/internal/cmd/thread_reply.go
+++ b/internal/cmd/thread_reply.go
@@ -13,16 +13,22 @@ import (
 // the recipients are not optional.
 type threadReplyTarget struct {
 	EntryID   int64
+	AccountID int64
 	Addressed *htmlutil.TopicAddressed
 }
 
-// resolveThreadReply works out what replying to a thread means: the last entry on it, and
-// who that entry went to.
-//
-// It still reads the topic's HTML pages. The SDK gained typed reads for both in v0.4.0 —
-// Topics.Get carries the topic's entries — and this is the one place to change when the
-// CLI moves onto them.
+// resolveThreadReply returns the thread's latest entry, linked account, and addressed
+// recipients. The typed topic carries entry and account data; the rendered topic header
+// carries the recipient groups HEY expects on a reply.
 func resolveThreadReply(ctx context.Context, threadID int64) (*threadReplyTarget, error) {
+	topic, err := sdk.Topics().Get(ctx, threadID)
+	if err != nil {
+		return nil, convertSDKError(err)
+	}
+	if topic == nil || len(topic.Entries) == 0 {
+		return nil, output.ErrNotFound("entries for thread", fmt.Sprintf("%d", threadID))
+	}
+
 	topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", threadID))
 	if err != nil {
 		return nil, convertSDKError(err)
@@ -32,14 +38,9 @@ func resolveThreadReply(ctx context.Context, threadID int64) (*threadReplyTarget
 		return nil, output.ErrUsage("could not determine thread recipients")
 	}
 
-	entriesResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d/entries", threadID))
-	if err != nil {
-		return nil, convertSDKError(err)
-	}
-	entries := htmlutil.ParseTopicEntriesHTML(string(entriesResp.Data))
-	if len(entries) == 0 {
-		return nil, output.ErrNotFound("entries for thread", fmt.Sprintf("%d", threadID))
-	}
-
-	return &threadReplyTarget{EntryID: entries[len(entries)-1].ID, Addressed: addressed}, nil
+	return &threadReplyTarget{
+		EntryID:   topic.Entries[len(topic.Entries)-1].Id,
+		AccountID: topic.AccountId,
+		Addressed: addressed,
+	}, nil
 }

--- a/internal/cmd/thread_reply_test.go
+++ b/internal/cmd/thread_reply_test.go
@@ -24,14 +24,15 @@ const (
 
 // sentReply is what the server saw a reply arrive as.
 type sentReply struct {
-	Path    string
-	Content string
-	To      []string
-	CC      []string
-	BCC     []string
+	Path           string
+	Content        string
+	ActingSenderID int64
+	To             []string
+	CC             []string
+	BCC            []string
 }
 
-// threadReplyServer answers the two topic pages resolveThreadReply reads, the identity
+// threadReplyServer answers the typed topic, its rendered recipient header, the identity
 // the SDK needs for a sending operation, and the reply itself — recording it so a test
 // can say what actually went out.
 func threadReplyServer(t *testing.T, topicHTML, entriesHTML string) (*httptest.Server, *sentReply) {
@@ -40,8 +41,12 @@ func threadReplyServer(t *testing.T, topicHTML, entriesHTML string) (*httptest.S
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(r.URL.Path, "/replies"):
+			if got := r.URL.Query().Get("filtered_account_id"); got != "9" {
+				t.Errorf("reply account = %q, want 9", got)
+			}
 			var body struct {
-				Message struct {
+				ActingSenderID int64 `json:"acting_sender_id"`
+				Message        struct {
 					Content string `json:"content"`
 				} `json:"message"`
 				Entry struct {
@@ -55,16 +60,24 @@ func threadReplyServer(t *testing.T, topicHTML, entriesHTML string) (*httptest.S
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			sent.Path = r.URL.Path
 			sent.Content = body.Message.Content
+			sent.ActingSenderID = body.ActingSenderID
 			sent.To, sent.CC, sent.BCC = body.Entry.Addressed.Directly, body.Entry.Addressed.Copied, body.Entry.Addressed.Blindcopied
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
 			fmt.Fprint(w, `{}`)
 		case strings.Contains(r.URL.Path, "identity"):
+			if got := r.URL.Query().Get("filtered_account_id"); got != "" {
+				t.Errorf("identity account = %q, want unscoped", got)
+			}
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"id":1,"senders":[{"id":42,"default":true}]}`)
-		case strings.HasSuffix(r.URL.Path, "/entries"):
-			w.Header().Set("Content-Type", "text/html")
-			fmt.Fprint(w, entriesHTML)
+			fmt.Fprint(w, `{"id":1,"accounts":[{"id":9,"status":"active"}],"senders":[{"id":42,"account_id":9,"default":true}]}`)
+		case r.URL.Path == "/topics/7.json":
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(entriesHTML, "12") {
+				fmt.Fprint(w, `{"id":7,"account_id":9,"entries":[{"id":11},{"id":12}]}`)
+			} else {
+				fmt.Fprint(w, `{"id":7,"account_id":9,"entries":[]}`)
+			}
 		default:
 			w.Header().Set("Content-Type", "text/html")
 			fmt.Fprint(w, topicHTML)
@@ -82,7 +95,11 @@ func withSDKPointedAt(t *testing.T, server *httptest.Server) {
 	t.Setenv("HEY_NO_KEYRING", "1")
 
 	previous := sdk
-	t.Cleanup(func() { sdk = previous })
+	previousRoot := rootSDK
+	t.Cleanup(func() {
+		sdk = previous
+		rootSDK = previousRoot
+	})
 	initSDK(nil, server.URL)
 }
 
@@ -98,6 +115,9 @@ func TestResolveThreadReply(t *testing.T) {
 	// HEY replies to the last entry on the thread, not the first.
 	if target.EntryID != 12 {
 		t.Errorf("entry = %d, want the last one (12)", target.EntryID)
+	}
+	if target.AccountID != 9 {
+		t.Errorf("account = %d, want 9", target.AccountID)
 	}
 	if len(target.Addressed.To) != 1 || target.Addressed.To[0] != "jane@example.com" {
 		t.Errorf("to = %v", target.Addressed.To)

--- a/internal/cmd/thread_reply_test.go
+++ b/internal/cmd/thread_reply_test.go
@@ -24,12 +24,14 @@ const (
 
 // sentReply is what the server saw a reply arrive as.
 type sentReply struct {
-	Path           string
-	Content        string
-	ActingSenderID int64
-	To             []string
-	CC             []string
-	BCC            []string
+	Path               string
+	Content            string
+	TopicAccountFilter string
+	HTMLAccountFilter  string
+	ActingSenderID     int64
+	To                 []string
+	CC                 []string
+	BCC                []string
 }
 
 // threadReplyServer answers the typed topic, its rendered recipient header, the identity
@@ -70,8 +72,9 @@ func threadReplyServer(t *testing.T, topicHTML, entriesHTML string) (*httptest.S
 				t.Errorf("identity account = %q, want unscoped", got)
 			}
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"id":1,"accounts":[{"id":9,"status":"active"}],"senders":[{"id":42,"account_id":9,"default":true}]}`)
+			fmt.Fprint(w, `{"id":1,"accounts":[{"id":8,"status":"active"},{"id":9,"status":"active"}],"senders":[{"id":42,"account_id":9,"default":true}]}`)
 		case r.URL.Path == "/topics/7.json":
+			sent.TopicAccountFilter = r.URL.Query().Get("filtered_account_id")
 			w.Header().Set("Content-Type", "application/json")
 			if strings.Contains(entriesHTML, "12") {
 				fmt.Fprint(w, `{"id":7,"account_id":9,"entries":[{"id":11},{"id":12}]}`)
@@ -79,6 +82,7 @@ func threadReplyServer(t *testing.T, topicHTML, entriesHTML string) (*httptest.S
 				fmt.Fprint(w, `{"id":7,"account_id":9,"entries":[]}`)
 			}
 		default:
+			sent.HTMLAccountFilter = r.URL.Query().Get("filtered_account_id")
 			w.Header().Set("Content-Type", "text/html")
 			fmt.Fprint(w, topicHTML)
 		}
@@ -104,7 +108,7 @@ func withSDKPointedAt(t *testing.T, server *httptest.Server) {
 }
 
 func TestResolveThreadReply(t *testing.T) {
-	server, _ := threadReplyServer(t, topicWithRecipients, topicEntries)
+	server, sent := threadReplyServer(t, topicWithRecipients, topicEntries)
 	withSDKPointedAt(t, server)
 
 	target, err := resolveThreadReply(context.Background(), 7)
@@ -124,6 +128,15 @@ func TestResolveThreadReply(t *testing.T) {
 	}
 	if len(target.Addressed.CC) != 1 || target.Addressed.CC[0] != "cc@example.com" {
 		t.Errorf("cc = %v", target.Addressed.CC)
+	}
+	if target.client == nil {
+		t.Fatal("reply target has no thread-account client")
+	}
+	if sent.TopicAccountFilter != "" {
+		t.Errorf("topic account filter = %q, want unscoped discovery", sent.TopicAccountFilter)
+	}
+	if sent.HTMLAccountFilter != "9" {
+		t.Errorf("topic HTML account filter = %q, want thread account 9", sent.HTMLAccountFilter)
 	}
 }
 

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -19,7 +19,7 @@ func newTuiCommand() *tuiCommand {
 			if err := requireAuth(); err != nil {
 				return err
 			}
-			return tui.Run(sdk)
+			return tui.Run(rootSDK, sdk, cfg.AccountID)
 		},
 	}
 	return c

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,12 +38,17 @@ type Config struct {
 	BaseURL   string `json:"base_url"`
 	AccountID string `json:"account_id,omitempty"`
 
-	sources map[string]Source
+	sources             map[string]Source
+	globalConfig        fileConfig
+	localConfig         *LocalConfig
+	trustedLocalConfigs map[string]trustedLocalConfigRecord
 }
 
 type fileConfig struct {
-	BaseURL   string `json:"base_url,omitempty"`
-	AccountID string `json:"account_id,omitempty"`
+	BaseURL             string                              `json:"base_url,omitempty"`
+	AccountID           string                              `json:"account_id,omitempty"`
+	AccountDefaults     map[string]string                   `json:"account_defaults,omitempty"`
+	TrustedLocalConfigs map[string]trustedLocalConfigRecord `json:"trusted_local_configs,omitempty"`
 }
 
 // OldConfig represents the legacy config format with embedded credentials.
@@ -130,71 +135,128 @@ func Load() (*Config, error) {
 		},
 	}
 
-	// Layer 1: global config
-	if err := cfg.loadFile(globalConfigPath(), SourceGlobal); err != nil {
+	global, err := readFileConfig(globalConfigPath())
+	if err != nil {
 		return nil, err
 	}
+	cfg.globalConfig = global
+	if global.BaseURL != "" {
+		cfg.BaseURL = global.BaseURL
+		cfg.sources["base_url"] = SourceGlobal
+	}
 
-	// Layer 2: local config (.hey/config.json walking up)
-	if local := localConfigPath(); local != "" {
-		if err := cfg.loadFile(local, SourceLocal); err != nil {
+	var local fileConfig
+	localPath := localConfigPath()
+	if localPath != "" {
+		local, err = readFileConfig(localPath)
+		if err != nil {
 			return nil, err
+		}
+		if local.BaseURL != "" {
+			cfg.BaseURL = local.BaseURL
+			cfg.sources["base_url"] = SourceLocal
+		}
+		if local.AccountID != "" {
+			cfg.AccountID = local.AccountID
+			cfg.sources["account_id"] = SourceLocal
 		}
 	}
 
-	// Layer 3: environment variables
 	if env := os.Getenv("HEY_BASE_URL"); env != "" {
 		cfg.BaseURL = env
 		cfg.sources["base_url"] = SourceEnv
 	}
 	if env := os.Getenv("HEY_ACCOUNT_ID"); env != "" {
-		accountID, err := normalizeAccountID(env)
-		if err != nil {
-			return nil, err
+		accountID, accountErr := normalizeAccountID(env)
+		if accountErr != nil {
+			return nil, accountErr
 		}
 		cfg.AccountID = accountID
 		cfg.sources["account_id"] = SourceEnv
 	}
 
-	if err := validateBaseURL(cfg.BaseURL); err != nil {
-		return nil, err
+	if validationErr := validateBaseURL(cfg.BaseURL); validationErr != nil {
+		return nil, validationErr
+	}
+	if cfg.SourceOf("account_id") == SourceDefault {
+		if accountID, ok := accountDefaultFor(global, cfg.BaseURL); ok {
+			cfg.AccountID = accountID
+			cfg.sources["account_id"] = SourceGlobal
+		}
+	}
+	cfg.trustedLocalConfigs = global.TrustedLocalConfigs
+	if localPath != "" {
+		cfg.localConfig, err = makeLocalConfig(localPath, local, cfg.BaseURL, global.TrustedLocalConfigs)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return cfg, nil
 }
 
-func (c *Config) loadFile(path string, source Source) error {
+func readFileConfig(path string) (fileConfig, error) {
 	if path == "" {
-		return nil
+		return fileConfig{}, nil
 	}
-
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return fileConfig{}, nil
 		}
-		return fmt.Errorf("could not read config %s: %w", path, err)
+		return fileConfig{}, fmt.Errorf("could not read config %s: %w", path, err)
 	}
-
 	var file fileConfig
-	if err := json.Unmarshal(data, &file); err != nil {
-		return fmt.Errorf("could not parse config %s: %w", path, err)
-	}
-
-	if file.BaseURL != "" {
-		c.BaseURL = file.BaseURL
-		c.sources["base_url"] = source
+	if unmarshalErr := json.Unmarshal(data, &file); unmarshalErr != nil {
+		return fileConfig{}, fmt.Errorf("could not parse config %s: %w", path, unmarshalErr)
 	}
 	if file.AccountID != "" {
-		accountID, err := normalizeAccountID(file.AccountID)
+		file.AccountID, err = normalizeAccountID(file.AccountID)
 		if err != nil {
-			return fmt.Errorf("could not parse config %s: %w", path, err)
+			return fileConfig{}, fmt.Errorf("could not parse config %s: %w", path, err)
 		}
-		c.AccountID = accountID
-		c.sources["account_id"] = source
 	}
+	if len(file.AccountDefaults) > 0 {
+		normalizedDefaults := make(map[string]string, len(file.AccountDefaults))
+		for origin, accountID := range file.AccountDefaults {
+			normalizedOrigin, originErr := serverOrigin(origin)
+			if originErr != nil {
+				return fileConfig{}, fmt.Errorf("could not parse account default origin %s in %s: %w", origin, path, originErr)
+			}
+			normalized, normalizeErr := normalizeAccountID(accountID)
+			if normalizeErr != nil {
+				return fileConfig{}, fmt.Errorf("could not parse account default for %s in %s: %w", origin, path, normalizeErr)
+			}
+			if existing, duplicate := normalizedDefaults[normalizedOrigin]; duplicate && existing != normalized {
+				return fileConfig{}, fmt.Errorf("conflicting account defaults for %s in %s", normalizedOrigin, path)
+			}
+			normalizedDefaults[normalizedOrigin] = normalized
+		}
+		file.AccountDefaults = normalizedDefaults
+	}
+	return file, nil
+}
 
-	return nil
+func accountDefaultFor(file fileConfig, baseURL string) (string, bool) {
+	origin, err := serverOrigin(baseURL)
+	if err != nil {
+		return "", false
+	}
+	if accountID, ok := file.AccountDefaults[origin]; ok {
+		return accountID, true
+	}
+	legacyOrigin, err := serverOrigin(firstNonEmpty(file.BaseURL, defaultBase))
+	if err == nil && legacyOrigin == origin && file.AccountID != "" {
+		return file.AccountID, true
+	}
+	return "", false
+}
+
+func firstNonEmpty(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
 }
 
 func (c *Config) SourceOf(key string) Source {
@@ -214,11 +276,21 @@ func (c *Config) SetFromFlag(key, value string) error {
 		if err := validateBaseURL(value); err != nil {
 			return err
 		}
+		accountSource := c.SourceOf("account_id")
 		c.BaseURL = value
 		if c.sources == nil {
 			c.sources = map[string]Source{}
 		}
 		c.sources["base_url"] = SourceFlag
+		if accountSource == SourceDefault || accountSource == SourceGlobal {
+			c.AccountID = AllAccounts
+			c.sources["account_id"] = SourceDefault
+			if accountID, ok := accountDefaultFor(c.globalConfig, value); ok {
+				c.AccountID = accountID
+				c.sources["account_id"] = SourceGlobal
+			}
+		}
+		c.refreshLocalConfigTrust()
 	case "account_id":
 		accountID, err := normalizeAccountID(value)
 		if err != nil {
@@ -257,20 +329,27 @@ func LoadOld() (*OldConfig, error) {
 	return &cfg, nil
 }
 
-// SaveBaseURL stores the global server URL while preserving the global account default.
+// SaveBaseURL stores the global server URL while preserving account defaults for every server.
 func (c *Config) SaveBaseURL(baseURL string) error {
 	file, err := loadGlobalFileConfig()
 	if err != nil {
+		return err
+	}
+	if err := migrateLegacyAccountDefault(&file); err != nil {
 		return err
 	}
 	file.BaseURL = baseURL
 	return saveGlobalConfig(file)
 }
 
-// SaveAccountID stores the default linked-account filter without replacing
-// other global settings with local, environment, or flag overrides.
+// SaveAccountID stores the default linked-account filter for the effective server
+// without replacing settings for any other server.
 func (c *Config) SaveAccountID(accountID string) error {
 	accountID, err := normalizeAccountID(accountID)
+	if err != nil {
+		return err
+	}
+	origin, err := serverOrigin(c.BaseURL)
 	if err != nil {
 		return err
 	}
@@ -279,39 +358,74 @@ func (c *Config) SaveAccountID(accountID string) error {
 	if err != nil {
 		return err
 	}
-	file.AccountID = accountID
+	if err := migrateLegacyAccountDefault(&file); err != nil {
+		return err
+	}
+	if file.AccountDefaults == nil {
+		file.AccountDefaults = make(map[string]string)
+	}
+	file.AccountDefaults[origin] = accountID
 	return saveGlobalConfig(file)
 }
 
 func loadGlobalFileConfig() (fileConfig, error) {
-	path := globalConfigPath()
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fileConfig{}, nil
-		}
-		return fileConfig{}, fmt.Errorf("could not read config %s: %w", path, err)
-	}
+	return readFileConfig(globalConfigPath())
+}
 
-	var file fileConfig
-	if err := json.Unmarshal(data, &file); err != nil {
-		return fileConfig{}, fmt.Errorf("could not parse config %s: %w", path, err)
+func migrateLegacyAccountDefault(file *fileConfig) error {
+	if file.AccountID == "" {
+		return nil
 	}
-	return file, nil
+	origin, err := serverOrigin(firstNonEmpty(file.BaseURL, defaultBase))
+	if err != nil {
+		return err
+	}
+	if file.AccountDefaults == nil {
+		file.AccountDefaults = make(map[string]string)
+	}
+	if _, exists := file.AccountDefaults[origin]; !exists {
+		file.AccountDefaults[origin] = file.AccountID
+	}
+	file.AccountID = ""
+	return nil
 }
 
 func saveGlobalConfig(file fileConfig) error {
 	path := globalConfigPath()
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+	if path == "" {
+		return fmt.Errorf("could not determine config path")
+	}
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0700); err != nil {
 		return fmt.Errorf("could not create config directory: %w", err)
+	}
+	if err := os.Chmod(directory, 0700); err != nil {
+		return fmt.Errorf("could not secure config directory: %w", err)
 	}
 
 	data, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		return fmt.Errorf("could not marshal config: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		return fmt.Errorf("could not write config: %w", err)
+	temporary, err := os.CreateTemp(directory, ".config-*")
+	if err != nil {
+		return fmt.Errorf("could not create temporary config: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+	if err := temporary.Chmod(0600); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("could not secure temporary config: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("could not write temporary config: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("could not close temporary config: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("could not replace config: %w", err)
 	}
 	return nil
 }
@@ -326,6 +440,14 @@ func normalizeAccountID(accountID string) (string, error) {
 		return "", apierr.ErrUsage(fmt.Sprintf("account must be a positive ID or %q (got %q)", AllAccounts, accountID))
 	}
 	return strconv.FormatInt(id, 10), nil
+}
+
+func serverOrigin(base string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", apierr.ErrUsage(fmt.Sprintf("invalid base URL %q", base))
+	}
+	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host), nil
 }
 
 func validateBaseURL(base string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
@@ -15,6 +16,7 @@ const (
 	configDirName = "hey-cli"
 	configFile    = "config.json"
 	defaultBase   = "https://app.hey.com"
+	AllAccounts   = "all"
 )
 
 type Source string
@@ -33,9 +35,15 @@ type Value struct {
 }
 
 type Config struct {
-	BaseURL string `json:"base_url"`
+	BaseURL   string `json:"base_url"`
+	AccountID string `json:"account_id,omitempty"`
 
 	sources map[string]Source
+}
+
+type fileConfig struct {
+	BaseURL   string `json:"base_url,omitempty"`
+	AccountID string `json:"account_id,omitempty"`
 }
 
 // OldConfig represents the legacy config format with embedded credentials.
@@ -114,8 +122,12 @@ func localConfigPath() string {
 
 func Load() (*Config, error) {
 	cfg := &Config{
-		BaseURL: defaultBase,
-		sources: map[string]Source{"base_url": SourceDefault},
+		BaseURL:   defaultBase,
+		AccountID: AllAccounts,
+		sources: map[string]Source{
+			"base_url":   SourceDefault,
+			"account_id": SourceDefault,
+		},
 	}
 
 	// Layer 1: global config
@@ -135,8 +147,15 @@ func Load() (*Config, error) {
 		cfg.BaseURL = env
 		cfg.sources["base_url"] = SourceEnv
 	}
+	if env := os.Getenv("HEY_ACCOUNT_ID"); env != "" {
+		accountID, err := normalizeAccountID(env)
+		if err != nil {
+			return nil, err
+		}
+		cfg.AccountID = accountID
+		cfg.sources["account_id"] = SourceEnv
+	}
 
-	// Validate base URL
 	if err := validateBaseURL(cfg.BaseURL); err != nil {
 		return nil, err
 	}
@@ -157,9 +176,7 @@ func (c *Config) loadFile(path string, source Source) error {
 		return fmt.Errorf("could not read config %s: %w", path, err)
 	}
 
-	var file struct {
-		BaseURL string `json:"base_url"`
-	}
+	var file fileConfig
 	if err := json.Unmarshal(data, &file); err != nil {
 		return fmt.Errorf("could not parse config %s: %w", path, err)
 	}
@@ -167,6 +184,14 @@ func (c *Config) loadFile(path string, source Source) error {
 	if file.BaseURL != "" {
 		c.BaseURL = file.BaseURL
 		c.sources["base_url"] = source
+	}
+	if file.AccountID != "" {
+		accountID, err := normalizeAccountID(file.AccountID)
+		if err != nil {
+			return fmt.Errorf("could not parse config %s: %w", path, err)
+		}
+		c.AccountID = accountID
+		c.sources["account_id"] = source
 	}
 
 	return nil
@@ -194,6 +219,16 @@ func (c *Config) SetFromFlag(key, value string) error {
 			c.sources = map[string]Source{}
 		}
 		c.sources["base_url"] = SourceFlag
+	case "account_id":
+		accountID, err := normalizeAccountID(value)
+		if err != nil {
+			return err
+		}
+		c.AccountID = accountID
+		if c.sources == nil {
+			c.sources = map[string]Source{}
+		}
+		c.sources["account_id"] = SourceFlag
 	}
 	return nil
 }
@@ -201,6 +236,7 @@ func (c *Config) SetFromFlag(key, value string) error {
 func (c *Config) Values() []Value {
 	return []Value{
 		{Value: c.BaseURL, Source: c.SourceOf("base_url")},
+		{Value: c.AccountID, Source: c.SourceOf("account_id")},
 	}
 }
 
@@ -221,22 +257,75 @@ func LoadOld() (*OldConfig, error) {
 	return &cfg, nil
 }
 
-func (c *Config) Save() error {
-	path := globalConfigPath()
+// SaveBaseURL stores the global server URL while preserving the global account default.
+func (c *Config) SaveBaseURL(baseURL string) error {
+	file, err := loadGlobalFileConfig()
+	if err != nil {
+		return err
+	}
+	file.BaseURL = baseURL
+	return saveGlobalConfig(file)
+}
 
+// SaveAccountID stores the default linked-account filter without replacing
+// other global settings with local, environment, or flag overrides.
+func (c *Config) SaveAccountID(accountID string) error {
+	accountID, err := normalizeAccountID(accountID)
+	if err != nil {
+		return err
+	}
+
+	file, err := loadGlobalFileConfig()
+	if err != nil {
+		return err
+	}
+	file.AccountID = accountID
+	return saveGlobalConfig(file)
+}
+
+func loadGlobalFileConfig() (fileConfig, error) {
+	path := globalConfigPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fileConfig{}, nil
+		}
+		return fileConfig{}, fmt.Errorf("could not read config %s: %w", path, err)
+	}
+
+	var file fileConfig
+	if err := json.Unmarshal(data, &file); err != nil {
+		return fileConfig{}, fmt.Errorf("could not parse config %s: %w", path, err)
+	}
+	return file, nil
+}
+
+func saveGlobalConfig(file fileConfig) error {
+	path := globalConfigPath()
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return fmt.Errorf("could not create config directory: %w", err)
 	}
 
-	data, err := json.MarshalIndent(c, "", "  ")
+	data, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		return fmt.Errorf("could not marshal config: %w", err)
 	}
-
 	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("could not write config: %w", err)
 	}
 	return nil
+}
+
+func normalizeAccountID(accountID string) (string, error) {
+	accountID = strings.TrimSpace(accountID)
+	if strings.EqualFold(accountID, AllAccounts) {
+		return AllAccounts, nil
+	}
+	id, err := strconv.ParseInt(accountID, 10, 64)
+	if err != nil || id <= 0 {
+		return "", apierr.ErrUsage(fmt.Sprintf("account must be a positive ID or %q (got %q)", AllAccounts, accountID))
+	}
+	return strconv.FormatInt(id, 10), nil
 }
 
 func validateBaseURL(base string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -447,7 +448,19 @@ func serverOrigin(base string) (string, error) {
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return "", apierr.ErrUsage(fmt.Sprintf("invalid base URL %q", base))
 	}
-	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host), nil
+	scheme := strings.ToLower(u.Scheme)
+	hostname := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+		port = ""
+	}
+	host := hostname
+	if port != "" {
+		host = net.JoinHostPort(hostname, port)
+	} else if strings.Contains(hostname, ":") {
+		host = "[" + hostname + "]"
+	}
+	return (&url.URL{Scheme: scheme, Host: host}).String(), nil
 }
 
 func validateBaseURL(base string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -255,6 +255,74 @@ func TestAccountDefaultsAreBoundToServerOrigin(t *testing.T) {
 	}
 }
 
+func TestServerOriginCanonicalizesDefaultPorts(t *testing.T) {
+	tests := []struct {
+		base string
+		want string
+	}{
+		{"https://APP.HEY.COM:443/path", "https://app.hey.com"},
+		{"http://app.hey.localhost:80/path", "http://app.hey.localhost"},
+		{"https://app.hey.com:8443/path", "https://app.hey.com:8443"},
+		{"http://[::1]:80/path", "http://[::1]"},
+		{"https://[2001:db8::1]:8443/path", "https://[2001:db8::1]:8443"},
+		{"https://[fe80::1%25eth0]:8443/path", "https://[fe80::1%25eth0]:8443"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.base, func(t *testing.T) {
+			got, err := serverOrigin(tt.base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("serverOrigin(%q) = %q, want %q", tt.base, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAccountDefaultMatchesEquivalentDefaultPortOrigin(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HEY_BASE_URL", "https://app.hey.com:443")
+	t.Setenv("HEY_ACCOUNT_ID", "")
+	dir := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), configDirName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	data := `{"account_defaults":{"https://app.hey.com":"101"}}`
+	if err := os.WriteFile(filepath.Join(dir, configFile), []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AccountID != "101" || cfg.SourceOf("account_id") != SourceGlobal {
+		t.Fatalf("default-port account = %q (%s), want 101 (global)", cfg.AccountID, cfg.SourceOf("account_id"))
+	}
+}
+
+func TestZoneScopedOriginAccountDefaultRoundTrips(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HEY_BASE_URL", "https://[fe80::1%25eth0]:8443")
+	t.Setenv("HEY_ACCOUNT_ID", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.SaveAccountID("101"); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.AccountID != "101" || reloaded.SourceOf("account_id") != SourceGlobal {
+		t.Fatalf("zone-scoped account = %q (%s), want 101 (global)", reloaded.AccountID, reloaded.SourceOf("account_id"))
+	}
+}
+
 func TestBaseURLFlagResolvesAccountForNewOrigin(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HEY_BASE_URL", "")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,6 +23,12 @@ func TestDefaultConfig(t *testing.T) {
 	if src := cfg.SourceOf("base_url"); src != SourceDefault {
 		t.Errorf("source = %q, want %q", src, SourceDefault)
 	}
+	if cfg.AccountID != AllAccounts {
+		t.Errorf("AccountID = %q, want %q", cfg.AccountID, AllAccounts)
+	}
+	if src := cfg.SourceOf("account_id"); src != SourceDefault {
+		t.Errorf("account source = %q, want %q", src, SourceDefault)
+	}
 }
 
 func TestGlobalConfigOverride(t *testing.T) {
@@ -90,6 +96,123 @@ func TestFlagOverride(t *testing.T) {
 	}
 	if src := cfg.SourceOf("base_url"); src != SourceFlag {
 		t.Errorf("source = %q, want %q", src, SourceFlag)
+	}
+}
+
+func TestAccountIDPrecedence(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("HEY_ACCOUNT_ID", "303")
+	if err := os.MkdirAll(filepath.Join(tmp, "workspace", ".hey"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(filepath.Join(tmp, "workspace"))
+
+	globalDir := filepath.Join(tmp, "config", configDirName)
+	if err := os.MkdirAll(globalDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, configFile), []byte(`{"account_id":"101"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "workspace", ".hey", configFile), []byte(`{"account_id":"202"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AccountID != "303" || cfg.SourceOf("account_id") != SourceEnv {
+		t.Fatalf("environment account = %q (%s), want 303 (env)", cfg.AccountID, cfg.SourceOf("account_id"))
+	}
+	if err := cfg.SetFromFlag("account_id", "00404"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AccountID != "404" || cfg.SourceOf("account_id") != SourceFlag {
+		t.Fatalf("flag account = %q (%s), want 404 (flag)", cfg.AccountID, cfg.SourceOf("account_id"))
+	}
+}
+
+func TestInvalidAccountID(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HEY_ACCOUNT_ID", "personal")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load returned no error for invalid account")
+	}
+}
+
+func TestSaveAccountIDPreservesGlobalSettings(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("HEY_BASE_URL", "https://env.hey.com")
+	t.Setenv("HEY_ACCOUNT_ID", "")
+
+	dir := filepath.Join(tmp, configDirName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, configFile), []byte(`{"base_url":"https://global.hey.com"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.SaveAccountID("42"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, configFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var file fileConfig
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatal(err)
+	}
+	if file.BaseURL != "https://global.hey.com" || file.AccountID != "42" {
+		t.Fatalf("saved config = %#v", file)
+	}
+}
+
+func TestSaveBaseURLPreservesGlobalAccount(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("HEY_ACCOUNT_ID", "202")
+
+	dir := filepath.Join(tmp, configDirName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, configFile), []byte(`{"base_url":"https://old.hey.com","account_id":"101"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.SetFromFlag("base_url", "https://new.hey.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.SaveBaseURL(cfg.BaseURL); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, configFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var file fileConfig
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatal(err)
+	}
+	if file.BaseURL != "https://new.hey.com" || file.AccountID != "101" {
+		t.Fatalf("saved config = %#v", file)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -173,7 +173,7 @@ func TestSaveAccountIDPreservesGlobalSettings(t *testing.T) {
 	if err := json.Unmarshal(data, &file); err != nil {
 		t.Fatal(err)
 	}
-	if file.BaseURL != "https://global.hey.com" || file.AccountID != "42" {
+	if file.BaseURL != "https://global.hey.com" || file.AccountID != "" || file.AccountDefaults["https://env.hey.com"] != "42" {
 		t.Fatalf("saved config = %#v", file)
 	}
 }
@@ -211,8 +211,150 @@ func TestSaveBaseURLPreservesGlobalAccount(t *testing.T) {
 	if err := json.Unmarshal(data, &file); err != nil {
 		t.Fatal(err)
 	}
-	if file.BaseURL != "https://new.hey.com" || file.AccountID != "101" {
+	if file.BaseURL != "https://new.hey.com" || file.AccountID != "" || file.AccountDefaults["https://old.hey.com"] != "101" {
 		t.Fatalf("saved config = %#v", file)
+	}
+}
+
+func TestAccountDefaultsAreBoundToServerOrigin(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HEY_ACCOUNT_ID", "")
+	dir := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), configDirName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	data := `{
+		"base_url":"https://app.hey.com",
+		"account_defaults":{
+			"https://app.hey.com":"101",
+			"http://app.hey.localhost:3003":"202"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dir, configFile), []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		baseURL string
+		want    string
+	}{
+		{"https://app.hey.com", "101"},
+		{"http://app.hey.localhost:3003", "202"},
+		{"https://staging.hey.com", AllAccounts},
+	} {
+		t.Run(test.baseURL, func(t *testing.T) {
+			t.Setenv("HEY_BASE_URL", test.baseURL)
+			cfg, err := Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.AccountID != test.want {
+				t.Fatalf("account for %s = %q, want %q", test.baseURL, cfg.AccountID, test.want)
+			}
+		})
+	}
+}
+
+func TestBaseURLFlagResolvesAccountForNewOrigin(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("HEY_ACCOUNT_ID", "")
+	dir := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), configDirName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	data := `{
+		"base_url":"https://app.hey.com",
+		"account_defaults":{
+			"https://app.hey.com":"101",
+			"https://staging.hey.com":"202"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dir, configFile), []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.SetFromFlag("base_url", "https://staging.hey.com"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AccountID != "202" {
+		t.Fatalf("staging account = %q, want 202", cfg.AccountID)
+	}
+	if err := cfg.SetFromFlag("base_url", "https://other.hey.com"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AccountID != AllAccounts || cfg.SourceOf("account_id") != SourceDefault {
+		t.Fatalf("unknown-origin account = %q (%s), want all (default)", cfg.AccountID, cfg.SourceOf("account_id"))
+	}
+	if err := cfg.SetFromFlag("account_id", "303"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AccountID != "303" || cfg.SourceOf("account_id") != SourceFlag {
+		t.Fatalf("explicit account = %q (%s), want 303 (flag)", cfg.AccountID, cfg.SourceOf("account_id"))
+	}
+}
+
+func TestLocalConfigTrustTracksPathAndSensitiveValues(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("HEY_ACCOUNT_ID", "")
+	workspace := filepath.Join(tmp, "workspace")
+	localDir := filepath.Join(workspace, ".hey")
+	if err := os.MkdirAll(localDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(workspace)
+	path := filepath.Join(localDir, configFile)
+	if err := os.WriteFile(path, []byte(`{"base_url":"https://app.hey.com","account_id":"202"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.UntrustedLocalConfig() == nil {
+		t.Fatal("new local config was trusted without user approval")
+	}
+	if err := cfg.TrustLocalConfig(); err != nil {
+		t.Fatal(err)
+	}
+	globalPath := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), configDirName, configFile)
+	if info, err := os.Stat(globalPath); err != nil || info.Mode().Perm() != 0600 {
+		t.Fatalf("global config permissions = %v, %v; want 0600", info, err)
+	}
+	reloaded, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if local := reloaded.LocalConfig(); local == nil || !local.Trusted || reloaded.UntrustedLocalConfig() != nil {
+		t.Fatalf("trusted local config = %#v", local)
+	}
+
+	t.Setenv("HEY_BASE_URL", "https://staging.hey.com")
+	otherServer, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if otherServer.UntrustedLocalConfig() == nil {
+		t.Fatal("local account trust carried to another server origin")
+	}
+	t.Setenv("HEY_BASE_URL", "")
+
+	if err := os.WriteFile(path, []byte(`{"base_url":"https://app.hey.com","account_id":"303"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if local := changed.UntrustedLocalConfig(); local == nil || local.AccountID != "303" {
+		t.Fatalf("changed local config did not invalidate trust: %#v", local)
 	}
 }
 

--- a/internal/config/local_trust.go
+++ b/internal/config/local_trust.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+)
+
+// LocalConfig describes the security-sensitive settings supplied by the nearest
+// repository-local .hey/config.json file.
+type LocalConfig struct {
+	Path         string `json:"path"`
+	BaseURL      string `json:"base_url,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	ServerOrigin string `json:"server_origin"`
+	Digest       string `json:"digest"`
+	Trusted      bool   `json:"trusted"`
+}
+
+// TrustedLocalConfig identifies a repository-local configuration trusted by this user.
+type TrustedLocalConfig struct {
+	Path         string `json:"path"`
+	ServerOrigin string `json:"server_origin"`
+	BaseURL      string `json:"base_url,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Digest       string `json:"digest"`
+}
+
+type trustedLocalConfigRecord struct {
+	ServerOrigin string `json:"server_origin"`
+	BaseURL      string `json:"base_url,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	Digest       string `json:"digest"`
+}
+
+func makeLocalConfig(path string, file fileConfig, effectiveBaseURL string, trusted map[string]trustedLocalConfigRecord) (*LocalConfig, error) {
+	if file.BaseURL == "" && file.AccountID == "" {
+		return nil, nil
+	}
+	canonicalPath, err := canonicalConfigPath(path)
+	if err != nil {
+		return nil, err
+	}
+	local := &LocalConfig{
+		Path:      canonicalPath,
+		BaseURL:   file.BaseURL,
+		AccountID: file.AccountID,
+	}
+	if err := fingerprintLocalConfig(local, effectiveBaseURL); err != nil {
+		return nil, err
+	}
+	local.Trusted = trusted[canonicalPath].Digest == local.Digest
+	return local, nil
+}
+
+func fingerprintLocalConfig(local *LocalConfig, effectiveBaseURL string) error {
+	origin, err := serverOrigin(effectiveBaseURL)
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(struct {
+		BaseURL      string `json:"base_url,omitempty"`
+		AccountID    string `json:"account_id,omitempty"`
+		ServerOrigin string `json:"server_origin"`
+	}{
+		BaseURL:      local.BaseURL,
+		AccountID:    local.AccountID,
+		ServerOrigin: origin,
+	})
+	if err != nil {
+		return fmt.Errorf("could not fingerprint local config %s: %w", local.Path, err)
+	}
+	sum := sha256.Sum256(payload)
+	local.ServerOrigin = origin
+	local.Digest = hex.EncodeToString(sum[:])
+	return nil
+}
+
+func (c *Config) refreshLocalConfigTrust() {
+	if c.localConfig == nil {
+		return
+	}
+	if err := fingerprintLocalConfig(c.localConfig, c.BaseURL); err != nil {
+		c.localConfig.Trusted = false
+		return
+	}
+	c.localConfig.Trusted = c.trustedLocalConfigs[c.localConfig.Path].Digest == c.localConfig.Digest
+}
+
+func canonicalConfigPath(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve local config path %s: %w", path, err)
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve local config path %s: %w", path, err)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+// UntrustedLocalConfig returns the local configuration when one of its values is
+// effective for this invocation and the user has not trusted its current contents.
+func (c *Config) UntrustedLocalConfig() *LocalConfig {
+	if c.localConfig == nil || c.localConfig.Trusted {
+		return nil
+	}
+	if c.SourceOf("base_url") != SourceLocal && c.SourceOf("account_id") != SourceLocal {
+		return nil
+	}
+	local := *c.localConfig
+	return &local
+}
+
+// LocalConfig returns the discovered local configuration and its trust status.
+func (c *Config) LocalConfig() *LocalConfig {
+	if c.localConfig == nil {
+		return nil
+	}
+	local := *c.localConfig
+	return &local
+}
+
+// TrustLocalConfig trusts the current security-sensitive values in the discovered
+// local configuration. A later change produces a different digest and requires trust again.
+func (c *Config) TrustLocalConfig() error {
+	if c.localConfig == nil {
+		return fmt.Errorf("no local .hey/config.json with security-sensitive settings was found")
+	}
+	file, err := loadGlobalFileConfig()
+	if err != nil {
+		return err
+	}
+	if err := migrateLegacyAccountDefault(&file); err != nil {
+		return err
+	}
+	if file.TrustedLocalConfigs == nil {
+		file.TrustedLocalConfigs = make(map[string]trustedLocalConfigRecord)
+	}
+	record := trustedLocalConfigRecord{
+		ServerOrigin: c.localConfig.ServerOrigin,
+		BaseURL:      c.localConfig.BaseURL,
+		AccountID:    c.localConfig.AccountID,
+		Digest:       c.localConfig.Digest,
+	}
+	file.TrustedLocalConfigs[c.localConfig.Path] = record
+	if err := saveGlobalConfig(file); err != nil {
+		return err
+	}
+	if c.trustedLocalConfigs == nil {
+		c.trustedLocalConfigs = make(map[string]trustedLocalConfigRecord)
+	}
+	c.trustedLocalConfigs[c.localConfig.Path] = record
+	c.localConfig.Trusted = true
+	return nil
+}
+
+// UntrustLocalConfig removes trust for the discovered local configuration.
+func (c *Config) UntrustLocalConfig() error {
+	if c.localConfig == nil {
+		return fmt.Errorf("no local .hey/config.json with security-sensitive settings was found")
+	}
+	file, err := loadGlobalFileConfig()
+	if err != nil {
+		return err
+	}
+	if err := migrateLegacyAccountDefault(&file); err != nil {
+		return err
+	}
+	delete(file.TrustedLocalConfigs, c.localConfig.Path)
+	if err := saveGlobalConfig(file); err != nil {
+		return err
+	}
+	delete(c.trustedLocalConfigs, c.localConfig.Path)
+	c.localConfig.Trusted = false
+	return nil
+}
+
+// TrustedLocalConfigs returns the local configurations trusted in user-level config.
+func TrustedLocalConfigs() ([]TrustedLocalConfig, error) {
+	file, err := loadGlobalFileConfig()
+	if err != nil {
+		return nil, err
+	}
+	configs := make([]TrustedLocalConfig, 0, len(file.TrustedLocalConfigs))
+	for path, record := range file.TrustedLocalConfigs {
+		configs = append(configs, TrustedLocalConfig{
+			Path:         path,
+			ServerOrigin: record.ServerOrigin,
+			BaseURL:      record.BaseURL,
+			AccountID:    record.AccountID,
+			Digest:       record.Digest,
+		})
+	}
+	sort.Slice(configs, func(i, j int) bool { return configs[i].Path < configs[j].Path })
+	return configs, nil
+}

--- a/internal/tui/accounts.go
+++ b/internal/tui/accounts.go
@@ -1,0 +1,135 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+)
+
+type mailAccountChoice struct {
+	id    int64
+	label string
+}
+
+type mailAccountsLoadedMsg struct {
+	accounts            []mailAccountChoice
+	selected            int
+	loaded              bool
+	selectedUnavailable bool
+	err                 error
+}
+
+type mailAccountSwitchedMsg struct {
+	requestID uint64
+	account   mailAccountChoice
+	client    *hey.Client
+	err       error
+}
+
+type viewGenerationMsg struct {
+	generation uint64
+	msg        tea.Msg
+}
+
+func loadMailAccounts(ctx context.Context, client *hey.Client, selected string) tea.Cmd {
+	return func() tea.Msg {
+		accounts := []mailAccountChoice{{label: "All Accounts"}}
+		if client == nil {
+			return mailAccountsLoadedMsg{accounts: accounts}
+		}
+		identity, err := client.Identity().GetIdentity(ctx)
+		if err != nil {
+			return mailAccountsLoadedMsg{err: err}
+		}
+		if identity == nil {
+			return mailAccountsLoadedMsg{err: fmt.Errorf("HEY returned no identity data")}
+		}
+		for _, account := range identity.Accounts {
+			if !tuiAccountAccessible(account) {
+				continue
+			}
+			label := tuiAccountEmail(identity.AllUsers, account.Id)
+			if label == "" {
+				label = account.Name
+			}
+			if label == "" {
+				label = fmt.Sprintf("Account %d", account.Id)
+			}
+			accounts = append(accounts, mailAccountChoice{id: account.Id, label: terminalSafeAttachmentText(label)})
+		}
+
+		selectedIndex := 0
+		selectedUnavailable := false
+		if id, err := strconv.ParseInt(selected, 10, 64); err == nil && id > 0 {
+			selectedUnavailable = true
+			for index, account := range accounts {
+				if account.id == id {
+					selectedIndex = index
+					selectedUnavailable = false
+					break
+				}
+			}
+		}
+		return mailAccountsLoadedMsg{
+			accounts:            accounts,
+			selected:            selectedIndex,
+			loaded:              true,
+			selectedUnavailable: selectedUnavailable,
+		}
+	}
+}
+
+func switchMailAccount(ctx context.Context, root *hey.Client, account mailAccountChoice, requestID uint64) tea.Cmd {
+	return func() tea.Msg {
+		if root == nil {
+			return mailAccountSwitchedMsg{requestID: requestID, account: account, err: fmt.Errorf("mail account switching is unavailable")}
+		}
+		if account.id == 0 {
+			return mailAccountSwitchedMsg{requestID: requestID, account: account, client: root}
+		}
+		client, err := root.ForAccount(ctx, account.id)
+		return mailAccountSwitchedMsg{requestID: requestID, account: account, client: client, err: err}
+	}
+}
+
+func tuiAccountAccessible(account generated.Account) bool {
+	return account.Status == "active" ||
+		(account.Status == "inactive" && (account.Purpose == "work" || account.Purpose == "domains"))
+}
+
+func tuiAccountEmail(users []generated.User, accountID int64) string {
+	for _, user := range users {
+		if user.AccountId == accountID {
+			return user.Contact.EmailAddress
+		}
+	}
+	return ""
+}
+
+func renderMailAccountPicker(m *model) string {
+	var content strings.Builder
+	content.WriteString(m.styles.title.Render("Select mail account"))
+	content.WriteString("\n\n")
+	for index, account := range m.mailAccounts {
+		prefix := "  "
+		style := m.styles.entryBody
+		if index == m.mailAccountCursor {
+			prefix = "› "
+			style = m.styles.entryFrom
+		}
+		content.WriteString(prefix + style.Render(account.label) + "\n")
+	}
+	if m.mailAccountSwitching {
+		content.WriteString("\n" + m.styles.entryDate.Render("Switching account…"))
+	}
+	if m.mailAccountErr != "" {
+		content.WriteString("\n" + m.styles.entryDate.Render("Error: "+terminalSafeAttachmentText(m.mailAccountErr)))
+	}
+	return content.String()
+}

--- a/internal/tui/accounts_test.go
+++ b/internal/tui/accounts_test.go
@@ -136,6 +136,35 @@ func TestCtrlAOpensAccountPicker(t *testing.T) {
 	}
 }
 
+func TestAccountPickerWaitsForPendingMutation(t *testing.T) {
+	m := newModel()
+	m.loading = false
+	m.mailAccounts = []mailAccountChoice{
+		{label: "All Accounts"},
+		{id: 1, label: "jane@example.com"},
+		{id: 2, label: "jane@company.example"},
+	}
+	m.mailView.pendingMutations = 1
+
+	updated, cmd := m.handleKey(tea.KeyPressMsg(tea.Key{Code: 'a', Mod: tea.ModCtrl}))
+	m = updated.(model)
+	if cmd != nil || m.mailAccountPicker {
+		t.Fatal("ctrl+a opened the account picker during a pending mutation")
+	}
+	updated, cmd = m.switchSection(sectionCalendar)
+	m = updated.(model)
+	if cmd != nil || m.section != sectionMail {
+		t.Fatal("section changed before the pending mutation could report its result")
+	}
+
+	m.mailView.pendingMutations = 0
+	updated, cmd = m.handleKey(tea.KeyPressMsg(tea.Key{Code: 'a', Mod: tea.ModCtrl}))
+	m = updated.(model)
+	if cmd != nil || !m.mailAccountPicker {
+		t.Fatal("ctrl+a did not open the account picker after the mutation finished")
+	}
+}
+
 func TestAccountSwitchRebuildsViewsAndCancelsOldGeneration(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/tui/accounts_test.go
+++ b/internal/tui/accounts_test.go
@@ -1,0 +1,257 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+)
+
+func TestLoadMailAccountsUsesAccessibleLinkedAccounts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/identity.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id":1,
+			"accounts":[
+				{"id":1,"name":"Personal","purpose":"home","status":"active"},
+				{"id":2,"name":"Canceled","purpose":"home","status":"canceled"},
+				{"id":3,"name":"Work","purpose":"work","status":"inactive"}
+			],
+			"all_users":[
+				{"id":11,"account_id":1,"contact":{"id":101,"email_address":"jane@example.com"}},
+				{"id":33,"account_id":3,"contact":{"id":303,"email_address":"jane@company.example"}}
+			]
+		}`)
+	}))
+	t.Cleanup(server.Close)
+	client := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "token"}, hey.WithMaxRetries(0))
+
+	msg, ok := loadMailAccounts(t.Context(), client, "3")().(mailAccountsLoadedMsg)
+	if !ok {
+		t.Fatal("account loader returned the wrong message type")
+	}
+	if !msg.loaded || msg.selected != 2 || len(msg.accounts) != 3 {
+		t.Fatalf("loaded accounts = %#v", msg)
+	}
+	if msg.accounts[0].label != "All Accounts" || msg.accounts[1].label != "jane@example.com" || msg.accounts[2].label != "jane@company.example" {
+		t.Fatalf("account labels = %#v", msg.accounts)
+	}
+}
+
+func TestUnavailableSelectedAccountFailsClosedAndAllowsRecovery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":1,"accounts":[{"id":1,"status":"active"}]}`)
+	}))
+	t.Cleanup(server.Close)
+	root := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "token"}, hey.WithMaxRetries(0))
+	m := newModelWithMailAccounts(root, root, "99")
+
+	loaded := loadMailAccounts(t.Context(), root, "99")().(mailAccountsLoadedMsg)
+	if !loaded.selectedUnavailable {
+		t.Fatal("unavailable selected account was accepted")
+	}
+	updated, _ := m.Update(loaded)
+	m = updated.(model)
+	if m.err == nil || !m.canSwitchMailAccounts() {
+		t.Fatalf("unavailable account did not fail closed with recovery: err=%v switch=%v", m.err, m.canSwitchMailAccounts())
+	}
+}
+
+func TestAccountDiscoveryFailureCanRetry(t *testing.T) {
+	var fail atomic.Bool
+	fail.Store(true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if fail.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = fmt.Fprint(w, `{"error":"try again"}`)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"id":1,"accounts":[{"id":1,"status":"active"},{"id":2,"status":"active"}]}`)
+	}))
+	t.Cleanup(server.Close)
+	root := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "token"}, hey.WithMaxRetries(0))
+	m := newModelWithMailAccounts(root, root, "all")
+	m.loading = false
+
+	failed := loadMailAccounts(t.Context(), root, "all")().(mailAccountsLoadedMsg)
+	updated, _ := m.Update(failed)
+	m = updated.(model)
+	if m.mailAccountDiscoveryErr == "" || !m.canSwitchMailAccounts() {
+		t.Fatalf("discovery failure did not expose retry: %q", m.mailAccountDiscoveryErr)
+	}
+	fail.Store(false)
+	updated, retry := m.handleKey(tea.KeyPressMsg(tea.Key{Code: 'a', Mod: tea.ModCtrl}))
+	m = updated.(model)
+	if retry == nil {
+		t.Fatal("ctrl+a did not retry account discovery")
+	}
+	loaded := retry().(mailAccountsLoadedMsg)
+	updated, _ = m.Update(loaded)
+	m = updated.(model)
+	if m.mailAccountDiscoveryErr != "" || len(m.mailAccounts) != 3 {
+		t.Fatalf("retry did not load accounts: error=%q accounts=%#v", m.mailAccountDiscoveryErr, m.mailAccounts)
+	}
+}
+
+func TestAccountPickerRequiresMultipleLinkedAccounts(t *testing.T) {
+	m := newModel()
+	m.mailAccounts = []mailAccountChoice{{label: "All Accounts"}, {id: 1, label: "jane@example.com"}}
+	if m.canSwitchMailAccounts() {
+		t.Fatal("picker enabled for one linked account")
+	}
+	m.mailAccounts = append(m.mailAccounts, mailAccountChoice{id: 2, label: "jane@company.example"})
+	if !m.canSwitchMailAccounts() {
+		t.Fatal("picker disabled for multiple linked accounts")
+	}
+}
+
+func TestCtrlAOpensAccountPicker(t *testing.T) {
+	m := newModel()
+	m.loading = false
+	m.mailAccounts = []mailAccountChoice{
+		{label: "All Accounts"},
+		{id: 1, label: "jane@example.com"},
+		{id: 2, label: "jane@company.example"},
+	}
+	updated, cmd := m.handleKey(tea.KeyPressMsg(tea.Key{Code: 'a', Mod: tea.ModCtrl}))
+	m = updated.(model)
+	if cmd != nil || !m.mailAccountPicker {
+		t.Fatal("ctrl+a did not open the account picker")
+	}
+	if view := m.View().Content; !strings.Contains(view, "Select mail account") {
+		t.Fatalf("picker view = %q", view)
+	}
+}
+
+func TestAccountSwitchRebuildsViewsAndCancelsOldGeneration(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/identity.json":
+			_, _ = fmt.Fprint(w, `{"id":1,"accounts":[{"id":1,"status":"active"},{"id":2,"status":"active"}]}`)
+		case "/boxes.json":
+			_, _ = fmt.Fprint(w, `[]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	root := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "token"}, hey.WithMaxRetries(0))
+	m := newModelWithMailAccounts(root, root, "all")
+	m.mailAccounts = []mailAccountChoice{
+		{label: "All Accounts"},
+		{id: 1, label: "jane@example.com"},
+		{id: 2, label: "jane@company.example"},
+	}
+	m.mailAccountPicker = true
+	m.mailAccountCursor = 2
+	oldContext := m.vc.ctx
+	oldMailView := m.mailView
+
+	modelAfterKey, cmd := m.handleMailAccountKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = modelAfterKey.(model)
+	if cmd == nil || !m.mailAccountSwitching {
+		t.Fatal("account switch did not start")
+	}
+	switchMsg, ok := cmd().(mailAccountSwitchedMsg)
+	if !ok || switchMsg.err != nil {
+		t.Fatalf("switch result = %#v", switchMsg)
+	}
+	updatedModel, initCmd := m.Update(switchMsg)
+	m = updatedModel.(model)
+	if initCmd == nil {
+		t.Fatal("switched account did not reload the active view")
+	}
+	if m.mailAccount.id != 2 || m.mailAccount.label != "jane@company.example" {
+		t.Fatalf("selected account = %#v", m.mailAccount)
+	}
+	if m.viewGeneration != 1 || m.mailView == oldMailView || m.mailAccountPicker {
+		t.Fatalf("switch did not rebuild state: generation=%d picker=%v", m.viewGeneration, m.mailAccountPicker)
+	}
+	select {
+	case <-oldContext.Done():
+	default:
+		t.Fatal("old view context was not canceled")
+	}
+	if accountID, ok := m.vc.sdk.AccountID(); !ok || accountID != 2 {
+		t.Fatalf("view SDK account = %d, %v", accountID, ok)
+	}
+}
+
+func TestFailedAccountSwitchPreservesCurrentViews(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":1,"accounts":[{"id":1,"status":"active"}]}`)
+	}))
+	t.Cleanup(server.Close)
+	root := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "token"}, hey.WithMaxRetries(0))
+	m := newModelWithMailAccounts(root, root, "all")
+	m.mailAccounts = []mailAccountChoice{{label: "All Accounts"}, {id: 1, label: "jane@example.com"}, {id: 2, label: "missing@example.com"}}
+	m.mailAccountPicker = true
+	m.mailAccountCursor = 2
+	oldContext := m.vc.ctx
+	oldMailView := m.mailView
+
+	updated, cmd := m.handleMailAccountKey(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = updated.(model)
+	switchMsg := cmd().(mailAccountSwitchedMsg)
+	updated, _ = m.Update(switchMsg)
+	m = updated.(model)
+	if m.mailView != oldMailView || !m.mailAccountPicker || m.mailAccountErr == "" {
+		t.Fatalf("failed switch changed views: picker=%v error=%q", m.mailAccountPicker, m.mailAccountErr)
+	}
+	select {
+	case <-oldContext.Done():
+		t.Fatal("failed switch canceled the current view context")
+	default:
+	}
+}
+
+func TestGenerationGuardPreservesRawTerminalMessages(t *testing.T) {
+	m := newModel()
+	cmd := m.stampViewCmd(tea.Raw("image upload"))
+	if _, ok := cmd().(tea.RawMsg); !ok {
+		t.Fatal("generation guard hid tea.RawMsg from Bubble Tea")
+	}
+
+	stale := m.stampViewCmd(tea.Raw("stale image upload"))
+	m.viewGeneration++
+	m.viewGenerationToken.Store(m.viewGeneration)
+	if msg := stale(); msg != nil {
+		t.Fatalf("stale raw command returned %#v", msg)
+	}
+}
+
+func TestStaleViewGenerationIsIgnoredAfterAccountSwitch(t *testing.T) {
+	m := newModel()
+	m.viewGeneration = 2
+	updated, cmd := m.Update(viewGenerationMsg{
+		generation: 1,
+		msg:        boxesLoadedMsg{{ID: 99, Name: "Stale"}},
+	})
+	m = updated.(model)
+	if cmd != nil || len(m.mailView.boxes) != 0 {
+		t.Fatalf("stale message changed the active view: %#v", m.mailView.boxes)
+	}
+}
+
+func TestSwitchMailAccountCanReturnToAllAccounts(t *testing.T) {
+	root := hey.NewClient(&hey.Config{BaseURL: "http://localhost:3000"}, &hey.StaticTokenProvider{Token: "token"})
+	msg, ok := switchMailAccount(context.Background(), root, mailAccountChoice{label: "All Accounts"}, 7)().(mailAccountSwitchedMsg)
+	if !ok || msg.err != nil || msg.client != root || msg.requestID != 7 {
+		t.Fatalf("All Accounts switch = %#v", msg)
+	}
+}

--- a/internal/tui/bulk_reply.go
+++ b/internal/tui/bulk_reply.go
@@ -303,6 +303,7 @@ func (v *mailView) undoBulkReply() tea.Cmd {
 		v.notice = "No delayed bulk reply is available to undo"
 		return nil
 	}
+	v.pendingMutations++
 	return func() tea.Msg {
 		err := v.vc.sdk.BulkReplies().Undo(v.vc.ctx, id)
 		return bulkReplyUndoneMsg{id: id, err: err}

--- a/internal/tui/compose.go
+++ b/internal/tui/compose.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,6 +9,8 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/htmlutil"
 )
@@ -22,6 +25,7 @@ type replyContextLoadedMsg struct {
 	topicID   int64
 	topicName string
 	entryID   int64
+	sdk       *hey.Client
 	to, cc    []string
 	bcc       []string
 	err       error
@@ -34,6 +38,7 @@ type forwardContextLoadedMsg struct {
 	boxID     int64
 	topicID   int64
 	topicName string
+	sdk       *hey.Client
 	subject   string
 	content   string
 	err       error
@@ -73,6 +78,7 @@ type composeForm struct {
 	mode             composeMode
 	topicName        string
 	entryID          int64 // reply target (composeReply only)
+	sendSDK          *hey.Client
 	forwardedContent string
 
 	inputs []textinput.Model // to, cc, bcc, subject (subject omitted for replies)
@@ -123,6 +129,7 @@ func newReplyForm(ctxMsg replyContextLoadedMsg, s styles) *composeForm {
 	f := newComposeForm(composeReply, s)
 	f.topicName = ctxMsg.topicName
 	f.entryID = ctxMsg.entryID
+	f.sendSDK = ctxMsg.sdk
 	f.inputs[fieldTo].SetValue(strings.Join(ctxMsg.to, ", "))
 	f.inputs[fieldCc].SetValue(strings.Join(ctxMsg.cc, ", "))
 	f.inputs[fieldBcc].SetValue(strings.Join(ctxMsg.bcc, ", "))
@@ -133,6 +140,7 @@ func newReplyForm(ctxMsg replyContextLoadedMsg, s styles) *composeForm {
 func newForwardForm(ctxMsg forwardContextLoadedMsg, s styles) *composeForm {
 	f := newComposeForm(composeForward, s)
 	f.topicName = ctxMsg.topicName
+	f.sendSDK = ctxMsg.sdk
 	f.forwardedContent = ctxMsg.content
 	f.inputs[fieldSubject].SetValue(ctxMsg.subject)
 	f.body.Placeholder = "Add a note…"
@@ -312,37 +320,40 @@ func (v *mailView) startCompose() tea.Cmd {
 	return v.compose.init()
 }
 
-// loadReplyContext fetches the thread's recipients and latest entry, the same
-// way `hey reply` does, then opens the reply form on replyContextLoadedMsg.
+// loadReplyContext fetches the thread's account, latest entry, and recipients,
+// then opens a reply form bound to that account's sender.
 func (v *mailView) loadReplyContext(topicID int64, topicName string) tea.Cmd {
 	sdk := v.vc.sdk
 	boxID := v.currentBoxID()
 	requestID, ctx := v.beginRequest(mailRequestReply)
 	return func() tea.Msg {
-		topicResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d", topicID))
+		topic, err := sdk.Topics().Get(ctx, topicID)
 		if err != nil {
 			return replyContextLoadedMsg{requestID: requestID, boxID: boxID, err: err}
 		}
-		addressed := htmlutil.ParseTopicAddressed(string(topicResp.Data))
-
-		entriesResp, err := sdk.GetHTML(ctx, fmt.Sprintf("/topics/%d/entries", topicID))
-		if err != nil {
-			return replyContextLoadedMsg{requestID: requestID, boxID: boxID, err: err}
-		}
-		entries := htmlutil.ParseTopicEntriesHTML(string(entriesResp.Data))
-		if len(entries) == 0 {
+		if topic == nil || len(topic.Entries) == 0 {
 			return replyContextLoadedMsg{
 				requestID: requestID,
 				boxID:     boxID,
 				err:       fmt.Errorf("no entries found in thread %d", topicID),
 			}
 		}
+		accountSDK, err := v.clientForTopicAccount(ctx, topic.AccountId)
+		if err != nil {
+			return replyContextLoadedMsg{requestID: requestID, boxID: boxID, err: err}
+		}
+		topicResp, err := accountSDK.GetHTML(ctx, fmt.Sprintf("/topics/%d", topicID))
+		if err != nil {
+			return replyContextLoadedMsg{requestID: requestID, boxID: boxID, err: err}
+		}
+		addressed := htmlutil.ParseTopicAddressed(string(topicResp.Data))
 		return replyContextLoadedMsg{
 			requestID: requestID,
 			boxID:     boxID,
 			topicID:   topicID,
 			topicName: topicName,
-			entryID:   entries[len(entries)-1].ID,
+			entryID:   topic.Entries[len(topic.Entries)-1].Id,
+			sdk:       accountSDK,
 			to:        addressed.To,
 			cc:        addressed.CC,
 			bcc:       addressed.BCC,
@@ -368,8 +379,12 @@ func (v *mailView) loadForwardContext(topicID int64, topicName string) tea.Cmd {
 				err:       fmt.Errorf("no entries found in thread %d", topicID),
 			}
 		}
+		accountSDK, err := v.clientForTopicAccount(ctx, topic.AccountId)
+		if err != nil {
+			return forwardContextLoadedMsg{requestID: requestID, boxID: boxID, err: err}
+		}
 		entryID := topic.Entries[len(topic.Entries)-1].Id
-		draft, err := sdk.Entries().NewForward(ctx, entryID)
+		draft, err := accountSDK.Entries().NewForward(ctx, entryID)
 		if err != nil {
 			return forwardContextLoadedMsg{requestID: requestID, boxID: boxID, err: err}
 		}
@@ -385,10 +400,21 @@ func (v *mailView) loadForwardContext(topicID int64, topicName string) tea.Cmd {
 			boxID:     boxID,
 			topicID:   topicID,
 			topicName: topicName,
+			sdk:       accountSDK,
 			subject:   draft.Subject,
 			content:   draft.Content,
 		}
 	}
+}
+
+func (v *mailView) clientForTopicAccount(ctx context.Context, accountID int64) (*hey.Client, error) {
+	if accountID <= 0 {
+		return nil, fmt.Errorf("thread did not identify its mail account")
+	}
+	if v.vc.rootSDK == nil {
+		return nil, fmt.Errorf("mail account switching is unavailable")
+	}
+	return v.vc.rootSDK.ForAccount(ctx, accountID)
 }
 
 // send submits the open form through the SDK.
@@ -397,6 +423,9 @@ func (v *mailView) send() tea.Cmd {
 	to, cc, bcc, subject, body := f.values()
 	ctx := v.vc.ctx
 	sdk := v.vc.sdk
+	if f.sendSDK != nil {
+		sdk = f.sendSDK
+	}
 	switch f.mode {
 	case composeReply:
 		entryID := f.entryID

--- a/internal/tui/compose_test.go
+++ b/internal/tui/compose_test.go
@@ -36,24 +36,30 @@ func runCmd(cmd tea.Cmd) tea.Msg {
 // the send request. It returns the mailView wired to it and the recorder.
 func composeTestServer(t *testing.T) (*mailView, *struct {
 	method, path string
+	account      string
 	body         map[string]any
 }) {
 	t.Helper()
 	rec := &struct {
 		method, path string
+		account      string
 		body         map[string]any
 	}{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/identity.json":
-			_, _ = w.Write([]byte(`{"id":1,"email_address":"me@hey.com","senders":[{"id":42,"default":true}]}`))
+			_, _ = w.Write([]byte(`{"id":1,"accounts":[{"id":9,"status":"active"}],"senders":[{"id":42,"account_id":9,"default":true}]}`))
 		case "/topics/100.json":
-			_, _ = w.Write([]byte(`{"id":100,"name":"Quarterly planning","entries":[{"id":500},{"id":501}]}`))
+			_, _ = w.Write([]byte(`{"id":100,"account_id":9,"name":"Quarterly planning","entries":[{"id":500},{"id":501}]}`))
+		case "/topics/100":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<span class="entry__full-recipients"><a title="jane@example.com">Jane</a></span>`))
 		case "/entries/501/forwards/new.json":
 			_, _ = w.Write([]byte(`{"subject":"Fwd: Quarterly planning","content":"<div>Quoted message</div>"}`))
 		default:
 			rec.method, rec.path = r.Method, r.URL.Path
+			rec.account = r.URL.Query().Get("filtered_account_id")
 			if b, _ := io.ReadAll(r.Body); len(b) > 0 {
 				_ = json.Unmarshal(b, &rec.body)
 			}
@@ -64,6 +70,7 @@ func composeTestServer(t *testing.T) (*mailView, *struct {
 	t.Cleanup(srv.Close)
 	sdk := hey.NewClient(&hey.Config{BaseURL: srv.URL}, &hey.StaticTokenProvider{Token: "t"}, hey.WithMaxRetries(0))
 	vc := testVC()
+	vc.rootSDK = sdk
 	vc.sdk = sdk
 	vc.ctx = context.Background()
 	v := newMailView(vc)
@@ -242,6 +249,29 @@ func TestReplyFormPrefillsAndSends(t *testing.T) {
 	}
 }
 
+func TestReplyLoadsAndSendsThroughThreadAccount(t *testing.T) {
+	v, rec := composeTestServer(t)
+	v.Resize(80, 30)
+
+	loaded := runCmd(v.loadReplyContext(100, "Quarterly planning"))
+	ctxMsg, ok := loaded.(replyContextLoadedMsg)
+	if !ok || ctxMsg.err != nil {
+		t.Fatalf("reply command returned %#v", loaded)
+	}
+	if accountID, ok := ctxMsg.sdk.AccountID(); !ok || accountID != 9 {
+		t.Fatalf("reply SDK account = %d, %v", accountID, ok)
+	}
+	v.Update(ctxMsg)
+	typeText(v, "Thanks!")
+	msg := runCmd(v.HandleContentKey(ctrlS()))
+	if sent, ok := msg.(composeSentMsg); !ok || sent.err != nil {
+		t.Fatalf("reply send returned %#v", msg)
+	}
+	if rec.path != "/entries/501/replies.json" || rec.account != "9" {
+		t.Fatalf("reply path/account = %s/%q, want /entries/501/replies.json/9", rec.path, rec.account)
+	}
+}
+
 func TestForwardFormLoadsLatestEntryAndSends(t *testing.T) {
 	v, rec := composeTestServer(t)
 	v.Resize(80, 30)
@@ -280,6 +310,9 @@ func TestForwardFormLoadsLatestEntryAndSends(t *testing.T) {
 	}
 	if rec.method != http.MethodPost || rec.path != "/messages.json" {
 		t.Errorf("sent %s %s, want POST /messages.json", rec.method, rec.path)
+	}
+	if rec.account != "9" {
+		t.Errorf("forward account = %q, want 9", rec.account)
 	}
 	message := rec.body["message"].(map[string]any)
 	if message["subject"] != "Fwd: Quarterly planning" {

--- a/internal/tui/contacts.go
+++ b/internal/tui/contacts.go
@@ -419,6 +419,10 @@ func (v *contactsView) CapturingInput() bool {
 	return v.contactForm != nil || v.noteForm != nil
 }
 
+func (v *contactsView) AccountSwitchBlocked() bool {
+	return v.loading && v.activeRequestKind == contactRequestMutation
+}
+
 func (v *contactsView) Resize(width, height int) {
 	v.list.setSize(width, height)
 	v.detailView.SetWidth(width)

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -124,6 +124,7 @@ type mailView struct {
 	searchQuery       string
 	searchPage        int
 	lastBulkReplyID   int64  // delayed delivery currently available for undo
+	pendingMutations  int    // writes that must finish before changing the account context
 	notice            string // one-shot confirmation shown above the posting list
 	activeRequestID   uint64 // identifies the only mail read allowed to update the view
 	activeRequestKind mailRequestKind
@@ -299,6 +300,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case bulkReplyUndoneMsg:
+		v.finishMutation()
 		if msg.id != v.lastBulkReplyID {
 			return nil, true
 		}
@@ -351,6 +353,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case postingActionDoneMsg:
+		v.finishMutation()
 		if msg.err != nil {
 			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
@@ -441,6 +444,10 @@ func (v *mailView) View() string {
 // CapturingInput reports whether a form or picker is open and wants every key.
 func (v *mailView) CapturingInput() bool {
 	return v.compose != nil || v.bulkReply != nil || v.movePicker != nil || v.searchForm != nil
+}
+
+func (v *mailView) AccountSwitchBlocked() bool {
+	return v.pendingMutations > 0
 }
 
 func (v *mailView) HelpBindings() []helpBinding {
@@ -1019,6 +1026,7 @@ func (v *mailView) movesOutOfCurrentBox(destinationKind string) bool {
 }
 
 func (v *mailView) doPostingAction(label string, effect postingActionEffect, boxID, postingID int64, fn func() error) tea.Cmd {
+	v.pendingMutations++
 	return func() tea.Msg {
 		err := fn()
 		return postingActionDoneMsg{
@@ -1028,6 +1036,12 @@ func (v *mailView) doPostingAction(label string, effect postingActionEffect, box
 			effect:    effect,
 			err:       err,
 		}
+	}
+}
+
+func (v *mailView) finishMutation() {
+	if v.pendingMutations > 0 {
+		v.pendingMutations--
 	}
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -294,7 +294,11 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			v, recorded := mailWithTestServer(t, http.StatusNoContent)
 
-			msg := runCmd(v.HandleContentKey(keyPress(tt.key)))
+			cmd := v.HandleContentKey(keyPress(tt.key))
+			if !v.AccountSwitchBlocked() {
+				t.Fatal("posting mutation did not block account switching")
+			}
+			msg := runCmd(cmd)
 			done, ok := msg.(postingActionDoneMsg)
 			if !ok || done.err != nil {
 				t.Fatalf("posting command returned %#v", msg)
@@ -306,6 +310,9 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 				t.Errorf("action effect = %v, want %v", done.effect, tt.effect)
 			}
 			v.Update(done)
+			if v.AccountSwitchBlocked() {
+				t.Fatal("completed posting mutation still blocks account switching")
+			}
 
 			if recorded.method != http.MethodPost || recorded.path != tt.path {
 				t.Errorf("request = %s %s, want POST %s", recorded.method, recorded.path, tt.path)

--- a/internal/tui/nav.go
+++ b/internal/tui/nav.go
@@ -303,7 +303,7 @@ func renderHeader(m *model) string {
 	var b strings.Builder
 
 	// Row 1: section rule + items
-	sectionLabel := "HEY"
+	sectionLabel := "HEY · " + m.mailAccount.label
 	b.WriteString(renderRule(m.width, sectionLabel))
 	b.WriteString("\n")
 	b.WriteString(renderNavRow(sectionItems, int(m.section), m.focus == rowSection, m.width, true))

--- a/internal/tui/section_view.go
+++ b/internal/tui/section_view.go
@@ -72,6 +72,10 @@ type inputCapturer interface {
 	CapturingInput() bool
 }
 
+type accountSwitchBlocker interface {
+	AccountSwitchBlocked() bool
+}
+
 // pendingDetailCanceler is implemented by section views whose detail reads can
 // be canceled before the detail view opens.
 type pendingDetailCanceler interface {

--- a/internal/tui/section_view.go
+++ b/internal/tui/section_view.go
@@ -13,6 +13,7 @@ type attachmentSaveFunc func(context.Context, string, string, bool) (int64, erro
 type attachmentOpenFunc func(string) error
 
 type viewContext struct {
+	rootSDK              *hey.Client
 	sdk                  *hey.Client
 	ctx                  context.Context
 	styles               styles

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -397,7 +397,7 @@ func (m *model) updateHelpBindings() {
 			bindings = append(bindings, extra...)
 		}
 	}
-	if m.canSwitchMailAccounts() && !m.mailAccountPicker && !m.loading && !m.activeView.InThread() {
+	if m.canOpenMailAccountPicker() && !m.mailAccountPicker {
 		if ic, ok := m.activeView.(inputCapturer); !ok || !ic.CapturingInput() {
 			description := "mail account"
 			if m.mailAccountDiscoveryErr != "" {
@@ -448,7 +448,7 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
-	if key == "ctrl+a" && m.canSwitchMailAccounts() && !m.loading && !m.activeView.InThread() {
+	if key == "ctrl+a" && m.canOpenMailAccountPicker() {
 		if m.mailAccountDiscoveryErr != "" {
 			m.mailAccountDiscoveryErr = ""
 			m.updateHelpBindings()
@@ -529,6 +529,26 @@ func (m model) canSwitchMailAccounts() bool {
 	return m.mailAccountDiscoveryErr != "" || len(m.mailAccounts) > 2 || (m.mailAccountUnavailable && len(m.mailAccounts) > 0)
 }
 
+func (m model) canOpenMailAccountPicker() bool {
+	return m.canSwitchMailAccounts() && !m.loading && !m.activeView.InThread() && !m.hasPendingMutation()
+}
+
+func (m model) hasPendingMutation() bool {
+	views := []sectionView{m.activeView}
+	if m.mailView != nil && m.activeView != m.mailView {
+		views = append(views, m.mailView)
+	}
+	if m.contactsView != nil && m.activeView != m.contactsView {
+		views = append(views, m.contactsView)
+	}
+	for _, view := range views {
+		if blocker, ok := view.(accountSwitchBlocker); ok && blocker.AccountSwitchBlocked() {
+			return true
+		}
+	}
+	return false
+}
+
 func (m model) handleMailAccountKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 	if msg.Key().Code == tea.KeyEscape || key == "q" {
@@ -569,7 +589,7 @@ func (m model) handleMailAccountKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) switchSection(sec section) (tea.Model, tea.Cmd) {
-	if sec == m.section {
+	if sec == m.section || m.hasPendingMutation() {
 		return m, nil
 	}
 	m.section = sec

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2,8 +2,12 @@ package tui
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -25,12 +29,13 @@ type spinnerTickMsg struct{}
 // --- Model ---
 
 type model struct {
-	width  int
-	height int
-	vc     *viewContext
-	cancel context.CancelFunc
-	styles styles
-	help   helpBar
+	width   int
+	height  int
+	vc      *viewContext
+	rootSDK *hey.Client
+	cancel  context.CancelFunc
+	styles  styles
+	help    helpBar
 
 	// Navigation
 	section    section
@@ -43,6 +48,19 @@ type model struct {
 	calendarView *calendarView
 	journalView  *journalView
 
+	// Linked mail accounts
+	mailAccounts            []mailAccountChoice
+	mailAccount             mailAccountChoice
+	mailAccountCursor       int
+	mailAccountPicker       bool
+	mailAccountSwitching    bool
+	mailAccountUnavailable  bool
+	mailAccountDiscoveryErr string
+	mailAccountErr          string
+	mailAccountRequestID    uint64
+	viewGeneration          uint64
+	viewGenerationToken     *atomic.Uint64
+
 	// Loading & error
 	loading      bool
 	spinnerPhase float64
@@ -50,13 +68,49 @@ type model struct {
 	ctrlCOnce    bool
 }
 
-func newModel(sdk *hey.Client) model {
+func newModel() model {
+	return newModelWithMailAccounts(nil, nil, "all")
+}
+
+func newModelWithMailAccounts(rootSDK, sdk *hey.Client, selected string) model {
 	s := newStyles()
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel stored, called on ctrl+c
-	vc := &viewContext{
+	vc := newViewContext(ctx, rootSDK, sdk, s)
+	mv := newMailView(vc)
+	ov := newContactsView(vc)
+	cv := newCalendarView(vc)
+	jv := newJournalView(vc)
+	account := mailAccountChoice{label: "All Accounts"}
+	if accountID, err := strconv.ParseInt(selected, 10, 64); err == nil && accountID > 0 {
+		account = mailAccountChoice{id: accountID, label: fmt.Sprintf("Account %d", accountID)}
+	}
+
+	return model{
+		vc:                  vc,
+		rootSDK:             rootSDK,
+		cancel:              cancel,
+		styles:              s,
+		help:                newHelpBar(s),
+		section:             sectionMail,
+		focus:               rowContent,
+		activeView:          mv,
+		mailView:            mv,
+		contactsView:        ov,
+		calendarView:        cv,
+		journalView:         jv,
+		mailAccounts:        []mailAccountChoice{{label: "All Accounts"}},
+		mailAccount:         account,
+		viewGenerationToken: &atomic.Uint64{},
+		loading:             true,
+	}
+}
+
+func newViewContext(ctx context.Context, rootSDK, sdk *hey.Client, styles styles) *viewContext {
+	return &viewContext{
+		rootSDK:       rootSDK,
 		sdk:           sdk,
 		ctx:           ctx,
-		styles:        s,
+		styles:        styles,
 		imageRenderer: environmentImageRenderer(),
 		imageFetcher:  newTrustedImageFetcher(sdk),
 		saveAttachment: func(ctx context.Context, destination, sourceURL string, force bool) (int64, error) {
@@ -67,36 +121,58 @@ func newModel(sdk *hey.Client) model {
 			return os.MkdirTemp("", "hey-cli-attachment-*")
 		},
 	}
-
-	mv := newMailView(vc)
-	ov := newContactsView(vc)
-	cv := newCalendarView(vc)
-	jv := newJournalView(vc)
-
-	return model{
-		vc:           vc,
-		cancel:       cancel,
-		styles:       s,
-		help:         newHelpBar(s),
-		section:      sectionMail,
-		focus:        rowContent,
-		activeView:   mv,
-		mailView:     mv,
-		contactsView: ov,
-		calendarView: cv,
-		journalView:  jv,
-		loading:      true,
-	}
 }
 
 func (m model) Init() tea.Cmd {
-	return tea.Batch(m.activeView.Init(), spinnerTick())
+	return tea.Batch(
+		m.stampViewCmd(m.activeView.Init()),
+		loadMailAccounts(m.vc.ctx, m.rootSDK, strconv.FormatInt(m.mailAccount.id, 10)),
+		spinnerTick(),
+	)
 }
 
 // --- Update ---
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case viewGenerationMsg:
+		if msg.generation != m.viewGeneration {
+			return m, nil
+		}
+		return m.Update(msg.msg)
+
+	case mailAccountsLoadedMsg:
+		if msg.err != nil {
+			m.mailAccountDiscoveryErr = msg.err.Error()
+			m.updateHelpBindings()
+			return m, nil
+		}
+		m.mailAccountDiscoveryErr = ""
+		m.mailAccounts = msg.accounts
+		m.mailAccountUnavailable = msg.selectedUnavailable
+		if msg.selectedUnavailable {
+			m.loading = false
+			m.mailAccountErr = fmt.Sprintf("Selected mail account %d is no longer available", m.mailAccount.id)
+			m.err = errors.New(m.mailAccountErr)
+		} else if msg.loaded && msg.selected >= 0 && msg.selected < len(msg.accounts) {
+			m.mailAccount = msg.accounts[msg.selected]
+			m.mailAccountCursor = msg.selected
+		}
+		m.updateHelpBindings()
+		return m, nil
+
+	case mailAccountSwitchedMsg:
+		if msg.requestID != m.mailAccountRequestID {
+			return m, nil
+		}
+		m.mailAccountSwitching = false
+		if msg.err != nil {
+			m.mailAccountErr = msg.err.Error()
+			m.updateHelpBindings()
+			return m, nil
+		}
+		return m.applyMailAccount(msg.account, msg.client)
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -137,12 +213,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if consumed {
 		cmd = m.syncLoading(cmd)
 		m.updateHelpBindings()
+		return m, cmd
 	}
-	return m, cmd
+	return m, m.stampViewCmd(cmd)
 }
 
 // syncLoading synchronizes the main loading state with the active section view.
 func (m *model) syncLoading(cmd tea.Cmd) tea.Cmd {
+	cmd = m.stampViewCmd(cmd)
 	nowLoading := m.activeView.Loading()
 	if nowLoading && !m.loading {
 		m.loading = true
@@ -152,6 +230,70 @@ func (m *model) syncLoading(cmd tea.Cmd) tea.Cmd {
 		m.loading = false
 	}
 	return cmd
+}
+
+func (m model) stampViewCmd(cmd tea.Cmd) tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	generation := m.viewGeneration
+	token := m.viewGenerationToken
+	return func() tea.Msg {
+		if token != nil && token.Load() != generation {
+			return nil
+		}
+		msg := cmd()
+		if msg == nil || (token != nil && token.Load() != generation) {
+			return nil
+		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			stamped := make(tea.BatchMsg, len(batch))
+			for index, batchCmd := range batch {
+				stamped[index] = m.stampViewCmd(batchCmd)
+			}
+			return stamped
+		}
+		if _, ok := msg.(tea.RawMsg); ok {
+			return msg
+		}
+		return viewGenerationMsg{generation: generation, msg: msg}
+	}
+}
+
+func (m model) applyMailAccount(account mailAccountChoice, client *hey.Client) (tea.Model, tea.Cmd) {
+	m.viewGeneration++
+	m.viewGenerationToken.Store(m.viewGeneration)
+	m.cancel()
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel stored, called on switch or quit
+	m.cancel = cancel
+	m.vc = newViewContext(ctx, m.rootSDK, client, m.styles)
+	m.vc.width = m.width
+	m.vc.height = max(m.height-headerHeight-m.help.height()-3, 1)
+	m.mailView = newMailView(m.vc)
+	m.contactsView = newContactsView(m.vc)
+	m.calendarView = newCalendarView(m.vc)
+	m.journalView = newJournalView(m.vc)
+	switch m.section {
+	case sectionMail:
+		m.activeView = m.mailView
+	case sectionContacts:
+		m.activeView = m.contactsView
+	case sectionCalendar:
+		m.activeView = m.calendarView
+	case sectionJournal:
+		m.activeView = m.journalView
+	}
+	m.mailAccount = account
+	m.mailAccountPicker = false
+	m.mailAccountUnavailable = false
+	m.mailAccountErr = ""
+	m.err = nil
+	m.focus = rowContent
+	m.loading = false
+	m.activeView.Resize(m.vc.width, m.vc.height)
+	cmd := m.syncLoading(m.activeView.Init())
+	m.updateHelpBindings()
+	return m, cmd
 }
 
 // --- View ---
@@ -164,7 +306,9 @@ func (m model) View() tea.View {
 	b.WriteString(renderHeader(&m))
 	b.WriteString("\n")
 
-	if m.err != nil {
+	if m.mailAccountPicker {
+		b.WriteString(renderMailAccountPicker(&m))
+	} else if m.err != nil {
 		b.WriteString(errorView(m.err.Error(), m.width))
 	} else if m.loading {
 		contentH := m.height - headerHeight - m.help.height() - 3
@@ -206,7 +350,14 @@ func (m *model) updateHelpBindings() {
 
 	var bindings []helpBinding
 
-	if ic, ok := m.activeView.(inputCapturer); ok && ic.CapturingInput() {
+	if m.mailAccountPicker {
+		bindings = []helpBinding{
+			{"↑↓", "account"},
+			{"enter", "switch"},
+			{"esc/q", "cancel"},
+			quitHint,
+		}
+	} else if ic, ok := m.activeView.(inputCapturer); ok && ic.CapturingInput() {
 		bindings = append(m.activeView.HelpBindings(), quitHint)
 	} else if m.activeView.InThread() {
 		extra := m.activeView.HelpBindings()
@@ -246,6 +397,15 @@ func (m *model) updateHelpBindings() {
 			bindings = append(bindings, extra...)
 		}
 	}
+	if m.canSwitchMailAccounts() && !m.mailAccountPicker && !m.loading && !m.activeView.InThread() {
+		if ic, ok := m.activeView.(inputCapturer); !ok || !ic.CapturingInput() {
+			description := "mail account"
+			if m.mailAccountDiscoveryErr != "" {
+				description = "retry accounts"
+			}
+			bindings = append(bindings, helpBinding{"ctrl+a", description})
+		}
+	}
 	m.help.setBindings(bindings)
 	contentHeight := m.height - headerHeight - m.help.height() - 3
 	if contentHeight < 1 {
@@ -276,12 +436,34 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.updateHelpBindings()
 	}
 
+	if m.mailAccountPicker {
+		return m.handleMailAccountKey(msg)
+	}
+
 	// A view with an open text form gets every key (esc, tab, letters, ...).
 	if ic, ok := m.activeView.(inputCapturer); ok && ic.CapturingInput() {
 		cmd := m.activeView.HandleContentKey(msg)
 		cmd = m.syncLoading(cmd)
 		m.updateHelpBindings()
 		return m, cmd
+	}
+
+	if key == "ctrl+a" && m.canSwitchMailAccounts() && !m.loading && !m.activeView.InThread() {
+		if m.mailAccountDiscoveryErr != "" {
+			m.mailAccountDiscoveryErr = ""
+			m.updateHelpBindings()
+			return m, loadMailAccounts(m.vc.ctx, m.rootSDK, strconv.FormatInt(m.mailAccount.id, 10))
+		}
+		m.mailAccountPicker = true
+		m.mailAccountErr = ""
+		for index, account := range m.mailAccounts {
+			if account.id == m.mailAccount.id {
+				m.mailAccountCursor = index
+				break
+			}
+		}
+		m.updateHelpBindings()
+		return m, nil
 	}
 
 	if msg.Key().Code == tea.KeyEscape || key == "q" {
@@ -343,6 +525,49 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) canSwitchMailAccounts() bool {
+	return m.mailAccountDiscoveryErr != "" || len(m.mailAccounts) > 2 || (m.mailAccountUnavailable && len(m.mailAccounts) > 0)
+}
+
+func (m model) handleMailAccountKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+	if msg.Key().Code == tea.KeyEscape || key == "q" {
+		if !m.mailAccountSwitching {
+			m.mailAccountPicker = false
+			m.mailAccountErr = ""
+			m.updateHelpBindings()
+		}
+		return m, nil
+	}
+	if m.mailAccountSwitching {
+		return m, nil
+	}
+	switch msg.Key().Code {
+	case tea.KeyUp:
+		if m.mailAccountCursor > 0 {
+			m.mailAccountCursor--
+		}
+	case tea.KeyDown:
+		if m.mailAccountCursor < len(m.mailAccounts)-1 {
+			m.mailAccountCursor++
+		}
+	case tea.KeyEnter:
+		account := m.mailAccounts[m.mailAccountCursor]
+		if account.id == m.mailAccount.id {
+			m.mailAccountPicker = false
+			m.mailAccountErr = ""
+			m.updateHelpBindings()
+			return m, nil
+		}
+		m.mailAccountRequestID++
+		m.mailAccountSwitching = true
+		m.mailAccountErr = ""
+		m.updateHelpBindings()
+		return m, switchMailAccount(m.vc.ctx, m.rootSDK, account, m.mailAccountRequestID)
+	}
+	return m, nil
+}
+
 func (m model) switchSection(sec section) (tea.Model, tea.Cmd) {
 	if sec == m.section {
 		return m, nil
@@ -398,9 +623,10 @@ func formatTimestamp(ts time.Time) string {
 	return ts.UTC().Format("2006-01-02T15:04:05Z")
 }
 
-// Run starts the TUI program.
-func Run(sdk *hey.Client) error {
-	p := tea.NewProgram(newModel(sdk))
+// Run starts the TUI with the resolved mail account and the identity root client used
+// for interactive account switching.
+func Run(rootSDK, sdk *hey.Client, selected string) error {
+	p := tea.NewProgram(newModelWithMailAccounts(rootSDK, sdk, selected))
 	_, err := p.Run()
 	return err
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -15,7 +15,7 @@ import (
 // --- Test helpers ---
 
 func testModel() model {
-	return newModel(nil)
+	return newModel()
 }
 
 func sizedModel() model {

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -100,6 +100,7 @@ CLI for HEY: mailboxes, email threads, contacts, replies, compose, calendars, to
 2. **Authentication required** for all data commands — run `hey auth login` first
 3. **HTML output** is available via `--html` for commands that return HTML content
 4. **Linked mail accounts share one login** — use `hey accounts list --json`, then `--account <id|all>` when a task must target one account
+5. **Local HEY configuration requires human trust** — never run `hey config trust-local` without the user's explicit approval
 
 ## Quick Reference
 
@@ -108,6 +109,8 @@ CLI for HEY: mailboxes, email threads, contacts, replies, compose, calendars, to
 | List linked mail accounts | `hey accounts list --json` |
 | Set default mail account | `hey accounts use <id\|all>` |
 | Run once for one account | `hey --account <id> boxes --json` |
+| Review trusted local settings | `hey config trusted-locals --json` |
+| Trust this repository's settings | `hey config trust-local` (requires explicit user approval) |
 | List mailboxes | `hey boxes --json` |
 | List emails in a box | `hey box imbox --json` |
 | Search email | `hey search "quarterly planning" --json` |

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -9,6 +9,7 @@ triggers:
   - hey
   - /hey
   # Email actions
+  - hey accounts
   - hey boxes
   - hey box
   - hey search
@@ -98,11 +99,15 @@ CLI for HEY: mailboxes, email threads, contacts, replies, compose, calendars, to
 1. **Always use `--json`** for structured, predictable output
 2. **Authentication required** for all data commands — run `hey auth login` first
 3. **HTML output** is available via `--html` for commands that return HTML content
+4. **Linked mail accounts share one login** — use `hey accounts list --json`, then `--account <id|all>` when a task must target one account
 
 ## Quick Reference
 
 | Task | Command |
 |------|---------|
+| List linked mail accounts | `hey accounts list --json` |
+| Set default mail account | `hey accounts use <id\|all>` |
+| Run once for one account | `hey --account <id> boxes --json` |
 | List mailboxes | `hey boxes --json` |
 | List emails in a box | `hey box imbox --json` |
 | Search email | `hey search "quarterly planning" --json` |

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -152,7 +152,7 @@ CLI for HEY: mailboxes, email threads, contacts, replies, compose, calendars, to
 | Write journal entry | `hey journal write "Today was great"` |
 | Check auth status | `hey auth status` |
 | Print access token | `hey auth token` |
-| Launch TUI | `hey` |
+| Launch TUI | `hey` (Ctrl+A switches linked mail accounts) |
 
 ## Decision Trees
 

--- a/tests/smoke/accounts_test.go
+++ b/tests/smoke/accounts_test.go
@@ -1,0 +1,32 @@
+package smoke_test
+
+import "testing"
+
+func TestAccountsList(t *testing.T) {
+	resp := heyJSON(t, "accounts", "list")
+	accounts := dataAs[[]struct {
+		ID     string `json:"id"`
+		Name   string `json:"name"`
+		Active bool   `json:"active"`
+	}](t, resp)
+	if len(accounts) == 0 {
+		t.Fatal("accounts list returned no filters")
+	}
+	if accounts[0].ID != "all" || accounts[0].Name != "All Accounts" {
+		t.Fatalf("first account = %#v, want All Accounts", accounts[0])
+	}
+}
+
+func TestAccountsUseAll(t *testing.T) {
+	resp := heyJSON(t, "accounts", "use", "all")
+	data := dataAs[map[string]string](t, resp)
+	if data["account_id"] != "all" {
+		t.Fatalf("account_id = %q, want all", data["account_id"])
+	}
+
+	_ = heyJSON(t, "--account", "all", "boxes")
+}
+
+func TestAccountsRejectUnknownAccount(t *testing.T) {
+	heyFail(t, "--account", "9223372036854775807", "boxes")
+}

--- a/tests/smoke/attachments_test.go
+++ b/tests/smoke/attachments_test.go
@@ -35,7 +35,7 @@ func TestAttachmentSendListAndSave(t *testing.T) {
 	}
 
 	var result smokeSearchResult
-	for attempt := 0; attempt < 10 && result.TopicID == 0; attempt++ {
+	for attempt := 0; attempt < 60 && result.TopicID == 0; attempt++ {
 		searchOut, _, searchCode := hey(t, "search", "--subject", subject, "--all", "--json")
 		if searchCode == 0 {
 			var response Response
@@ -53,7 +53,7 @@ func TestAttachmentSendListAndSave(t *testing.T) {
 		}
 	}
 	if result.TopicID == 0 {
-		t.Skip("sent attachment thread was not searchable yet")
+		t.Fatal("sent attachment thread was not searchable after waiting for indexing")
 	}
 	if result.ID != 0 {
 		t.Cleanup(func() { _, _, _ = hey(t, "trash", fmt.Sprint(result.ID), "--json") })

--- a/tests/smoke/ignore_test.go
+++ b/tests/smoke/ignore_test.go
@@ -36,7 +36,7 @@ func TestIgnoreAndStopIgnoring(t *testing.T) {
 	}
 	assertContains(t, ignoreResp.Summary, "1 thread ignored")
 
-	afterIgnore := dataAs[BoxResp](t, heyJSON(t, "box", "imbox"))
+	afterIgnore := dataAs[BoxResp](t, heyJSON(t, "box", "imbox", "--all"))
 	muted, found := findPostingMute(afterIgnore.Postings, posting.ID)
 	if !found {
 		t.Fatal("ignored thread disappeared from Imbox")
@@ -52,7 +52,7 @@ func TestIgnoreAndStopIgnoring(t *testing.T) {
 	}
 	assertContains(t, stopResp.Summary, "Stopped ignoring 1 thread")
 
-	afterStop := dataAs[BoxResp](t, heyJSON(t, "box", "imbox"))
+	afterStop := dataAs[BoxResp](t, heyJSON(t, "box", "imbox", "--all"))
 	muted, found = findPostingMute(afterStop.Postings, posting.ID)
 	if !found {
 		t.Fatal("thread disappeared from Imbox after hey stop-ignoring")

--- a/tests/smoke/search_test.go
+++ b/tests/smoke/search_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 type smokeSearchResult struct {
@@ -51,9 +52,16 @@ func TestSearchFreeTextAndRefinements(t *testing.T) {
 		t.Skip("no Imbox thread available for read-only search validation")
 	}
 
-	freeText := dataAs[[]smokeSearchResult](t, heyJSON(t, "search", subject))
+	var freeText []smokeSearchResult
+	deadline := time.Now().Add(10 * time.Second)
+	for len(freeText) == 0 && time.Now().Before(deadline) {
+		freeText = dataAs[[]smokeSearchResult](t, heyJSON(t, "search", subject))
+		if len(freeText) == 0 {
+			time.Sleep(250 * time.Millisecond)
+		}
+	}
 	if len(freeText) == 0 {
-		t.Fatal("free-text search did not find the known Imbox thread")
+		t.Fatal("free-text search did not find the known Imbox thread after waiting for indexing")
 	}
 	for _, result := range freeText {
 		if result.TopicID == 0 {


### PR DESCRIPTION
## Summary

- add linked-account discovery and persisted/per-invocation mail filtering
- route account-sensitive creates through the selected account and replies/forwards through the target thread's account
- add interactive TUI switching with account-specific view reconstruction and stale-response protection
- require explicit first-use trust for repository-local server/account settings and bind persisted defaults to server origins
- update hey-cli to the released `hey-sdk/go@v0.6.0` immutable account-scoped client

## Behavior

```text
one HEY login
├── all accounts (default)
└── linked account ID
    ├── --account <id|all>
    ├── HEY_ACCOUNT_ID
    ├── local .hey/config.json
    └── global ~/.config/hey-cli/config.json
```

Selection precedence is flag → environment → trusted local → origin-specific global → All Accounts. Explicit and persisted IDs are validated against unfiltered identity data before normal authenticated commands, so unavailable accounts fail closed rather than widening to All Accounts.

The first interactive command that would use repository-local `base_url` or `account_id` values asks to use them once, always trust their exact values for the effective server origin, or cancel. JSON, agent, and non-TTY commands fail before authentication or network access until `hey config trust-local` is explicitly run. Trust is stored in user-level configuration, bound to the canonical config path plus a digest of its security-sensitive values and effective server origin, and invalidates when those values change. Global account defaults are stored separately per server origin.

New commands:

```text
hey accounts list
hey accounts use <id|all>
```

Compose and contact creation use an individually selected account's sender/user. Replies, compose replies, attachment uploads, and forwards derive the target topic's `account_id` and refuse to write when HEY omits it.

## Scope

Included:

- CLI discovery, persisted default, environment/flag overrides, help/config/auth visibility
- automatic scoped reads through the SDK runtime boundary
- account-aware compose, contact creation, reply, forward, and attachment upload paths
- TUI Ctrl+A account picker for multi-account identities, account label, context cancellation, complete view reset, and generation-guarded asynchronous messages
- TUI reply and forward forms bound to the target thread's account
- first-use local-config trust prompt plus `config trust-local`, `untrust-local`, and `trusted-locals`
- origin-bound global account defaults with legacy scalar-config migration
- pending-write guards that delay account and section changes until mutation results arrive
- README, embedded agent skill, surface snapshot, unit tests, and smoke coverage

Deferred:

- unlinked identity profiles and separate credentials
- strict rejection of resource IDs outside the selected mail filter

## CLI and TUI evidence

Recorded against the local Haystack development server with fixture accounts and an isolated CLI configuration. Authentication was prepared before recording; no production account or credential appears in these clips. The final review follow-up changes only thread-account request routing and regression coverage, so these visible workflows remain current for this head.

### Linked-account discovery and persisted selection

![HEY CLI linked account selection](https://github.com/user-attachments/assets/d0969d19-991a-41d4-a4f8-72cd6759ffc3)

### First-use repository trust

![HEY CLI local configuration trust](https://github.com/user-attachments/assets/df38034e-99bb-4fa5-b2ff-e7047c5dc32c)

### TUI account picker and account-specific mail

![HEY TUI linked account switching](https://github.com/user-attachments/assets/4dfeadfe-37d9-43a9-b641-2990649a0aca)

## Validation

```text
GOWORK=off make check
→ passed

GOWORK=off go test -race -count=1 ./internal/...
→ passed

GOWORK=off make lint
→ 0 issues

go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
→ no vulnerabilities found

go run github.com/zricethezav/gitleaks/v8@v8.28.0 detect --source . --config .gitleaks.toml
→ no leaks found
```

Authenticated checks:

- Production read-only `accounts list` succeeded.
- Production read-only `--account <id> boxes` succeeded.
- The full smoke suite passes against the local HEY server after rebuilding its stale Elasticsearch indexes and restarting the stale Rails process. The only skip is the move test's documented no-seen-posting data precondition; no request fails and no server 500 remains.
- Stateful smoke checks now fetch the complete Imbox when validating mute state and allow asynchronous search indexing to catch up for search and attachment delivery.

Independent review found and fixed two CLI issues before the first push: key-specific config writes preserve unrelated settings, and the sender-routing regression test asserts the actual top-level wire field. TUI review found and fixed raw terminal message handling and transient discovery retry behavior. A later adversarial security review identified repository-controlled account selection and cross-origin default persistence; this head adds explicit local trust and origin-bound defaults. Follow-up review found and fixed flag-origin re-resolution and hidden overridden values in the trust prompt. Copilot's ready-for-review pass then identified recipient HTML still using the invocation account; `82ee428` now discovers through the root client and reuses the thread-account client for HTML, attachments, and sending, with selected-account-A/target-account-B coverage. Final focused re-review found no remaining P1/P2 issues.

## Reviewer focus

1. Local-config trust boundaries, origin-specific persistence/migration, and fail-closed account validation.
2. The root/scoped SDK boundary and target-thread routing for replies, forwards, and attachment uploads.
3. TUI account-switch lifecycle: async validation, context cancellation, view rebuilding, pending-write guards, generation guards, raw terminal commands, and recovery after discovery failure.

Basecamp card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10220542794

This PR is intentionally draft and must not be merged without explicit approval.
