### PR TITLE
Point the installer URLs at hey.com/install-cli

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -5,11 +5,11 @@ name: Installer Smoke
 # pre-merge, and this catches a broken published installer after. Runs the
 # documented Quick Start shape (curl pipe to bash), not a checkout.
 #
-# TODO(hey.com/install-cli): switch the curl URLs to
-# https://hey.com/install-cli?sha=... once the haystack redirect is live. The
-# raw URL is the documented shape until then; ?sha= still cache-busts
-# raw.githubusercontent.com (max-age=300), so a push-triggered run cannot
-# fetch the pre-push installer and falsely pass.
+# Fetches through the hey.com/install-cli redirect (a 302 to the raw file on
+# main) so the documented URL is what gets exercised. nginx carries the query
+# string across the hop, and ?sha= cache-busts raw.githubusercontent.com
+# (max-age=300), so a push-triggered run cannot fetch the pre-push installer
+# and falsely pass.
 
 on:
   schedule:
@@ -43,7 +43,7 @@ jobs:
           export HOME="$smoke_root/home"
           export HEY_BIN_DIR="$smoke_root/bin"
 
-          curl -fsSL "https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh?sha=${GITHUB_SHA}" | bash
+          curl -fsSL "https://hey.com/install-cli?sha=${GITHUB_SHA}" | bash
 
           # Assert the deterministic installed path, not ambient PATH.
           "$HEY_BIN_DIR/hey" --version
@@ -66,7 +66,7 @@ jobs:
           export HOME="$smoke_root/home"
           export HEY_BIN_DIR="$smoke_root/bin"
 
-          curl -fsSL "https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh?sha=${GITHUB_SHA}" | /bin/bash
+          curl -fsSL "https://hey.com/install-cli?sha=${GITHUB_SHA}" | /bin/bash
 
           "$HEY_BIN_DIR/hey" --version
 
@@ -103,7 +103,7 @@ jobs:
 
           # Documented Quick Start shape, cache-busted. Single-quoted so the
           # inner interpreter expands $env:GITHUB_SHA itself.
-          & $env:SMOKE_SHELL -NoProfile -Command 'irm "https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.ps1?sha=$env:GITHUB_SHA" | iex'
+          & $env:SMOKE_SHELL -NoProfile -Command 'irm "https://hey.com/install-cli.ps1?sha=$env:GITHUB_SHA" | iex'
           if ($LASTEXITCODE -ne 0) { throw "installer exited $LASTEXITCODE under $env:SMOKE_SHELL" }
 
           & "$env:HEY_BIN_DIR\hey.exe" --version

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ A CLI and TUI for [HEY](https://hey.com).
 **macOS / Linux / WSL2**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash
+curl -fsSL https://hey.com/install-cli | bash
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-irm https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.ps1 | iex
+irm https://hey.com/install-cli.ps1 | iex
 ```
 
 On Windows 11 with Smart App Control, see [Troubleshooting](#windows-smart-app-control-and-smartscreen) if the install is blocked.
@@ -358,7 +358,7 @@ blocks an unsigned `hey.exe`, two options:
 1. **Use WSL2 (preferred).** Install the Linux build inside WSL2 — Smart App
    Control doesn't apply there and your Windows security setup is untouched:
    `wsl --install`, then inside the WSL terminal:
-   `curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash`
+   `curl -fsSL https://hey.com/install-cli | bash`
 2. **Turn Smart App Control off** (Windows Security → App & browser control →
    Smart App Control settings) **and leave it off while using the unsigned
    build.** Because there are no per-app exceptions, turning it back on

--- a/internal/cmd/upgrade_selfupdate.go
+++ b/internal/cmd/upgrade_selfupdate.go
@@ -113,9 +113,9 @@ func releaseTagURL(ver string) string {
 // installerHint is the one-line reinstall command for this platform.
 func installerHint() string {
 	if runtime.GOOS == "windows" {
-		return "irm https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.ps1 | iex"
+		return "irm https://hey.com/install-cli.ps1 | iex"
 	}
-	return "curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash"
+	return "curl -fsSL https://hey.com/install-cli | bash"
 }
 
 // resolveSelfUpdateTarget returns the canonical, case-preserving path of the

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -214,7 +214,7 @@ This build of hey.exe is not code-signed, and Smart App Control is enabled. Smar
   1. (Preferred) Install the Linux build inside WSL2 - Smart App Control does not apply there and your Windows security setup is untouched:
        wsl --install
      then, inside the WSL terminal:
-       curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash
+       curl -fsSL https://hey.com/install-cli | bash
 
   2. Turn Smart App Control off (Windows Security > App & browser control > Smart App Control settings) and leave it off while using this unsigned build. Because there are no per-app exceptions, turning it back on re-blocks hey.exe on its next run - only re-enable after upgrading to a signed release. Windows 11 with the March/April 2026 updates can re-enable Smart App Control from Windows Security without a reset; on older builds re-enabling requires resetting Windows, so prefer the WSL2 option there.
 "@

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 # install.sh - Install the hey CLI
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash
+#   curl -fsSL https://hey.com/install-cli | bash
 #
 # Options (via environment):
 #   HEY_BIN_DIR    Where to install the binary
@@ -393,11 +393,9 @@ verify_install() {
     detail="$detail: $run_error"
   fi
   if [[ "$platform" == windows_* ]]; then
-    # TODO(hey.com/install-cli): point the WSL2 hint at the short URL once the
-    # haystack redirect is live.
     detail="$detail
   Windows may have blocked the executable: Smart App Control only runs code-signed binaries.
-  Either install inside WSL2 (curl -fsSL https://raw.githubusercontent.com/basecamp/hey-cli/main/scripts/install.sh | bash) or see
+  Either install inside WSL2 (curl -fsSL https://hey.com/install-cli | bash) or see
   https://github.com/basecamp/hey-cli#windows-smart-app-control-and-smartscreen"
   fi
   error "$detail"


### PR DESCRIPTION
Follow-up to basecamp/hey.com#210, which adds \`/install-cli\`, \`/install-cli.sh\` and \`/install-cli.ps1\` as 302s to the raw installers on main.

Flips the two \`TODO(hey.com/install-cli)\` markers (installer-smoke canary URLs, install.sh WSL2 hint), the README Quick Start and Smart App Control section, the install.ps1 WSL2 hint, and the \`hey upgrade\` reinstall hint. The canary keeps \`?sha=\` — nginx carries the query string across the redirect, so raw.githubusercontent.com is still cache-busted.

Draft until the hey.com redirect is live (PR merged + \`skiff restart\`); the first \`installer-smoke\` push run after merge proves the endpoint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point installer commands to hey.com short URLs. Previously we used raw.githubusercontent.com; now we use https://hey.com/install-cli and https://hey.com/install-cli.ps1, which 302 to the raw installers. nginx forwards query strings, so CI cache-busting with ?sha= still works.

- README Quick Start and Windows instructions now use the short URLs.
- `scripts/install.sh` and `scripts/install.ps1` WSL2 hints point to the short URL.
- `internal/cmd/upgrade_selfupdate.go` reinstall hint uses the short URL.
- `.github/workflows/installer-smoke.yml` fetches through the short URL and preserves ?sha= for cache-busting.
- Rollout: Merge after the hey.com redirects are live; the next installer-smoke run will validate the endpoint. No other migration actions.

<sup>Written for commit 87746935d362f779d9657bb21c78a9be628eed06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

