### PR TITLE
Add verified installers, bats suite, and installer canaries

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -1,0 +1,149 @@
+name: Installer Smoke
+
+# Post-deploy canary for the published installer. The install endpoint serves
+# main, so merge == deploy for scripts/install.sh: the bats suite gates
+# pre-merge, and this catches a broken published installer after. Runs the
+# documented Quick Start shape (curl pipe to bash), not a checkout.
+#
+# TODO(hey.com/install-cli): switch the curl URLs to
+# https://hey.com/install-cli?sha=... once the haystack redirect is live. The
+# raw URL is the documented shape until then; ?sha= still cache-busts
+# raw.githubusercontent.com (max-age=300), so a push-triggered run cannot
+# fetch the pre-push installer and falsely pass.
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - scripts/install.sh
+      - scripts/install.ps1
+      - .github/workflows/installer-smoke.yml
+
+permissions: {}
+
+concurrency:
+  group: installer-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  linux:
+    name: Linux (modern bash)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install from the published endpoint
+        run: |
+          # Scratch HOME + explicit HEY_BIN_DIR contain the installer's writes
+          # (it edits shell config for PATH).
+          smoke_root=$(mktemp -d)
+          mkdir -p "$smoke_root/home" "$smoke_root/bin"
+          export HOME="$smoke_root/home"
+          export HEY_BIN_DIR="$smoke_root/bin"
+
+          curl -fsSL "https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh?sha=${GITHUB_SHA}" | bash
+
+          # Assert the deterministic installed path, not ambient PATH.
+          "$HEY_BIN_DIR/hey" --version
+
+  macos:
+    name: macOS (stock bash 3.2)
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install via stock /bin/bash
+        run: |
+          # Assert exactly Bash 3.2, through the same interpreter that runs
+          # the install — honest 3.2 coverage instead of silently degrading
+          # if a future runner image changes /bin/bash.
+          /bin/bash -c '[[ "${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}" == "3.2" ]]' \
+            || { echo "/bin/bash is not Bash 3.2:" >&2; /bin/bash --version >&2; exit 1; }
+
+          smoke_root=$(mktemp -d)
+          mkdir -p "$smoke_root/home" "$smoke_root/bin"
+          export HOME="$smoke_root/home"
+          export HEY_BIN_DIR="$smoke_root/bin"
+
+          curl -fsSL "https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh?sha=${GITHUB_SHA}" | /bin/bash
+
+          "$HEY_BIN_DIR/hey" --version
+
+  windows:
+    name: Windows (${{ matrix.shell }})
+    runs-on: windows-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # powershell (5.1) is the stock interpreter the README's `irm | iex`
+        # shape targets and exercises install.ps1's 5.1-specific branches;
+        # pwsh covers PowerShell 7.
+        shell: [powershell, pwsh]
+    steps:
+      - name: Install from the published endpoint
+        # GitHub Actions does not evaluate expressions in steps[*].shell, so a
+        # pwsh launcher step invokes the matrix interpreter explicitly. The
+        # documented `irm | iex` shape — fetch and execution both — runs
+        # entirely inside the target interpreter; the launcher only sets env
+        # (inherited by the child) and asserts afterwards.
+        shell: pwsh
+        env:
+          SMOKE_SHELL: ${{ matrix.shell }}
+        run: |
+          # Scratch USERPROFILE + explicit HEY_BIN_DIR contain the installer's
+          # writes (Go os.UserHomeDir reads USERPROFILE). Ensure-UserPath's
+          # HKCU PATH write is unavoidable but disposable on ephemeral runners.
+          $smokeRoot = Join-Path $env:RUNNER_TEMP 'installer-smoke'
+          New-Item -ItemType Directory -Force -Path (Join-Path $smokeRoot 'home') | Out-Null
+          New-Item -ItemType Directory -Force -Path (Join-Path $smokeRoot 'bin') | Out-Null
+          $env:USERPROFILE = Join-Path $smokeRoot 'home'
+          $env:HEY_BIN_DIR = Join-Path $smokeRoot 'bin'
+
+          # Documented Quick Start shape, cache-busted. Single-quoted so the
+          # inner interpreter expands $env:GITHUB_SHA itself.
+          & $env:SMOKE_SHELL -NoProfile -Command 'irm "https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.ps1?sha=$env:GITHUB_SHA" | iex'
+          if ($LASTEXITCODE -ne 0) { throw "installer exited $LASTEXITCODE under $env:SMOKE_SHELL" }
+
+          & "$env:HEY_BIN_DIR\hey.exe" --version
+          if ($LASTEXITCODE -ne 0) { throw "hey --version exited $LASTEXITCODE" }
+
+  notify:
+    name: Notify on failure
+    needs: [linux, macos, windows]
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: File or update canary failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_SLUG: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          LINUX_RESULT: ${{ needs.linux.result }}
+          MACOS_RESULT: ${{ needs.macos.result }}
+          WINDOWS_RESULT: ${{ needs.windows.result }}
+        run: |
+          BODY="The installer canary failed (event: ${EVENT_NAME}). Legs: linux=${LINUX_RESULT}, macos=${MACOS_RESULT}, windows=${WINDOWS_RESULT}. See ${RUN_URL} for details."
+
+          # Deduped by label via notify-issue.sh (shared with release.yml and
+          # aur-publish.yml): a retitled issue does not spawn a duplicate, and
+          # a failed lookup files nothing rather than guessing.
+          notify_status=0
+          scripts/notify-issue.sh \
+            --repo "$REPO_SLUG" \
+            --label installer-canary \
+            --title "Installer canary failure" \
+            --body "$BODY" || notify_status=$?
+
+          echo "::error::Installer canary failed. See ${RUN_URL}"
+          exit "$notify_status"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,9 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      # Dispatch the upgrade smoke: goreleaser publishes with GITHUB_TOKEN,
+      # whose release event does not start other workflows.
+      actions: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -210,6 +213,18 @@ jobs:
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-checksums: ./dist/checksums.txt
+
+      # A release published with the built-in GITHUB_TOKEN does not fire the
+      # `release: published` trigger (GitHub suppresses workflow-to-workflow
+      # events except workflow_dispatch/repository_dispatch), so start the
+      # upgrade smoke explicitly, pinned to this release. The tag ref makes
+      # the smoke run this release's installers, not main's.
+      - name: Trigger the upgrade smoke against this release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run upgrade-smoke.yml --repo "$GITHUB_REPOSITORY" \
+            --ref "$GITHUB_REF_NAME" -f version="${GITHUB_REF_NAME#v}"
 
   # The AUR goes down for maintenance often enough that a release must not
   # depend on it being reachable — isolated and continue-on-error, an AUR outage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,26 @@ jobs:
           version: v2.11.1  # keep in lockstep with test.yml Lint
           install-only: true
 
+      - name: Cache BATS
+        id: cache-bats
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
+        with:
+          path: ~/.local
+          key: bats-1.11.0-home
+
+      - name: Install BATS
+        if: steps.cache-bats.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch v1.11.0 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          /tmp/bats-core/install.sh ~/.local
+
+      - name: Add BATS to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Run release quality gate
         run: |
-          make check-lint-lockstep fmt-check vet lint test tidy-check
+          make check-lint-lockstep fmt-check vet lint test test-e2e tidy-check
           go test ./internal/cmd/ -run TestSurfaceSnapshot -count=1
           go test -race -count=1 ./...
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,176 @@ jobs:
       - name: Run tests with race detector
         run: go test -race -count=1 ./...
 
+  e2e:
+    name: Bats e2e
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      HEY_NO_KEYRING: "1"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Cache BATS
+        id: cache-bats
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
+        with:
+          path: ~/.local
+          key: bats-1.11.0-home
+
+      - name: Install BATS
+        if: steps.cache-bats.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch v1.11.0 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          /tmp/bats-core/install.sh ~/.local
+
+      - name: Add BATS to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run bats suite
+        run: make test-e2e
+
+  installer-bash32:
+    name: Installer (bash 3.2)
+    runs-on: macos-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read  # dorny/paths-filter enumerates PR files via the REST API
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check for installer changes
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          # test.yml is in its own filter so the job proves itself on the PR
+          # that introduces or edits it.
+          filters: |
+            installer:
+              - 'scripts/install.sh'
+              - 'tests/e2e/installer.bats'
+              - '.github/workflows/test.yml'
+
+      - name: Assert /bin/bash is Bash 3.2
+        if: steps.filter.outputs.installer == 'true'
+        run: |
+          # Same guard as the installer-smoke canary: honest 3.2 coverage
+          # instead of silently degrading if a future runner image changes
+          # /bin/bash. The bats suite cannot provide this — bats execs
+          # `env bash` at every layer, so the interpreter is not pinnable
+          # through it.
+          /bin/bash -c '[[ "${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}" == "3.2" ]]' \
+            || { echo "/bin/bash is not Bash 3.2:" >&2; /bin/bash --version >&2; exit 1; }
+
+      - name: Syntax-check installer under Bash 3.2
+        if: steps.filter.outputs.installer == 'true'
+        run: /bin/bash -n scripts/install.sh
+
+      - name: Piped execution under Bash 3.2
+        if: steps.filter.outputs.installer == 'true'
+        run: |
+          # PATH=/nonexistent forces the curl guard: the run must fail with
+          # the guard's own message, never with an unbound-variable error.
+          # A bare out=$(...) assignment of the failing pipeline would exit
+          # this step immediately under the runner's `bash -e -o pipefail`,
+          # so capture via if-else.
+          status=0
+          if out=$(cat scripts/install.sh | PATH=/nonexistent /bin/bash 2>&1); then
+            status=0
+          else
+            status=$?
+          fi
+          printf '%s\n' "$out"
+          if [ "$status" -eq 0 ]; then
+            echo "expected the curl guard to fail without curl on PATH" >&2
+            exit 1
+          fi
+          printf '%s\n' "$out" | grep -q 'curl is required but not installed'
+          if printf '%s\n' "$out" | grep -q 'unbound variable'; then
+            echo "installer emitted an unbound variable error under Bash 3.2" >&2
+            exit 1
+          fi
+
+      - name: Offline full install under Bash 3.2
+        if: steps.filter.outputs.installer == 'true'
+        run: |
+          # The curl-guard step above never gets past the prerequisite check,
+          # and `bash -n` only checks grammar — neither catches Bash-4-only
+          # constructs (declare -A, mapfile, 4.x expansions) in the download,
+          # checksum, extract, or post-install code. Run one complete install
+          # under real 3.2: a fixture curl serves a local release from disk,
+          # and a pinned HEY_VERSION skips version resolution. PATH is
+          # restricted to fixture + system dirs so Homebrew tools (bash 4+,
+          # cosign) cannot leak in.
+          fixture_root=$(mktemp -d)
+          mkdir -p "$fixture_root/bin" "$fixture_root/release" "$fixture_root/home" "$fixture_root/install"
+
+          cat > "$fixture_root/release/hey" <<'STUB'
+          #!/bin/bash
+          if [ "$1" = "--version" ]; then echo "hey version 9.9.9"; fi
+          exit 0
+          STUB
+          chmod +x "$fixture_root/release/hey"
+          for arch in arm64 amd64; do
+            tar -czf "$fixture_root/release/hey_9.9.9_darwin_${arch}.tar.gz" -C "$fixture_root/release" hey
+          done
+          (cd "$fixture_root/release" && shasum -a 256 ./*.tar.gz | sed 's|\./||' > checksums.txt)
+
+          cat > "$fixture_root/bin/curl" <<'STUB'
+          #!/bin/bash
+          # Fixture curl: serves the local release dir. Handles the two shapes
+          # install.sh uses: `--version` and `[-flags] <url> -o <dest>`.
+          out=""; url=""
+          while [ $# -gt 0 ]; do
+            case "$1" in
+              --version) echo "curl 8.0.0 (fixture)"; exit 0 ;;
+              -o) out="$2"; shift ;;
+              http://*|https://*) url="$1" ;;
+            esac
+            shift
+          done
+          name="${url##*/}"
+          if [ -n "$out" ] && [ -f "$FIXTURE_RELEASE_DIR/$name" ]; then
+            cp "$FIXTURE_RELEASE_DIR/$name" "$out"
+            exit 0
+          fi
+          echo "fixture curl: no fixture for: $url" >&2
+          exit 22
+          STUB
+          chmod +x "$fixture_root/bin/curl"
+
+          status=0
+          if out=$(cat scripts/install.sh | \
+              HOME="$fixture_root/home" \
+              FIXTURE_RELEASE_DIR="$fixture_root/release" \
+              HEY_BIN_DIR="$fixture_root/install" \
+              HEY_VERSION=9.9.9 \
+              PATH="$fixture_root/bin:/usr/bin:/bin" \
+              /bin/bash 2>&1); then
+            status=0
+          else
+            status=$?
+          fi
+          printf '%s\n' "$out"
+          if [ "$status" -ne 0 ]; then
+            echo "offline install failed under Bash 3.2 (exit $status)" >&2
+            exit 1
+          fi
+          printf '%s\n' "$out" | grep -q 'Installed hey to'
+          printf '%s\n' "$out" | grep -q 'version 9.9.9 installed'
+          if printf '%s\n' "$out" | grep -q 'unbound variable'; then
+            echo "installer emitted an unbound variable error under Bash 3.2" >&2
+            exit 1
+          fi
+          "$fixture_root/install/hey" --version
+
   cli-surface:
     name: CLI Surface Check
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -48,8 +48,39 @@ env:
   RELEASE_TAG: ${{ github.event.release.tag_name || inputs.version }}
 
 jobs:
+  # Until the first release is published there is nothing real to verify, and a
+  # permanently red canary blocks merges on a condition only a release can
+  # clear. The gate skips the legs with a visible warning instead — and
+  # self-arms: the moment a release exists (or a run pins a version), the legs
+  # run for real. Pinned runs bypass the probe on purpose: asking for a version
+  # that does not exist should fail loudly, not skip.
+  has-release:
+    name: Resolve release under test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      exists: ${{ steps.probe.outputs.exists }}
+    steps:
+      - name: Probe for a published release
+        id: probe
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "$RELEASE_TAG" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No published release yet — the upgrade smoke legs are skipped. They arm automatically once the first release is published."
+          fi
+
   installer-sh:
     name: install.sh cosign ${{ matrix.cosign }}
+    needs: [has-release]
+    if: needs.has-release.outputs.exists == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -120,6 +151,8 @@ jobs:
 
   installer-ps1:
     name: install.ps1 cosign ${{ matrix.cosign }}
+    needs: [has-release]
+    if: needs.has-release.outputs.exists == 'true'
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -6,8 +6,11 @@
 #
 # Branch pushes necessarily verify the previous release, so the workflow also
 # runs on every published release (pinned to that release's tag) -- the first
-# bundle a changed .goreleaser.yaml actually produces gets exercised. Manual
-# runs can pin a version too.
+# bundle a changed .goreleaser.yaml actually produces gets exercised. Normal
+# releases arrive as a workflow_dispatch from release.yml: goreleaser publishes
+# with the built-in GITHUB_TOKEN, whose release event never starts another
+# workflow. The `release: published` trigger covers releases published by a
+# person (e.g. a draft in the UI). Manual runs can pin a version too.
 name: Upgrade Smoke
 
 on:

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -1,0 +1,141 @@
+---
+# Upgrade smoke: installer legs pinning the cosign version→flag capability gate
+# against the REAL published bundle format of the latest release — real
+# download, real Sigstore verification. A native `hey upgrade` matrix joins
+# once the command exists.
+name: Upgrade Smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".goreleaser.yaml"
+      - "scripts/install.sh"
+      - "scripts/install.ps1"
+      - ".github/workflows/upgrade-smoke.yml"
+  pull_request:
+    paths:
+      - ".goreleaser.yaml"
+      - "scripts/install.sh"
+      - "scripts/install.ps1"
+      - ".github/workflows/upgrade-smoke.yml"
+
+permissions: {}
+
+concurrency:
+  group: upgrade-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  installer-sh:
+    name: install.sh cosign ${{ matrix.cosign }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # sha256 values come from each cosign release's cosign_checksums.txt.
+        include:
+          - cosign: v3.0.5 # new bundle format is the default: bare verify-blob
+            sha256: db15cc99e6e4837daabab023742aaddc3841ce57f193d11b7c3e06c8003642b2
+            expect: verified
+          - cosign: v2.6.0 # floor for --new-bundle-format=true
+            sha256: ea5c65f99425d6cfbb5c4b5de5dac035f14d09131c1a0ea7c7fc32eab39364f9
+            expect: verified
+          - cosign: v2.4.0 # unsupported: warn + skip, install still succeeds
+            sha256: cd7636b3586a3bdac2d9c8f3b421ed119edcb20499107887fd929211110e8418
+            expect: skipped
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install cosign ${{ matrix.cosign }} (digest-pinned)
+        run: |
+          curl -fsSL -o /tmp/cosign \
+            "https://github.com/sigstore/cosign/releases/download/${{ matrix.cosign }}/cosign-linux-amd64"
+          echo "${{ matrix.sha256 }}  /tmp/cosign" | sha256sum -c -
+          chmod +x /tmp/cosign
+          sudo mv /tmp/cosign /usr/local/bin/cosign
+          cosign version
+
+      - name: Run install.sh against the latest release
+        env:
+          HEY_BIN_DIR: /home/runner/.local/bin
+          HEY_NO_KEYRING: "1"
+        run: |
+          set -o pipefail
+          bash scripts/install.sh | tee install.log
+
+      - name: Assert the signature verification path
+        run: |
+          if [[ "${{ matrix.expect }}" == "verified" ]]; then
+            grep -q "Signature verified" install.log
+          else
+            grep -q "Skipping signature verification" install.log
+            if grep -q "Signature verified" install.log; then
+              echo "must not claim the signature was verified" >&2
+              exit 1
+            fi
+          fi
+          grep -q "Checksum verified" install.log
+          "$HOME/.local/bin/hey" --version
+
+  installer-ps1:
+    name: install.ps1 cosign ${{ matrix.cosign }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # sha256 values come from each cosign release's cosign_checksums.txt.
+        include:
+          - cosign: v3.0.5
+            sha256: 44e9e44202b67ddfaaf5ea1234f5a265417960c4ae98c5b57c35bc40ba9dd714
+            expect: verified
+          - cosign: v2.6.0
+            sha256: 7beb4dd1e19a72c328bbf7c0d7342d744edbf5cbb082f227b2b76e04a21c16ef
+            expect: verified
+          - cosign: v2.4.0
+            sha256: 88f1addbae6bdd83ec2c067470c1f56b6d0d3ba35f49ad34603f2502cb2933f3
+            expect: skipped
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install cosign ${{ matrix.cosign }} (digest-pinned)
+        run: |
+          $binDir = Join-Path $env:RUNNER_TEMP 'cosign-bin'
+          New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+          $exe = Join-Path $binDir 'cosign.exe'
+          Invoke-WebRequest -UseBasicParsing `
+            -Uri "https://github.com/sigstore/cosign/releases/download/${{ matrix.cosign }}/cosign-windows-amd64.exe" `
+            -OutFile $exe
+          $actual = (Get-FileHash -Algorithm SHA256 -Path $exe).Hash.ToLowerInvariant()
+          if ($actual -ne '${{ matrix.sha256 }}') { throw "cosign digest mismatch: $actual" }
+          Add-Content $env:GITHUB_PATH $binDir
+
+      - name: Run install.ps1 against the latest release
+        env:
+          HEY_NO_KEYRING: "1"
+        run: |
+          cosign version
+          & .\scripts\install.ps1 *>&1 | Tee-Object -FilePath install.log
+
+      - name: Assert the signature verification path
+        run: |
+          $log = Get-Content install.log -Raw
+          if ('${{ matrix.expect }}' -eq 'verified') {
+            if ($log -notmatch 'Signature verified') { throw 'expected cosign signature verification' }
+          } else {
+            if ($log -notmatch "Skipping signature verification") { throw 'expected the skip warning' }
+            if ($log -match 'Signature verified') { throw 'must not claim the signature was verified' }
+          }
+          if ($log -notmatch 'Checksum verified') { throw 'expected checksum verification' }
+          & "$env:USERPROFILE\bin\hey.exe" --version

--- a/.github/workflows/upgrade-smoke.yml
+++ b/.github/workflows/upgrade-smoke.yml
@@ -3,9 +3,22 @@
 # against the REAL published bundle format of the latest release — real
 # download, real Sigstore verification. A native `hey upgrade` matrix joins
 # once the command exists.
+#
+# Branch pushes necessarily verify the previous release, so the workflow also
+# runs on every published release (pinned to that release's tag) -- the first
+# bundle a changed .goreleaser.yaml actually produces gets exercised. Manual
+# runs can pin a version too.
 name: Upgrade Smoke
 
 on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release to install (e.g. 1.2.3); empty means latest"
+        required: false
+        default: ""
   push:
     branches: [main]
     paths:
@@ -25,6 +38,11 @@ permissions: {}
 concurrency:
   group: upgrade-smoke-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  # "v1.2.3" on release events, the input on workflow_dispatch, empty (latest)
+  # otherwise. The installers take the bare version; the "v" is stripped below.
+  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.version }}
 
 jobs:
   installer-sh:
@@ -60,12 +78,27 @@ jobs:
           sudo mv /tmp/cosign /usr/local/bin/cosign
           cosign version
 
-      - name: Run install.sh against the latest release
+      # goreleaser publishes the release before its assets finish uploading,
+      # so a release-triggered run waits for the bundle to appear.
+      - name: Wait for release assets
+        if: env.RELEASE_TAG != ''
+        run: |
+          tag="v${RELEASE_TAG#v}"
+          url="https://github.com/basecamp/hey-cli/releases/download/${tag}/checksums.txt.bundle"
+          for _ in $(seq 1 30); do
+            if curl -fsSIL "$url" >/dev/null; then exit 0; fi
+            sleep 20
+          done
+          echo "::error::${url} never appeared" >&2
+          exit 1
+
+      - name: Run install.sh against the release
         env:
           HEY_BIN_DIR: /home/runner/.local/bin
           HEY_NO_KEYRING: "1"
         run: |
           set -o pipefail
+          export HEY_VERSION="${RELEASE_TAG#v}"
           bash scripts/install.sh | tee install.log
 
       - name: Assert the signature verification path
@@ -121,11 +154,25 @@ jobs:
           if ($actual -ne '${{ matrix.sha256 }}') { throw "cosign digest mismatch: $actual" }
           Add-Content $env:GITHUB_PATH $binDir
 
-      - name: Run install.ps1 against the latest release
+      - name: Wait for release assets
+        if: env.RELEASE_TAG != ''
+        run: |
+          $tag = 'v' + ($env:RELEASE_TAG -replace '^v', '')
+          $url = "https://github.com/basecamp/hey-cli/releases/download/$tag/checksums.txt.bundle"
+          foreach ($i in 1..30) {
+            try {
+              Invoke-WebRequest -UseBasicParsing -Method Head -Uri $url | Out-Null
+              exit 0
+            } catch { Start-Sleep -Seconds 20 }
+          }
+          throw "$url never appeared"
+
+      - name: Run install.ps1 against the release
         env:
           HEY_NO_KEYRING: "1"
         run: |
           cosign version
+          $env:HEY_VERSION = $env:RELEASE_TAG -replace '^v', ''
           & .\scripts\install.ps1 *>&1 | Tee-Object -FilePath install.log
 
       - name: Assert the signature verification path

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,8 @@
 ## Prerequisites
 
 - [Go](https://go.dev/dl/) (version in `go.mod`)
-- [golangci-lint](https://golangci-lint.run/) v2+
+- [golangci-lint](https://golangci-lint.run/) v2+ (`make tools` installs the pinned version)
+- [bats-core](https://github.com/bats-core/bats-core) and `jq` for `make test-e2e`
 - [mise](https://mise.jdx.dev/) (optional, for toolchain management)
 
 Install dev tools:
@@ -31,6 +32,15 @@ Run with race detector:
 ```sh
 make race-test
 ```
+
+The bats suite covers the installers and release scripts (`scripts/install.sh`,
+`scripts/install.ps1`, `scripts/notify-issue.sh`, …), which Go tests cannot reach:
+
+```sh
+make test-e2e
+```
+
+Tests that exercise `install.ps1` need `pwsh` and skip without it locally.
 
 ## Lint
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-unit test-smoke preview-callback coverage fmt fmt-check vet lint tidy tidy-check \
+.PHONY: build test test-unit test-e2e test-smoke preview-callback coverage fmt fmt-check vet lint tidy tidy-check \
 	race-test vuln secrets replace-check check-toolchain check security \
 	release-check release test-release bench bench-save bench-compare \
 	check-surface check-surface-compat check-lint-lockstep tools clean install help
@@ -22,6 +22,7 @@ help:
 	@echo "  make build           Build the CLI"
 	@echo "  make test-unit       Run unit tests"
 	@echo "  make test            Alias for test-unit"
+	@echo "  make test-e2e        Run the bats suite (installer and script contracts)"
 	@echo "  make test-smoke      Run smoke tests against a live server"
 	@echo "  make preview-callback Preview the OAuth callback screens in a browser"
 	@echo "  make coverage        Run cross-package coverage and enforce the 70.8% floor"
@@ -89,6 +90,10 @@ coverage: check-toolchain
 # and refresh the browser. Ctrl-C to stop.
 preview-callback: check-toolchain
 	PREVIEW=1 go test -run TestPreviewCallbackPages ./internal/auth/ -count=1 -v -timeout=0
+
+# Run the bats end-to-end suite (installers, release scripts). Needs bats-core.
+test-e2e:
+	@./tests/e2e/run.sh
 
 # Run smoke tests against a live HEY server.
 # Requires: a running server (default http://app.hey.localhost:3003) and Chrome.

--- a/README.md
+++ b/README.md
@@ -25,12 +25,69 @@ A CLI and TUI for [HEY](https://hey.com).
 
 ## Install
 
-Requires Go 1.26+. Use [mise](https://mise.jdx.dev) to install the correct version:
+**macOS / Linux / WSL2**
 
+```bash
+curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.ps1 | iex
+```
+
+On Windows 11 with Smart App Control, see [Troubleshooting](#windows-smart-app-control-and-smartscreen) if the install is blocked.
+
+Both scripts download the release for your platform, verify its SHA-256 checksum, and — when `cosign` is installed — verify the release's keyless Sigstore signature (cosign v3 as-is, v2.6+ with `--new-bundle-format=true`; older versions skip signature verification with a warning). Set `HEY_VERSION` to pin a release and `HEY_BIN_DIR` to choose the install directory.
+
+<details>
+<summary>Other installation methods</summary>
+
+**Homebrew (macOS / Linux):**
+```bash
+brew install --cask basecamp/tap/hey
+```
+
+**Arch Linux / Omarchy (AUR):**
+```bash
+yay -S hey-cli
+```
+
+**Linux (deb/rpm/apk):**
+```bash
+# Download from https://github.com/basecamp/hey-cli/releases/latest
+sudo apt install ./hey-cli_*_linux_amd64.deb                 # Debian/Ubuntu
+sudo dnf install ./hey-cli_*_linux_amd64.rpm                 # Fedora/RHEL
+sudo apk add --allow-untrusted ./hey-cli_*_linux_amd64.apk   # Alpine
+```
+Arm64: substitute `arm64` for `amd64` in the filename. Verify the SHA-256 checksum from `checksums.txt` before installing unsigned Alpine packages.
+
+**Scoop (Windows):**
+```powershell
+scoop bucket add basecamp https://github.com/basecamp/homebrew-tap
+scoop install hey
+```
+
+**Go install:**
+```bash
+go install github.com/basecamp/hey-cli/cmd/hey@latest
+```
+
+**From source** (requires Go 1.26+; [mise](https://mise.jdx.dev) installs the right version):
 ```bash
 mise install       # install Go 1.26
 make install       # build and install into /usr/local/bin/hey
 ```
+
+**GitHub Release:** download from [Releases](https://github.com/basecamp/hey-cli/releases). Every release ships `checksums.txt` and a keyless Sigstore signature `checksums.txt.bundle`, verifiable with:
+```bash
+cosign verify-blob --bundle checksums.txt.bundle \
+  --certificate-identity "https://github.com/basecamp/hey-cli/.github/workflows/release.yml@refs/tags/v<VERSION>" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com checksums.txt
+```
+
+</details>
 
 ## Authentication
 
@@ -215,6 +272,41 @@ hey-cli ships with an embedded agent skill so your agent can interact with HEY o
 ```bash
 hey skill install   # install the skill globally for your agent
 ```
+
+## Troubleshooting
+
+```bash
+hey doctor           # Check CLI health and diagnose issues
+```
+
+### Windows: Smart App Control and SmartScreen
+
+To check whether your installed binary is signed:
+
+```powershell
+Get-AuthenticodeSignature (Get-Command hey).Source
+```
+
+**Smart App Control** (Windows 11) blocks unsigned executables no matter where
+they were downloaded from, and it has no per-app exceptions — this applies to
+the PowerShell installer, Scoop installs, and manual downloads alike. If it
+blocks an unsigned `hey.exe`, two options:
+
+1. **Use WSL2 (preferred).** Install the Linux build inside WSL2 — Smart App
+   Control doesn't apply there and your Windows security setup is untouched:
+   `wsl --install`, then inside the WSL terminal:
+   `curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash`
+2. **Turn Smart App Control off** (Windows Security → App & browser control →
+   Smart App Control settings) **and leave it off while using the unsigned
+   build.** Because there are no per-app exceptions, turning it back on
+   re-blocks `hey.exe` on its next run — only re-enable after upgrading to a
+   signed build. Windows 11 with the March/April 2026 updates can re-enable
+   Smart App Control from Windows Security without a reset; on older builds
+   re-enabling requires resetting Windows, so prefer WSL2 there.
+
+**SmartScreen** (without Smart App Control) may warn on first run of an
+unrecognized executable — choose "More info" → "Run anyway" if you downloaded
+the release from this repository.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ cosign verify-blob --bundle checksums.txt.bundle \
   --certificate-identity "https://github.com/basecamp/hey-cli/.github/workflows/release.yml@refs/tags/v<VERSION>" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com checksums.txt
 ```
+That command is for cosign v3. With cosign v2.6–v2.x add `--new-bundle-format=true`; older versions cannot verify the bundle.
 
 </details>
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -187,7 +187,9 @@ function Get-FirstRunFailureMessage([string]$Binary, [string]$Reason) {
     $sigStatus = (Get-AuthenticodeSignature -FilePath $Binary -ErrorAction Stop).Status
   } catch { }
 
-  # Smart App Control state: 0 = off, 1 = on, 2 = evaluation mode.
+  # Smart App Control state: 0 = off, 1 = on, 2 = evaluation mode. Only 1
+  # enforces; evaluation mode observes without blocking, so it must not
+  # claim the failure.
   $sacState = $null
   try {
     $policy = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CI\Policy' -ErrorAction Stop
@@ -196,7 +198,7 @@ function Get-FirstRunFailureMessage([string]$Binary, [string]$Reason) {
 
   $lead = "Installed hey.exe to $Binary, but running it failed: $Reason"
 
-  if ("$sigStatus" -eq 'NotSigned' -and ($sacState -eq 1 -or $sacState -eq 2)) {
+  if ("$sigStatus" -eq 'NotSigned' -and $sacState -eq 1) {
     return @"
 $lead
 
@@ -334,11 +336,15 @@ function Main {
 
     # Smart App Control kills CreateProcess for unsigned executables, so the
     # first run is where a block surfaces. Generic catch per the Copy-Item
-    # precedent above.
+    # precedent above. A launch that succeeds but exits nonzero does not
+    # throw in Windows PowerShell 5.1, so check $LASTEXITCODE as well.
     try {
       $installedVersion = & $installedBinary --version
     } catch {
       Fail (Get-FirstRunFailureMessage -Binary $installedBinary -Reason $_.Exception.Message)
+    }
+    if ($LASTEXITCODE -ne 0) {
+      Fail (Get-FirstRunFailureMessage -Binary $installedBinary -Reason "hey --version exited with code $LASTEXITCODE")
     }
     Info "$installedVersion installed"
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,3 +1,10 @@
+# The documented install path is `irm ... | iex`, and Invoke-Expression
+# evaluates this file in the caller's scope. The invoked script block below
+# gives the installer its own scope, so $ErrorActionPreference and the helper
+# functions do not leak into (or clobber) the interactive session. The body
+# stays unindented: the here-strings' closing "@ must sit at column zero.
+& {
+
 $ErrorActionPreference = 'Stop'
 
 try {
@@ -243,7 +250,7 @@ function Normalize-PathEntry([string]$PathValue) {
     return ''
   }
 
-  return $PathValue.Trim().TrimEnd('\\')
+  return $PathValue.Trim().TrimEnd('\')
 }
 
 function Get-DefaultBinDir {
@@ -284,7 +291,7 @@ function Ensure-UserPath([string]$Dir) {
 function Main {
   $arch = Get-PlatformArch
   if (-not $BinDir) {
-    $script:BinDir = Get-DefaultBinDir
+    $BinDir = Get-DefaultBinDir
   }
 
   $resolvedVersion = if ($Version) { $Version } else { Get-LatestVersion }
@@ -367,3 +374,5 @@ function Main {
 }
 
 Main
+
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,363 @@
+$ErrorActionPreference = 'Stop'
+
+try {
+  [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {
+  # Ignore when the runtime manages TLS defaults.
+}
+
+# Environment options:
+#   HEY_VERSION   Specific version to install (default: latest)
+#   HEY_BIN_DIR   Where to install the binary
+#
+# This file must stay pure ASCII: the release pipeline stages and
+# Authenticode-signs a CRLF copy of it, and Windows PowerShell 5.1 decodes a
+# BOM-less file as Windows-1252 while jsign assumes UTF-8, so any byte above
+# 0x7F makes the two digests disagree (HashMismatch).
+$Repo = 'basecamp/hey-cli'
+$Version = $env:HEY_VERSION
+$BinDir = $env:HEY_BIN_DIR
+
+function Step([string]$Message) {
+  Write-Host "  -> $Message"
+}
+
+function Info([string]$Message) {
+  Write-Host "  + $Message" -ForegroundColor Green
+}
+
+function Fail([string]$Message) {
+  throw $Message
+}
+
+function Get-PlatformArch {
+  $arch = $env:PROCESSOR_ARCHITECTURE
+  if ($env:PROCESSOR_ARCHITEW6432) {
+    $arch = $env:PROCESSOR_ARCHITEW6432
+  }
+
+  switch -Regex ($arch) {
+    '^(AMD64|x86_64)$' { return 'amd64' }
+    '^ARM64$' { return 'arm64' }
+    default { Fail "Unsupported Windows architecture: $arch" }
+  }
+}
+
+function Get-LatestVersion {
+  Step 'Resolving latest release version...'
+
+  # Follow the releases/latest redirect first to avoid GitHub API rate limits.
+  # -MaximumRedirection 0 turns the expected 302 into a terminating error, so
+  # we read Location off the caught response. Headers.Location is Uri on
+  # PowerShell Core and string on Windows PowerShell 5.1, so coerce to string.
+  $location = $null
+  try {
+    $response = Invoke-WebRequest -MaximumRedirection 0 -UseBasicParsing `
+      -Headers @{ 'User-Agent' = 'hey-cli-installer' } `
+      -Uri "https://github.com/$Repo/releases/latest" -ErrorAction Stop
+    $location = $response.Headers.Location
+  } catch {
+    if ($_.Exception.Response) {
+      $location = $_.Exception.Response.Headers.Location
+      if (-not $location) {
+        $location = $_.Exception.Response.Headers['Location']
+      }
+    }
+  }
+
+  if ($location) {
+    $tag = ([string]$location).TrimEnd('/').Split('/')[-1]
+    $candidate = $tag.TrimStart('v')
+    if ($candidate -match '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') {
+      return $candidate
+    }
+  }
+
+  # Fall back to the GitHub API if the redirect path didn't yield a semver tag.
+  $release = Invoke-RestMethod -ErrorAction Stop `
+    -Headers @{ 'User-Agent' = 'hey-cli-installer' } `
+    -Uri "https://api.github.com/repos/$Repo/releases/latest"
+  if (-not $release.tag_name) {
+    Fail 'Could not determine latest release version from GitHub.'
+  }
+
+  return $release.tag_name.TrimStart('v')
+}
+
+function Download-File([string]$Url, [string]$Destination) {
+  # -UseBasicParsing avoids initializing IE's MSHTML parser on Windows
+  # PowerShell 5.1 -- required on Server Core and locked-down installs.
+  # No-op on PowerShell 6+, where basic parsing is the only mode.
+  Invoke-WebRequest -UseBasicParsing -ErrorAction Stop `
+    -Headers @{ 'User-Agent' = 'hey-cli-installer' } `
+    -Uri $Url -OutFile $Destination
+}
+
+function Verify-Checksum([string]$ChecksumsPath, [string]$ArchivePath, [string]$ArchiveName) {
+  $expected = $null
+  foreach ($line in Get-Content $ChecksumsPath) {
+    if ($line -match '^(?<hash>[0-9a-fA-F]{64})\s+\*?(?<name>.+)$') {
+      if ($Matches.name -eq $ArchiveName) {
+        $expected = $Matches.hash.ToLowerInvariant()
+        break
+      }
+    }
+  }
+
+  if (-not $expected) {
+    Fail "Could not find checksum entry for $ArchiveName"
+  }
+
+  $actual = (Get-FileHash -Algorithm SHA256 -Path $ArchivePath).Hash.ToLowerInvariant()
+  if ($actual -ne $expected) {
+    Fail "Checksum verification failed for $ArchiveName"
+  }
+
+  Info 'Checksum verified'
+}
+
+# Get-CosignBundleSupport decides how to verify the release's Sigstore bundle,
+# which is the new (protobuf, v0.3+json) format:
+#   v3+          -> new-format parsing is the default; no extra flag ('')
+#   v2.6 - v2.x  -> needs '--new-bundle-format=true' (v2.x defaults it to false)
+#   < v2.6 / unparseable -> $null: cannot verify (v2.4 chokes on the bundle's
+#                  tlog key type, v2.2 lacks the flag); caller warns and skips
+function Get-CosignBundleSupport {
+  try { $versionOutput = & cosign version 2>$null } catch { return $null }
+
+  foreach ($line in @($versionOutput)) {
+    if ("$line" -match 'GitVersion:\s*v?(\d+)\.(\d+)\.') {
+      $major = [int]$Matches[1]
+      $minor = [int]$Matches[2]
+      if ($major -ge 3) { return '' }
+      if ($major -eq 2 -and $minor -ge 6) { return '--new-bundle-format=true' }
+      return $null
+    }
+  }
+
+  return $null
+}
+
+function Verify-CosignSignature([string]$Version, [string]$BaseUrl, [string]$TmpDir) {
+  if (-not (Get-Command cosign -ErrorAction SilentlyContinue)) {
+    return
+  }
+
+  $bundleFlag = Get-CosignBundleSupport
+  if ($null -eq $bundleFlag) {
+    Step "Skipping signature verification: this cosign can't verify the release bundle format (need cosign >= 2.6)"
+    return
+  }
+
+  Step 'Verifying cosign signature...'
+
+  $bundlePath = Join-Path $TmpDir 'checksums.txt.bundle'
+  $checksumsPath = Join-Path $TmpDir 'checksums.txt'
+  Download-File -Url "$BaseUrl/checksums.txt.bundle" -Destination $bundlePath
+
+  $cosignArgs = @('verify-blob', '--bundle', $bundlePath)
+  if ($bundleFlag) {
+    $cosignArgs += $bundleFlag
+  }
+  $cosignArgs += @(
+    '--certificate-identity', "https://github.com/basecamp/hey-cli/.github/workflows/release.yml@refs/tags/v$Version",
+    '--certificate-oidc-issuer', 'https://token.actions.githubusercontent.com',
+    $checksumsPath
+  )
+
+  # Native exits don't trigger ErrorActionPreference=Stop on Windows PowerShell 5.1,
+  # so check $LASTEXITCODE explicitly -- otherwise a verify failure would false-green.
+  & cosign @cosignArgs
+  if ($LASTEXITCODE -ne 0) {
+    Fail 'Cosign signature verification failed'
+  }
+
+  Info 'Signature verified'
+}
+
+# Get-FirstRunFailureMessage diagnoses why running the freshly installed
+# hey.exe failed. It best-effort probes the binary's Authenticode status and
+# the Smart App Control state (Smart App Control blocks unsigned executables
+# at process creation). Every branch leads with the original failure:
+# diagnosis augments, never masks, the underlying error. PowerShell
+# 5.1-compatible.
+function Get-FirstRunFailureMessage([string]$Binary, [string]$Reason) {
+  $sigStatus = $null
+  try {
+    $sigStatus = (Get-AuthenticodeSignature -FilePath $Binary -ErrorAction Stop).Status
+  } catch { }
+
+  # Smart App Control state: 0 = off, 1 = on, 2 = evaluation mode.
+  $sacState = $null
+  try {
+    $policy = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CI\Policy' -ErrorAction Stop
+    $sacState = $policy.VerifiedAndReputablePolicyState
+  } catch { }
+
+  $lead = "Installed hey.exe to $Binary, but running it failed: $Reason"
+
+  if ("$sigStatus" -eq 'NotSigned' -and ($sacState -eq 1 -or $sacState -eq 2)) {
+    return @"
+$lead
+
+This build of hey.exe is not code-signed, and Smart App Control is enabled. Smart App Control blocks unsigned executables no matter where they were downloaded from, and it has no per-app exceptions. Two options:
+
+  1. (Preferred) Install the Linux build inside WSL2 - Smart App Control does not apply there and your Windows security setup is untouched:
+       wsl --install
+     then, inside the WSL terminal:
+       curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash
+
+  2. Turn Smart App Control off (Windows Security > App & browser control > Smart App Control settings) and leave it off while using this unsigned build. Because there are no per-app exceptions, turning it back on re-blocks hey.exe on its next run - only re-enable after upgrading to a signed release. Windows 11 with the March/April 2026 updates can re-enable Smart App Control from Windows Security without a reset; on older builds re-enabling requires resetting Windows, so prefer the WSL2 option there.
+"@
+  }
+
+  if ("$sigStatus" -eq 'NotSigned') {
+    return @"
+$lead
+
+This build of hey.exe is not code-signed, and Windows Security or SmartScreen may have blocked or quarantined it. Check Windows Security > Protection history for a block or quarantine event, restore or allow hey.exe, then re-run the installer.
+"@
+  }
+
+  return @"
+$lead
+
+If Windows Security or antivirus interfered, check Windows Security > Protection history, restore or allow hey.exe, then re-run the installer.
+"@
+}
+
+function Get-PathEntries {
+  param([string]$PathValue)
+
+  if (-not $PathValue) {
+    return @()
+  }
+
+  return $PathValue -split ';' | Where-Object { $_ }
+}
+
+function Normalize-PathEntry([string]$PathValue) {
+  if (-not $PathValue) {
+    return ''
+  }
+
+  return $PathValue.Trim().TrimEnd('\\')
+}
+
+function Get-DefaultBinDir {
+  $currentPathEntries = Get-PathEntries $env:Path
+  $userPathEntries = Get-PathEntries ([Environment]::GetEnvironmentVariable('Path', 'User'))
+  $allEntries = @($currentPathEntries + $userPathEntries) | ForEach-Object { Normalize-PathEntry $_ }
+
+  $homeBin = Normalize-PathEntry (Join-Path $HOME 'bin')
+  $homeLocalBin = Normalize-PathEntry (Join-Path $HOME '.local\bin')
+
+  if ($allEntries -contains $homeBin) {
+    return $homeBin
+  }
+
+  if ($allEntries -contains $homeLocalBin) {
+    return $homeLocalBin
+  }
+
+  return $homeBin
+}
+
+function Ensure-UserPath([string]$Dir) {
+  $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  $segments = Get-PathEntries $userPath
+
+  $normalizedSegments = $segments | ForEach-Object { Normalize-PathEntry $_ }
+  $normalizedDir = Normalize-PathEntry $Dir
+  if ($normalizedSegments -contains $normalizedDir) {
+    return
+  }
+
+  $newPath = if ($userPath) { "$Dir;$userPath" } else { $Dir }
+  [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+  $env:Path = "$Dir;$env:Path"
+  Info "Added $Dir to your user PATH"
+}
+
+function Main {
+  $arch = Get-PlatformArch
+  if (-not $BinDir) {
+    $script:BinDir = Get-DefaultBinDir
+  }
+
+  $resolvedVersion = if ($Version) { $Version } else { Get-LatestVersion }
+
+  if ($resolvedVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$') {
+    Fail "Invalid version '$resolvedVersion'. Expected semver format like 1.2.3 or 1.2.3-rc.1."
+  }
+
+  $archiveName = "hey_${resolvedVersion}_windows_${arch}.zip"
+  $baseUrl = "https://github.com/$Repo/releases/download/v$resolvedVersion"
+
+  Step "Downloading hey v$resolvedVersion for windows_$arch..."
+  $tmpDir = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName())
+  New-Item -ItemType Directory -Path $tmpDir | Out-Null
+
+  try {
+    $archivePath = Join-Path $tmpDir $archiveName
+    $checksumsPath = Join-Path $tmpDir 'checksums.txt'
+    $extractDir = Join-Path $tmpDir 'extract'
+
+    Download-File -Url "$baseUrl/$archiveName" -Destination $archivePath
+
+    Step 'Verifying checksums...'
+    Download-File -Url "$baseUrl/checksums.txt" -Destination $checksumsPath
+    Verify-Checksum -ChecksumsPath $checksumsPath -ArchivePath $archivePath -ArchiveName $archiveName
+
+    Verify-CosignSignature -Version $resolvedVersion -BaseUrl $baseUrl -TmpDir $tmpDir
+
+    Step 'Extracting...'
+    Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+
+    $binaryPath = Join-Path $extractDir 'hey.exe'
+    if (-not (Test-Path $binaryPath)) {
+      Fail 'hey.exe not found in archive. If Windows Security or antivirus removed it during extraction, check Windows Security > Protection history, restore it, and re-run the installer.'
+    }
+
+    $installedBinary = Join-Path $BinDir 'hey.exe'
+
+    New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+    # Windows holds an exclusive lock on running PE files; -Force doesn't help.
+    # Generic catch -- typed catches miss ActionPreferenceStopException wrapping.
+    try {
+      Copy-Item -Force $binaryPath $installedBinary -ErrorAction Stop
+    } catch {
+      Fail "Failed to install hey.exe. If it is in use, close any running 'hey' processes and re-run the installer. If Windows Security quarantined it, check Windows Security > Protection history and restore it. (Original error: $($_.Exception.Message))"
+    }
+    Ensure-UserPath -Dir $BinDir
+    Info "Installed hey to $installedBinary"
+
+    # Smart App Control kills CreateProcess for unsigned executables, so the
+    # first run is where a block surfaces. Generic catch per the Copy-Item
+    # precedent above.
+    try {
+      $installedVersion = & $installedBinary --version
+    } catch {
+      Fail (Get-FirstRunFailureMessage -Binary $installedBinary -Reason $_.Exception.Message)
+    }
+    Info "$installedVersion installed"
+
+    Write-Host ''
+    Write-Host '  Next steps:'
+    Write-Host '    hey auth login    Authenticate with HEY'
+    Write-Host '    hey --help        See what you can do'
+    Write-Host ''
+    Write-Host '  Installed executable:'
+    Write-Host "    $installedBinary"
+    Write-Host ''
+    Write-Host '  New terminals pick up the PATH change; in this session, use the installed executable path directly.'
+    Write-Host ''
+  }
+  finally {
+    if (Test-Path $tmpDir) {
+      Remove-Item -Recurse -Force $tmpDir
+    }
+  }
+}
+
+Main

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,8 +46,11 @@ find_sha256_cmd() {
     echo "sha256sum"
   elif command -v shasum &>/dev/null; then
     echo "shasum -a 256"
+  elif command -v sha256 &>/dev/null; then
+    # FreeBSD/OpenBSD base system; -q prints the bare digest.
+    echo "sha256 -q"
   else
-    error "No SHA256 tool found (need sha256sum or shasum)"
+    error "No SHA256 tool found (need sha256sum, shasum or sha256)"
   fi
 }
 
@@ -334,17 +337,21 @@ setup_path() {
   step "Adding $BIN_DIR to PATH"
 
   local shell_rc=""
+  local path_line="export PATH=\"$BIN_DIR:\$PATH\""
   case "${SHELL:-}" in
     */zsh)  shell_rc="$HOME/.zshrc" ;;
     */bash) shell_rc="$HOME/.bashrc" ;;
+    # fish sources neither ~/.profile nor Bourne syntax; fish_add_path
+    # (fish >= 3.2) persists the entry and is idempotent across runs.
+    */fish) shell_rc="${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
+            path_line="fish_add_path \"$BIN_DIR\"" ;;
     *)      shell_rc="$HOME/.profile" ;;
   esac
-
-  local path_line="export PATH=\"$BIN_DIR:\$PATH\""
 
   if [[ -f "$shell_rc" ]] && grep -qF "$BIN_DIR" "$shell_rc" 2>/dev/null; then
     info "PATH already configured in $shell_rc"
   else
+    mkdir -p "$(dirname "$shell_rc")"
     {
       echo ""
       echo "# Added by hey installer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,126 +1,447 @@
 #!/usr/bin/env bash
+# install.sh - Install the hey CLI
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash
+#
+# Options (via environment):
+#   HEY_BIN_DIR    Where to install the binary
+#                  (default: ~/bin if on PATH, else ~/.local/bin if on PATH;
+#                   otherwise ~/bin on Windows, ~/.local/bin elsewhere)
+#   HEY_VERSION    Specific version to install (default: latest)
+#
+# Verification: the SHA-256 checksum is always verified against the release's
+# checksums.txt. When cosign is installed, checksums.txt is additionally
+# verified against its keyless Sigstore bundle (checksums.txt.bundle), pinned
+# to this repository's release workflow identity.
+
 set -euo pipefail
 
 REPO="basecamp/hey-cli"
-INSTALL_DIR="${HEY_BIN_DIR:-$HOME/.local/bin}"
+BIN_DIR="${HEY_BIN_DIR:-}"
+VERSION="${HEY_VERSION:-}"
+CURL_SCHANNEL_FALLBACK_FLAG=""
+CURL_LAST_ERROR=""
+CURL_FALLBACK_NOTED=0
 
-# Detect OS and architecture
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m)
-
-case "$ARCH" in
-  x86_64|amd64) ARCH="amd64" ;;
-  aarch64|arm64) ARCH="arm64" ;;
-  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
-esac
-
-case "$OS" in
-  linux|darwin) ;;
-  mingw*|msys*|cygwin*) OS="windows" ;;
-  *) echo "Unsupported OS: $OS"; exit 1 ;;
-esac
-
-# Fetch latest version
-echo "Fetching latest version..."
-VERSION=$(curl -sI "https://github.com/$REPO/releases/latest" | grep -i '^location:' | sed 's/.*tag\///' | tr -d '\r\n')
-if ! [[ "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-  echo "Failed to determine latest version"
-  exit 1
-fi
-echo "Latest version: $VERSION"
-
-# Download archive
-EXT="tar.gz"
-if [ "$OS" = "windows" ]; then
-  EXT="zip"
-fi
-
-ARCHIVE="hey_${VERSION#v}_${OS}_${ARCH}.${EXT}"
-DOWNLOAD_URL="https://github.com/$REPO/releases/download/${VERSION}/${ARCHIVE}"
-CHECKSUMS_URL="https://github.com/$REPO/releases/download/${VERSION}/checksums.txt"
-
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
-
-echo "Downloading $ARCHIVE..."
-curl -fsSL "$DOWNLOAD_URL" -o "$TMPDIR/$ARCHIVE"
-curl -fsSL "$CHECKSUMS_URL" -o "$TMPDIR/checksums.txt"
-
-# Verify SHA256
-echo "Verifying checksum..."
-cd "$TMPDIR"
-EXPECTED=$(awk -v f="$ARCHIVE" '$2 == f {print $1}' checksums.txt)
-if [ -z "$EXPECTED" ]; then
-  echo "ERROR: Archive not found in checksums file"
-  exit 1
+# Color helpers — respect NO_COLOR (https://no-color.org)
+if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
+  bold()  { printf '\033[1m%s\033[0m' "$1"; }
+  green() { printf '\033[32m%s\033[0m' "$1"; }
+  red()   { printf '\033[31m%s\033[0m' "$1"; }
+  dim()   { printf '\033[2m%s\033[0m' "$1"; }
 else
-  ACTUAL=$(sha256sum "$ARCHIVE" 2>/dev/null || shasum -a 256 "$ARCHIVE" | awk '{print $1}')
-  ACTUAL=$(echo "$ACTUAL" | awk '{print $1}')
-  if [ "$EXPECTED" != "$ACTUAL" ]; then
-    echo "ERROR: Checksum mismatch!"
-    echo "  Expected: $EXPECTED"
-    echo "  Actual:   $ACTUAL"
-    exit 1
-  fi
-  echo "Checksum verified."
+  bold()  { printf '%s' "$1"; }
+  green() { printf '%s' "$1"; }
+  red()   { printf '%s' "$1"; }
+  dim()   { printf '%s' "$1"; }
 fi
 
-# Verify cosign signature (if cosign available)
-if command -v cosign >/dev/null 2>&1 && [ -z "${HEY_INSECURE_SKIP_COSIGN:-}" ]; then
-  SIG_URL="https://github.com/$REPO/releases/download/${VERSION}/checksums.txt.bundle"
-  if curl -fsSL "$SIG_URL" -o checksums.txt.bundle 2>/dev/null; then
-    echo "Verifying cosign signature..."
-    if cosign verify-blob \
-      --bundle checksums.txt.bundle \
-      --certificate-identity-regexp="https://github.com/$REPO/.github/workflows/release.yml@refs/tags/v" \
-      --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-      checksums.txt 2>/dev/null; then
-      echo "Signature verified."
+info()  { echo "  $(green "✓") $1"; }
+step()  { echo "  $(bold "→") $1"; }
+error() { echo "  $(red "✗ ERROR:") $1" >&2; exit 1; }
+
+find_sha256_cmd() {
+  if command -v sha256sum &>/dev/null; then
+    echo "sha256sum"
+  elif command -v shasum &>/dev/null; then
+    echo "shasum -a 256"
+  else
+    error "No SHA256 tool found (need sha256sum or shasum)"
+  fi
+}
+
+path_contains_dir() {
+  local dir="$1"
+  [[ ":$PATH:" == *":$dir:"* ]]
+}
+
+default_bin_dir() {
+  local platform="$1"
+
+  if path_contains_dir "$HOME/bin"; then
+    echo "$HOME/bin"
+    return 0
+  fi
+
+  if path_contains_dir "$HOME/.local/bin"; then
+    echo "$HOME/.local/bin"
+    return 0
+  fi
+
+  if [[ "$platform" == windows_* ]]; then
+    echo "$HOME/bin"
+  else
+    echo "$HOME/.local/bin"
+  fi
+}
+
+# detect_platform prints "<os>_<arch>" in the exact shape the release archives
+# use. macOS is per-arch (darwin_amd64, darwin_arm64): no universal
+# "darwin_all" archive is built, and requesting one 404s.
+detect_platform() {
+  local os arch
+
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  case "$os" in
+    darwin) os="darwin" ;;
+    linux) os="linux" ;;
+    freebsd) os="freebsd" ;;
+    openbsd) os="openbsd" ;;
+    mingw*|msys*|cygwin*) os="windows" ;;
+    *) error "Unsupported OS: $os" ;;
+  esac
+
+  arch=$(uname -m)
+  case "$arch" in
+    x86_64|amd64) arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *) error "Unsupported architecture: $arch" ;;
+  esac
+
+  echo "${os}_${arch}"
+}
+
+detect_curl_fallback() {
+  local version_output help_output
+
+  version_output=$(curl --version 2>/dev/null || true)
+  if [[ "$version_output" != *[Ss]channel* ]]; then
+    return 0
+  fi
+
+  help_output=$(curl --help all 2>/dev/null || true)
+  if [[ "$help_output" == *"--ssl-revoke-best-effort"* ]]; then
+    CURL_SCHANNEL_FALLBACK_FLAG="--ssl-revoke-best-effort"
+  elif [[ "$help_output" == *"--ssl-no-revoke"* ]]; then
+    CURL_SCHANNEL_FALLBACK_FLAG="--ssl-no-revoke"
+  fi
+}
+
+curl_run() {
+  # --show-error guarantees curl writes errors to stderr even if a future caller
+  # passes -s without -S. The Schannel revocation detection below depends on
+  # finding CRYPT_E_NO_REVOCATION_CHECK in stderr; without --show-error a -s
+  # caller would silently lose the fallback.
+  local err_file status err
+  err_file=$(mktemp "${TMPDIR:-/tmp}/hey-curl.XXXXXX")
+
+  if curl --show-error "$@" 2>"$err_file"; then
+    rm -f "$err_file"
+    CURL_LAST_ERROR=""
+    return 0
+  else
+    status=$?
+  fi
+
+  err=$(<"$err_file")
+  rm -f "$err_file"
+
+  if [[ $status -ne 0 ]] && [[ -n "$CURL_SCHANNEL_FALLBACK_FLAG" ]] && [[ "$err" == *"CRYPT_E_NO_REVOCATION_CHECK"* ]]; then
+    if [[ $CURL_FALLBACK_NOTED -eq 0 ]]; then
+      echo "  $(bold "→") Windows certificate revocation checks are unavailable; retrying curl with ${CURL_SCHANNEL_FALLBACK_FLAG}" >&2
+      CURL_FALLBACK_NOTED=1
+    fi
+
+    err_file=$(mktemp "${TMPDIR:-/tmp}/hey-curl.XXXXXX")
+    if curl --show-error "$CURL_SCHANNEL_FALLBACK_FLAG" "$@" 2>"$err_file"; then
+      rm -f "$err_file"
+      CURL_LAST_ERROR=""
+      return 0
     else
-      echo "ERROR: Signature verification failed"
-      echo "Set HEY_INSECURE_SKIP_COSIGN=1 to bypass"
-      exit 1
+      status=$?
+    fi
+
+    err=$(<"$err_file")
+    rm -f "$err_file"
+  fi
+
+  CURL_LAST_ERROR="$err"
+  return "$status"
+}
+
+get_latest_version() {
+  local url version api_json
+
+  # Follow the releases/latest redirect to get the version from the final URL.
+  # Avoids the GitHub API (no rate limiting) and grep/sed (better Windows compat).
+  if url=$(curl_run -fsSL -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest"); then
+    version="${url##*/}"
+    version="${version#v}"
+    if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+      echo "$version"
+      return 0
     fi
   fi
-fi
 
-# Extract
-echo "Extracting..."
-if [ "$EXT" = "zip" ]; then
-  unzip -q "$ARCHIVE" -d extract
-else
-  mkdir -p extract
-  tar -xzf "$ARCHIVE" -C extract
-fi
+  # Fallback to the GitHub API if redirect parsing fails. Whitespace-tolerant
+  # regex so a future GitHub format change (pretty-print, extra spaces) doesn't
+  # silently break the fallback. Pure bash so no GNU-awk dependency.
+  if api_json=$(curl_run -fsSL -H 'Accept: application/vnd.github+json' -H 'User-Agent: hey-cli-installer' "https://api.github.com/repos/${REPO}/releases/latest"); then
+    if [[ $api_json =~ \"tag_name\"[[:space:]]*:[[:space:]]*\"v?([^\"]+)\" ]]; then
+      version="${BASH_REMATCH[1]}"
+      if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+        echo "$version"
+        return 0
+      fi
+    fi
+  fi
 
-# Install
-mkdir -p "$INSTALL_DIR"
-BINARY="hey"
-if [ "$OS" = "windows" ]; then
-  BINARY="hey.exe"
-fi
-FOUND=$(find extract -name "${BINARY}" -type f | head -1)
-if [ -z "$FOUND" ]; then
-  echo "ERROR: Could not find ${BINARY} in archive"
-  exit 1
-fi
-cp "$FOUND" "$INSTALL_DIR/${BINARY}"
-chmod +x "$INSTALL_DIR/${BINARY}"
+  error "Could not determine latest version. ${CURL_LAST_ERROR:+curl said: ${CURL_LAST_ERROR}. }If native Windows curl fails, try Scoop or PowerShell. If using Git Bash, try /usr/bin/curl instead."
+}
 
-echo ""
-echo "hey ${VERSION} installed to $INSTALL_DIR/${BINARY}"
+# cosign_version prints the installed cosign's version (e.g. "v2.6.0"), empty
+# when it can't be determined. The trailing `|| true` is load-bearing: under
+# `set -euo pipefail` a broken cosign (nonzero `cosign version`) would
+# otherwise abort the whole installer from inside the caller's command
+# substitution — an unusable cosign must degrade to warn-and-skip, not abort.
+cosign_version() {
+  cosign version 2>/dev/null | awk -F': *' '/^GitVersion/ {print $2; exit}' || true
+}
 
-# Check if install dir is in PATH
-if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
-  echo ""
-  echo "Add $INSTALL_DIR to your PATH:"
-  SHELL_NAME=$(basename "${SHELL:-bash}")
-  case "$SHELL_NAME" in
-    zsh)  echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc && source ~/.zshrc" ;;
-    fish) echo "  fish_add_path $INSTALL_DIR" ;;
-    *)    echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.bashrc && source ~/.bashrc" ;;
+# cosign_bundle_support decides how to verify the release's Sigstore bundle,
+# which is the new (protobuf, v0.3+json) format. Prints the extra verify-blob
+# flag to use ("" for none) and returns 0 when verification can proceed:
+#   v3+          → new-format parsing is the default; no flag
+#   v2.6 – v2.x  → needs --new-bundle-format=true (v2.x defaults it to false)
+#   < v2.6       → cannot verify (v2.4 chokes on the bundle's tlog key type,
+#                  v2.2 lacks the flag entirely); caller warns and skips
+cosign_bundle_support() {
+  local version="$1" major minor
+
+  if [[ "$version" =~ ^v?([0-9]+)\.([0-9]+)\. ]]; then
+    major="${BASH_REMATCH[1]}"
+    minor="${BASH_REMATCH[2]}"
+  else
+    return 1
+  fi
+
+  if (( major >= 3 )); then
+    echo ""
+  elif (( major == 2 && minor >= 6 )); then
+    echo "--new-bundle-format=true"
+  else
+    return 1
+  fi
+}
+
+verify_checksums() {
+  local version="$1"
+  local tmp_dir="$2"
+  local archive_name="$3"
+  local base_url="https://github.com/${REPO}/releases/download/v${version}"
+  step "Verifying checksums..."
+
+  if ! curl_run -fsSL "${base_url}/checksums.txt" -o "${tmp_dir}/checksums.txt"; then
+    error "Failed to download checksums.txt${CURL_LAST_ERROR:+ (${CURL_LAST_ERROR})}"
+  fi
+
+  # Verify SHA256 checksum of the downloaded archive
+  local expected actual
+  expected=$(awk -v f="$archive_name" '$2 == f || $2 == ("*" f) {print $1; exit}' "${tmp_dir}/checksums.txt")
+  actual=$(cd "$tmp_dir" && $(find_sha256_cmd) "$archive_name" | awk '{print $1}')
+  [[ -n "$expected" && "$expected" == "$actual" ]]  \
+    || error "Checksum verification failed for $archive_name"
+
+  info "Checksum verified"
+
+  # If cosign is available and understands the bundle format, verify the signature
+  if command -v cosign &>/dev/null; then
+    local cosign_ver bundle_flag
+    cosign_ver=$(cosign_version)
+    if bundle_flag=$(cosign_bundle_support "$cosign_ver"); then
+      step "Verifying cosign signature..."
+
+      if ! curl_run -fsSL "${base_url}/checksums.txt.bundle" -o "${tmp_dir}/checksums.txt.bundle"; then
+        error "Failed to download checksums.txt.bundle${CURL_LAST_ERROR:+ (${CURL_LAST_ERROR})}"
+      fi
+
+      local -a cosign_args=(verify-blob --bundle "${tmp_dir}/checksums.txt.bundle")
+      if [[ -n "$bundle_flag" ]]; then
+        cosign_args+=("$bundle_flag")
+      fi
+      cosign_args+=( \
+        --certificate-identity "https://github.com/basecamp/hey-cli/.github/workflows/release.yml@refs/tags/v${version}" \
+        --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+        "${tmp_dir}/checksums.txt")
+
+      cosign "${cosign_args[@]}" \
+        || error "Cosign signature verification failed"
+
+      info "Signature verified"
+    else
+      step "Skipping signature verification: cosign ${cosign_ver:-unknown} can't verify this release's bundle format (need cosign >= 2.6)"
+    fi
+  fi
+}
+
+download_binary() {
+  local version="$1"
+  local platform="$2"
+  local tmp_dir="$3"
+  local url archive_name ext
+
+  # Determine archive extension
+  if [[ "$platform" == windows_* ]]; then
+    ext="zip"
+  else
+    ext="tar.gz"
+  fi
+
+  archive_name="hey_${version}_${platform}.${ext}"
+  url="https://github.com/${REPO}/releases/download/v${version}/${archive_name}"
+
+  step "Downloading hey v${version} for ${platform}..."
+
+  if ! curl_run -fsSL "$url" -o "${tmp_dir}/${archive_name}"; then
+    error "Failed to download from $url${CURL_LAST_ERROR:+ (${CURL_LAST_ERROR})}"
+  fi
+
+  # Verify integrity before extraction
+  verify_checksums "$version" "$tmp_dir" "$archive_name"
+
+  # Extract binary
+  step "Extracting..."
+  if [[ "$ext" == "zip" ]]; then
+    unzip -q "${tmp_dir}/${archive_name}" -d "$tmp_dir"
+  else
+    tar -xzf "${tmp_dir}/${archive_name}" -C "$tmp_dir"
+  fi
+
+  # Find and install binary
+  local binary_name="hey"
+  if [[ "$platform" == windows_* ]]; then
+    binary_name="hey.exe"
+  fi
+
+  if [[ ! -f "${tmp_dir}/${binary_name}" ]]; then
+    error "Binary not found in archive"
+  fi
+
+  mkdir -p "$BIN_DIR"
+  mv "${tmp_dir}/${binary_name}" "$BIN_DIR/"
+  chmod +x "$BIN_DIR/$binary_name"
+
+  info "Installed hey to $BIN_DIR/$binary_name"
+}
+
+setup_path() {
+  # Check if BIN_DIR is in PATH
+  if [[ ":$PATH:" == *":$BIN_DIR:"* ]]; then
+    return 0
+  fi
+
+  step "Adding $BIN_DIR to PATH"
+
+  local shell_rc=""
+  case "${SHELL:-}" in
+    */zsh)  shell_rc="$HOME/.zshrc" ;;
+    */bash) shell_rc="$HOME/.bashrc" ;;
+    *)      shell_rc="$HOME/.profile" ;;
   esac
-fi
 
-echo ""
-echo "Run 'hey auth login' to get started."
+  local path_line="export PATH=\"$BIN_DIR:\$PATH\""
+
+  if [[ -f "$shell_rc" ]] && grep -qF "$BIN_DIR" "$shell_rc" 2>/dev/null; then
+    info "PATH already configured in $shell_rc"
+  else
+    {
+      echo ""
+      echo "# Added by hey installer"
+      echo "$path_line"
+    } >> "$shell_rc"
+    info "Added to $shell_rc"
+    info "Run: source $shell_rc"
+  fi
+}
+
+verify_install() {
+  local platform="$1"
+  local binary_name="hey"
+  if [[ "$platform" == windows_* ]]; then
+    binary_name="hey.exe"
+  fi
+
+  local installed_version err_file
+  err_file=$(mktemp)
+  if installed_version=$("$BIN_DIR/$binary_name" --version 2>"$err_file"); then
+    rm -f "$err_file"
+    info "$(green "${installed_version} installed")"
+    return 0
+  fi
+
+  local run_error
+  run_error=$(cat "$err_file")
+  rm -f "$err_file"
+
+  local detail="Installation failed - hey not working"
+  if [[ -n "$run_error" ]]; then
+    detail="$detail: $run_error"
+  fi
+  if [[ "$platform" == windows_* ]]; then
+    # TODO(hey.com/install-cli): point the WSL2 hint at the short URL once the
+    # haystack redirect is live.
+    detail="$detail
+  Windows may have blocked the executable: Smart App Control only runs code-signed binaries.
+  Either install inside WSL2 (curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash) or see
+  https://github.com/basecamp/hey-cli#windows-smart-app-control-and-smartscreen"
+  fi
+  error "$detail"
+}
+
+show_banner() {
+  echo ""
+  echo "  $(bold "HEY CLI")"
+  echo ""
+}
+
+main() {
+  show_banner
+
+  # Check for curl
+  if ! command -v curl &>/dev/null; then
+    error "curl is required but not installed"
+  fi
+
+  local platform version tmp_dir
+  platform=$(detect_platform)
+  detect_curl_fallback
+
+  if [[ -z "$BIN_DIR" ]]; then
+    BIN_DIR=$(default_bin_dir "$platform")
+  fi
+
+  if [[ -n "$VERSION" ]]; then
+    version="$VERSION"
+    if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+      error "Invalid version '${version}'. Expected semver format (e.g. 1.2.3 or 1.2.3-rc.1)."
+    fi
+  else
+    version=$(get_latest_version)
+  fi
+
+  tmp_dir=$(mktemp -d)
+  # Expand now on purpose: tmp_dir is local to main and gone by the time the
+  # EXIT trap fires.
+  # shellcheck disable=SC2064
+  trap "rm -rf '${tmp_dir}'" EXIT
+
+  download_binary "$version" "$platform" "$tmp_dir"
+  setup_path
+  verify_install "$platform"
+
+  echo ""
+  echo "  Next steps:"
+  echo "    $(bold "hey auth login")    Authenticate with HEY"
+  echo "    $(bold "hey --help")        See what you can do"
+  echo ""
+}
+
+# Guard so sourcing the script (e.g. from tests) doesn't run the installer.
+# The if-form is required: `[[ … ]] && main` returns 1 when sourced, which
+# trips `set -e` in the sourcing shell. The `:-$0` fallback is also
+# required: bash executing from stdin (curl | bash) or -c leaves BASH_SOURCE
+# unset, and the bare expansion aborts under `set -u`.
+if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -340,7 +340,14 @@ setup_path() {
   local path_line="export PATH=\"$BIN_DIR:\$PATH\""
   case "${SHELL:-}" in
     */zsh)  shell_rc="$HOME/.zshrc" ;;
-    */bash) shell_rc="$HOME/.bashrc" ;;
+    # macOS terminals start bash as a login shell, which reads ~/.bash_profile
+    # and not ~/.bashrc. Linux login shells (consoles, SSH) reach ~/.bashrc
+    # through the distros' stock profile files.
+    */bash) if [[ "$(uname -s)" == "Darwin" ]]; then
+              shell_rc="$HOME/.bash_profile"
+            else
+              shell_rc="$HOME/.bashrc"
+            fi ;;
     # fish sources neither ~/.profile nor Bourne syntax; fish_add_path
     # (fish >= 3.2) persists the entry and is idempotent across runs.
     */fish) shell_rc="${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"

--- a/scripts/stage-installer-ps1.sh
+++ b/scripts/stage-installer-ps1.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+# Usage: scripts/stage-installer-ps1.sh SOURCE DEST
+#
+# Stage a copy of the PowerShell installer for Authenticode signing, in the
+# only shape where jsign's digest and PowerShell's agree.
+#
+# jsign computes the script digest as UTF-16LE of the file content with the
+# signature block stripped, and applies NO line-ending normalization
+# (SignableScript.computeDigest). PowerShell's script SIP normalizes to CRLF
+# before hashing. Sign an LF file and the two digests differ, so
+# Get-AuthenticodeSignature reports HashMismatch and the installer is refused
+# under AllSigned/RemoteSigned. That is what shipped in v0.8.0-rc.2.
+#
+# Two invariants make the digests agree:
+#
+#   CRLF        removes the normalization disagreement above.
+#
+#   pure ASCII  removes an encoding disagreement that CRLF alone would not
+#               fix. The file has no BOM; jsign assumes UTF-8, but Windows
+#               PowerShell 5.1 assumes ANSI (Windows-1252) for BOM-less files.
+#               Any byte above 0x7F therefore decodes to different characters
+#               on each side and the digests diverge again. Within ASCII the
+#               two encodings are identical byte-for-byte, so the question
+#               never arises. Adding a BOM would be the other way out, but it
+#               trades a known-good invariant for jsign's
+#               isByteOrderMarkSigned() matching Microsoft's undocumented
+#               treatment of the BOM in the hash — untestable without a
+#               signing round-trip.
+#
+# The source file is left alone: raw-main install.ps1 stays LF and unsigned,
+# which is the `irm | iex` path and needs neither.
+
+set -eu
+
+SRC="${1:?usage: stage-installer-ps1.sh SOURCE DEST}"
+DEST="${2:?usage: stage-installer-ps1.sh SOURCE DEST}"
+
+[ -f "$SRC" ] || { echo "stage-installer-ps1: source not found: $SRC" >&2; exit 1; }
+
+# Reject non-ASCII before signing rather than after. Under LC_ALL=C every byte
+# above 0x7F is non-printable, so this matches exactly the bytes that would
+# make jsign and PowerShell 5.1 disagree.
+if LC_ALL=C grep -n '[^[:print:][:space:]]' "$SRC" >/dev/null 2>&1; then
+  echo "stage-installer-ps1: $SRC contains non-ASCII bytes, which would produce" >&2
+  echo "  a signature PowerShell 5.1 rejects as HashMismatch (it decodes BOM-less" >&2
+  echo "  files as Windows-1252 while jsign assumes UTF-8). Offending lines:" >&2
+  LC_ALL=C grep -n '[^[:print:][:space:]]' "$SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$DEST")"
+
+# LF -> CRLF, idempotent: strip any existing CR first so a CRLF source does
+# not become CR CR LF.
+awk '{ sub(/\r$/, ""); printf "%s\r\n", $0 }' "$SRC" > "$DEST"
+
+echo "stage-installer-ps1: staged $DEST (pure ASCII, CRLF)"

--- a/scripts/stage-installer-ps1.sh
+++ b/scripts/stage-installer-ps1.sh
@@ -9,7 +9,8 @@
 # (SignableScript.computeDigest). PowerShell's script SIP normalizes to CRLF
 # before hashing. Sign an LF file and the two digests differ, so
 # Get-AuthenticodeSignature reports HashMismatch and the installer is refused
-# under AllSigned/RemoteSigned. That is what shipped in v0.8.0-rc.2.
+# under AllSigned/RemoteSigned. That is what basecamp-cli
+# shipped in v0.8.0-rc.2, and hey-cli inherits the same pipeline.
 #
 # Two invariants make the digests agree:
 #

--- a/tests/e2e/installer.bats
+++ b/tests/e2e/installer.bats
@@ -1,0 +1,450 @@
+#!/usr/bin/env bats
+# installer.bats - Contracts for scripts/install.sh and scripts/install.ps1.
+#
+# The installers are the one piece of the release pipeline that runs on a
+# machine nobody controls, under whatever bash (3.2 on stock macOS), curl and
+# cosign happen to be there. Each test here pins a behaviour that went wrong
+# once in basecamp-cli's installer and must not come back in hey's: sourcing
+# vs executing, per-arch darwin archives, the cosign version gate, a failing
+# first run diagnosed rather than swallowed.
+
+setup() {
+  INSTALL_SH="${BATS_TEST_DIRNAME}/../../scripts/install.sh"
+  INSTALL_PS1="${BATS_TEST_DIRNAME}/../../scripts/install.ps1"
+
+  STUB_DIR="$(mktemp -d)"
+  LOG="$STUB_DIR/calls.log"
+}
+
+teardown() {
+  [[ -n "${STUB_DIR:-}" ]] && rm -rf "$STUB_DIR"
+}
+
+# The if-form guard must let sourcing define functions without running main.
+@test "install.sh can be sourced without running the installer" {
+  run bash -c "set -euo pipefail; source '$INSTALL_SH'; echo sourced-ok"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"sourced-ok"* ]]
+  [[ "$output" != *"HEY CLI"* ]]  # banner would print if main ran
+}
+
+@test "install.sh runs main when piped to bash" {
+  # PATH points at a binary-free tmpdir so main stops at its curl
+  # prerequisite without downloading anything or touching the host.
+  run bash -c "cat '$INSTALL_SH' | PATH='$BATS_TEST_TMPDIR' '$BASH'"
+  [[ "$status" -ne 0 ]]
+  [[ "$output" == *"curl is required but not installed"* ]]
+  [[ "$output" != *"BASH_SOURCE[0]: unbound variable"* ]]
+}
+
+# No interactive setup wizard exists: the installer must end with printed next
+# steps, never by exec'ing the freshly installed binary into a prompt.
+@test "install.sh ends with next steps, not an interactive setup" {
+  run grep -nE '"\$BIN_DIR/\$binary_name" setup|HEY_SKIP_SETUP|post_install_setup' "$INSTALL_SH"
+  [[ "$status" -ne 0 ]]
+  grep -q 'hey auth login' "$INSTALL_SH"
+}
+
+# The release builds darwin_amd64 and darwin_arm64, never a universal
+# darwin_all. The root install.sh this replaced requested darwin_all and 404'd
+# on every Mac.
+@test "detect_platform reports per-arch darwin, never darwin_all" {
+  cat > "$STUB_DIR/uname" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  -s) echo Darwin ;;
+  -m) echo "${FAKE_ARCH:-arm64}" ;;
+esac
+EOF
+  chmod +x "$STUB_DIR/uname"
+
+  run bash -c "export PATH=\"$STUB_DIR:\$PATH\"; source '$INSTALL_SH'; detect_platform"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "darwin_arm64" ]]
+
+  run bash -c "export PATH=\"$STUB_DIR:\$PATH\" FAKE_ARCH=x86_64; source '$INSTALL_SH'; detect_platform"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "darwin_amd64" ]]
+
+  # Comments may mention it; code may not.
+  run grep -nE '^[^#]*darwin_all' "$INSTALL_SH" "$INSTALL_PS1"
+  [[ "$status" -ne 0 ]]
+}
+
+@test "download_binary requests the per-platform archive name the release publishes" {
+  run bash -c "
+    set -euo pipefail
+    source '$INSTALL_SH'
+    curl_run() { echo \"\$@\" >> '$LOG'; return 1; }
+    # error() exits, so run in a subshell and read the log afterwards.
+    ( download_binary 9.9.9 darwin_arm64 '$STUB_DIR' ) || true
+    cat '$LOG'
+  "
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"/releases/download/v9.9.9/hey_9.9.9_darwin_arm64.tar.gz"* ]]
+}
+
+# Smart App Control blocks unsigned executables at process creation, so the
+# install scripts must surface WHY the first run failed instead of a bare
+# "not working".
+
+@test "verify_install surfaces stderr and adds the Windows SAC hint" {
+  cat > "$STUB_DIR/hey.exe" <<'EOF'
+#!/usr/bin/env bash
+echo "simulated block: cannot execute" >&2
+exit 126
+EOF
+  chmod +x "$STUB_DIR/hey.exe"
+
+  run bash -c "
+    set -euo pipefail
+    source '$INSTALL_SH'
+    BIN_DIR='$STUB_DIR'
+    verify_install windows_amd64
+  "
+  [[ "$status" -ne 0 ]]
+  [[ "$output" == *"simulated block: cannot execute"* ]]
+  [[ "$output" == *"Smart App Control"* ]]
+  [[ "$output" == *"#windows-smart-app-control-and-smartscreen"* ]]
+}
+
+@test "verify_install on linux surfaces stderr without the Windows hint" {
+  cat > "$STUB_DIR/hey" <<'EOF'
+#!/usr/bin/env bash
+echo "simulated failure" >&2
+exit 1
+EOF
+  chmod +x "$STUB_DIR/hey"
+
+  run bash -c "
+    set -euo pipefail
+    source '$INSTALL_SH'
+    BIN_DIR='$STUB_DIR'
+    verify_install linux_amd64
+  "
+  [[ "$status" -ne 0 ]]
+  [[ "$output" == *"simulated failure"* ]]
+  [[ "$output" != *"Smart App Control"* ]]
+}
+
+@test "install.ps1 carries the Smart App Control first-run diagnosis" {
+  grep -q 'function Get-FirstRunFailureMessage' "$INSTALL_PS1"
+  grep -q 'Smart App Control' "$INSTALL_PS1"
+  grep -q 'Protection history' "$INSTALL_PS1"
+  # The first-run failure path routes through the diagnosis helper.
+  grep -qF 'Fail (Get-FirstRunFailureMessage' "$INSTALL_PS1"
+}
+
+# All three diagnosis branches, driven by shadowing the probes. Only the
+# function under test is extracted from install.ps1's AST and evaluated; Main
+# never runs, and the installer needs no test hooks.
+@test "install.ps1 Get-FirstRunFailureMessage diagnoses SAC, quarantine, and generic failures" {
+  if ! command -v pwsh >/dev/null 2>&1; then
+    if [[ -n "${CI:-}" ]]; then
+      echo "pwsh is required in CI for install.ps1 diagnosis coverage" >&2
+      return 1
+    fi
+    skip "pwsh not installed"
+  fi
+
+  cat > "$STUB_DIR/sac-driver.ps1" <<'EOF'
+$ErrorActionPreference = 'Stop'
+$tokens = $null; $parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($env:INSTALL_PS1_PATH, [ref]$tokens, [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) { throw "install.ps1 parse errors: $($parseErrors -join '; ')" }
+$fn = $ast.Find({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Get-FirstRunFailureMessage' }, $true)
+if (-not $fn) { throw 'Get-FirstRunFailureMessage not found in install.ps1' }
+. ([scriptblock]::Create($fn.Extent.Text))
+
+# Shadow the probes the helper relies on. Advanced functions so the helper's
+# -ErrorAction Stop common parameter binds.
+$script:SigStatus = 'NotSigned'
+$script:SacState = 1
+function Get-AuthenticodeSignature { [CmdletBinding()] param([string]$FilePath) [pscustomobject]@{ Status = $script:SigStatus } }
+function Get-ItemProperty { [CmdletBinding()] param([string]$Path) [pscustomobject]@{ VerifiedAndReputablePolicyState = $script:SacState } }
+
+# Branch 1: unsigned binary, SAC on.
+$msg = Get-FirstRunFailureMessage -Binary 'C:\bin\hey.exe' -Reason 'boom-sac'
+if ($msg -notmatch '^Installed hey\.exe .+ running it failed: boom-sac') { throw "branch1 does not lead with the original failure: $msg" }
+if ($msg -notlike '*Smart App Control*') { throw 'branch1 missing SAC explanation' }
+if ($msg -notlike '*wsl --install*') { throw 'branch1 missing WSL option' }
+if ($msg -notlike '*no per-app exceptions*') { throw 'branch1 missing no-exceptions caveat' }
+if ($msg -notlike '*leave it off while using this unsigned build*') { throw 'branch1 missing stay-off caveat' }
+'branch1-ok'
+
+# Branch 2: unsigned binary, SAC off -- quarantine advice, no WSL pitch.
+$script:SacState = 0
+$msg = Get-FirstRunFailureMessage -Binary 'C:\bin\hey.exe' -Reason 'boom-quarantine'
+if ($msg -notlike '*boom-quarantine*') { throw 'branch2 missing original failure' }
+if ($msg -notlike '*Protection history*') { throw 'branch2 missing Protection history advice' }
+if ($msg -like '*wsl --install*') { throw 'branch2 should not pitch WSL' }
+'branch2-ok'
+
+# Branch 3: signed binary -- generic hint, no unsigned claim.
+$script:SigStatus = 'Valid'
+$msg = Get-FirstRunFailureMessage -Binary 'C:\bin\hey.exe' -Reason 'boom-generic'
+if ($msg -notlike '*boom-generic*') { throw 'branch3 missing original failure' }
+if ($msg -notlike '*Protection history*') { throw 'branch3 missing generic hint' }
+if ($msg -like '*not code-signed*') { throw 'branch3 must not claim the binary is unsigned' }
+'branch3-ok'
+EOF
+
+  run bash -c "
+    set -euo pipefail
+    export INSTALL_PS1_PATH='$INSTALL_PS1'
+    pwsh -NoProfile -File '$STUB_DIR/sac-driver.ps1'
+  "
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"branch1-ok"* ]]
+  [[ "$output" == *"branch2-ok"* ]]
+  [[ "$output" == *"branch3-ok"* ]]
+}
+
+# Releases publish the new (protobuf) Sigstore bundle format. cosign v3 parses
+# it by default, v2.6–v2.x needs --new-bundle-format=true, and older cosign
+# cannot verify it at all (v2.4 chokes on the bundle's tlog key type, v2.2
+# lacks the flag) — those must warn and skip, preserving cosign's optional
+# posture, never fail the install or false-green the verification.
+
+@test "cosign_bundle_support: v3 verifies with no extra flag" {
+  run bash -c "source '$INSTALL_SH'; cosign_bundle_support v3.0.2"
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+@test "cosign_bundle_support: v2.6 verifies with --new-bundle-format=true" {
+  run bash -c "source '$INSTALL_SH'; cosign_bundle_support v2.6.0"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "--new-bundle-format=true" ]]
+}
+
+@test "cosign_bundle_support: v2.4 is unsupported" {
+  run bash -c "source '$INSTALL_SH'; cosign_bundle_support v2.4.0"
+  [[ "$status" -ne 0 ]]
+}
+
+@test "cosign_bundle_support: garbage version is unsupported" {
+  run bash -c "source '$INSTALL_SH'; cosign_bundle_support 'devel-deadbeef'"
+  [[ "$status" -ne 0 ]]
+  run bash -c "source '$INSTALL_SH'; cosign_bundle_support ''"
+  [[ "$status" -ne 0 ]]
+}
+
+# write_cosign_stub emits a cosign stub whose `cosign version` reports the
+# given GitVersion and which logs every other invocation's argv.
+write_cosign_stub() {
+  local ver="$1"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'if [[ "$1" == "version" ]]; then'
+    echo "  echo 'GitVersion:    ${ver}'"
+    echo '  exit 0'
+    echo 'fi'
+    echo "echo \"\$@\" >> \"$LOG\""
+    echo 'exit 0'
+  } > "$STUB_DIR/cosign"
+  chmod +x "$STUB_DIR/cosign"
+}
+
+# run_verify_checksums drives the real verify_checksums with a stubbed cosign
+# and a no-network curl_run, against a locally-built archive + checksums.txt.
+run_verify_checksums() {
+  run bash -c "
+    set -euo pipefail
+    export PATH=\"$STUB_DIR:\$PATH\"
+    source '$INSTALL_SH'
+    tmp_dir='$STUB_DIR/work'
+    mkdir -p \"\$tmp_dir\"
+    printf 'archive-bytes' > \"\$tmp_dir/hey_9.9.9_linux_amd64.tar.gz\"
+    sha=\$(cd \"\$tmp_dir\" && \$(find_sha256_cmd) hey_9.9.9_linux_amd64.tar.gz | awk '{print \$1}')
+    verify_checksums_stub_sums() { printf '%s  hey_9.9.9_linux_amd64.tar.gz\n' \"\$sha\" > \"\$tmp_dir/checksums.txt\"; }
+    # No-network curl_run: serve the locally-computed checksums.txt and a
+    # placeholder bundle (cosign is stubbed, so its content is irrelevant).
+    curl_run() {
+      local arg dest=''
+      local prev=''
+      for arg in \"\$@\"; do
+        [[ \"\$prev\" == '-o' ]] && dest=\"\$arg\"
+        prev=\"\$arg\"
+      done
+      if [[ \"\$dest\" == *checksums.txt ]]; then
+        verify_checksums_stub_sums
+      elif [[ -n \"\$dest\" ]]; then
+        printf 'stub-bundle' > \"\$dest\"
+      fi
+      return 0
+    }
+    verify_checksums 9.9.9 \"\$tmp_dir\" hey_9.9.9_linux_amd64.tar.gz
+    cat '$LOG' 2>/dev/null || true
+  "
+}
+
+@test "verify_checksums with cosign v3 runs verify-blob without the compat flag" {
+  write_cosign_stub v3.0.2
+  run_verify_checksums
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Signature verified"* ]]
+  [[ "$output" == *"verify-blob"* ]]
+  [[ "$output" != *"--new-bundle-format"* ]]
+}
+
+@test "verify_checksums pins the release workflow identity" {
+  write_cosign_stub v3.0.2
+  run_verify_checksums
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"--certificate-identity https://github.com/basecamp/hey-cli/.github/workflows/release.yml@refs/tags/v9.9.9"* ]]
+  [[ "$output" == *"--certificate-oidc-issuer https://token.actions.githubusercontent.com"* ]]
+}
+
+@test "verify_checksums with cosign v2.6 adds --new-bundle-format=true" {
+  write_cosign_stub v2.6.0
+  run_verify_checksums
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Signature verified"* ]]
+  [[ "$output" == *"--new-bundle-format=true"* ]]
+}
+
+@test "verify_checksums with cosign v2.4 warns, skips verification, still succeeds" {
+  write_cosign_stub v2.4.0
+  run_verify_checksums
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Checksum verified"* ]]
+  [[ "$output" == *"Skipping signature verification"* ]]
+  [[ "$output" != *"verify-blob"* ]]
+}
+
+@test "verify_checksums with unparseable cosign version warns and skips" {
+  write_cosign_stub 'devel'
+  run_verify_checksums
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Skipping signature verification"* ]]
+  [[ "$output" != *"verify-blob"* ]]
+}
+
+# A cosign whose `version` subcommand itself FAILS must not abort the
+# installer: under `set -euo pipefail` the version probe runs inside a command
+# substitution, and without the guard in cosign_version the nonzero exit
+# propagates and kills the install. It must degrade to the warn-and-skip path
+# with checksum verification intact.
+@test "verify_checksums with broken cosign (version exits nonzero) warns, skips, still succeeds" {
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'if [[ "$1" == "version" ]]; then'
+    echo '  echo "cosign: catastrophic startup failure" >&2'
+    echo '  exit 42'
+    echo 'fi'
+    echo "echo \"\$@\" >> \"$LOG\""
+    echo 'exit 0'
+  } > "$STUB_DIR/cosign"
+  chmod +x "$STUB_DIR/cosign"
+
+  run_verify_checksums
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Checksum verified"* ]]
+  [[ "$output" == *"Skipping signature verification"* ]]
+  [[ "$output" != *"verify-blob"* ]]
+}
+
+# A wrong checksum must fail the install outright; there is no skip path for
+# the SHA-256 check, cosign or not.
+@test "verify_checksums fails on a checksum mismatch" {
+  run bash -c "
+    set -euo pipefail
+    source '$INSTALL_SH'
+    tmp_dir='$STUB_DIR/work'
+    mkdir -p \"\$tmp_dir\"
+    printf 'archive-bytes' > \"\$tmp_dir/hey_9.9.9_linux_amd64.tar.gz\"
+    curl_run() {
+      printf '%s  hey_9.9.9_linux_amd64.tar.gz\n' 0000000000000000000000000000000000000000000000000000000000000000 > \"\$tmp_dir/checksums.txt\"
+      return 0
+    }
+    verify_checksums 9.9.9 \"\$tmp_dir\" hey_9.9.9_linux_amd64.tar.gz
+  "
+  [[ "$status" -ne 0 ]]
+  [[ "$output" == *"Checksum verification failed"* ]]
+}
+
+# install.ps1 equivalent, executed (not review-only): extract the two cosign
+# functions from the AST — Main never runs — shadow cosign/Download-File, and
+# drive all three version tiers.
+@test "install.ps1 cosign version gate selects bare, flagged, and skip paths" {
+  if ! command -v pwsh >/dev/null 2>&1; then
+    if [[ -n "${CI:-}" ]]; then
+      echo "pwsh is required in CI for install.ps1 cosign gate coverage" >&2
+      return 1
+    fi
+    skip "pwsh not installed"
+  fi
+
+  cat > "$STUB_DIR/cosign-driver.ps1" <<'EOF'
+$ErrorActionPreference = 'Stop'
+$tokens = $null; $parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($env:INSTALL_PS1_PATH, [ref]$tokens, [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) { throw "install.ps1 parse errors: $($parseErrors -join '; ')" }
+foreach ($name in @('Get-CosignBundleSupport', 'Verify-CosignSignature')) {
+  $fn = $ast.Find({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $name }, $true)
+  if (-not $fn) { throw "$name not found in install.ps1" }
+  . ([scriptblock]::Create($fn.Extent.Text))
+}
+
+function Step([string]$Message) { Write-Host "step: $Message" }
+function Info([string]$Message) { Write-Host "info: $Message" }
+function Fail([string]$Message) { throw $Message }
+function Download-File([string]$Url, [string]$Destination) { Set-Content -Path $Destination -Value 'stub-bundle' }
+
+$script:CosignVersion = ''
+$script:CosignArgs = $null
+function cosign {
+  if ($args[0] -eq 'version') {
+    "GitVersion:    $script:CosignVersion"
+  } else {
+    $script:CosignArgs = $args -join ' '
+  }
+  $global:LASTEXITCODE = 0
+}
+
+$tmp = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $tmp | Out-Null
+Set-Content -Path (Join-Path $tmp 'checksums.txt') -Value 'stub'
+
+# v3: bare verify-blob, no compat flag, hey-cli identity.
+$script:CosignVersion = 'v3.0.2'; $script:CosignArgs = $null
+Verify-CosignSignature -Version '9.9.9' -BaseUrl 'https://example.invalid' -TmpDir $tmp
+if (-not $script:CosignArgs) { throw 'v3: cosign verify-blob was not invoked' }
+if ($script:CosignArgs -notmatch 'verify-blob') { throw "v3: unexpected args: $script:CosignArgs" }
+if ($script:CosignArgs -match 'new-bundle-format') { throw "v3: compat flag must not be passed: $script:CosignArgs" }
+if ($script:CosignArgs -notmatch 'github.com/basecamp/hey-cli/.github/workflows/release.yml@refs/tags/v9.9.9') { throw "v3: identity not pinned: $script:CosignArgs" }
+'v3-ok'
+
+# v2.6: compat flag required.
+$script:CosignVersion = 'v2.6.0'; $script:CosignArgs = $null
+Verify-CosignSignature -Version '9.9.9' -BaseUrl 'https://example.invalid' -TmpDir $tmp
+if ($script:CosignArgs -notmatch '--new-bundle-format=true') { throw "v2.6: compat flag missing: $script:CosignArgs" }
+'v26-ok'
+
+# v2.4: warn + skip, verify-blob never runs.
+$script:CosignVersion = 'v2.4.0'; $script:CosignArgs = $null
+Verify-CosignSignature -Version '9.9.9' -BaseUrl 'https://example.invalid' -TmpDir $tmp
+if ($null -ne $script:CosignArgs) { throw "v2.4: verify-blob must not run: $script:CosignArgs" }
+'v24-ok'
+
+# Garbage version: warn + skip.
+$script:CosignVersion = 'devel'; $script:CosignArgs = $null
+Verify-CosignSignature -Version '9.9.9' -BaseUrl 'https://example.invalid' -TmpDir $tmp
+if ($null -ne $script:CosignArgs) { throw "garbage: verify-blob must not run: $script:CosignArgs" }
+'garbage-ok'
+
+Remove-Item -Recurse -Force $tmp
+EOF
+
+  run bash -c "
+    set -euo pipefail
+    export INSTALL_PS1_PATH='$INSTALL_PS1'
+    pwsh -NoProfile -File '$STUB_DIR/cosign-driver.ps1'
+  "
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"v3-ok"* ]]
+  [[ "$output" == *"v26-ok"* ]]
+  [[ "$output" == *"v24-ok"* ]]
+  [[ "$output" == *"garbage-ok"* ]]
+}

--- a/tests/e2e/installer.bats
+++ b/tests/e2e/installer.bats
@@ -253,6 +253,42 @@ EOF
   [[ ! -f "$home/.profile" ]]
 }
 
+# Linux bash login shells (consoles, SSH) reach ~/.bashrc through the
+# distros' stock profile files, so the entry lands there.
+@test "setup_path appends to .bashrc for bash on linux" {
+  local home="$STUB_DIR/home"
+  mkdir -p "$home"
+  printf '#!/bin/sh\necho Linux\n' > "$STUB_DIR/uname"
+  chmod +x "$STUB_DIR/uname"
+  run bash -c "
+    export HOME='$home' SHELL=/bin/bash PATH='$STUB_DIR':/usr/bin:/bin
+    source '$INSTALL_SH'
+    BIN_DIR='$home/.local/bin'
+    setup_path
+  "
+  [[ "$status" -eq 0 ]]
+  grep -qF "export PATH=\"$home/.local/bin:\$PATH\"" "$home/.bashrc"
+  [[ ! -f "$home/.bash_profile" ]]
+}
+
+# macOS terminals start bash as a login shell, which reads ~/.bash_profile
+# and never ~/.bashrc, so .bashrc would configure PATH for nobody there.
+@test "setup_path appends to .bash_profile for bash on darwin" {
+  local home="$STUB_DIR/home"
+  mkdir -p "$home"
+  printf '#!/bin/sh\necho Darwin\n' > "$STUB_DIR/uname"
+  chmod +x "$STUB_DIR/uname"
+  run bash -c "
+    export HOME='$home' SHELL=/bin/bash PATH='$STUB_DIR':/usr/bin:/bin
+    source '$INSTALL_SH'
+    BIN_DIR='$home/.local/bin'
+    setup_path
+  "
+  [[ "$status" -eq 0 ]]
+  grep -qF "export PATH=\"$home/.local/bin:\$PATH\"" "$home/.bash_profile"
+  [[ ! -f "$home/.bashrc" ]]
+}
+
 @test "setup_path appends export PATH to .profile for other shells" {
   local home="$STUB_DIR/home"
   mkdir -p "$home"
@@ -513,4 +549,40 @@ EOF
   [[ "$output" == *"v26-ok"* ]]
   [[ "$output" == *"v24-ok"* ]]
   [[ "$output" == *"garbage-ok"* ]]
+}
+
+# The documented install path is `irm ... | iex`, and Invoke-Expression
+# evaluates install.ps1 in the caller's scope. The invoked script block must
+# keep the installer's state there: $ErrorActionPreference and the helper
+# functions may not survive into (or clobber) the invoking session.
+@test "install.ps1 leaves no state behind when evaluated via iex" {
+  if ! command -v pwsh >/dev/null 2>&1; then
+    if [[ -n "${CI:-}" ]]; then
+      echo "pwsh is required in CI for install.ps1 iex scope coverage" >&2
+      return 1
+    fi
+    skip "pwsh not installed"
+  fi
+
+  cat > "$STUB_DIR/iex-driver.ps1" <<'EOF'
+$ErrorActionPreference = 'Continue'
+# An unsupported architecture makes Main fail fast in Get-PlatformArch --
+# before any network access -- which is all this needs: the file was
+# evaluated in this scope exactly the way `irm | iex` evaluates it.
+$env:PROCESSOR_ARCHITEW6432 = 'MIPS'
+try { Invoke-Expression (Get-Content -Raw $env:INSTALL_PS1_PATH) } catch { }
+if ($ErrorActionPreference -ne 'Continue') { throw "leaked ErrorActionPreference=$ErrorActionPreference" }
+foreach ($name in @('Step', 'Info', 'Fail', 'Main', 'Get-DefaultBinDir')) {
+  if (Get-Command $name -CommandType Function -ErrorAction SilentlyContinue) { throw "leaked function $name" }
+}
+'iex-scope-ok'
+EOF
+
+  run bash -c "
+    set -euo pipefail
+    export INSTALL_PS1_PATH='$INSTALL_PS1'
+    pwsh -NoProfile -File '$STUB_DIR/iex-driver.ps1'
+  "
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"iex-scope-ok"* ]]
 }

--- a/tests/e2e/installer.bats
+++ b/tests/e2e/installer.bats
@@ -131,8 +131,11 @@ EOF
   grep -q 'function Get-FirstRunFailureMessage' "$INSTALL_PS1"
   grep -q 'Smart App Control' "$INSTALL_PS1"
   grep -q 'Protection history' "$INSTALL_PS1"
-  # The first-run failure path routes through the diagnosis helper.
+  # The first-run failure path routes through the diagnosis helper, for a
+  # launch that throws and for one that exits nonzero (PowerShell 5.1 does
+  # not throw on a native nonzero exit).
   grep -qF 'Fail (Get-FirstRunFailureMessage' "$INSTALL_PS1"
+  grep -qF -- '-Reason "hey --version exited with code $LASTEXITCODE"' "$INSTALL_PS1"
 }
 
 # All three diagnosis branches, driven by shadowing the probes. Only the
@@ -172,6 +175,15 @@ if ($msg -notlike '*no per-app exceptions*') { throw 'branch1 missing no-excepti
 if ($msg -notlike '*leave it off while using this unsigned build*') { throw 'branch1 missing stay-off caveat' }
 'branch1-ok'
 
+# Branch 1b: SAC in evaluation mode (2) observes without blocking, so it must
+# not be blamed -- falls through to the quarantine advice.
+$script:SacState = 2
+$msg = Get-FirstRunFailureMessage -Binary 'C:\bin\hey.exe' -Reason 'boom-eval'
+if ($msg -notlike '*boom-eval*') { throw 'branch1b missing original failure' }
+if ($msg -like '*wsl --install*') { throw 'branch1b must not blame SAC evaluation mode' }
+if ($msg -notlike '*Protection history*') { throw 'branch1b missing quarantine advice' }
+'branch1b-ok'
+
 # Branch 2: unsigned binary, SAC off -- quarantine advice, no WSL pitch.
 $script:SacState = 0
 $msg = Get-FirstRunFailureMessage -Binary 'C:\bin\hey.exe' -Reason 'boom-quarantine'
@@ -196,8 +208,62 @@ EOF
   "
   [[ "$status" -eq 0 ]]
   [[ "$output" == *"branch1-ok"* ]]
+  [[ "$output" == *"branch1b-ok"* ]]
   [[ "$output" == *"branch2-ok"* ]]
   [[ "$output" == *"branch3-ok"* ]]
+}
+
+# FreeBSD/OpenBSD base systems ship sha256(1), not sha256sum or shasum, and
+# detect_platform accepts both -- so the checksum step must too.
+@test "find_sha256_cmd falls back to the BSD sha256 -q" {
+  printf '#!/bin/sh\necho deadbeef\n' > "$STUB_DIR/sha256"
+  chmod +x "$STUB_DIR/sha256"
+  run bash -c "PATH='$STUB_DIR'; source '$INSTALL_SH'; find_sha256_cmd"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "sha256 -q" ]]
+
+  # Invoked the way verify_checksums does: the command word splits into
+  # sha256 plus its -q flag, and the digest lands in field 1.
+  run bash -c "PATH='$STUB_DIR'; source '$INSTALL_SH'; \$(find_sha256_cmd) somefile"
+  [[ "$status" -eq 0 ]]
+  [[ "${output%% *}" == "deadbeef" ]]
+}
+
+@test "find_sha256_cmd errors when no SHA256 tool exists" {
+  run bash -c "PATH='$STUB_DIR'; source '$INSTALL_SH'; find_sha256_cmd"
+  [[ "$status" -ne 0 ]]
+  [[ "$output" == *"No SHA256 tool found"* ]]
+}
+
+# fish sources neither ~/.profile nor Bourne `export`, so the PATH line for
+# a fish login shell has to land in config.fish in fish syntax.
+@test "setup_path writes fish_add_path to config.fish for fish shells" {
+  local home="$STUB_DIR/home"
+  mkdir -p "$home"
+  run bash -c "
+    export HOME='$home' SHELL=/usr/local/bin/fish PATH=/usr/bin:/bin
+    unset XDG_CONFIG_HOME
+    source '$INSTALL_SH'
+    BIN_DIR='$home/.local/bin'
+    setup_path
+  "
+  [[ "$status" -eq 0 ]]
+  [[ -f "$home/.config/fish/config.fish" ]]
+  grep -qF "fish_add_path \"$home/.local/bin\"" "$home/.config/fish/config.fish"
+  [[ ! -f "$home/.profile" ]]
+}
+
+@test "setup_path appends export PATH to .profile for other shells" {
+  local home="$STUB_DIR/home"
+  mkdir -p "$home"
+  run bash -c "
+    export HOME='$home' SHELL=/bin/ksh PATH=/usr/bin:/bin
+    source '$INSTALL_SH'
+    BIN_DIR='$home/.local/bin'
+    setup_path
+  "
+  [[ "$status" -eq 0 ]]
+  grep -qF "export PATH=\"$home/.local/bin:\$PATH\"" "$home/.profile"
 }
 
 # Releases publish the new (protobuf) Sigstore bundle format. cosign v3 parses

--- a/tests/e2e/installer_signing.bats
+++ b/tests/e2e/installer_signing.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# installer_signing.bats - Tests for the shape the PowerShell installer must
+# have before Authenticode signing.
+#
+# v0.8.0-rc.2 shipped a hey_installer.ps1 that PowerShell rejected as
+# HashMismatch, so the installer would not run under AllSigned/RemoteSigned.
+# Cause: jsign digests the script as UTF-16LE of the content with NO
+# line-ending normalization, while PowerShell's script SIP normalizes to CRLF
+# first. An LF file therefore yields two different digests.
+#
+# A second, latent cause would have survived a CRLF-only fix: the file carries
+# no BOM, jsign assumes UTF-8, and Windows PowerShell 5.1 assumes ANSI
+# (Windows-1252). Any byte above 0x7F decodes differently on each side. Within
+# ASCII the encodings are identical, so staging rejects non-ASCII outright.
+
+setup() {
+  STAGE="${BATS_TEST_DIRNAME}/../../scripts/stage-installer-ps1.sh"
+  INSTALL_PS1="${BATS_TEST_DIRNAME}/../../scripts/install.ps1"
+  WORK="$(mktemp -d)"
+}
+
+teardown() {
+  [[ -n "${WORK:-}" ]] && rm -rf "$WORK"
+}
+
+@test "install.ps1 is pure ASCII so staging can succeed at release time" {
+  # Guards the source, not just the staged copy: a stray em-dash here fails
+  # the release, and this is where it is cheap to catch.
+  run env LC_ALL=C grep -n '[^[:print:][:space:]]' "$INSTALL_PS1"
+  [ "$status" -ne 0 ]
+}
+
+@test "staging converts LF to CRLF" {
+  run "$STAGE" "$INSTALL_PS1" "$WORK/out.ps1"
+  [ "$status" -eq 0 ]
+  # Every line ends CRLF; none is bare LF.
+  total=$(wc -l < "$WORK/out.ps1")
+  crlf=$(grep -c $'\r$' "$WORK/out.ps1")
+  [ "$total" -eq "$crlf" ]
+}
+
+@test "staging is idempotent (no CR CR LF on a second pass)" {
+  "$STAGE" "$INSTALL_PS1" "$WORK/once.ps1"
+  "$STAGE" "$WORK/once.ps1" "$WORK/twice.ps1"
+  run cmp -s "$WORK/once.ps1" "$WORK/twice.ps1"
+  [ "$status" -eq 0 ]
+  run grep -c $'\r\r' "$WORK/twice.ps1"
+  [ "$status" -ne 0 ]
+}
+
+@test "staging rejects non-ASCII rather than signing an unverifiable file" {
+  printf '# dash \xe2\x80\x94 here\nWrite-Host x\n' > "$WORK/bad.ps1"
+  run "$STAGE" "$WORK/bad.ps1" "$WORK/bad-out.ps1"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"non-ASCII"* ]]
+  [ ! -f "$WORK/bad-out.ps1" ]
+}
+
+@test "staged file makes jsign's digest and PowerShell's agree" {
+  # The actual property under test. jsign hashes UTF-16LE of the content as-is;
+  # PowerShell hashes UTF-16LE after normalizing to CRLF. On a correctly staged
+  # file those are the same bytes, so the digests match and the signature
+  # verifies. This reproduces both sides rather than trusting the shape.
+  "$STAGE" "$INSTALL_PS1" "$WORK/out.ps1"
+  run python3 -c '
+import hashlib, sys
+raw = open(sys.argv[1], "rb").read()
+txt = raw.decode("utf-8")
+jsign = hashlib.sha256(txt.encode("utf-16-le")).hexdigest()
+ps = hashlib.sha256(txt.replace("\r\n", "\n").replace("\n", "\r\n").encode("utf-16-le")).hexdigest()
+print("MATCH" if jsign == ps else f"DIFFER jsign={jsign} powershell={ps}")
+' "$WORK/out.ps1"
+  [ "$status" -eq 0 ]
+  [ "$output" = "MATCH" ]
+}
+
+@test "an unstaged LF copy would NOT verify (the rc.2 regression)" {
+  # Negative control: without staging, the two digests diverge. If this ever
+  # passes, the digest model above has stopped reflecting reality and the
+  # positive test is no longer evidence of anything.
+  run python3 -c '
+import hashlib, sys
+raw = open(sys.argv[1], "rb").read()
+txt = raw.decode("utf-8")
+jsign = hashlib.sha256(txt.encode("utf-16-le")).hexdigest()
+ps = hashlib.sha256(txt.replace("\r\n", "\n").replace("\n", "\r\n").encode("utf-16-le")).hexdigest()
+print("MATCH" if jsign == ps else "DIFFER")
+' "$INSTALL_PS1"
+  [ "$status" -eq 0 ]
+  [ "$output" = "DIFFER" ]
+}

--- a/tests/e2e/installer_signing.bats
+++ b/tests/e2e/installer_signing.bats
@@ -2,7 +2,7 @@
 # installer_signing.bats - Tests for the shape the PowerShell installer must
 # have before Authenticode signing.
 #
-# v0.8.0-rc.2 shipped a hey_installer.ps1 that PowerShell rejected as
+# basecamp-cli v0.8.0-rc.2 shipped a hey_installer.ps1 that PowerShell rejected as
 # HashMismatch, so the installer would not run under AllSigned/RemoteSigned.
 # Cause: jsign digests the script as UTF-16LE of the content with NO
 # line-ending normalization, while PowerShell's script SIP normalizes to CRLF

--- a/tests/e2e/notify_issue.bats
+++ b/tests/e2e/notify_issue.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+#
+# Dedup behaviour for scripts/notify-issue.sh, shared by release.yml and
+# aur-publish.yml and installer-smoke.yml.
+#
+# Two defects are pinned here, both inherited from basecamp-cli. The first: an
+# inline lookup that matched on *title*, so retitling the canonical issue while
+# triaging it — the normal fate of an issue that stays open across an outage —
+# made the next failure open a duplicate. The second: a lookup wrapped in
+# `2>/dev/null || true`, which makes a rate limit, a permissions gap and a
+# GitHub outage indistinguishable from "no open issue", and the very next line
+# files one.
+#
+# `gh` is stubbed via PATH. Its four possible answers each get a branch, because
+# the failure mode of guessing wrong is a public issue nobody asked for.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  NOTIFY="$REPO_ROOT/scripts/notify-issue.sh"
+  WORK="$(mktemp -d)"
+  STUB_DIR="$WORK/bin"
+  mkdir -p "$STUB_DIR"
+  GH_CALLS="$WORK/gh-calls"
+  : > "$GH_CALLS"
+  PATH="$STUB_DIR:$PATH"
+  export GH_CALLS
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+# Stubs `gh`. $1 is what `gh issue list` prints (one issue number per line),
+# $2 its exit status. Every invocation is recorded to $GH_CALLS so the tests can
+# assert on what was *not* called as well as what was.
+stub_gh() {
+  local list_output="$1" list_status="${2:-0}"
+
+  printf '%s\n' "$list_output" > "$WORK/list-output"
+
+  cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "\$GH_CALLS"
+if [ "\$2" = "list" ]; then
+  cat "$WORK/list-output"
+  exit $list_status
+fi
+exit 0
+STUB
+  chmod +x "$STUB_DIR/gh"
+}
+
+run_notify() {
+  run "$NOTIFY" \
+    --repo basecamp/hey-cli \
+    --label aur-publish \
+    --title "AUR publish failure" \
+    --body "The AUR publish failed."
+}
+
+@test "comments on the single labelled issue" {
+  stub_gh "602" 0
+
+  run_notify
+  [ "$status" -eq 0 ]
+  grep -q "issue comment .* 602" "$GH_CALLS"
+  ! grep -q "issue create" "$GH_CALLS"
+}
+
+@test "files one issue, carrying the label, when none is open" {
+  stub_gh "" 0
+
+  run_notify
+  [ "$status" -eq 0 ]
+  grep -q "issue create" "$GH_CALLS"
+  # Without the label the issue it just filed would not be found next time, and
+  # the run after that would file a third.
+  grep -q -- "--label aur-publish" "$GH_CALLS"
+  ! grep -q "issue comment" "$GH_CALLS"
+}
+
+@test "fails closed when the lookup errors, filing nothing" {
+  # The regression that matters. `|| true` here reads an API failure as "no
+  # match" and opens a duplicate on every subsequent failed run.
+  stub_gh "" 1
+
+  run_notify
+  [ "$status" -eq 2 ]
+  ! grep -q "issue create" "$GH_CALLS"
+  ! grep -q "issue comment" "$GH_CALLS"
+  [[ "$output" == *"Could not list"* ]]
+}
+
+@test "fails closed when several issues carry the label" {
+  # Two open issues means a human split them on purpose. Commenting on whichever
+  # sorts first scatters one outage's history across both.
+  stub_gh "602
+607" 0
+
+  run_notify
+  [ "$status" -eq 3 ]
+  ! grep -q "issue create" "$GH_CALLS"
+  ! grep -q "issue comment" "$GH_CALLS"
+  [[ "$output" == *"602"* ]]
+  [[ "$output" == *"607"* ]]
+}
+
+@test "looks up by label, never by title" {
+  # A title search (`in:title`) misses a retitled issue; a label survives
+  # retitling.
+  stub_gh "602" 0
+
+  run_notify
+  [ "$status" -eq 0 ]
+  grep -q -- "issue list .*--label aur-publish" "$GH_CALLS"
+  ! grep -q -- "--search" "$GH_CALLS"
+  ! grep -q "in:title" "$GH_CALLS"
+}
+
+@test "ignores blank lines in the lookup output" {
+  # `--jq '.[].number'` prints nothing for an empty list, which arrives here as
+  # a single empty line. Counting it would make "none open" look like "one open"
+  # and send a comment to issue "".
+  stub_gh "
+" 0
+
+  run_notify
+  [ "$status" -eq 0 ]
+  grep -q "issue create" "$GH_CALLS"
+  ! grep -q "issue comment" "$GH_CALLS"
+}
+
+@test "propagates a failure to comment rather than reporting success" {
+  cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$GH_CALLS"
+if [ "$2" = "list" ]; then
+  echo 602
+  exit 0
+fi
+echo "HTTP 403" >&2
+exit 1
+STUB
+  chmod +x "$STUB_DIR/gh"
+
+  run_notify
+  [ "$status" -ne 0 ]
+}
+
+@test "rejects a missing required argument" {
+  stub_gh "602" 0
+
+  run "$NOTIFY" --repo basecamp/hey-cli --label aur-publish --title "t"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--body"* ]]
+  [ ! -s "$GH_CALLS" ]
+}

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Runs the bats end-to-end suite: installer and release-script contracts that
+# Go tests cannot reach. Requires bats-core (pacman -S bats, brew install
+# bats-core). Some install.ps1 tests need pwsh and skip without it locally;
+# in CI (CI=1) they fail instead, so a runner image dropping pwsh cannot turn
+# into silent coverage loss.
+
+set -euo pipefail
+
+# Headless: never touch the OS keyring from a test.
+export HEY_NO_KEYRING=1
+
+cd "$(dirname "$0")"
+
+if ! command -v bats &>/dev/null; then
+  echo "Error: bats not found. Install with your package manager (e.g., pacman -S bats, brew install bats-core)" >&2
+  exit 1
+fi
+
+jobs=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+
+# bats parallelises with GNU parallel (Linux) or rush (macOS) when present.
+if command -v rush &>/dev/null; then
+  exec bats --parallel-binary-name rush -j "$jobs" "$@" ./*.bats
+elif command -v parallel &>/dev/null && parallel --version 2>&1 | grep -q "GNU"; then
+  exec bats -j "$jobs" "$@" ./*.bats
+else
+  exec bats "$@" ./*.bats
+fi


### PR DESCRIPTION
Stacked on #194.

## What

- **`scripts/install.sh`** ← basecamp-cli's, renamed (`HEY_VERSION`, `HEY_BIN_DIR`, UA `hey-cli-installer`, identity `…/hey-cli/.github/workflows/release.yml@refs/tags/v<ver>`). Dropped: setup wizard, `*_SKIP_SETUP`/`*_SETUP_AGENT`/`post_install_setup`, theme linking, braille banner, `*_INSECURE_SKIP_COSIGN`. Kept: mandatory checksum, tiered cosign (v3 / v2.6+ / warn-and-skip), Schannel retry, bash 3.2 compatibility, SAC hint. Per-arch darwin only. Ends with "Next: `hey auth login`". Root `install.sh` was deleted in #192.
- **`scripts/install.ps1`** (pure ASCII) + **`scripts/stage-installer-ps1.sh`** (verbatim, for the Authenticode PR).
- **`tests/e2e/`** bats suite: `installer.bats` (sourcing guard, piped main, per-arch darwin, archive naming, SAC diagnosis incl. pwsh AST-driven branches, cosign gate ×4, `verify_checksums` ×7 incl. identity pin and mismatch, ps1 cosign gate), `installer_signing.bats`, `notify_issue.bats`. `make test-e2e`; `e2e` job in test.yml; `installer-bash32` macOS job (paths-filtered, full offline install via fixture curl); release.yml's gate now includes `test-e2e`.
- **`installer-smoke.yml`**: daily canary, linux / macOS bash 3.2 / Windows 5.1+pwsh, raw URLs with `TODO(hey.com/install-cli)` until the haystack redirect exists, notify via `notify-issue.sh --label installer-canary`.
- **`upgrade-smoke.yml`**: installer legs over digest-pinned cosign v3.0.5 / v2.6.0 / v2.4.0 asserting verified / verified / skipped. Native `hey upgrade` matrix comes with the upgrade PR.
- README: quick start (curl / irm), other channels (brew cask `hey`, AUR, deb/rpm/apk, Scoop, `go install`, source, release assets + `cosign verify-blob` recipe), Troubleshooting → "Windows: Smart App Control and SmartScreen" anchor. CONTRIBUTING: bats/jq, `make test-e2e`.

## Heads-up

The `upgrade-smoke` legs and the canary install the **latest release**. `v0.1.0` is a draft with no assets, so they will be red until `v0.1.1` ships from #192 — that is the check doing its job, not a bug in this PR.

## Verified

`make test-e2e`: 35 tests, 33 pass, 2 skipped locally (pwsh — they fail closed in CI). shellcheck clean on the new scripts; actionlint + zizmor clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the Bash and PowerShell installers and adds end-to-end canaries to keep install paths verified. Old behavior: the root installer requested a non-existent darwin_all and signature checks diverged; new behavior: both installers always verify SHA-256 and verify Sigstore bundles when `cosign` supports them (v3 default; v2.6+ with `--new-bundle-format=true`; older versions warn and skip).

- Installers
  - scripts/install.sh: runs on Bash 3.2; selects per-arch darwin archives; accepts GNU sha256sum and BSD sha256; retries Schannel revocation on Windows curl; updates PATH in ~/.bash_profile (macOS), ~/.bashrc (Linux), and configures fish via fish_add_path in config.fish; supports HEY_VERSION and HEY_BIN_DIR; pins Sigstore identity to this repo’s release workflow.
  - scripts/install.ps1: runs inside an invoked script block for `irm | iex` so scope does not leak; pure ASCII with a CRLF-staged copy via scripts/stage-installer-ps1.sh for Authenticode; checks $LASTEXITCODE after first run; treats Smart App Control state 1 as enforcing (evaluation does not block).

- Tests, CI, and docs
  - Adds a `bats-core` e2e suite (`make test-e2e`); runs in test.yml plus a macOS Bash 3.2 offline path; release.yml runs the e2e gate and dispatches upgrade-smoke.yml after publishing.
  - installer-smoke.yml canaries curl|bash and irm|iex across Linux, macOS (stock Bash 3.2), and Windows; notifies via notify-issue.sh --label installer-canary.
  - upgrade-smoke.yml installs the latest release with digest-pinned `cosign` v3.0.5/v2.6.0/v2.4.0 asserting verified/verified/skipped; skips legs until a release exists and also runs on published releases pinned to their tag.
  - README adds Quick Start, a manual verify recipe (notes the `cosign` v2.6 flag), and Smart App Control notes; CONTRIBUTING documents `bats-core`/`jq`; Makefile adds test-e2e.

<sup>Written for commit cce12eaff96a58df34cc9edfe62a2b5c67b58b77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

