### PR TITLE
Request only contents permission for the skills sync token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -558,7 +558,6 @@ jobs:
           owner: basecamp
           repositories: skills
           permission-contents: write
-          permission-pull-requests: write
 
       - name: Sync skills to distribution repo
         id: sync

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -95,7 +95,6 @@ jobs:
           owner: basecamp
           repositories: skills
           permission-contents: ${{ inputs.dry_run && 'read' || 'write' }}
-          permission-pull-requests: ${{ inputs.dry_run && 'read' || 'write' }}
 
       # github.sha is the dispatching ref's SHA (main), not the tag's, so
       # resolve the tagged commit from its own checkout — otherwise the sync


### PR DESCRIPTION
First live run of the stable-only skills sync (v0.1.1, run 32403631976) failed at `Generate token for skills repo`: *"The permissions requested are not granted to this installation."* The same app minted the Homebrew tap token (contents: write only) successfully in the same run, and `scripts/sync-skills.sh` performs only contents operations (clone, commit, push — no PR API). Drop the unused `permission-pull-requests` request from both the release job and the manual dispatch so the token request matches what the installation grants and the script needs.

Once merged: dispatch `sync-skills.yml` with tag `v0.1.1` to recover; #215 gets closed manually after the sync is green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Request only contents permission for the skills sync token to match the installation’s granted scopes and unblock token minting. Previously we also requested pull-requests; now we request contents only. This aligns with `scripts/sync-skills.sh` (clone, commit, push) and fixes the release-time failure.

- Removes `permission-pull-requests` from `release.yml` and `sync-skills.yml`. No behavior change to the sync itself; scope is narrower and matches actual use.

**Rollout**
- After merge, manually dispatch `sync-skills.yml` with tag `v0.1.1` to recover the failed run.

<sup>Written for commit a115fa800a6eaf480b5a75fcdac4284f1bcb1d58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

