### PR TITLE
Sign Windows binaries and the PowerShell installer via DigiCert KeyLocker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,56 @@ jobs:
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
 
+      - name: Verify Windows signing secrets
+        if: github.repository == 'basecamp/hey-cli'
+        run: |
+          missing=()
+          for var in SM_API_KEY SM_CLIENT_CERT_FILE_B64 SM_CLIENT_CERT_PASSWORD; do
+            if [ -z "${!var}" ]; then
+              missing+=("$var")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing Windows signing secrets: ${missing[*]}"
+            exit 1
+          fi
+          echo "All Windows signing secrets present"
+        env:
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+
+      - name: Set up Java for jsign
+        if: github.repository == 'basecamp/hey-cli'
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # Guarded like the preflight above: on forks this must not run at all —
+      # decoding an empty secret would export a nonempty SM_CLIENT_CERT_FILE,
+      # which the wrapper correctly treats as partial configuration and fails.
+      # With no SM_* env exported, forks take the wrapper's skip path instead
+      # and release unsigned.
+      - name: Prepare Windows signing
+        if: github.repository == 'basecamp/hey-cli'
+        env:
+          SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
+        run: |
+          # jsign >= 7.5 is mandatory: 7.1-7.3 are broken against DigiCert
+          # ONE's current API.
+          JSIGN_VERSION=7.5
+          JSIGN_SHA256=602a51c3545a6dc4fb99bd2ea7152b26d1345916d0c93ddfbd5936cb735af91c
+          umask 077
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/jsign-$JSIGN_VERSION.jar" \
+            "https://github.com/ebourg/jsign/releases/download/$JSIGN_VERSION/jsign-$JSIGN_VERSION.jar"
+          echo "$JSIGN_SHA256  $RUNNER_TEMP/jsign-$JSIGN_VERSION.jar" | sha256sum -c -
+          printf '%s' "$SM_CLIENT_CERT_FILE_B64" | base64 -d > "$RUNNER_TEMP/digicert-client-cert.p12"
+          {
+            echo "JSIGN_JAR=$RUNNER_TEMP/jsign-$JSIGN_VERSION.jar"
+            echo "SM_CLIENT_CERT_FILE=$RUNNER_TEMP/digicert-client-cert.p12"
+          } >> "$GITHUB_ENV"
+
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
@@ -185,11 +235,24 @@ jobs:
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          # Windows Authenticode signing via DigiCert KeyLocker (jsign).
+          # JSIGN_JAR and SM_CLIENT_CERT_FILE arrive via GITHUB_ENV from the
+          # "Prepare Windows signing" step above.
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          # DigiCert ONE certificate ID (not the keypair alias) for the OV cert
+          # CN=37signals LLC, expires 2027-04-30. Shared with basecamp-cli and
+          # bc3-desktop.
+          SIGN_ALIAS: 1346fa41-d9f0-4580-b7b9-a95cf5674354
         run: goreleaser release --clean
 
       # The gate itself runs as a goreleaser build hook (.goreleaser.yaml),
       # before archives, signing and publishing; this pass over dist/ is the
       # consolidated per-platform table for the job summary.
+      - name: Clean up Windows signing material
+        if: always()
+        run: rm -f "$RUNNER_TEMP/digicert-client-cert.p12" "$RUNNER_TEMP"/jsign-*.jar
+
       - name: Report release size budget
         run: scripts/check-size-budget.sh
 
@@ -387,6 +450,83 @@ jobs:
             echo "::error::Nix flake built ${out#hey version }, expected ${TAG#v}. nix/package.nix was not bumped before tagging."
             exit 1
           }
+  windows-verify:
+    name: Verify Windows signing
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: windows-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - name: Download release binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\verify" | Out-Null
+          gh release download $env:GITHUB_REF_NAME `
+            --repo $env:GITHUB_REPOSITORY `
+            --pattern "hey_*_windows_${{ matrix.arch }}.zip" `
+            --dir "$env:RUNNER_TEMP\verify"
+          if ($LASTEXITCODE -ne 0) { throw 'gh release download failed' }
+          $zip = Get-ChildItem "$env:RUNNER_TEMP\verify\hey_*_windows_${{ matrix.arch }}.zip"
+          Expand-Archive -Path $zip.FullName -DestinationPath "$env:RUNNER_TEMP\verify\extract" -Force
+
+      - name: Verify Authenticode signature
+        shell: pwsh
+        run: |
+          # Signature validation of an arm64 PE needs no execution, so both
+          # arches verify on the x64 runner.
+          $sig = Get-AuthenticodeSignature "$env:RUNNER_TEMP\verify\extract\hey.exe"
+          Write-Host "Status (${{ matrix.arch }}): $($sig.Status) - $($sig.StatusMessage)"
+          Write-Host "Signer: $($sig.SignerCertificate.Subject)"
+          if ($sig.Status -ne 'Valid') {
+            Write-Host "::error::Authenticode status (${{ matrix.arch }}): $($sig.Status) - $($sig.StatusMessage)"
+            exit 1
+          }
+          if ($sig.SignerCertificate.Subject -notmatch 'CN=37signals LLC') {
+            Write-Host "::error::Unexpected signer (${{ matrix.arch }}): $($sig.SignerCertificate.Subject)"
+            exit 1
+          }
+          if (-not $sig.TimeStamperCertificate) {
+            Write-Host "::error::No timestamp countersignature (${{ matrix.arch }}) - signature would expire with the cert on 2027-04-30"
+            exit 1
+          }
+          Write-Host "Signature valid, signer and timestamp verified (${{ matrix.arch }})"
+
+      - name: Download installer asset
+        if: matrix.arch == 'amd64'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          gh release download $env:GITHUB_REF_NAME `
+            --repo $env:GITHUB_REPOSITORY `
+            --pattern 'hey_installer.ps1' `
+            --dir "$env:RUNNER_TEMP\verify"
+          if ($LASTEXITCODE -ne 0) { throw 'gh release download failed' }
+
+      # Both engines: confirms jsign's ps1 content-hash encoding matches what
+      # PowerShell computes, on Core and on Windows PowerShell 5.1.
+      - name: Verify installer signature (pwsh)
+        if: matrix.arch == 'amd64'
+        shell: pwsh
+        run: |
+          $sig = Get-AuthenticodeSignature "$env:RUNNER_TEMP\verify\hey_installer.ps1"
+          Write-Host "Installer status (pwsh): $($sig.Status) - $($sig.StatusMessage)"
+          if ($sig.Status -ne 'Valid') { exit 1 }
+
+      - name: Verify installer signature (Windows PowerShell 5.1)
+        if: matrix.arch == 'amd64'
+        shell: powershell
+        run: |
+          $sig = Get-AuthenticodeSignature "$env:RUNNER_TEMP\verify\hey_installer.ps1"
+          Write-Host "Installer status (powershell): $($sig.Status) - $($sig.StatusMessage)"
+          if ($sig.Status -ne 'Valid') { exit 1 }
 
   sync-skills:
     name: Sync skills

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,9 @@ jobs:
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
           # DigiCert ONE certificate ID (not the keypair alias) for the OV cert
           # CN=37signals LLC, expires 2027-04-30. Shared with basecamp-cli and
-          # bc3-desktop.
+          # bc3-desktop. The ID is a valid jsign --alias: DigiCertOneSigningService
+          # accepts the certificate's id or alias (hex-and-dash values query
+          # certificates?id=) and derives the keypair from the certificate record.
           SIGN_ALIAS: 1346fa41-d9f0-4580-b7b9-a95cf5674354
         run: goreleaser release --clean
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,16 @@ before:
     # after the release is already public. Prereleases and snapshots leave
     # stable metadata on the latest stable version.
     - sh -c '{{ if or .Prerelease .IsSnapshot }}echo "Skipping stable metadata check for {{ .Version }}"{{ else }}scripts/check-stable-metadata.sh {{ .Version }}{{ end }}'
+    # Authenticode-sign a copy of the PowerShell installer inside the pipeline
+    # so it lands in checksums.txt (cosign-signed, provenance-attested) and on
+    # the release as hey_installer.ps1. Staged outside dist/ because goreleaser
+    # requires dist to be empty after before-hooks run. Unsigned copy when the
+    # SM_* env is absent (forks, make test-release). Raw-main install.ps1 stays
+    # unsigned and LF -- that is the `irm | iex` path, which needs neither. The
+    # staging step converts to CRLF and rejects non-ASCII, without which
+    # PowerShell reports HashMismatch (see the script for why both invariants
+    # are load-bearing).
+    - sh -c 'scripts/stage-installer-ps1.sh scripts/install.ps1 .release-extra/hey_installer.ps1 && scripts/sign-windows.sh windows .release-extra/hey_installer.ps1'
 
 builds:
   - id: hey
@@ -38,11 +48,17 @@ builds:
       - -X github.com/basecamp/hey-cli/internal/version.Commit={{.Commit}}
       - -X github.com/basecamp/hey-cli/internal/version.Date={{.Date}}
     hooks:
-      # Size gate per binary, before anything is archived, signed or
-      # published. Report-only while .size-budget has enforce = false. The
-      # release workflow prints the consolidated table afterwards, so the
-      # per-binary run stays out of the job summary.
       post:
+        # Authenticode-sign Windows binaries in place before archiving, so the
+        # zip, checksums.txt, cosign bundle, and provenance attestation all
+        # cover the signed binary. No-op for non-windows targets and when the
+        # SM_* signing env is absent (forks, make test-release).
+        - cmd: scripts/sign-windows.sh "{{ .Target }}" "{{ .Path }}"
+          output: true
+        # Size gate per binary, after signing and before anything is archived
+        # or published. Report-only while .size-budget has enforce = false. The
+        # release workflow prints the consolidated table afterwards, so the
+        # per-binary run stays out of the job summary.
         - sh -c 'GITHUB_STEP_SUMMARY= scripts/check-size-budget.sh {{ .Path }}'
 
 archives:
@@ -61,6 +77,8 @@ archives:
 checksum:
   name_template: checksums.txt
   algorithm: sha256
+  extra_files:
+    - glob: .release-extra/hey_installer.ps1
 
 sboms:
   - artifacts: archive
@@ -109,6 +127,8 @@ release:
   prerelease: auto
   make_latest: "{{ if .Prerelease }}false{{ else }}auto{{ end }}"
   replace_existing_artifacts: true
+  extra_files:
+    - glob: .release-extra/hey_installer.ps1
   name_template: "{{.ProjectName}} v{{.Version}}"
   header: |
     ### Install

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,26 +46,26 @@ SHA** (which is why the prep commit is pushed first):
 - `test`: lint lockstep, fmt, vet, lint, unit tests, bats suite, tidy, surface
   snapshot, race detector, govulncheck, CLI surface compatibility vs the previous tag
 - `security`: gitleaks, Trivy, gosec
-- `release`: preflights the macOS signing secrets, verifies the tag is on main,
-  then GoReleaser checks that a stable tag carries the plugin stamp and the
-  Nix package version, builds
+- `release`: preflights the macOS and Windows signing secrets, verifies the tag
+  is on main, installs Temurin 21 and a sha256-checked jsign, then GoReleaser
+  checks that a stable tag carries the plugin stamp and the Nix package
+  version, builds
   darwin/linux/windows/freebsd/openbsd × amd64/arm64 and deb/rpm/apk packages,
-  signs and notarizes macOS binaries, signs `checksums.txt` with cosign (keyless,
-  `checksums.txt.bundle`), generates SBOMs, publishes the GitHub release, and
-  updates the Homebrew cask and Scoop manifest; the checksums are then attested
-  with GitHub build provenance
-- After publication: `macos-verify`, `nix-verify` (stable only), `aur-publish`
-  (stable only, non-blocking), `sync-skills` (stable only, non-blocking)
-
-Windows binaries and `install.ps1` are **not** Authenticode-signed yet; see
-[Windows signing](#windows-signing).
+  signs and notarizes macOS binaries, Authenticode-signs the Windows binaries and
+  a staged copy of `install.ps1` (`hey_installer.ps1`), signs `checksums.txt`
+  with cosign (keyless, `checksums.txt.bundle`), generates SBOMs, publishes the
+  GitHub release, and updates the Homebrew cask and Scoop manifest; the checksums
+  are then attested with GitHub build provenance
+- After publication: `macos-verify`, `windows-verify`, `nix-verify` (stable
+  only), `aur-publish` (stable only, non-blocking), `sync-skills` (stable only,
+  non-blocking)
 
 ## Stable vs prerelease
 
 | Surface | Stable `0.2.0` | Prerelease `0.2.0-rc.1` |
 |---------|----------------|-------------------------|
 | GitHub Releases | Normal release, marked Latest | Marked prerelease; Latest stays on stable |
-| Release assets | Archives, checksums + bundle, SBOMs, deb/rpm/apk | Same |
+| Release assets | Archives, checksums + bundle, SBOMs, deb/rpm/apk, signed installer | Same |
 | Homebrew cask `hey` | Updated in `basecamp/homebrew-tap` | Unchanged |
 | Scoop `hey` | Updated in `basecamp/homebrew-tap` | Unchanged |
 | AUR `hey-cli` | Updated by `publish-aur.sh` | Unchanged |
@@ -99,24 +99,46 @@ converges the environment across the CLI repos and copies secrets in from
 | `MACOS_NOTARY_KEY` | secret | Base64 App Store Connect API key (.p8) |
 | `MACOS_NOTARY_KEY_ID` | secret | App Store Connect key ID |
 | `MACOS_NOTARY_ISSUER_ID` | secret | App Store Connect issuer UUID |
+| `SM_API_KEY` | secret | DigiCert ONE API key for KeyLocker |
+| `SM_CLIENT_CERT_FILE_B64` | secret | Base64 (single line) of the DigiCert ONE mTLS client certificate `.p12` attachment |
+| `SM_CLIENT_CERT_PASSWORD` | secret | Client certificate password |
 | `AUR_KEY` | secret | ed25519 SSH private key for the AUR (optional; publish skips without it) |
 
-The macOS preflight is gated on `github.repository == 'basecamp/hey-cli'`, so the
+The `SM_*` values come from the **DigiCert CodeSigning Cert** item (Development
+vault): the two text fields byte-exact with no trailing newline, and the `.p12`
+attachment encoded with `base64 -w0`. Malformed certificate material has bitten
+before — validate the decoded `.p12` opens with the password (`openssl pkcs12
+-info -noout`) before setting the secret.
+
+The macOS and Windows preflights are gated on `github.repository == 'basecamp/hey-cli'`, so the
 canonical repo refuses to release unsigned. Forks cannot release at all: the
 GitHub App token step needs the `release` environment and GoReleaser publishes to
 `basecamp/hey-cli`.
 
 ## Windows signing
 
-Not wired yet. `release.yml` has no Windows signing step and `.goreleaser.yaml`
-does not sign Windows artifacts, so the `hey.exe` binaries and `install.ps1` are
-published unsigned; `install.ps1` only consults the Authenticode status when
-diagnosing a first-run failure. The port from basecamp-cli (Authenticode via
-[jsign](https://ebourg.github.io/jsign/) against DigiCert KeyLocker, with
-`SM_API_KEY`, `SM_CLIENT_CERT_FILE_B64` and `SM_CLIENT_CERT_PASSWORD` on the
-`release` environment) is a separate change; `scripts/stage-installer-ps1.sh` and
-`tests/e2e/installer_signing.bats` are already here for it. Until it lands, do
-not tell users the Windows artifacts are signed.
+Windows binaries and the installer copy are Authenticode-signed from Linux CI via
+[jsign](https://ebourg.github.io/jsign/) against DigiCert KeyLocker (cloud HSM).
+bc3-desktop's `docs/windows-signing.md` is the canonical runbook; this repo and
+basecamp-cli are further consumers of the same certificate.
+
+- Certificate: OV code signing, `CN=37signals LLC`, expires **2027-04-30**. The
+  DigiCert ONE certificate ID (not the 1Password item's keypair alias) is pinned
+  once, as `SIGN_ALIAS` in `release.yml` — keep it in sync with bc3-desktop and
+  basecamp-cli when the certificate is renewed.
+- jsign version and jar sha256 are pinned in the "Prepare Windows signing" step.
+  jsign ≥ 7.5 is required; 7.1–7.3 are broken against DigiCert ONE's current API.
+- Quota: KeyLocker signatures draw from a budget shared with bc3-desktop and
+  basecamp-cli. Each tag consumes **3 signatures** (two exes + the installer copy);
+  rc(s) + stable is ≥ 6, and re-runs after post-signing failures consume more.
+  Confirm headroom with the certificate owner before a release burst.
+- `scripts/sign-windows.sh` fails closed: all `SM_*` empty skips (forks,
+  `make test-release`), partial configuration or a signing/timestamp error aborts
+  the release during the build phase — nothing is published. Re-run the workflow
+  on the same tag after the outage clears.
+- `windows-verify` asserts a Valid signature, the `37signals LLC` signer and a
+  timestamp countersignature on both arches, and verifies `hey_installer.ps1`
+  under pwsh and Windows PowerShell 5.1.
 
 ## Nix flake maintenance
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -125,7 +125,11 @@ basecamp-cli are further consumers of the same certificate.
 - Certificate: OV code signing, `CN=37signals LLC`, expires **2027-04-30**. The
   DigiCert ONE certificate ID (not the 1Password item's keypair alias) is pinned
   once, as `SIGN_ALIAS` in `release.yml` — keep it in sync with bc3-desktop and
-  basecamp-cli when the certificate is renewed.
+  basecamp-cli when the certificate is renewed. The certificate ID is a valid
+  jsign `--alias`: for `DIGICERTONE`, jsign accepts the certificate's ID or its
+  alias (hex-and-dash values are looked up as `certificates?id=`) and derives
+  the signing keypair from the certificate record — basecamp-cli releases sign
+  with this exact value.
 - jsign version and jar sha256 are pinned in the "Prepare Windows signing" step.
   jsign ≥ 7.5 is required; 7.1–7.3 are broken against DigiCert ONE's current API.
 - Quota: KeyLocker signatures draw from a budget shared with bc3-desktop and

--- a/scripts/sign-windows.sh
+++ b/scripts/sign-windows.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# sign-windows.sh — Authenticode-sign a Windows artifact in place via
+# DigiCert KeyLocker (cloud HSM) using jsign.
+#
+# Usage: sign-windows.sh TARGET PATH
+#   TARGET  goreleaser build target (windows_amd64, windows_arm64) or the
+#           literal "windows" for non-goreleaser callers; anything else no-ops
+#
+# Contract:
+#   - non-windows target                   → exit 0, silent no-op
+#   - all SM_* signing env vars empty      → exit 0 with a skip notice
+#                                            (forks, make test-release, local builds)
+#   - partial signing env                  → exit 1 (misconfiguration, not a skip)
+#   - signing or timestamping failure      → nonzero (goreleaser aborts before
+#                                            publish — a release never silently
+#                                            ships unsigned)
+#
+# Required env when signing: SM_API_KEY, SM_CLIENT_CERT_FILE,
+# SM_CLIENT_CERT_PASSWORD, SIGN_ALIAS, JSIGN_JAR. See RELEASING.md and
+# bc3-desktop docs/windows-signing.md for the KeyLocker runbook.
+set -euo pipefail
+
+target="${1:?usage: sign-windows.sh TARGET PATH}"
+path="${2:?usage: sign-windows.sh TARGET PATH}"
+
+case "$target" in
+  windows|windows_*) ;;
+  *) exit 0 ;;
+esac
+
+if [ -z "${SM_API_KEY:-}" ] && [ -z "${SM_CLIENT_CERT_FILE:-}" ] && [ -z "${SM_CLIENT_CERT_PASSWORD:-}" ]; then
+  echo "sign-windows: SM_* signing env not set — skipping Authenticode signing for $path" >&2
+  exit 0
+fi
+
+for var in SM_API_KEY SM_CLIENT_CERT_FILE SM_CLIENT_CERT_PASSWORD SIGN_ALIAS JSIGN_JAR; do
+  if [ -z "${!var:-}" ]; then
+    echo "sign-windows: $var is empty while other signing env is set — refusing to continue" >&2
+    exit 1
+  fi
+done
+
+[ -f "$SM_CLIENT_CERT_FILE" ] || { echo "sign-windows: client cert not found: $SM_CLIENT_CERT_FILE" >&2; exit 1; }
+[ -f "$JSIGN_JAR" ] || { echo "sign-windows: jsign jar not found: $JSIGN_JAR" >&2; exit 1; }
+
+echo "sign-windows: signing $path via DigiCert KeyLocker"
+java -jar "$JSIGN_JAR" \
+  --storetype DIGICERTONE \
+  --alias "$SIGN_ALIAS" \
+  --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" \
+  --tsaurl http://timestamp.digicert.com \
+  --tsretries 3 \
+  --tsretrywait 10 \
+  "$path"

--- a/tests/e2e/sign_windows.bats
+++ b/tests/e2e/sign_windows.bats
@@ -45,11 +45,14 @@ run_sign() {
     "$SIGN_SH" "$1" "$TARGET_FILE"
 }
 
+# SIGN_ALIAS carries the certificate-ID shape pinned in release.yml: jsign
+# routes hex-and-dash aliases to a certificates?id= lookup, so the fixture
+# must exercise that shape, not a mnemonic alias.
 full_env() {
   echo "SM_API_KEY=api-key" \
     "SM_CLIENT_CERT_FILE=$CERT_FILE" \
     "SM_CLIENT_CERT_PASSWORD=cert-pass" \
-    "SIGN_ALIAS=alias-guid" \
+    "SIGN_ALIAS=0f6d8c1a-4b2e-4d59-9a31-7c8e5b2f4a10" \
     "JSIGN_JAR=$JAR_FILE"
 }
 
@@ -100,7 +103,7 @@ full_env() {
 
 @test "nonexistent client cert path fails" {
   run_sign SM_API_KEY=api-key "SM_CLIENT_CERT_FILE=$STUB_DIR/missing.p12" \
-    SM_CLIENT_CERT_PASSWORD=cert-pass SIGN_ALIAS=alias-guid "JSIGN_JAR=$JAR_FILE" \
+    SM_CLIENT_CERT_PASSWORD=cert-pass SIGN_ALIAS=0f6d8c1a-4b2e-4d59-9a31-7c8e5b2f4a10 "JSIGN_JAR=$JAR_FILE" \
     windows_amd64
   [[ "$status" -eq 1 ]]
   [[ "$output" == *"client cert not found"* ]]
@@ -108,7 +111,7 @@ full_env() {
 
 @test "nonexistent jsign jar path fails" {
   run_sign SM_API_KEY=api-key "SM_CLIENT_CERT_FILE=$CERT_FILE" \
-    SM_CLIENT_CERT_PASSWORD=cert-pass SIGN_ALIAS=alias-guid \
+    SM_CLIENT_CERT_PASSWORD=cert-pass SIGN_ALIAS=0f6d8c1a-4b2e-4d59-9a31-7c8e5b2f4a10 \
     "JSIGN_JAR=$STUB_DIR/missing.jar" windows_amd64
   [[ "$status" -eq 1 ]]
   [[ "$output" == *"jsign jar not found"* ]]
@@ -125,7 +128,7 @@ $JAR_FILE
 --storetype
 DIGICERTONE
 --alias
-alias-guid
+0f6d8c1a-4b2e-4d59-9a31-7c8e5b2f4a10
 --storepass
 api-key|$CERT_FILE|cert-pass
 --tsaurl

--- a/tests/e2e/sign_windows.bats
+++ b/tests/e2e/sign_windows.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# sign_windows.bats - Tests for scripts/sign-windows.sh's fail-closed contract.
+#
+# The wrapper gates Authenticode signing in the release pipeline: it must
+# skip cleanly when signing is unconfigured (forks, make test-release), but
+# hard-fail on partial configuration or missing material so a tagged release
+# can never silently ship unsigned.
+
+setup() {
+  SIGN_SH="${BATS_TEST_DIRNAME}/../../scripts/sign-windows.sh"
+
+  STUB_DIR="$(mktemp -d)"
+  LOG="$STUB_DIR/java-args.log"
+  TARGET_FILE="$STUB_DIR/hey.exe"
+  CERT_FILE="$STUB_DIR/client-cert.p12"
+  JAR_FILE="$STUB_DIR/jsign.jar"
+  echo "pe-bytes" > "$TARGET_FILE"
+  echo "cert" > "$CERT_FILE"
+  echo "jar" > "$JAR_FILE"
+
+  # A `java` stub that records its argv one-per-line and exits JAVA_EXIT.
+  {
+    echo '#!/usr/bin/env bash'
+    echo "printf '%s\\n' \"\$@\" > \"$LOG\""
+    echo 'exit "${JAVA_EXIT:-0}"'
+  } > "$STUB_DIR/java"
+  chmod +x "$STUB_DIR/java"
+}
+
+teardown() {
+  [[ -n "${STUB_DIR:-}" ]] && rm -rf "$STUB_DIR"
+}
+
+# run_sign VAR=VALUE... TARGET — runs the wrapper with exactly the given
+# signing env (everything else cleared), against $TARGET_FILE.
+run_sign() {
+  local env_args=()
+  while [[ "$1" == *=* ]]; do
+    env_args+=("$1")
+    shift
+  done
+  run env -u SM_API_KEY -u SM_CLIENT_CERT_FILE -u SM_CLIENT_CERT_PASSWORD \
+    -u SIGN_ALIAS -u JSIGN_JAR "${env_args[@]}" \
+    PATH="$STUB_DIR:$PATH" \
+    "$SIGN_SH" "$1" "$TARGET_FILE"
+}
+
+full_env() {
+  echo "SM_API_KEY=api-key" \
+    "SM_CLIENT_CERT_FILE=$CERT_FILE" \
+    "SM_CLIENT_CERT_PASSWORD=cert-pass" \
+    "SIGN_ALIAS=alias-guid" \
+    "JSIGN_JAR=$JAR_FILE"
+}
+
+@test "non-windows target is a silent no-op even with full signing env" {
+  # shellcheck disable=SC2046
+  run_sign $(full_env) darwin_amd64
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+  [[ "$(cat "$TARGET_FILE")" == "pe-bytes" ]]
+  [[ ! -f "$LOG" ]]  # java never invoked
+}
+
+@test "all SM_* empty skips with a notice" {
+  run_sign windows_amd64
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"skipping Authenticode signing"* ]]
+  [[ ! -f "$LOG" ]]
+}
+
+@test "skip notice applies to the plain 'windows' target too" {
+  run_sign windows
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"skipping Authenticode signing"* ]]
+}
+
+# Partial configuration is a misconfigured release, not a fork building from
+# source — each missing var must hard-fail and be named.
+@test "partial config: each empty var fails naming the var" {
+  local var
+  for var in SM_API_KEY SM_CLIENT_CERT_FILE SM_CLIENT_CERT_PASSWORD SIGN_ALIAS JSIGN_JAR; do
+    local env_args=()
+    local pair
+    for pair in $(full_env); do
+      if [[ "$pair" == "$var="* ]]; then
+        env_args+=("$var=")
+      else
+        env_args+=("$pair")
+      fi
+    done
+    run env -u SM_API_KEY -u SM_CLIENT_CERT_FILE -u SM_CLIENT_CERT_PASSWORD \
+      -u SIGN_ALIAS -u JSIGN_JAR "${env_args[@]}" \
+      PATH="$STUB_DIR:$PATH" \
+      "$SIGN_SH" windows_amd64 "$TARGET_FILE"
+    [[ "$status" -eq 1 ]] || { echo "expected exit 1 for empty $var, got $status"; return 1; }
+    [[ "$output" == *"$var is empty"* ]] || { echo "missing var name for $var in: $output"; return 1; }
+  done
+}
+
+@test "nonexistent client cert path fails" {
+  run_sign SM_API_KEY=api-key "SM_CLIENT_CERT_FILE=$STUB_DIR/missing.p12" \
+    SM_CLIENT_CERT_PASSWORD=cert-pass SIGN_ALIAS=alias-guid "JSIGN_JAR=$JAR_FILE" \
+    windows_amd64
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"client cert not found"* ]]
+}
+
+@test "nonexistent jsign jar path fails" {
+  run_sign SM_API_KEY=api-key "SM_CLIENT_CERT_FILE=$CERT_FILE" \
+    SM_CLIENT_CERT_PASSWORD=cert-pass SIGN_ALIAS=alias-guid \
+    "JSIGN_JAR=$STUB_DIR/missing.jar" windows_amd64
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"jsign jar not found"* ]]
+}
+
+@test "happy path invokes jsign with the exact KeyLocker argv" {
+  # shellcheck disable=SC2046
+  run_sign $(full_env) windows_amd64
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"signing $TARGET_FILE via DigiCert KeyLocker"* ]]
+
+  expected="-jar
+$JAR_FILE
+--storetype
+DIGICERTONE
+--alias
+alias-guid
+--storepass
+api-key|$CERT_FILE|cert-pass
+--tsaurl
+http://timestamp.digicert.com
+--tsretries
+3
+--tsretrywait
+10
+$TARGET_FILE"
+  [[ "$(cat "$LOG")" == "$expected" ]]
+}
+
+@test "jsign failure propagates its exit code" {
+  # shellcheck disable=SC2046
+  run_sign $(full_env) JAVA_EXIT=7 windows_amd64
+  [[ "$status" -eq 7 ]]
+}


### PR DESCRIPTION
Stacked on #199. `SM_API_KEY`, `SM_CLIENT_CERT_FILE_B64` and `SM_CLIENT_CERT_PASSWORD` are now set on the `release` environment (from the DigiCert CodeSigning Cert item; `.p12` validated with the password before upload). Now last in the stack so it can carry the RELEASING.md Windows section.

## What

- `scripts/sign-windows.sh` (verbatim contract from basecamp-cli): non-windows → silent no-op; all `SM_*` empty → skip with notice; partial → exit 1 naming the var; jsign failure → propagated, so goreleaser aborts before publish. `tests/e2e/sign_windows.bats` (8 tests, `hey.exe`).
- `.goreleaser.yaml`: `builds.hooks.post` signs each Windows PE in place before archiving; a before-hook stages + signs `.release-extra/hey_installer.ps1`; `checksum.extra_files` and `release.extra_files` ship it.
- `release.yml`: SM_* preflight, `setup-java` Temurin 21, jsign 7.5 with `JSIGN_SHA256=602a51c3…` check, `SIGN_ALIAS 1346fa41-d9f0-4580-b7b9-a95cf5674354` (DigiCert ONE cert ID, CN=37signals LLC, exp 2027-04-30 — **please confirm it's the shared cert**), cleanup `if: always()`, `windows-verify` matrix (Valid, CN match, timestamp countersignature; installer verified under pwsh and 5.1).

## Before merging

1. Land the companion basecamp-cli PR adding hey-cli's `SM_*` rows to `scripts/manage-release-env.sh`, then run `migrate-secrets --op-vault …` for `basecamp/hey-cli`.
2. Confirm `SIGN_ALIAS` is correct for hey (KeyLocker quota: 3 signatures per tag — amd64, arm64, installer).
3. Flip off draft.

## Verified

`make test-e2e` (43 tests), `goreleaser check`, actionlint + zizmor, `make test-release` with SM_* blanked: both `hey.exe` hooks take the skip path, `hey_installer.ps1` is staged (CRLF, ASCII) and listed in `checksums.txt`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticode-signs Windows hey.exe (amd64/arm64) and a staged CRLF/ASCII hey_installer.ps1 via DigiCert KeyLocker. Before: unsigned Windows artifacts. Now: signed binaries and installer, with fail-closed gating, pinned `jsign` 7.5, and a Windows verification job.

**Review notes**
- `scripts/sign-windows.sh` gates signing: non-windows → no-op; all `SM_*` empty → skip with notice; any partial config or `jsign` error → exit nonzero. `tests/e2e/sign_windows.bats` pins this contract and the exact `jsign` argv.
- `.goreleaser.yaml` signs Windows PEs as a post-build hook so zips, `checksums.txt`, the cosign bundle, and provenance cover the signed binaries; a before-hook stages and signs `hey_installer.ps1` (CRLF, ASCII); the size gate runs after signing; the installer ships in checksums and release assets.
- `release.yml` preflights `SM_*` (repo-gated), installs Temurin 21, fetches `jsign` 7.5 with a pinned SHA-256, decodes the client cert into `RUNNER_TEMP`, exports `JSIGN_JAR/SM_CLIENT_CERT_FILE`, and removes both on completion. Adds `windows-verify` asserting Valid status, signer CN “37signals LLC,” and a TSA timestamp for both arches; verifies the installer under `pwsh` and Windows PowerShell 5.1. `SIGN_ALIAS` is the DigiCert ONE certificate ID (accepted by `jsign --alias` for `DIGICERTONE`; cert expires 2027-04-30). Updates RELEASING.md with Windows signing and secret handling.

**Required actions**
- Add `SM_API_KEY`, `SM_CLIENT_CERT_FILE_B64`, and `SM_CLIENT_CERT_PASSWORD` to the `release` environment.
- Confirm `SIGN_ALIAS` matches this project’s DigiCert ONE certificate ID.
- Ensure KeyLocker quota covers three signatures per tag (amd64, arm64, installer).

<sup>Written for commit 034622829ebe15805d6e67befa9af31cd3e6a823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

