### PR TITLE
Annotate the watch shell sites for the standalone gosec scan

### DIFF
--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -593,10 +593,10 @@ func (w *postingsWatch) writeJSON(event watchEvent) {
 
 func shellCommand(ctx context.Context, script string) *exec.Cmd {
 	if runtime.GOOS == "windows" {
-		return exec.CommandContext(ctx, "cmd", "/c", script) //nolint:gosec // G204: running the command the caller asked for is the point
+		return exec.CommandContext(ctx, "cmd", "/c", script) // #nosec G204 -- running the command the caller asked for is the point
 	}
 
-	return exec.CommandContext(ctx, "sh", "-c", script) //nolint:gosec // G204: running the command the caller asked for is the point
+	return exec.CommandContext(ctx, "sh", "-c", script) // #nosec G204 -- running the command the caller asked for is the point
 }
 
 func (e watchEvent) environment() []string {


### PR DESCRIPTION
The standalone gosec scan (\`securego/gosec\` in \`security.yml\`) failed on the \`v0.1.1-rc.1\` tag and on the last push to main, which blocks the release job (\`needs: [test, security]\`). Cause: \`hey watch\`'s two \`shellCommand\` sites use \`//nolint:gosec\`, which golangci-lint honors but gosec itself does not. Switch them to the \`// #nosec G204 -- reason\` form the other subprocess sites already use (see 80d2a88).

Verified locally: \`go run github.com/securego/gosec/v2/cmd/gosec@v2.28.0 ./...\` reports 0 issues, \`make lint\` 0 issues.

Why a PR didn't catch it: the gosec job carries \`if: github.event_name != 'pull_request'\`, so it only runs on main pushes, tags and the weekly schedule. Worth reconsidering separately — a \`--no-upload\` variant on PRs would gate before merge.

The rc tag can't move, so once this is in, the candidate is re-cut as \`v0.1.1-rc.2\`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the two `hey watch` shellCommand sites from `//nolint:gosec` to `// #nosec G204`, so the standalone `securego/gosec` scan in `security.yml` stops failing; previously `gosec` ignored `//nolint:gosec` and blocked the release job.

- No runtime behavior change; only comment annotations updated and consistent with other subprocess sites.
- Unblocks the `security.yml` security job and the release gate.
- Verified locally: `gosec` v2.28.0 and `make lint` report 0 issues.
- After merge, re-cut the RC as `v0.1.1-rc.2`.

<sup>Written for commit 6d4cf0128e9f47e02b54f86ec5ecfa7535474de4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

