### PR TITLE
Add a Nix flake with drift-proof vendorHash tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,6 +369,29 @@ jobs:
             echo "::warning::Notarization not yet accepted for ${{ matrix.arch }} (ticket propagation may lag)"
           fi
 
+  # Not continue-on-error: a broken flake is a broken release artifact, so it
+  # must colour the run even though it lands after publication.
+  nix-verify:
+    name: Verify Nix flake
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+
+      - name: Build and verify
+        run: |
+          STORE_PATH=$(nix build --no-link --print-out-paths)
+          "$STORE_PATH/bin/hey" --version
+
   sync-skills:
     name: Sync skills
     needs: [release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,10 +387,20 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
 
+      # The version check closes the loop on scripts/release.sh's gate: a flake
+      # that builds but still advertises the previous release is a broken
+      # artifact for `nix profile install`, and only the tag knows the truth.
       - name: Build and verify
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
           STORE_PATH=$(nix build --no-link --print-out-paths)
-          "$STORE_PATH/bin/hey" --version
+          out=$("$STORE_PATH/bin/hey" --version)
+          echo "$out"
+          [ "$out" = "hey version ${TAG#v}" ] || {
+            echo "::error::Nix flake built ${out#hey version }, expected ${TAG#v}. nix/package.nix was not bumped before tagging."
+            exit 1
+          }
 
   sync-skills:
     name: Sync skills

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -314,6 +314,11 @@ jobs:
   # exists so it lands red with the correct hash and `make update-nix-hash`
   # attached, instead of a raw nix dump.
   #
+  # Go sources are in the filter too: vendorHash covers the vendored *files*,
+  # not go.sum, so a new import from a module already in go.mod changes the
+  # hash while leaving go.mod and go.sum alone. The filter exists to skip
+  # docs-only and workflow-only PRs, not Go changes.
+  #
   # The filter includes this file: a PR that changes only the job would
   # otherwise skip the job it changed.
   nix-build:
@@ -334,6 +339,7 @@ jobs:
         with:
           filters: |
             nix:
+              - '**/*.go'
               - 'go.mod'
               - 'go.sum'
               - 'flake.nix'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,6 +304,53 @@ jobs:
           fi
           "$fixture_root/install/hey" --version
 
+  # A Go bump in go.mod that outpaces flake.lock breaks the flake without
+  # touching go.sum, and nothing would notice until the tag (nix-verify). Catch
+  # the drift where it is introduced instead.
+  #
+  # This job is *meant* to fail on a dependency bump: any go.mod or go.sum
+  # change invalidates vendorHash, and dependabot does not update it, so every
+  # weekly `gomod` PR lands here red. That is the check working. nix-build-check.sh
+  # exists so it lands red with the correct hash and `make update-nix-hash`
+  # attached, instead of a raw nix dump.
+  #
+  # The filter includes this file: a PR that changes only the job would
+  # otherwise skip the job it changed.
+  nix-build:
+    name: Nix flake builds
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read  # dorny/paths-filter enumerates PR files via the REST API
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Check for flake-relevant changes
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            nix:
+              - 'go.mod'
+              - 'go.sum'
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'nix/**'
+              - 'scripts/nix-build-check.sh'
+              - 'scripts/extract-nix-vendor-hash.sh'
+              - '.github/workflows/test.yml'
+
+      - name: Install Nix
+        if: steps.filter.outputs.nix == 'true'
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+
+      - name: Build the flake
+        if: steps.filter.outputs.nix == 'true'
+        run: scripts/nix-build-check.sh
+
   cli-surface:
     name: CLI Surface Check
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ help:
 	@echo ""
 	@echo "  make check-surface        Generate CLI surface snapshot"
 	@echo "  make check-surface-compat Compare surface against previous tag"
-	@echo "  make update-nix-hash      Recompute the Nix vendorHash via Docker"
+	@echo "  make update-nix-hash Recompute the Nix vendorHash via Docker ([VERSION=v1.2.3] bumps the version)"
 	@echo "  make tools                Install dev tools"
 
 # Toolchain guard — fails fast when PATH go and GOROOT go disagree
@@ -187,13 +187,16 @@ check-surface-compat: build
 		fi; \
 	fi
 
-# Recompute Nix vendorHash via Docker and update nix/package.nix.
-# 0 = updated, 2 = nothing to do. Anything else is a real failure and must
-# propagate: a blanket `|| true` here would silently undo the script's own
-# fail-closed check.
+# Recompute Nix vendorHash via Docker and update nix/package.nix. Pass
+# VERSION=vX.Y.Z to also bump the package version (scripts/release.sh refuses
+# to tag a stable release until it matches); without it the stored version is
+# kept. 0 = updated, 2 = nothing to do. Anything else is a real failure and
+# must propagate: a blanket `|| true` here would silently undo the script's
+# own fail-closed check.
 update-nix-hash:
-	@VERSION=$$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' nix/package.nix | head -1); \
-	scripts/update-nix-flake.sh "$$VERSION"; RC=$$?; \
+	@V="$(VERSION)"; \
+	if [ "$$V" = dev ]; then V=$$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' nix/package.nix | head -1); fi; \
+	scripts/update-nix-flake.sh "$${V#v}"; RC=$$?; \
 	if [ $$RC -ne 0 ] && [ $$RC -ne 2 ]; then exit $$RC; fi
 
 # Security suite

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build test test-unit test-e2e test-smoke preview-callback coverage fmt fmt-check vet lint tidy tidy-check \
 	race-test vuln secrets replace-check check-toolchain check security \
 	release-check release test-release bench bench-save bench-compare \
-	check-surface check-surface-compat check-lint-lockstep tools clean install help
+	check-surface check-surface-compat check-lint-lockstep update-nix-hash tools clean install help
 
 BINARY := $(CURDIR)/bin/hey
 COVERAGE_FLOOR ?= 70.8
@@ -52,6 +52,7 @@ help:
 	@echo ""
 	@echo "  make check-surface        Generate CLI surface snapshot"
 	@echo "  make check-surface-compat Compare surface against previous tag"
+	@echo "  make update-nix-hash      Recompute the Nix vendorHash via Docker"
 	@echo "  make tools                Install dev tools"
 
 # Toolchain guard — fails fast when PATH go and GOROOT go disagree
@@ -185,6 +186,15 @@ check-surface-compat: build
 			echo "Baseline ($$PREV_TAG) does not support --help --agent — skipping surface diff"; \
 		fi; \
 	fi
+
+# Recompute Nix vendorHash via Docker and update nix/package.nix.
+# 0 = updated, 2 = nothing to do. Anything else is a real failure and must
+# propagate: a blanket `|| true` here would silently undo the script's own
+# fail-closed check.
+update-nix-hash:
+	@VERSION=$$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' nix/package.nix | head -1); \
+	scripts/update-nix-flake.sh "$$VERSION"; RC=$$?; \
+	if [ $$RC -ne 0 ] && [ $$RC -ne 2 ]; then exit $$RC; fi
 
 # Security suite
 security: lint vuln secrets

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ scoop bucket add basecamp https://github.com/basecamp/homebrew-tap
 scoop install hey
 ```
 
+**Nix:**
+```bash
+nix profile install github:basecamp/hey-cli
+```
+
 **Go install:**
 ```bash
 go install github.com/basecamp/hey-cli/cmd/hey@latest

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787172299,
+        "narHash": "sha256-PShzS87awOlE5XWkxUGBd/58/F+AtE2ZMgFffKj4r8s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "07e1d92cdc0ed416cfa11ff3ca40d17e61cfba7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,21 +25,23 @@
       );
 
       devShells = forAllSystems (system:
-        let pkgs = nixpkgsFor.${system};
+        let
+          pkgs = nixpkgsFor.${system};
+          # The same toolchain the package builds with — see nix/go.nix.
+          go = pkgs.callPackage ./nix/go.nix { };
         in {
           default = pkgs.mkShell {
-            packages = with pkgs; [
+            packages = [ go ] ++ (with pkgs; [
               actionlint
               bats
               git
-              go_1_26
               golangci-lint
               goreleaser
               gnumake
               jq
               ripgrep
               zizmor
-            ];
+            ]);
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "Command-line interface for HEY email";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in {
+      packages = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system};
+        in {
+          hey = pkgs.callPackage ./nix/package.nix { };
+          default = self.packages.${system}.hey;
+        }
+      );
+
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system};
+        in {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              actionlint
+              bats
+              git
+              go_1_26
+              golangci-lint
+              goreleaser
+              gnumake
+              jq
+              ripgrep
+              zizmor
+            ];
+          };
+        }
+      );
+    };
+}

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -1,0 +1,28 @@
+{ lib, fetchurl, go_1_26 }:
+
+# The Go toolchain shared by the package build and the dev shell.
+#
+# go.mod's `go` directive is the floor; nixpkgs-unstable lagged it at 1.26.5
+# when this flake was written, so the toolchain is rebuilt from the upstream
+# source tarball until nixpkgs catches up. The override is conditional and
+# drops itself once go_1_26 reaches 1.26.6 — delete this file's override and
+# return go_1_26 directly after a `nix flake update` that makes
+# `lib.versionOlder` false. Keep minGo in step with go.mod: a toolchain bump
+# that outpaces flake.lock breaks the build without touching go.mod or go.sum,
+# which is why the nix-build CI job runs on every go.mod change and on tags.
+#
+# Both consumers must use this one derivation. The dev shell once listed
+# go_1_26 directly, which handed `nix develop` a Go older than go.mod's
+# directive — `make build` then failed under GOTOOLCHAIN=local or offline.
+let
+  minGo = "1.26.6";
+in
+if lib.versionOlder go_1_26.version minGo
+then go_1_26.overrideAttrs (_: {
+  version = minGo;
+  src = fetchurl {
+    url = "https://go.dev/dl/go${minGo}.src.tar.gz";
+    hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
+  };
+})
+else go_1_26

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,58 @@
+{ lib, buildGoModule, fetchurl, go_1_26, installShellFiles, stdenv }:
+
+let
+  # go.mod's `go` directive is the floor; nixpkgs-unstable lagged it at 1.26.5
+  # when this flake was written, so the toolchain is rebuilt from the upstream
+  # source tarball until nixpkgs catches up. The override is conditional and
+  # drops itself once go_1_26 reaches 1.26.6 — delete this block after a
+  # `nix flake update` that makes `lib.versionOlder` false. Keep MIN_GO in
+  # step with go.mod: a toolchain bump that outpaces flake.lock breaks the
+  # build without touching go.mod or go.sum, which is why the nix-build CI job
+  # runs on every go.mod change and on tags.
+  minGo = "1.26.6";
+  go = if lib.versionOlder go_1_26.version minGo
+    then go_1_26.overrideAttrs (_: {
+      version = minGo;
+      src = fetchurl {
+        url = "https://go.dev/dl/go${minGo}.src.tar.gz";
+        hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
+      };
+    })
+    else go_1_26;
+in
+buildGoModule.override { inherit go; } (finalAttrs: {
+  pname = "hey";
+  # Updated automatically by scripts/update-nix-flake.sh on each release.
+  version = "0.1.1";
+
+  src = lib.cleanSource ./..;
+
+  # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
+  # value in place, so keep it a string literal rather than lib.fakeHash.
+  vendorHash = "sha256-Yf+Y7DFm6rBFxX7evMfGY7/O4l7bk5LP1++ZJmW7O4I=";
+
+  subPackages = [ "cmd/hey" ];
+
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/basecamp/hey-cli/internal/version.Version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString
+    (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd hey \
+      --bash <($out/bin/hey completion bash) \
+      --fish <($out/bin/hey completion fish) \
+      --zsh  <($out/bin/hey completion zsh)
+  '';
+
+  meta = {
+    description = "Command-line interface for HEY email";
+    homepage = "https://github.com/basecamp/hey-cli";
+    changelog = "https://github.com/basecamp/hey-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "hey";
+  };
+})

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-IUWKpOcT4Wf6wmCol+cmH4akUP8ZriURSDKW1AzjFos=";
+  vendorHash = "sha256-/oFkW1B4zR6EGmBvuOMt78vBiUb+hQhY4Rctqy5084o=";
 
   subPackages = [ "cmd/hey" ];
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,28 +1,17 @@
-{ lib, buildGoModule, fetchurl, go_1_26, installShellFiles, stdenv }:
+{ lib, buildGoModule, callPackage, installShellFiles, stdenv }:
 
 let
-  # go.mod's `go` directive is the floor; nixpkgs-unstable lagged it at 1.26.5
-  # when this flake was written, so the toolchain is rebuilt from the upstream
-  # source tarball until nixpkgs catches up. The override is conditional and
-  # drops itself once go_1_26 reaches 1.26.6 — delete this block after a
-  # `nix flake update` that makes `lib.versionOlder` false. Keep MIN_GO in
-  # step with go.mod: a toolchain bump that outpaces flake.lock breaks the
-  # build without touching go.mod or go.sum, which is why the nix-build CI job
-  # runs on every go.mod change and on tags.
-  minGo = "1.26.6";
-  go = if lib.versionOlder go_1_26.version minGo
-    then go_1_26.overrideAttrs (_: {
-      version = minGo;
-      src = fetchurl {
-        url = "https://go.dev/dl/go${minGo}.src.tar.gz";
-        hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
-      };
-    })
-    else go_1_26;
+  # The toolchain lives in nix/go.nix, shared with the flake's dev shell so
+  # both build with the same Go. Bound here rather than taken as a function
+  # argument: callPackage fills any argument whose name exists in pkgs, and
+  # `pkgs.go` does, so a `go ? ...` default would be silently overridden by
+  # the stock toolchain.
+  go = callPackage ./go.nix { };
 in
 buildGoModule.override { inherit go; } (finalAttrs: {
   pname = "hey";
-  # Updated automatically by scripts/update-nix-flake.sh on each release.
+  # Bumped by `make update-nix-hash VERSION=vX.Y.Z` before each stable
+  # release; scripts/release.sh refuses to tag until it matches.
   version = "0.1.1";
 
   src = lib.cleanSource ./..;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-Yf+Y7DFm6rBFxX7evMfGY7/O4l7bk5LP1++ZJmW7O4I=";
+  vendorHash = "sha256-IUWKpOcT4Wf6wmCol+cmH4akUP8ZriURSDKW1AzjFos=";
 
   subPackages = [ "cmd/hey" ];
 

--- a/scripts/extract-nix-vendor-hash.sh
+++ b/scripts/extract-nix-vendor-hash.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Extracts the corrected vendorHash from a nix build log.
+#
+# Usage: scripts/extract-nix-vendor-hash.sh [LOGFILE]   (reads stdin when omitted)
+#
+# The single classifier for "did this build fail because of the vendorHash?".
+# Both production callers use it — update-nix-flake.sh, which writes the value
+# into nix/package.nix, and nix-build-check.sh, which reports it in CI. They
+# each carried their own copy of this parse once; two classifiers that can
+# drift is one classifier too many, because the one that drifts is the one
+# that writes to a tracked file.
+#
+# Two independent conditions must hold before a hash comes back. Nix must have
+# actually reported a fixed-output hash mismatch, and the captured value must
+# look like an SRI hash. Matching a bare `got:` is far too loose: any failing
+# build whose log happens to contain one — a Go test assertion printing
+# `got: 42`, say — would otherwise yield "42" as a vendorHash and misreport an
+# unrelated failure as a hash problem.
+#
+# Exit codes:
+#   0 — a fixed-output hash mismatch was reported; the SRI hash is on stdout
+#   1 — the log reports no vendorHash mismatch; nothing on stdout
+
+set -euo pipefail
+
+LOG=$(cat -- "${1:--}")
+
+if ! grep -q 'hash mismatch in fixed-output derivation' <<<"$LOG"; then
+  exit 1
+fi
+
+HASH=$(grep -oE 'got:[[:space:]]+sha256-[A-Za-z0-9+/]+=*' <<<"$LOG" \
+         | awk '{print $2}' | head -1 || true)
+
+if [[ -z "$HASH" ]]; then
+  exit 1
+fi
+
+printf '%s\n' "$HASH"

--- a/scripts/extract-nix-vendor-hash.sh
+++ b/scripts/extract-nix-vendor-hash.sh
@@ -10,27 +10,40 @@
 # drift is one classifier too many, because the one that drifts is the one
 # that writes to a tracked file.
 #
-# Two independent conditions must hold before a hash comes back. Nix must have
-# actually reported a fixed-output hash mismatch, and the captured value must
-# look like an SRI hash. Matching a bare `got:` is far too loose: any failing
-# build whose log happens to contain one — a Go test assertion printing
-# `got: 42`, say — would otherwise yield "42" as a vendorHash and misreport an
-# unrelated failure as a hash problem.
+# Three conditions must hold before a hash comes back. Nix must have reported
+# a fixed-output hash mismatch, that mismatch must belong to buildGoModule's
+# vendor derivation (`*-go-modules.drv`), and the `got:` value taken from that
+# same diagnostic must look like an SRI hash. Each guard is load-bearing:
+#
+# - Matching a bare `got:` is far too loose: any failing build whose log happens
+#   to contain one — a Go test assertion printing `got: 42`, say — would yield
+#   "42" as a vendorHash and misreport an unrelated failure as a hash problem.
+# - Accepting any fixed-output mismatch is also too loose. This flake has a
+#   second fixed-output derivation — the Go source tarball nix/go.nix fetches
+#   while nixpkgs lags go.mod — and a stale hash there must not be written
+#   into vendorHash, nor reported to a contributor as the vendorHash remedy.
+#   The rebuild would then fail with nix/package.nix already corrupted.
 #
 # Exit codes:
-#   0 — a fixed-output hash mismatch was reported; the SRI hash is on stdout
+#   0 — a go-modules fixed-output hash mismatch was reported; the SRI hash is
+#       on stdout
 #   1 — the log reports no vendorHash mismatch; nothing on stdout
 
 set -euo pipefail
 
 LOG=$(cat -- "${1:--}")
 
-if ! grep -q 'hash mismatch in fixed-output derivation' <<<"$LOG"; then
-  exit 1
-fi
-
-HASH=$(grep -oE 'got:[[:space:]]+sha256-[A-Za-z0-9+/]+=*' <<<"$LOG" \
-         | awk '{print $2}' | head -1 || true)
+# The mismatch diagnostic names the derivation on its own line; `specified:`
+# and `got:` follow on the next lines. Take the first `got:` after a
+# go-modules mismatch and stop there, so a later mismatch for some other
+# derivation cannot supply the value.
+HASH=$(awk '
+  /hash mismatch in fixed-output derivation .*-go-modules\.drv/ { in_block = 1; next }
+  in_block && /got:/ {
+    if (match($0, /sha256-[A-Za-z0-9+\/]+=*/)) { print substr($0, RSTART, RLENGTH) }
+    exit
+  }
+' <<<"$LOG")
 
 if [[ -z "$HASH" ]]; then
   exit 1

--- a/scripts/nix-build-check.sh
+++ b/scripts/nix-build-check.sh
@@ -37,7 +37,7 @@ if [[ "$STATUS" -ne 0 ]]; then
   # other failure — a stale flake.lock whose Go is older than go.mod's
   # directive, say — falls through with nix's own output and no false remedy.
   if HASH="$("$SCRIPT_DIR/extract-nix-vendor-hash.sh" "$LOG")"; then
-    echo "::error::Stale Nix vendorHash. Expected ${HASH}. A go.mod or go.sum change invalidates it and dependabot does not update it — run 'make update-nix-hash' and commit nix/package.nix."
+    echo "::error::Stale Nix vendorHash. Expected ${HASH}. A dependency change (go.mod, go.sum, or a new import from an existing module) invalidates it and dependabot does not update it — run 'make update-nix-hash' and commit nix/package.nix."
   fi
   exit "$STATUS"
 fi

--- a/scripts/nix-build-check.sh
+++ b/scripts/nix-build-check.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Builds the Nix flake, runs the resulting binary, and turns a stale vendorHash
+# into an actionable annotation instead of a raw nix dump.
+#
+# Usage: scripts/nix-build-check.sh
+#
+# This exists because the nix-build job is *supposed* to fail on a dependency
+# bump: changing go.mod or go.sum invalidates vendorHash, and dependabot will
+# not update it, so every weekly `gomod` PR fails here. The failure is correct.
+# What was wrong is that it arrived as an unexplained nix log with no remedy.
+#
+# Lives in a script rather than inline in the workflow so the classification is
+# reachable from tests — an inline `run:` block can only be exercised by
+# breaking main.
+#
+# Exit status is the nix build's own. Nothing here may swallow a failure: a
+# `|| true` plus a "did it look like it built" heuristic is what let v0.8.0
+# ship a flake that could not build at all.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+LOG="$(mktemp)"
+trap 'rm -f "$LOG"' EXIT
+
+STATUS=0
+STORE_PATH="$(nix build --no-link --print-out-paths 2>"$LOG")" || STATUS=$?
+
+# Always replay what nix said, whichever way this goes. The annotation below is
+# a hint layered on top of the diagnostics, never a replacement for them.
+cat "$LOG" >&2
+
+if [[ "$STATUS" -ne 0 ]]; then
+  # Only claim this is a hash problem when the shared classifier agrees, which
+  # requires both the fixed-output diagnostic and an SRI-shaped value. Every
+  # other failure — a stale flake.lock whose Go is older than go.mod's
+  # directive, say — falls through with nix's own output and no false remedy.
+  if HASH="$("$SCRIPT_DIR/extract-nix-vendor-hash.sh" "$LOG")"; then
+    echo "::error::Stale Nix vendorHash. Expected ${HASH}. A go.mod or go.sum change invalidates it and dependabot does not update it — run 'make update-nix-hash' and commit nix/package.nix."
+  fi
+  exit "$STATUS"
+fi
+
+if [[ -z "$STORE_PATH" ]]; then
+  echo "::error::nix build reported success but printed no store path"
+  exit 1
+fi
+
+"$STORE_PATH/bin/hey" --version

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,6 +41,20 @@ if [[ "$DRY_RUN" == "1" || "$DRY_RUN" == "true" ]]; then
   echo ""
 fi
 
+# nix/package.nix carries its own version literal: it is what `nix profile
+# install github:basecamp/hey-cli` builds and what that binary's --version
+# reports. Tagging without it means the flake keeps advertising the previous
+# release, and nix-verify cannot tell — it only proves the flake builds. The
+# update is deliberate rather than automatic because it rebuilds the flake
+# via Docker and produces a commit to review; this gate makes skipping it
+# impossible. Prereleases are exempt: the flake tracks stable releases only.
+if [[ "$VERSION" != *-* ]]; then
+  NIX_VERSION=$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' nix/package.nix | head -1)
+  if [[ "$NIX_VERSION" != "${VERSION#v}" ]]; then
+    die "nix/package.nix is at ${NIX_VERSION}, not ${VERSION#v}. Run \`make update-nix-hash VERSION=${VERSION}\`, then commit and push before releasing."
+  fi
+fi
+
 # Detect default branch
 DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -19,6 +19,25 @@ fi
 NIX_PKG="nix/package.nix"
 CHANGED=false
 
+# The build source below is staged from tracked files only, so an untracked
+# .go file never reaches the verification build — but once committed it does
+# reach CI's build, and an import it adds shifts `go mod vendor`'s output and
+# with it the vendorHash. Verifying without it would stamp "verified" on a
+# hash CI then rejects. Refuse to verify a tree that diverges from what will
+# be committed, rather than silently verifying the wrong one. Scoped to files
+# that feed the Go build graph: untracked notes or scratch dirs cannot move
+# the vendorHash and must not block the tool.
+UNTRACKED_GO=$(git ls-files --others --exclude-standard -- \
+  '*.go' 'go.mod' 'go.sum' 'go.work' 'go.work.sum')
+if [[ -n "$UNTRACKED_GO" ]]; then
+  echo "ERROR: untracked Go source would be missing from the verified build:"
+  while IFS= read -r f; do echo "  $f"; done <<<"$UNTRACKED_GO"
+  echo "The build stages tracked files only, so the vendorHash verified here"
+  echo "would not match what CI computes once these files are committed."
+  echo "\`git add\` them (or gitignore them) and re-run."
+  exit 1
+fi
+
 # Leave no partial edits behind: restore nix/package.nix on any failure so a
 # failed run is indistinguishable from no run. Otherwise a leftover version
 # bump makes the next invocation report "no changes needed" (exit 2) while an

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -82,10 +82,19 @@ NIX_IMAGE="${NIX_IMAGE:-nixos/nix@sha256:b9c9611c8530fa8049a1215b20638536e1e71dc
 # v0.8.0 ship a flake that could not build at all — nix logs
 # `building '...hey-0.8.0-go-modules.drv'` when it *starts* the build it
 # then fails, so the heuristic reported success on a hard failure.
+# The build source is staged from tracked files only (at their working-tree
+# content, so the version edit above is included). Mounting the checkout
+# directly would sweep untracked files into the temporary flake source, where
+# a scratch .go file adding an import could shift the computed vendorHash away
+# from what a clean checkout produces — and CI would then reject the
+# supposedly verified update. Staged fresh per call so the verification
+# rebuild sees the vendorHash written between calls.
 run_nix_build() {
-  docker run --rm -v "$(pwd):/src:ro" "$NIX_IMAGE" bash -c '
+  local stage rc=0 out
+  stage=$(mktemp -d)
+  git ls-files -z | tar -cf - --null -T - | tar -xf - -C "$stage"
+  out=$(docker run --rm -v "$stage:/src:ro" "$NIX_IMAGE" bash -c '
     cp -a /src /build && cd /build
-    rm -rf .git
     git config --global --add safe.directory /build
     git init -q && git add -A && \
       GIT_COMMITTER_NAME=ci GIT_COMMITTER_EMAIL=ci@ci \
@@ -93,7 +102,10 @@ run_nix_build() {
       git commit -q -m init
     nix --extra-experimental-features "nix-command flakes" build --no-link 2>&1
     echo "NIX_BUILD_EXIT=$?"
-  ' 2>&1
+  ' 2>&1) || rc=$?
+  rm -rf "$stage"
+  printf '%s\n' "$out"
+  return "$rc"
 }
 
 # The sentinel must be the LAST line: a `NIX_BUILD_EXIT=0` echoed anywhere

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -80,8 +80,10 @@ run_nix_build() {
   ' 2>&1
 }
 
+# The sentinel must be the LAST line: a `NIX_BUILD_EXIT=0` echoed anywhere
+# earlier (a log line quoting this script, say) must not read as success.
 nix_build_failed() {
-  ! grep -q 'NIX_BUILD_EXIT=0' <<<"$1"
+  [[ "$(tail -n1 <<<"$1")" != "NIX_BUILD_EXIT=0" ]]
 }
 
 BUILD_OUTPUT=$(run_nix_build)

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -111,7 +111,17 @@ NIX_IMAGE="${NIX_IMAGE:-nixos/nix@sha256:b9c9611c8530fa8049a1215b20638536e1e71dc
 run_nix_build() {
   local stage rc=0 out
   stage=$(mktemp -d)
-  git ls-files -z | tar -cf - --null -T - | tar -xf - -C "$stage"
+  # Errexit does not survive into this $()-invoked function (bash strips it in
+  # command substitution), so the staging pipeline must be checked by hand.
+  # tar still emits a partial archive — alongside a nonzero status — when a
+  # tracked file is missing or unreadable (a plain `rm` without `git rm`, a
+  # sparse checkout), and building that partial tree would verify source CI
+  # never sees.
+  if ! git ls-files -z | tar -cf - --null -T - | tar -xf - -C "$stage"; then
+    rm -rf "$stage"
+    echo "ERROR: staging tracked files for the build failed" >&2
+    return 1
+  fi
   out=$(docker run --rm -v "$stage:/src:ro" "$NIX_IMAGE" bash -c '
     cp -a /src /build && cd /build
     git config --global --add safe.directory /build
@@ -133,7 +143,15 @@ nix_build_failed() {
   [[ "$(tail -n1 <<<"$1")" != "NIX_BUILD_EXIT=0" ]]
 }
 
-BUILD_OUTPUT=$(run_nix_build)
+# The || is load-bearing twice over: it makes the abort explicit rather than
+# leaning on errexit-through-assignment, and it surfaces the captured output
+# when docker itself fails (daemon down, image pull) — previously that path
+# died via errexit with the diagnostic swallowed by the substitution.
+BUILD_OUTPUT=$(run_nix_build) || {
+  echo "ERROR: could not run the Nix build"
+  tail -25 <<<"$BUILD_OUTPUT"
+  exit 1
+}
 
 if nix_build_failed "$BUILD_OUTPUT"; then
   # Classification lives in extract-nix-vendor-hash.sh, shared with CI's
@@ -160,7 +178,11 @@ if nix_build_failed "$BUILD_OUTPUT"; then
   # Prove the corrected hash actually builds. The old code trusted the hash it
   # had just written without ever rebuilding.
   echo "  verifying the updated vendorHash builds..."
-  BUILD_OUTPUT=$(run_nix_build)
+  BUILD_OUTPUT=$(run_nix_build) || {
+    echo "ERROR: could not run the Nix build"
+    tail -25 <<<"$BUILD_OUTPUT"
+    exit 1
+  }
   if nix_build_failed "$BUILD_OUTPUT"; then
     echo "ERROR: nix build still fails after updating the vendorHash"
     tail -25 <<<"$BUILD_OUTPUT"

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Updates nix/package.nix version and recomputes vendorHash when go.mod changes.
+# Usage: scripts/update-nix-flake.sh VERSION
+#
+# Exit codes:
+#   0 — changes made
+#   2 — no changes needed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: scripts/update-nix-flake.sh VERSION"
+  exit 1
+fi
+
+NIX_PKG="nix/package.nix"
+CHANGED=false
+
+# --- Update version ---
+CURRENT_VERSION=$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' "$NIX_PKG" | head -1)
+if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+  sed -i.bak "s/version = \"${CURRENT_VERSION}\"/version = \"${VERSION}\"/" "$NIX_PKG"
+  rm -f "${NIX_PKG}.bak"
+  CHANGED=true
+  echo "  nix version: ${CURRENT_VERSION} → ${VERSION}"
+fi
+
+# --- Report whether dependencies moved ---
+# Prerelease tags skip Nix metadata updates, so compare dependency changes
+# against the latest stable tag instead of an intervening RC tag.
+#
+# This no longer decides *whether* to build — only what to say about it. The
+# build is unconditional: v0.8.0's flake was broken by a Go toolchain bump
+# outpacing flake.lock, which changes neither go.mod nor go.sum, so a
+# deps-changed gate would have skipped the very check that catches it.
+PREV_TAG=$(git tag --merged HEAD --sort=-version:refname --list 'v[0-9]*.[0-9]*.[0-9]*' | awk '!/-/ { print; exit }')
+DEPS_CHANGED=false
+if [[ -z "$PREV_TAG" ]]; then
+  DEPS_CHANGED=true
+elif ! git diff --quiet "$PREV_TAG"..HEAD -- go.mod go.sum 2>/dev/null; then
+  DEPS_CHANGED=true
+fi
+
+if ! command -v docker &>/dev/null; then
+  echo "ERROR: Docker unavailable — cannot verify the Nix build"
+  echo "Install Docker and re-run; a release must not ship an unverified flake."
+  exit 1
+fi
+
+if [[ "$DEPS_CHANGED" == "true" ]]; then
+  echo "  dependencies changed — verifying the Nix build via Docker..."
+else
+  echo "  dependencies unchanged — verifying the Nix build anyway..."
+fi
+
+# Pin image digest for supply-chain integrity. Update periodically:
+#   docker pull nixos/nix && docker inspect nixos/nix:latest --format '{{index .RepoDigests 0}}'
+NIX_IMAGE="${NIX_IMAGE:-nixos/nix@sha256:b9c9611c8530fa8049a1215b20638536e1e71dcaf85212e47845112caf3adeea}"
+
+# Runs `nix build` and echoes a trailing NIX_BUILD_EXIT= line so the real exit
+# status survives command substitution. Nothing here may swallow a failure: a
+# `|| true` plus a "did it print 'building hey'" heuristic is what let
+# v0.8.0 ship a flake that could not build at all — nix logs
+# `building '...hey-0.8.0-go-modules.drv'` when it *starts* the build it
+# then fails, so the heuristic reported success on a hard failure.
+run_nix_build() {
+  docker run --rm -v "$(pwd):/src:ro" "$NIX_IMAGE" bash -c '
+    cp -a /src /build && cd /build
+    rm -rf .git
+    git config --global --add safe.directory /build
+    git init -q && git add -A && \
+      GIT_COMMITTER_NAME=ci GIT_COMMITTER_EMAIL=ci@ci \
+      GIT_AUTHOR_NAME=ci GIT_AUTHOR_EMAIL=ci@ci \
+      git commit -q -m init
+    nix --extra-experimental-features "nix-command flakes" build --no-link 2>&1
+    echo "NIX_BUILD_EXIT=$?"
+  ' 2>&1
+}
+
+nix_build_failed() {
+  ! grep -q 'NIX_BUILD_EXIT=0' <<<"$1"
+}
+
+BUILD_OUTPUT=$(run_nix_build)
+
+if nix_build_failed "$BUILD_OUTPUT"; then
+  # Classification lives in extract-nix-vendor-hash.sh, shared with CI's
+  # nix-build-check.sh. It requires both a fixed-output mismatch diagnostic and
+  # an SRI-shaped value before yielding anything — deliberately, because this
+  # caller writes the result into a tracked file.
+  NEW_HASH=$("$SCRIPT_DIR/extract-nix-vendor-hash.sh" <<<"$BUILD_OUTPUT" || true)
+
+  if [[ -z "$NEW_HASH" ]]; then
+    # The build broke for some other reason — a stale flake.lock whose Go is
+    # older than go.mod's directive is the one that has actually bitten us.
+    # Never continue from here, and never write to nix/package.nix.
+    echo "ERROR: nix build failed, and not because of the vendorHash"
+    tail -25 <<<"$BUILD_OUTPUT"
+    exit 1
+  fi
+
+  CURRENT_HASH=$(sed -n 's/.*vendorHash = "\([^"]*\)".*/\1/p' "$NIX_PKG" | head -1)
+  sed -i.bak "s|vendorHash = \"${CURRENT_HASH}\"|vendorHash = \"${NEW_HASH}\"|" "$NIX_PKG"
+  rm -f "${NIX_PKG}.bak"
+  CHANGED=true
+  echo "  vendorHash: updated"
+
+  # Prove the corrected hash actually builds. The old code trusted the hash it
+  # had just written without ever rebuilding.
+  echo "  verifying the updated vendorHash builds..."
+  BUILD_OUTPUT=$(run_nix_build)
+  if nix_build_failed "$BUILD_OUTPUT"; then
+    echo "ERROR: nix build still fails after updating the vendorHash"
+    tail -25 <<<"$BUILD_OUTPUT"
+    exit 1
+  fi
+fi
+
+echo "  vendorHash: verified (build succeeded)"
+
+if [[ "$CHANGED" == "true" ]]; then
+  exit 0
+else
+  exit 2
+fi

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -19,6 +19,22 @@ fi
 NIX_PKG="nix/package.nix"
 CHANGED=false
 
+# Leave no partial edits behind: restore nix/package.nix on any failure so a
+# failed run is indistinguishable from no run. Otherwise a leftover version
+# bump makes the next invocation report "no changes needed" (exit 2) while an
+# unverified edit sits in the worktree waiting to be committed.
+ORIG_PKG="$(mktemp)"
+cp "$NIX_PKG" "$ORIG_PKG"
+# shellcheck disable=SC2329  # invoked via the EXIT trap below
+restore_on_failure() {
+  local status=$?
+  if [[ $status -ne 0 && $status -ne 2 ]]; then
+    cp "$ORIG_PKG" "$NIX_PKG"
+  fi
+  rm -f "$ORIG_PKG"
+}
+trap restore_on_failure EXIT
+
 # --- Update version ---
 CURRENT_VERSION=$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' "$NIX_PKG" | head -1)
 if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then

--- a/tests/e2e/extract_nix_vendor_hash.bats
+++ b/tests/e2e/extract_nix_vendor_hash.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+#
+# Fixtures for scripts/extract-nix-vendor-hash.sh — the single classifier that
+# decides whether a failing nix build failed *because of the vendorHash*.
+#
+# Both production callers depend on this answer, and they depend on it for
+# different reasons: update-nix-flake.sh writes the returned value into a
+# tracked file, and nix-build-check.sh puts it in front of a contributor as a
+# remedy. A loose parse corrupts nix/package.nix in one and misdirects a human
+# in the other, which is why the guard is tested here rather than twice at the
+# call sites.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  EXTRACT="$REPO_ROOT/scripts/extract-nix-vendor-hash.sh"
+  WORK="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+@test "extracts the SRI hash from a fixed-output mismatch" {
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/abc-hey-0.1.2-go-modules.drv':
+         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=
+            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=
+error: 1 dependencies of derivation '/nix/store/xyz-hey-0.1.2.drv' failed to build
+LOG
+  [ "$status" -eq 0 ]
+  [ "$output" = "sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=" ]
+}
+
+@test "reads from a file argument as well as stdin" {
+  cat > "$WORK/nix.log" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/abc-go-modules.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=
+LOG
+  run "$EXTRACT" "$WORK/nix.log"
+  [ "$status" -eq 0 ]
+  [ "$output" = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=" ]
+}
+
+@test "rejects a bare 'got:' with no mismatch diagnostic" {
+  # A Go test assertion printing `got: 42`. Matching a bare `got:` would return
+  # "42" — which update-nix-flake.sh would then write into vendorHash.
+  run "$EXTRACT" <<'LOG'
+--- FAIL: TestSomething
+    thing_test.go:42: got: 42
+    thing_test.go:43: want: 7
+error: builder for '/nix/store/xyz.drv' failed with exit code 1
+LOG
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "rejects a mismatch diagnostic whose value is not SRI-shaped" {
+  # Both guards are load-bearing independently: the diagnostic is present here,
+  # so a diagnostic-only check would accept "not-a-hash".
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/abc-go-modules.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    not-a-hash
+LOG
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "rejects an md5-style hash that is not sha256 SRI" {
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/abc-go-modules.drv':
+            got:    md5-d41d8cd98f00b204e9800998ecf8427e
+LOG
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "rejects the Go toolchain drift that broke v0.1.1" {
+  # The failure this whole lineage exists for. It reports no hash mismatch, so
+  # it must never be classified as one — the fix is flake.lock, not vendorHash.
+  run "$EXTRACT" <<'LOG'
+building '/nix/store/abc-hey-0.1.1-go-modules.drv'...
+     > go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
+error: Build failed due to failed dependency
+LOG
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "rejects an empty log" {
+  run "$EXTRACT" </dev/null
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "returns the first hash when nix reports several mismatches" {
+  # Deterministic rather than arbitrary: update-nix-flake.sh rebuilds after
+  # writing, so it converges across repeated runs. Picking a different one each
+  # time would not.
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/one-go-modules.drv':
+            got:    sha256-1111111111111111111111111111111111111111111=
+error: hash mismatch in fixed-output derivation '/nix/store/two-go-modules.drv':
+            got:    sha256-2222222222222222222222222222222222222222222=
+LOG
+  [ "$status" -eq 0 ]
+  [ "$output" = "sha256-1111111111111111111111111111111111111111111=" ]
+}

--- a/tests/e2e/extract_nix_vendor_hash.bats
+++ b/tests/e2e/extract_nix_vendor_hash.bats
@@ -88,6 +88,49 @@ LOG
   [ -z "$output" ]
 }
 
+@test "rejects a mismatch in a fixed-output derivation that is not go-modules" {
+  # This flake carries a second fixed-output derivation: the Go source tarball
+  # nix/go.nix fetches while nixpkgs lags go.mod. A stale hash there is a
+  # nix/go.nix problem; writing it into vendorHash corrupts the tracked file and
+  # then fails the verification rebuild anyway.
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/abc-go1.26.6.src.tar.gz.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=
+error: 1 dependencies of derivation '/nix/store/xyz-go-1.26.6.drv' failed to build
+LOG
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "takes the go-modules hash even when another mismatch precedes it" {
+  # The `got:` must come from the go-modules block itself, not from whichever
+  # mismatch nix happened to print first.
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/abc-go1.26.6.src.tar.gz.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=
+error: hash mismatch in fixed-output derivation '/nix/store/def-hey-0.1.2-go-modules.drv':
+         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=
+            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=
+LOG
+  [ "$status" -eq 0 ]
+  [ "$output" = "sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=" ]
+}
+
+@test "does not borrow a later derivation's got: for a go-modules mismatch" {
+  # A go-modules diagnostic whose own value is unusable must not fall through
+  # to the next block's hash.
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/def-hey-0.1.2-go-modules.drv':
+            got:    not-a-hash
+error: hash mismatch in fixed-output derivation '/nix/store/abc-go1.26.6.src.tar.gz.drv':
+            got:    sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=
+LOG
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
 @test "rejects an empty log" {
   run "$EXTRACT" </dev/null
   [ "$status" -ne 0 ]

--- a/tests/e2e/nix_build_check.bats
+++ b/tests/e2e/nix_build_check.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+#
+# Wrapper behaviour for scripts/nix-build-check.sh — CI's flake gate.
+#
+# The classifier itself is covered by extract_nix_vendor_hash.bats. What is
+# tested here is everything wrapped around it: that the build's real exit status
+# survives, that nix's own diagnostics are always replayed, that the `::error::`
+# remedy appears only when the classifier agrees, and that a successful build is
+# not trusted until the binary it produced actually runs.
+#
+# `nix` is stubbed via PATH, so these run anywhere in milliseconds and can stage
+# failures that are otherwise awkward to reproduce.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  CHECK="$REPO_ROOT/scripts/nix-build-check.sh"
+  WORK="$(mktemp -d)"
+  STUB_DIR="$WORK/bin"
+  mkdir -p "$STUB_DIR"
+  PATH="$STUB_DIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+# Stubs `nix build`: $1 is the store path echoed on stdout, $2 the log written
+# to stderr, $3 the exit status.
+stub_nix() {
+  cat > "$STUB_DIR/nix" <<STUB
+#!/usr/bin/env bash
+printf '%s' '$1'
+[ -n '$1' ] && echo
+cat >&2 <<'NIXLOG'
+$2
+NIXLOG
+exit $3
+STUB
+  chmod +x "$STUB_DIR/nix"
+}
+
+# Stubs the built binary at STORE/bin/hey.
+stub_store_binary() {
+  local store="$WORK/store"
+  mkdir -p "$store/bin"
+  cat > "$store/bin/hey" <<STUB
+#!/usr/bin/env bash
+echo "hey version ${1:-0.1.2}"
+exit ${2:-0}
+STUB
+  chmod +x "$store/bin/hey"
+  echo "$store"
+}
+
+@test "succeeds and runs the built binary" {
+  store="$(stub_store_binary 0.1.2 0)"
+  stub_nix "$store" "building '/nix/store/abc-hey.drv'..." 0
+
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hey version 0.1.2"* ]]
+}
+
+@test "fails when the flake builds but the binary does not run" {
+  # A store path that exists proves nix succeeded, not that the result works.
+  store="$(stub_store_binary 0.1.2 1)"
+  stub_nix "$store" "" 0
+
+  run "$CHECK"
+  [ "$status" -ne 0 ]
+}
+
+@test "propagates the build's exit status rather than masking it" {
+  stub_nix "" "error: builder failed" 7
+
+  run "$CHECK"
+  [ "$status" -eq 7 ]
+}
+
+@test "replays nix diagnostics on failure" {
+  stub_nix "" "error: attribute 'hey' missing
+       at /nix/store/flake.nix:12:5" 1
+
+  run "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"attribute 'hey' missing"* ]]
+  [[ "$output" == *"flake.nix:12:5"* ]]
+}
+
+@test "replays nix diagnostics on success too" {
+  store="$(stub_store_binary)"
+  stub_nix "$store" "warning: Git tree '/src' is dirty" 0
+
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Git tree '/src' is dirty"* ]]
+}
+
+@test "annotates a stale vendorHash with the correct hash and the remedy" {
+  # The dependabot case: a go.mod bump invalidates vendorHash, so the job fails
+  # by design. It must fail with instructions, not a raw nix dump.
+  stub_nix "" "error: hash mismatch in fixed-output derivation '/nix/store/abc-go-modules.drv':
+         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=
+            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=
+error: 1 dependencies of derivation '/nix/store/xyz.drv' failed to build" 1
+
+  run "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::"* ]]
+  [[ "$output" == *"sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB="* ]]
+  [[ "$output" == *"make update-nix-hash"* ]]
+  # The remedy is layered on top of the diagnostics, never a replacement.
+  [[ "$output" == *"hash mismatch in fixed-output derivation"* ]]
+}
+
+@test "emits no hash remedy for an unrelated build failure" {
+  # The v0.1.1 shape: the fix is flake.lock, and pointing at
+  # `make update-nix-hash` would send a contributor down the wrong path.
+  stub_nix "" "building '/nix/store/abc-hey-0.1.1-go-modules.drv'...
+     > go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
+error: Build failed due to failed dependency" 1
+
+  run "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"make update-nix-hash"* ]]
+  [[ "$output" == *"GOTOOLCHAIN=local"* ]]
+}
+
+@test "emits no hash remedy for a bare 'got:' in a failing build" {
+  stub_nix "" "--- FAIL: TestSomething
+    thing_test.go:42: got: 42
+error: builder failed with exit code 1" 1
+
+  run "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"make update-nix-hash"* ]]
+}
+
+@test "fails when nix reports success but prints no store path" {
+  stub_nix "" "" 0
+
+  run "$CHECK"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no store path"* ]]
+}

--- a/tests/e2e/release_nix_version.bats
+++ b/tests/e2e/release_nix_version.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+#
+# The nix/package.nix version gate in scripts/release.sh. The flake's version
+# is a literal nothing else updates, so a stable tag must not be created while
+# it still names the previous release.
+#
+# The gate sits before the branch check, so a throwaway repo on a side branch
+# reaches it; a version that passes the gate then fails on that next check,
+# which is how "passed" is observed here.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  WORK="$(mktemp -d)"
+  mkdir -p "$WORK/repo/nix" "$WORK/repo/scripts"
+  cp "$REPO_ROOT/scripts/release.sh" "$WORK/repo/scripts/"
+  cat > "$WORK/repo/nix/package.nix" <<'NIXPKG'
+{
+  version = "0.1.1";
+  vendorHash = "sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=";
+}
+NIXPKG
+  git init -q --bare -b main "$WORK/origin.git"
+  cd "$WORK/repo"
+  git init -q -b main .
+  git config user.email t@t && git config user.name t
+  git add -A && git commit -qm init
+  git remote add origin "$WORK/origin.git"
+  git push -q origin main
+  git checkout -q -b release-test
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+@test "refuses a stable tag that nix/package.nix does not carry" {
+  run scripts/release.sh v0.2.0 --dry-run
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"nix/package.nix is at 0.1.1, not 0.2.0"* ]]
+  [[ "$output" == *"make update-nix-hash VERSION=v0.2.0"* ]]
+}
+
+@test "passes a stable tag that matches nix/package.nix" {
+  run scripts/release.sh v0.1.1 --dry-run
+  [[ "$output" != *"nix/package.nix is at"* ]]
+  # Past the gate: the next check is the one that fails here.
+  [[ "$output" == *"Not on main"* ]]
+}
+
+@test "exempts prereleases" {
+  run scripts/release.sh v0.2.0-rc.1 --dry-run
+  [[ "$output" != *"nix/package.nix is at"* ]]
+  [[ "$output" == *"Not on main"* ]]
+}

--- a/tests/e2e/update_nix_flake.bats
+++ b/tests/e2e/update_nix_flake.bats
@@ -236,11 +236,38 @@ NIX_BUILD_EXIT=1"
   [[ "$output" != *"verified (build succeeded)"* ]]
 }
 
-@test "stages only tracked files into the build source" {
-  # An untracked scratch .go file must not reach the temporary flake source:
-  # an import it adds could shift the computed vendorHash away from what a
-  # clean checkout produces, and CI would then reject the "verified" update.
+@test "refuses to verify when an untracked Go file would be omitted" {
+  # The build source stages tracked files only, so an untracked .go file never
+  # reaches the verification build — but once committed it reaches CI's build,
+  # and an import it adds shifts `go mod vendor`'s output and the vendorHash
+  # with it (demonstrated on this repo: identical go.mod/go.sum vendor to
+  # different trees with and without the file). Verifying anyway would stamp
+  # "verified" on a hash CI then rejects. The script must refuse instead,
+  # before any build runs or any edit lands.
   echo 'package scratch' > scratch.go
+  # Any docker invocation is itself a failure: the guard must fire first.
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+echo "error: build ran despite untracked Go source"
+echo "NIX_BUILD_EXIT=1"
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  run scripts/update-nix-flake.sh 0.2.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"untracked Go source"* ]]
+  [[ "$output" == *"scratch.go"* ]]
+  [[ "$output" != *"build ran despite"* ]]
+  [[ "$output" != *"verified (build succeeded)"* ]]
+  # Refused before the version edit — nothing to clean up or accidentally commit.
+  grep -q 'version = "0.1.1";' nix/package.nix
+}
+
+@test "stages tracked files only, and untracked non-Go files do not block" {
+  # Untracked files that cannot move the vendorHash (notes, scratch dirs) are
+  # excluded from the build source but must not stop the tool — the guard is
+  # scoped to the Go build graph, not to a pristine tree.
+  echo 'draft release notes' > NOTES.md
 
   cat > "$STUB_DIR/docker" <<'STUB'
 #!/usr/bin/env bash
@@ -253,7 +280,7 @@ done
 grep -q 'version = "0.1.1";' "$SRC/nix/package.nix" || {
   echo "error: tracked file missing from stage"; echo "NIX_BUILD_EXIT=1"; exit 0; }
 # ...and untracked files do not arrive at all.
-if [ -e "$SRC/scratch.go" ]; then
+if [ -e "$SRC/NOTES.md" ]; then
   echo "error: untracked file staged into build source"
   echo "NIX_BUILD_EXIT=1"
   exit 0
@@ -261,6 +288,20 @@ fi
 echo "NIX_BUILD_EXIT=0"
 STUB
   chmod +x "$STUB_DIR/docker"
+
+  run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"verified (build succeeded)"* ]]
+}
+
+@test "a gitignored Go file does not block verification" {
+  # Ignored files are never committed, so they cannot cause the local/CI
+  # divergence the guard exists for — and gitignoring is the documented way
+  # to keep a scratch .go file while running the tool.
+  echo 'scratch.go' > .gitignore
+  git add .gitignore && git commit -qm ignore
+  echo 'package scratch' > scratch.go
+  stub_docker "NIX_BUILD_EXIT=0"
 
   run scripts/update-nix-flake.sh 0.1.1
   [ "$status" -eq 2 ]

--- a/tests/e2e/update_nix_flake.bats
+++ b/tests/e2e/update_nix_flake.bats
@@ -77,6 +77,51 @@ NIX_BUILD_EXIT=0"
   [[ "$output" == *"verified (build succeeded)"* ]]
 }
 
+@test "rewrites the version literal when a new version is requested" {
+  # The script's other responsibility. Without this case a regression in the
+  # version rewrite passes CI, because every other test asks for the version
+  # already stored in package.nix.
+  stub_docker "NIX_BUILD_EXIT=0"
+
+  run scripts/update-nix-flake.sh 0.2.0
+  [ "$status" -eq 0 ]   # 0 = changes written
+  [[ "$output" == *"nix version: 0.1.1 → 0.2.0"* ]]
+  [[ "$output" == *"verified (build succeeded)"* ]]
+  grep -q 'version = "0.2.0";' nix/package.nix
+  ! grep -q 'version = "0.1.1";' nix/package.nix
+  # The hash line is untouched by a version-only change.
+  grep -q 'sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=' nix/package.nix
+}
+
+@test "does not write a version when the build fails" {
+  # A version bump and a broken flake must not be half-committed: the literal
+  # is rewritten before the build, so the non-zero exit is what keeps the
+  # caller from committing it.
+  stub_docker "error: builder failed with exit code 1
+NIX_BUILD_EXIT=1"
+
+  run scripts/update-nix-flake.sh 0.2.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not because of the vendorHash"* ]]
+}
+
+@test "does not write the Go source tarball's hash into vendorHash" {
+  # nix/go.nix fetches the Go source with its own fixed-output hash. When that
+  # one is stale, the remedy is in go.nix; the classifier must not hand its
+  # `got:` to this script, which would corrupt package.nix and then fail the
+  # verification rebuild.
+  stub_docker "error: hash mismatch in fixed-output derivation '/nix/store/abc-go1.26.6.src.tar.gz.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=
+NIX_BUILD_EXIT=1"
+
+  run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not because of the vendorHash"* ]]
+  grep -q 'sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=' nix/package.nix
+  ! grep -q 'sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=' nix/package.nix
+}
+
 @test "fails closed when the build fails without a hash mismatch" {
   # The exact v0.1.1 shape: nix logs that it is *building* hey, then dies
   # on the Go toolchain. The old heuristic matched that line and reported
@@ -101,7 +146,7 @@ if [ -f "$STATE" ]; then
   echo "NIX_BUILD_EXIT=0"
 else
   touch "$STATE"
-  echo "error: hash mismatch in fixed-output derivation"
+  echo "error: hash mismatch in fixed-output derivation '/nix/store/abc-hey-0.1.1-go-modules.drv':"
   echo "         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA="
   echo "            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB="
   echo "NIX_BUILD_EXIT=1"
@@ -119,7 +164,7 @@ STUB
 @test "fails when the corrected hash still does not build" {
   # Every call reports a mismatch — the rebuild never converges, so the script
   # must not claim success just because it wrote a new hash.
-  stub_docker "error: hash mismatch in fixed-output derivation
+  stub_docker "error: hash mismatch in fixed-output derivation '/nix/store/abc-hey-0.1.1-go-modules.drv':
          specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=
             got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=
 NIX_BUILD_EXIT=1"

--- a/tests/e2e/update_nix_flake.bats
+++ b/tests/e2e/update_nix_flake.bats
@@ -145,7 +145,20 @@ NIX_BUILD_EXIT=1"
   cat > "$STUB_DIR/docker" <<'STUB'
 #!/usr/bin/env bash
 STATE="${NIX_STUB_STATE:?}"
+# The staged source is mounted at SRC:/src:ro — find it.
+SRC=""
+for a in "$@"; do
+  case "$a" in *:/src:ro) SRC="${a%%:*}";; esac
+done
 if [ -f "$STATE" ]; then
+  # The verification rebuild must see the corrected hash: the source is
+  # restaged per call, so a stale first-call stage would silently verify the
+  # old hash instead.
+  if ! grep -q 'sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=' "$SRC/nix/package.nix"; then
+    echo "error: rebuild staged the stale vendorHash"
+    echo "NIX_BUILD_EXIT=1"
+    exit 0
+  fi
   echo "NIX_BUILD_EXIT=0"
 else
   touch "$STATE"
@@ -221,4 +234,35 @@ NIX_BUILD_EXIT=1"
   run scripts/update-nix-flake.sh 0.1.1
   [ "$status" -eq 1 ]
   [[ "$output" != *"verified (build succeeded)"* ]]
+}
+
+@test "stages only tracked files into the build source" {
+  # An untracked scratch .go file must not reach the temporary flake source:
+  # an import it adds could shift the computed vendorHash away from what a
+  # clean checkout produces, and CI would then reject the "verified" update.
+  echo 'package scratch' > scratch.go
+
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+SRC=""
+for a in "$@"; do
+  case "$a" in *:/src:ro) SRC="${a%%:*}";; esac
+done
+[ -n "$SRC" ] || { echo "error: no /src mount"; echo "NIX_BUILD_EXIT=1"; exit 0; }
+# Tracked files arrive at their working-tree content...
+grep -q 'version = "0.1.1";' "$SRC/nix/package.nix" || {
+  echo "error: tracked file missing from stage"; echo "NIX_BUILD_EXIT=1"; exit 0; }
+# ...and untracked files do not arrive at all.
+if [ -e "$SRC/scratch.go" ]; then
+  echo "error: untracked file staged into build source"
+  echo "NIX_BUILD_EXIT=1"
+  exit 0
+fi
+echo "NIX_BUILD_EXIT=0"
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"verified (build succeeded)"* ]]
 }

--- a/tests/e2e/update_nix_flake.bats
+++ b/tests/e2e/update_nix_flake.bats
@@ -94,15 +94,18 @@ NIX_BUILD_EXIT=0"
 }
 
 @test "does not write a version when the build fails" {
-  # A version bump and a broken flake must not be half-committed: the literal
-  # is rewritten before the build, so the non-zero exit is what keeps the
-  # caller from committing it.
+  # A failed run must leave no trace: the version literal is rewritten before
+  # the build, and the EXIT trap restores it when the build fails. Otherwise a
+  # re-run would report "no changes needed" while an unverified bump sat in
+  # the worktree waiting to be committed.
   stub_docker "error: builder failed with exit code 1
 NIX_BUILD_EXIT=1"
 
   run scripts/update-nix-flake.sh 0.2.0
   [ "$status" -eq 1 ]
   [[ "$output" == *"not because of the vendorHash"* ]]
+  grep -q 'version = "0.1.1";' nix/package.nix
+  ! grep -q 'version = "0.2.0";' nix/package.nix
 }
 
 @test "does not write the Go source tarball's hash into vendorHash" {
@@ -172,6 +175,9 @@ NIX_BUILD_EXIT=1"
   run scripts/update-nix-flake.sh 0.1.1
   [ "$status" -eq 1 ]
   [[ "$output" == *"still fails after updating the vendorHash"* ]]
+  # The unproven hash must not survive the failure.
+  grep -q 'sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=' nix/package.nix
+  ! grep -q 'sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=' nix/package.nix
 }
 
 @test "does not mistake an unrelated 'got:' line for a hash mismatch" {

--- a/tests/e2e/update_nix_flake.bats
+++ b/tests/e2e/update_nix_flake.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+#
+# Exit-status classification for scripts/update-nix-flake.sh.
+#
+# The PR-time flake build proves the *current* flake compiles; it says nothing
+# about whether this script correctly tells a passing build from a failing one.
+# That distinction is the actual defect that shipped: v0.1.1's flake could not
+# build, and the script reported "vendorHash: verified (build succeeded)".
+#
+# `docker` is stubbed so these run anywhere, in milliseconds, and can reproduce
+# failure modes that are otherwise awkward to stage.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  WORK="$(mktemp -d)"
+  STUB_DIR="$WORK/bin"
+  mkdir -p "$STUB_DIR" "$WORK/repo/nix" "$WORK/repo/scripts"
+
+  # The classifier travels with it — update-nix-flake.sh resolves it relative to
+  # its own directory, and shares it with CI's nix-build-check.sh.
+  cp "$REPO_ROOT/scripts/update-nix-flake.sh" \
+     "$REPO_ROOT/scripts/extract-nix-vendor-hash.sh" "$WORK/repo/scripts/"
+  cat > "$WORK/repo/nix/package.nix" <<'NIXPKG'
+{
+  version = "0.1.1";
+  vendorHash = "sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=";
+}
+NIXPKG
+
+  cd "$WORK/repo"
+  git init -q .
+  git config user.email t@t && git config user.name t
+  git add -A && git commit -qm init
+  # A stable tag at HEAD keeps go.mod/go.sum unchanged, so DEPS_CHANGED=false.
+  git tag v0.1.1
+
+  PATH="$STUB_DIR:$PATH"
+}
+
+teardown() {
+  # Cleanup must not decide whether the test passed. Under `bats -j` these tests
+  # each build a throwaway git repo in $TMPDIR, and on macOS `rm -rf`
+  # intermittently fails with ENOTEMPTY on .git/objects. bats treats a failing
+  # teardown as a failing test, so a green assertion was reported red — twice in
+  # six local runs, landing on a different test name each time.
+  #
+  # ENOTEMPTY says the directory was not empty when rm reached it; it does not
+  # say what refilled it, and that has not been established. Hence a fix at the
+  # teardown rather than at a presumed cause: retry briefly, then give up
+  # quietly. A leftover directory under $TMPDIR is worth less than a trustworthy
+  # signal, and the assertions have already run either way.
+  for _ in 1 2 3; do
+    rm -rf "$WORK" 2>/dev/null && return 0
+    sleep 0.1
+  done
+  rm -rf "$WORK" 2>/dev/null || true
+  return 0
+}
+
+# Emits a canned nix log plus the sentinel the script reads for exit status.
+stub_docker() {
+  cat > "$STUB_DIR/docker" <<STUB
+#!/usr/bin/env bash
+cat <<'OUT'
+$1
+OUT
+STUB
+  chmod +x "$STUB_DIR/docker"
+}
+
+@test "succeeds when the nix build succeeds" {
+  stub_docker "building '/nix/store/abc-hey-0.1.1-go-modules.drv'...
+NIX_BUILD_EXIT=0"
+
+  run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 2 ]   # 2 = no changes needed
+  [[ "$output" == *"verified (build succeeded)"* ]]
+}
+
+@test "fails closed when the build fails without a hash mismatch" {
+  # The exact v0.1.1 shape: nix logs that it is *building* hey, then dies
+  # on the Go toolchain. The old heuristic matched that line and reported
+  # success.
+  stub_docker "building '/nix/store/abc-hey-0.1.1-go-modules.drv'...
+       > go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
+error: Build failed due to failed dependency
+NIX_BUILD_EXIT=1"
+
+  run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not because of the vendorHash"* ]]
+  [[ "$output" != *"verified (build succeeded)"* ]]
+}
+
+@test "records a corrected hash only after a rebuild proves it" {
+  # First call reports the mismatch, second call succeeds.
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+STATE="${NIX_STUB_STATE:?}"
+if [ -f "$STATE" ]; then
+  echo "NIX_BUILD_EXIT=0"
+else
+  touch "$STATE"
+  echo "error: hash mismatch in fixed-output derivation"
+  echo "         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA="
+  echo "            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB="
+  echo "NIX_BUILD_EXIT=1"
+fi
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  NIX_STUB_STATE="$WORK/called" run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 0 ]   # 0 = changes written
+  [[ "$output" == *"vendorHash: updated"* ]]
+  [[ "$output" == *"verified (build succeeded)"* ]]
+  grep -q 'sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=' nix/package.nix
+}
+
+@test "fails when the corrected hash still does not build" {
+  # Every call reports a mismatch — the rebuild never converges, so the script
+  # must not claim success just because it wrote a new hash.
+  stub_docker "error: hash mismatch in fixed-output derivation
+         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=
+            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=
+NIX_BUILD_EXIT=1"
+
+  run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"still fails after updating the vendorHash"* ]]
+}
+
+@test "does not mistake an unrelated 'got:' line for a hash mismatch" {
+  # A failing build whose log happens to contain `got:` — a Go test assertion,
+  # say — must take the non-hash failure path. Matching a bare `got:` would
+  # capture "42" and write it into vendorHash, corrupting a tracked file while
+  # reporting the wrong kind of failure.
+  stub_docker "--- FAIL: TestSomething
+    thing_test.go:42: got: 42
+    thing_test.go:43: want: 7
+error: builder failed with exit code 1
+NIX_BUILD_EXIT=1"
+
+  run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not because of the vendorHash"* ]]
+  [[ "$output" != *"vendorHash: updated"* ]]
+  # The tracked file must be untouched.
+  grep -q 'sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=' nix/package.nix
+  ! grep -q '"42"' nix/package.nix
+}
+
+@test "verifies the build even when dependencies did not change" {
+  # DEPS_CHANGED=false must not skip the build: the Go-toolchain drift that
+  # broke v0.1.1 touches neither go.mod nor go.sum.
+  stub_docker "NIX_BUILD_EXIT=0"
+
+  run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"dependencies unchanged — verifying the Nix build anyway"* ]]
+  [[ "$output" == *"verified (build succeeded)"* ]]
+}

--- a/tests/e2e/update_nix_flake.bats
+++ b/tests/e2e/update_nix_flake.bats
@@ -204,3 +204,15 @@ NIX_BUILD_EXIT=1"
   [[ "$output" == *"dependencies unchanged — verifying the Nix build anyway"* ]]
   [[ "$output" == *"verified (build succeeded)"* ]]
 }
+
+@test "a NIX_BUILD_EXIT=0 that is not the final line is not a success" {
+  # The sentinel is emitted by the docker wrapper after the build; anything
+  # else printing that string earlier (a quoted log line) must not count.
+  stub_docker "echo NIX_BUILD_EXIT=0 is what success looks like
+error: builder failed with exit code 1
+NIX_BUILD_EXIT=1"
+
+  run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"verified (build succeeded)"* ]]
+}

--- a/tests/e2e/update_nix_flake.bats
+++ b/tests/e2e/update_nix_flake.bats
@@ -307,3 +307,32 @@ STUB
   [ "$status" -eq 2 ]
   [[ "$output" == *"verified (build succeeded)"* ]]
 }
+
+@test "fails when staging the tracked source fails" {
+  # `git ls-files` lists a tracked file deleted from the worktree with plain
+  # `rm`, so the staging tar exits nonzero while still emitting the readable
+  # files — a partial tree. Left unchecked (errexit is stripped inside the
+  # $(run_nix_build) substitution), the build runs against that partial source
+  # and can report "verified" for a tree that is not what CI will build, or
+  # compute a vendorHash from a partial import graph. The script must abort
+  # before invoking Docker.
+  echo 'tracked' > notes.md
+  git add notes.md && git commit -qm notes
+  rm notes.md
+  # Any docker invocation is itself a failure: staging must abort first.
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+echo "error: build ran despite a failed staging pipeline"
+echo "NIX_BUILD_EXIT=0"
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  run scripts/update-nix-flake.sh 0.2.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"staging tracked files for the build failed"* ]]
+  [[ "$output" != *"build ran despite"* ]]
+  [[ "$output" != *"verified (build succeeded)"* ]]
+  # The version edit precedes the build; the failure must roll it back.
+  grep -q 'version = "0.1.1";' nix/package.nix
+  ! grep -q 'version = "0.2.0";' nix/package.nix
+}


### PR DESCRIPTION
Stacked on #195.

## What

- `flake.nix` + `nix/package.nix` (`pname hey`, `subPackages cmd/hey`, ldflags Version only, completions, `mainProgram hey`), `flake.lock` pinned to nixpkgs-unstable as of 2026-08-19.
- **Go drift, handled up front:** nixpkgs-unstable still carries Go **1.26.5**; `go.mod` says **1.26.6** (1.26.6/1.26.7 are merged to staging-next on Aug 14/20 but not yet in unstable). `package.nix` overrides `go_1_26` with the upstream 1.26.6 source tarball behind `lib.versionOlder go_1_26.version minGo`, so the override is inert once a `nix flake update` brings nixpkgs level — then delete the block. Without this the flake would have shipped exactly the v0.8.0 failure.
- Ported `update-nix-flake.sh`, `extract-nix-vendor-hash.sh`, `nix-build-check.sh` + their three bats files (23 tests); `make update-nix-hash` (exit 0/2 only).
- test.yml `nix-build` (paths-filtered on go.mod/go.sum/flake/nix/scripts/test.yml); release.yml `nix-verify` stable-only, **not** continue-on-error.
- README: Nix install line.

## Verified

`scripts/update-nix-flake.sh 0.1.1` via the pinned `nixos/nix` Docker image: built Go 1.26.6 from source, computed `vendorHash sha256-Yf+Y7DFm6rBFxX7evMfGY7/O4l7bk5LP1++ZJmW7O4I=`, and the follow-up verification build succeeded (`vendorHash: verified (build succeeded)`). `make test-e2e` 58 tests green; actionlint/zizmor/shellcheck clean.

One script behaviour worth knowing: `update-nix-flake.sh` rewrites the *quoted* `vendorHash` string, so `package.nix` must keep a string literal there rather than `lib.fakeHash` (comment added).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Nix flake that builds and publishes `hey` and makes vendorHash/toolchain/release checks drift-proof. Previously a `go.mod` bump or a lagging `nixpkgs` Go could pass; now the flake must build, the binary’s `--version` must match the tag, and only a rebuild‑proven `vendorHash` is written.

- Builds `hey` via `buildGoModule` with shell completions and a dev shell; `flake.lock` pins `nixpkgs-unstable`. One shared toolchain from `nix/go.nix` is used by both package and dev shell; it conditionally rebuilds `go_1_26` to 1.26.6 and is bound to avoid `pkgs.go` replacing it.
- Drift-proof `vendorHash`: `make update-nix-hash` (digest‑pinned `nixos/nix`) stages tracked files only, refuses when untracked `.go` files would be omitted, aborts when staging tracked files fails, accepts only `*-go-modules.drv` mismatches and takes the SRI `got:` from that block, rewrites `vendorHash` then rebuilds to prove it, restores `nix/package.nix` on failure, and requires a final-line build sentinel. CI (`scripts/nix-build-check.sh`) replays nix output and annotates stale hashes using the shared classifier.
- CI/release: a paths‑filtered Nix build runs on Go sources, `go.mod`, `go.sum`, flake files, `nix/**`, and Nix scripts. Stable tags run `nix-verify` to build the flake and assert `hey --version` equals the tag. `scripts/release.sh` refuses tagging until `nix/package.nix`’s version matches.
- Docs/tests: README adds a Nix install line. bats tests cover the classifier, CI wrapper, release gate, updater, and staging/sentinel guards.

Required actions
- After changing `go.mod`, `go.sum`, or imports: ensure no untracked `.go` files (or gitignore them), then run `make update-nix-hash` and commit `nix/package.nix`.
- Before tagging a stable release: run `make update-nix-hash VERSION=vX.Y.Z` so `nix/package.nix` matches; the release job enforces this.
- When `nixpkgs` includes Go ≥ 1.26.6: remove the conditional override in `nix/go.nix`.

<sup>Written for commit 2d86a71b67acd605e9629ad1bcec910c25b38ea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

