### PR TITLE
Add contact bundle commands

### DIFF
--- a/.surface
+++ b/.surface
@@ -63,6 +63,7 @@ hey contacts add --account-user-id
 hey contacts add --alias
 hey contacts add --email
 hey contacts add --name
+hey contacts bundle
 hey contacts hide
 hey contacts list
 hey contacts list --all
@@ -74,6 +75,7 @@ hey contacts note set --note
 hey contacts note show
 hey contacts show
 hey contacts show-again
+hey contacts unbundle
 hey contacts update
 hey contacts update --alias
 hey contacts update --email

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -21,6 +21,8 @@ The remaining HTML-reading gaps use the SDK's authenticated HTML helper and are 
 | `/contacts/{id}.json` | PATCH | SDK `Contacts().Update` | `hey contacts update`, Contacts TUI | covered |
 | `/contacts/{id}.json` | DELETE | SDK `Contacts().Hide` | `hey contacts hide`, Contacts TUI | covered |
 | `/contacts/{id}/reveal.json` | POST | SDK `Contacts().Reveal` | `hey contacts show-again`, Contacts TUI | covered |
+| `/contacts/{id}/bundle.json` | POST | SDK `Contacts().Bundle` | `hey contacts bundle` | covered |
+| `/contacts/{id}/bundle.json` | DELETE | SDK `Contacts().Unbundle` | `hey contacts unbundle` | covered |
 | `/contacts/{id}/note.json` | GET | SDK `Contacts().Note` | `hey contacts note show`, Contacts TUI | covered |
 | `/contacts/{id}/note.json` | PATCH | SDK `Contacts().SetNote` | `hey contacts note set`, Contacts TUI | covered |
 | `/contacts/{id}/note.json` | DELETE | SDK `Contacts().DeleteNote` | `hey contacts note delete`, Contacts TUI | covered |

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ hey contacts add --name "Jane Doe" --email jane@example.com
 hey contacts update 12345 --name "Jane Dawson"
 hey contacts hide 12345            # hide without permanently deleting
 hey contacts show-again 12345      # show a hidden contact again
+hey contacts bundle 12345          # group this contact's mail into one row
+hey contacts unbundle 12345        # list this contact's mail separately
 hey contacts note set 12345 "Prefers email"
 hey contacts note delete 12345
 hey threads 123                    # read a full email thread
@@ -140,7 +142,7 @@ hey stop-ignoring 12345            # resume attention for a thread
 
 Search accepts free text plus `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. Use `--page` for one page or `--all` to fetch up to 100 pages; capped searches report the next page for continuation. Search results include `topic_id` for reading the thread and the matching message summaries. Results with an active box item also include `id` for organization actions.
 
-Contact updates preserve omitted name, email, and alias fields. Supplying `--alias` replaces the complete alias list; `--alias=` clears it. Contact notes accept positional content, `--note`, stdin, or `$EDITOR`. HEY hides contacts rather than permanently deleting them; hidden contacts leave lists, autocomplete, and search, and can be shown again by ID.
+Contact updates preserve omitted name, email, and alias fields. Supplying `--alias` replaces the complete alias list; `--alias=` clears it. Contact notes accept positional content, `--note`, stdin, or `$EDITOR`. HEY hides contacts rather than permanently deleting them; hidden contacts leave lists, autocomplete, and search, and can be shown again by ID. Bundling groups a contact's mail into one row without merging or deleting the underlying threads; unbundling lists those threads separately again. HEY applies bundling when the contact's current delivery setting supports bundles.
 
 `hey bulk-reply preview` is read-only and resolves each posting to its latest replyable entry. `hey bulk-reply send` resolves the selection again, skips threads without a replyable entry, keeps HEY's server-provided name tag, and returns the exact reply count, delivery ID, delayed state, undo URL, and undo command. Posting IDs must be positive and unique. The message can come from `-m`, stdin, or `$EDITOR`; `--attach` is repeatable.
 

--- a/internal/cmd/accounts_test.go
+++ b/internal/cmd/accounts_test.go
@@ -147,7 +147,7 @@ func TestPersistedAccountScopesMailRequests(t *testing.T) {
 }
 
 func TestSelectedAccountUsesMatchingSenderAndUser(t *testing.T) {
-	var messageAccount, contactAccount string
+	var messageAccount, contactAccount, bundleAccount string
 	var actingSenderID, actingUserID int64
 	server := linkedAccountServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -168,6 +168,9 @@ func TestSelectedAccountUsesMatchingSenderAndUser(t *testing.T) {
 			actingUserID = body.ActingUserID
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"id":77,"name":"Jane Doe","email_address":"jane@example.org"}`))
+		case "/contacts/77/bundle.json":
+			bundleAccount = r.URL.Query().Get("filtered_account_id")
+			w.WriteHeader(http.StatusCreated)
 		default:
 			http.NotFound(w, r)
 		}
@@ -185,11 +188,19 @@ func TestSelectedAccountUsesMatchingSenderAndUser(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := runAccountsCLI(t, server,
+		"--account", "2", "contacts", "bundle", "77",
+	); err != nil {
+		t.Fatal(err)
+	}
 	if messageAccount != "2" || actingSenderID != 222 {
 		t.Fatalf("message account/sender = %q/%d, want 2/222", messageAccount, actingSenderID)
 	}
 	if contactAccount != "2" || actingUserID != 22 {
 		t.Fatalf("contact account/user = %q/%d, want 2/22", contactAccount, actingUserID)
+	}
+	if bundleAccount != "2" {
+		t.Fatalf("bundle account = %q, want 2", bundleAccount)
 	}
 }
 

--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -22,9 +22,9 @@ func newContactsCommand() *contactsCommand {
 	contactsCommand.cmd = &cobra.Command{
 		Use:   "contacts",
 		Short: "Manage contacts",
-		Long:  "List, view, add, edit, hide, and annotate HEY contacts.",
+		Long:  "List, view, add, edit, hide, bundle, and annotate HEY contacts.",
 		Annotations: map[string]string{
-			"agent_notes": "Contact IDs come from `hey contacts list`. Hiding is reversible with `hey contacts show-again <id>`. Private notes are managed under `hey contacts note`.",
+			"agent_notes": "Contact IDs come from `hey contacts list`. Hiding and bundling are reversible. Private notes are managed under `hey contacts note`.",
 		},
 	}
 
@@ -34,6 +34,8 @@ func newContactsCommand() *contactsCommand {
 	contactsCommand.cmd.AddCommand(newContactsUpdateCommand().cmd)
 	contactsCommand.cmd.AddCommand(newContactsHideCommand().cmd)
 	contactsCommand.cmd.AddCommand(newContactsShowAgainCommand().cmd)
+	contactsCommand.cmd.AddCommand(newContactsBundleCommand().cmd)
+	contactsCommand.cmd.AddCommand(newContactsUnbundleCommand().cmd)
 	contactsCommand.cmd.AddCommand(newContactNoteCommand().cmd)
 	return contactsCommand
 }

--- a/internal/cmd/contacts_bundle.go
+++ b/internal/cmd/contacts_bundle.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactsBundleCommand struct {
+	cmd *cobra.Command
+}
+
+type contactBundleResult struct {
+	ID     int64  `json:"id"`
+	Action string `json:"action"`
+}
+
+func newContactsBundleCommand() *contactsBundleCommand {
+	bundleCommand := &contactsBundleCommand{}
+	bundleCommand.cmd = &cobra.Command{
+		Use:   "bundle <id>",
+		Short: "Bundle a contact's mail",
+		Long:  "Group mail from a contact into one bundle in HEY instead of listing every thread separately.",
+		Annotations: map[string]string{
+			"agent_notes": "Bundling is a per-contact preference. HEY applies it when the contact's delivery setting supports bundles. Reverse it with `hey contacts unbundle <id>`.",
+		},
+		Example: `  hey contacts bundle 12345`,
+		RunE:    bundleCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return bundleCommand
+}
+
+func (c *contactsBundleCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	contactID, err := parseContactID(args[0])
+	if err != nil {
+		return err
+	}
+	if err := sdk.Contacts().Bundle(cmd.Context(), contactID); err != nil {
+		return convertSDKError(err)
+	}
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Bundle request accepted for contact %d.\n", contactID)
+		return nil
+	}
+	return writeOK(contactBundleResult{ID: contactID, Action: "bundle"},
+		output.WithSummary("Bundle request accepted"),
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "unbundle", Command: fmt.Sprintf("hey contacts unbundle %d", contactID), Description: "List this contact's mail separately"}),
+	)
+}

--- a/internal/cmd/contacts_test.go
+++ b/internal/cmd/contacts_test.go
@@ -52,8 +52,11 @@ func contactsServer(t *testing.T) (*httptest.Server, *recordedContacts) {
 		if status != 0 {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(status)
-			if status == http.StatusConflict {
+			switch status {
+			case http.StatusConflict:
 				_, _ = w.Write([]byte(`{"errors":["Some email addresses are already in use for other contacts"],"contact_id":9,"conflicting_contact_ids":[4,5]}`))
+			case http.StatusForbidden:
+				_, _ = w.Write([]byte(`{"message":"Forbidden"}`))
 			}
 			return
 		}
@@ -83,6 +86,10 @@ func contactsServer(t *testing.T) (*httptest.Server, *recordedContacts) {
 			w.WriteHeader(http.StatusNoContent)
 		case req.Method == http.MethodPost && req.URL.Path == "/contacts/7/reveal.json":
 			_, _ = w.Write([]byte(`{"id":7,"account_id":1,"name":"Jane Doe","email_address":"jane@example.com"}`))
+		case req.Method == http.MethodPost && req.URL.Path == "/contacts/7/bundle.json":
+			w.WriteHeader(http.StatusCreated)
+		case req.Method == http.MethodDelete && req.URL.Path == "/contacts/7/bundle.json":
+			w.WriteHeader(http.StatusNoContent)
 		case req.Method == http.MethodGet && req.URL.Path == "/contacts/7/note.json":
 			_, _ = w.Write([]byte(`{"contact_id":7,"note":"Prefers email","note_html":"<p>Prefers email</p>"}`))
 		case req.Method == http.MethodPatch && req.URL.Path == "/contacts/7/note.json":
@@ -294,6 +301,38 @@ func TestContactsHideAndReveal(t *testing.T) {
 	}
 }
 
+func TestContactsBundleAndUnbundle(t *testing.T) {
+	server, recorded := contactsServer(t)
+	bundled, err := runContacts(t, server, "bundle", "7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundleResult := decodeContactData[contactBundleResult](t, bundled.Data)
+	if bundleResult.ID != 7 || bundleResult.Action != "bundle" || bundled.Summary != "Bundle request accepted" {
+		t.Errorf("bundle: result=%+v summary=%q", bundleResult, bundled.Summary)
+	}
+	if len(bundled.Breadcrumbs) != 1 || bundled.Breadcrumbs[0].Command != "hey contacts unbundle 7" {
+		t.Errorf("bundle breadcrumbs = %+v", bundled.Breadcrumbs)
+	}
+
+	unbundled, err := runContacts(t, server, "unbundle", "7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unbundleResult := decodeContactData[contactBundleResult](t, unbundled.Data)
+	if unbundleResult.ID != 7 || unbundleResult.Action != "unbundle" || unbundled.Summary != "Unbundle request accepted" {
+		t.Errorf("unbundle: result=%+v summary=%q", unbundleResult, unbundled.Summary)
+	}
+	if len(unbundled.Breadcrumbs) != 1 || unbundled.Breadcrumbs[0].Command != "hey contacts bundle 7" {
+		t.Errorf("unbundle breadcrumbs = %+v", unbundled.Breadcrumbs)
+	}
+
+	requests := recorded.snapshot()
+	if len(requests) != 2 || requests[0].Method != http.MethodPost || requests[0].Path != "/contacts/7/bundle.json" || requests[1].Method != http.MethodDelete || requests[1].Path != "/contacts/7/bundle.json" {
+		t.Errorf("requests = %+v", requests)
+	}
+}
+
 func TestContactNotesShowSetAndDelete(t *testing.T) {
 	server, recorded := contactsServer(t)
 	show, err := runContacts(t, server, "note", "show", "7")
@@ -394,6 +433,8 @@ func TestContactCommandsValidateBeforeRequests(t *testing.T) {
 		{"add", "--name", "Jane", "--email", "jane@example.com", "--alias", "jane@example.com"},
 		{"update", "7"},
 		{"show", "not-an-id"},
+		{"bundle", "not-an-id"},
+		{"unbundle", "0"},
 		{"note", "set", "7", ""},
 	}
 	for _, args := range tests {
@@ -406,6 +447,29 @@ func TestContactCommandsValidateBeforeRequests(t *testing.T) {
 			}
 			if len(recorded.snapshot()) != 0 {
 				t.Errorf("validation made requests: %+v", recorded.snapshot())
+			}
+		})
+	}
+}
+
+func TestContactBundleErrorsAreReturned(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		method string
+		args   []string
+	}{
+		{name: "bundle", method: http.MethodPost, args: []string{"bundle", "7"}},
+		{name: "unbundle", method: http.MethodDelete, args: []string{"unbundle", "7"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server, recorded := contactsServer(t)
+			recorded.mu.Lock()
+			recorded.statuses[tt.method+" /contacts/7/bundle.json"] = http.StatusForbidden
+			recorded.mu.Unlock()
+			_, err := runContacts(t, server, tt.args...)
+			var cliErr *apierr.Error
+			if !errors.As(err, &cliErr) || cliErr.Code != "forbidden" {
+				t.Fatalf("error = %#v, want forbidden", err)
 			}
 		})
 	}

--- a/internal/cmd/contacts_unbundle.go
+++ b/internal/cmd/contacts_unbundle.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type contactsUnbundleCommand struct {
+	cmd *cobra.Command
+}
+
+func newContactsUnbundleCommand() *contactsUnbundleCommand {
+	unbundleCommand := &contactsUnbundleCommand{}
+	unbundleCommand.cmd = &cobra.Command{
+		Use:   "unbundle <id>",
+		Short: "List a contact's mail separately",
+		Long:  "Stop grouping mail from a contact so each thread appears separately in HEY.",
+		Annotations: map[string]string{
+			"agent_notes": "Unbundling reverses `hey contacts bundle <id>` and preserves the underlying threads.",
+		},
+		Example: `  hey contacts unbundle 12345`,
+		RunE:    unbundleCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return unbundleCommand
+}
+
+func (c *contactsUnbundleCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	contactID, err := parseContactID(args[0])
+	if err != nil {
+		return err
+	}
+	if err := sdk.Contacts().Unbundle(cmd.Context(), contactID); err != nil {
+		return convertSDKError(err)
+	}
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Unbundle request accepted for contact %d.\n", contactID)
+		return nil
+	}
+	return writeOK(contactBundleResult{ID: contactID, Action: "unbundle"},
+		output.WithSummary("Unbundle request accepted"),
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "bundle", Command: fmt.Sprintf("hey contacts bundle %d", contactID), Description: "Bundle this contact's mail"}),
+	)
+}

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -70,7 +70,7 @@ func TestContactCommandHelpUsesHEYTerminology(t *testing.T) {
 	if strings.Contains(lower, "reveal") || strings.Contains(lower, "delete a contact") {
 		t.Errorf("contact help exposes internal or destructive terminology:\n%s", text.String())
 	}
-	for _, want := range []string{"hide a contact", "show a hidden contact again", "delete a private contact note"} {
+	for _, want := range []string{"hide a contact", "show a hidden contact again", "bundle a contact's mail", "list a contact's mail separately", "delete a private contact note"} {
 		if !strings.Contains(lower, want) {
 			t.Errorf("contact help missing %q:\n%s", want, text.String())
 		}

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -63,6 +63,8 @@ triggers:
   - add contact
   - edit contact
   - hide contact
+  - bundle contact mail
+  - unbundle contact mail
   - contact note
   - check calendar
   - add todo
@@ -121,6 +123,8 @@ CLI for HEY: mailboxes, email threads, contacts, replies, compose, calendars, to
 | Edit contact | `hey contacts update <id> --name "Jane Dawson"` |
 | Hide contact | `hey contacts hide <id>` |
 | Show contact again | `hey contacts show-again <id>` |
+| Bundle a contact's mail | `hey contacts bundle <id>` |
+| List a contact's mail separately | `hey contacts unbundle <id>` |
 | Read private contact note | `hey contacts note show <id> --json` |
 | Set private contact note | `hey contacts note set <id> "Prefers email"` |
 | Delete private contact note | `hey contacts note delete <id>` |
@@ -248,6 +252,8 @@ hey contacts update 12345 --name "Jane Dawson"
 hey contacts update 12345 --alias=              # Clear aliases
 hey contacts hide 12345                         # Hide from lists and autocomplete
 hey contacts show-again 12345                   # Reverse hiding
+hey contacts bundle 12345                       # Group this contact's mail into one row
+hey contacts unbundle 12345                     # List this contact's mail separately
 hey contacts note show 12345 --json
 hey contacts note set 12345 "Prefers email"
 echo "Multiline private note" | hey contacts note set 12345
@@ -256,7 +262,7 @@ hey contacts note delete 12345
 
 `hey contacts list` returns contact IDs, names, email addresses, and update timestamps. `hey contacts show` adds aliases, screening status, and the private note. Contact updates preserve omitted fields. Supplying `--alias` replaces the complete alias list, and `--alias=` clears it.
 
-HEY hides contacts instead of permanently deleting them. A hidden contact leaves contact lists, autocomplete, and search results while remaining available by ID; `show-again` reverses the action. Contact notes are private and support positional content, `--note`, stdin, or `$EDITOR`. Deleting a note leaves the contact unchanged.
+HEY hides contacts instead of permanently deleting them. A hidden contact leaves contact lists, autocomplete, and search results while remaining available by ID; `show-again` reverses the action. Bundling groups a contact's mail into one row without merging or deleting the underlying threads; `unbundle` lists those threads separately again. HEY applies bundling when the contact's current delivery setting supports bundles. Contact notes are private and support positional content, `--note`, stdin, or `$EDITOR`. Deleting a note leaves the contact unchanged.
 
 ### Email - Threads
 

--- a/tests/smoke/contacts_test.go
+++ b/tests/smoke/contacts_test.go
@@ -36,7 +36,10 @@ func TestContactLifecycleAndPrivateNote(t *testing.T) {
 		t.Fatalf("created contact is incomplete: id=%d email_matches=%v", created.ID, created.EmailAddress == email)
 	}
 	id := intStr(created.ID)
-	t.Cleanup(func() { _, _, _ = hey(t, "contacts", "hide", id) })
+	t.Cleanup(func() {
+		_, _, _ = hey(t, "contacts", "unbundle", id)
+		_, _, _ = hey(t, "contacts", "hide", id)
+	})
 
 	updated := dataAs[smokeContact](t, contactWriteJSON(t, "contacts", "update", id, "--name", "Samuel Rivera", "--alias", alias))
 	if updated.ID == 0 || updated.Name != "Samuel Rivera" {
@@ -45,6 +48,21 @@ func TestContactLifecycleAndPrivateNote(t *testing.T) {
 	detail := dataAs[smokeContact](t, heyJSON(t, "contacts", "show", id))
 	if len(detail.Aliases) != 1 || detail.Aliases[0].EmailAddress != alias {
 		t.Errorf("contact aliases were not updated")
+	}
+
+	bundled := dataAs[struct {
+		ID     int    `json:"id"`
+		Action string `json:"action"`
+	}](t, contactWriteJSON(t, "contacts", "bundle", id))
+	if bundled.ID != created.ID || bundled.Action != "bundle" {
+		t.Error("accepted contact bundle action was not returned")
+	}
+	unbundled := dataAs[struct {
+		ID     int    `json:"id"`
+		Action string `json:"action"`
+	}](t, contactWriteJSON(t, "contacts", "unbundle", id))
+	if unbundled.ID != created.ID || unbundled.Action != "unbundle" {
+		t.Error("accepted contact unbundle action was not returned")
 	}
 
 	noteText := "Prefers email follow-ups for project planning."
@@ -97,4 +115,6 @@ func TestContactCommandsValidateInput(t *testing.T) {
 	heyFail(t, "contacts", "add", "--name", "Sam Rivera")
 	heyFail(t, "contacts", "update", "12345")
 	heyFail(t, "contacts", "show", "not-an-id")
+	heyFail(t, "contacts", "bundle", "not-an-id")
+	heyFail(t, "contacts", "unbundle", "0")
 }


### PR DESCRIPTION
## Summary

- add `hey contacts bundle <id>` and `hey contacts unbundle <id>` using the existing typed hey-sdk operations
- scope both mutations through the selected linked-account client and return machine-readable accepted actions with inverse-action breadcrumbs
- document the commands in the README, embedded HEY skill, API coverage inventory, and CLI surface
- add unit, linked-account, help, API-error, validation, and live smoke coverage

Haystack can accept a bundle request while retaining separate delivery when the contact's current delivery setting does not support bundles. The command therefore reports that HEY accepted the requested action rather than claiming a postcondition the endpoint does not return.

## Basecamp

- [CLI card #10206892823](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892823)
- [Separate API/SDK/TUI follow-up #10221773758](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10221773758)

## Validation

- `GOWORK=off make check`
- focused contact bundle/unbundle and linked-account tests
- `GOWORK=off make test-smoke` — full suite passed, including the contact lifecycle
- `git diff --check`
- independent review found no remaining P1/P2/P3 findings

## Risk

Low. This adds two command surfaces over existing SDK mutations. The primary behavioral edge case—an accepted but ineligible bundle request—is represented as an accepted action rather than fabricated bundle state.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `hey contacts bundle <id>` and `hey contacts unbundle <id>` to group or separate a contact’s mail. Reports accepted actions to match HEY’s apply-if-supported bundling behavior.

**Review notes**
- Calls SDK `Contacts().Bundle` (POST `/contacts/{id}/bundle.json`) and `Contacts().Unbundle` (DELETE `/contacts/{id}/bundle.json`).
- Scopes both mutations through the selected linked account; tests verify `filtered_account_id` routing.
- Behavior: previously no bundling commands. Now the CLI accepts a bundle/unbundle request and does not fabricate final state when delivery settings don’t support bundles.
- Output: machine-readable JSON `{id, action}`; styled mode prints a confirmation; includes inverse-action breadcrumbs.
- Validation and errors: validates contact ID; converts API errors (e.g., forbidden) via standard mapping; help text uses HEY terminology.
- Docs and tests: updates README, `.surface`, `skills/hey/SKILL.md`, and API coverage; adds unit, linked-account, help, API-error, validation, and smoke tests.

<sup>Written for commit 3e90ec3d0a17aa8658cbbf638629bd1b9c89902b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

