### PR TITLE
Move the TUI from bare hey to hey tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ identity-wide.
 
 ## TUI
 
-Run `hey` to launch the interactive terminal UI. For identities with multiple linked mail
-accounts, press Ctrl+A to switch between All Accounts and individual email addresses.
+Run `hey tui` to launch the interactive terminal UI. Bare `hey` prints the help. For
+identities with multiple linked mail accounts, press Ctrl+A to switch between All Accounts
+and individual email addresses.
 Switching cancels requests from the previous account and reloads the active section;
 Calendar and Journal remain identity-wide.
 

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -16,6 +16,10 @@ var curatedCategories = []struct {
 	names   []string
 }{
 	{
+		heading: "INTERACTIVE",
+		names:   []string{"tui"},
+	},
+	{
 		heading: "EMAIL",
 		names:   []string{"boxes", "box", "labels", "label", "search", "contacts", "screener", "threads", "attachments", "compose", "reply", "bulk-reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"},
 	},
@@ -60,7 +64,7 @@ func renderRootHelp(w io.Writer, cmd *cobra.Command) {
 	b.WriteString("\n")
 	b.WriteString(bold.format("USAGE") + "\n")
 	b.WriteString("  hey <command> [flags]\n")
-	b.WriteString("  hey                     Open the interactive app\n")
+	b.WriteString("  hey tui                 Open the interactive app\n")
 
 	// Build lookup from command name → registered cobra.Command
 	registered := make(map[string]*cobra.Command, len(cmd.Commands()))

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -89,7 +89,10 @@ func TestRenderRootHelpUsesUserFacingLanguage(t *testing.T) {
 
 USAGE
   hey <command> [flags]
-  hey                     Open the interactive app
+  hey tui                 Open the interactive app
+
+INTERACTIVE
+  tui  Launch the interactive terminal UI
 
 EMAIL
   boxes          List your HEY boxes

--- a/internal/cmd/jq_test.go
+++ b/internal/cmd/jq_test.go
@@ -32,11 +32,12 @@ func TestValidateJQFlags(t *testing.T) {
 		{name: "invalid", args: []string{"auth", "status"}, filter: ".[invalid", requested: true, want: "invalid --jq expression"},
 		{name: "ids conflict", args: []string{"auth", "status"}, filter: ".data", requested: true, ids: true, want: "cannot use --jq with --ids-only"},
 		{name: "count conflict", args: []string{"auth", "status"}, filter: ".data", requested: true, count: true, want: "cannot use --jq with --count"},
-		{name: "root app", filter: ".", requested: true, want: "--jq is not supported by the interactive app"},
+		{name: "root help", filter: ".", requested: true},
 		{name: "auth token", args: []string{"auth", "token"}, filter: ".", requested: true, want: "--jq is not supported by the auth token command"},
 		{name: "completion", args: []string{"completion"}, filter: ".", requested: true, want: "--jq is not supported by the completion command"},
 		{name: "skill display", args: []string{"skill"}, filter: ".", requested: true, want: "--jq is not supported by the skill display command"},
 		{name: "tui", args: []string{"tui"}, filter: ".", requested: true, want: "--jq is not supported by the interactive app"},
+		{name: "hey alias", args: []string{"hey"}, filter: ".", requested: true, want: "--jq is not supported by the interactive app"},
 	}
 
 	for _, tt := range tests {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,7 +15,6 @@ import (
 	"github.com/basecamp/hey-cli/internal/auth"
 	"github.com/basecamp/hey-cli/internal/config"
 	"github.com/basecamp/hey-cli/internal/output"
-	"github.com/basecamp/hey-cli/internal/tui"
 	"github.com/basecamp/hey-cli/internal/version"
 )
 
@@ -120,13 +119,7 @@ func newRootCmd() *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "hey version %s\n", version.Version)
 				return nil
 			}
-			if !stdinIsTerminal() || !stdoutIsTerminal() {
-				return cmd.Help()
-			}
-			if err := requireAuth(); err != nil {
-				return err
-			}
-			return tui.Run(rootSDK, sdk, cfg.AccountID)
+			return cmd.Help()
 		},
 	}
 
@@ -183,6 +176,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newStopIgnoringCommand().cmd)
 	root.AddCommand(newSetupCommand())
 	root.AddCommand(newTuiCommand().cmd)
+	root.AddCommand(newHeyCommand().cmd)
 	root.AddCommand(newSkillCommand().cmd)
 	root.AddCommand(newCommandsCommand())
 	root.AddCommand(newCompletionCommand())
@@ -246,15 +240,13 @@ func validateJQFlags(cmd *cobra.Command, filter string, requested, ids, count bo
 	}
 
 	switch cmd.CommandPath() {
-	case "hey":
-		return output.ErrJQNotSupported("the interactive app")
 	case "hey auth token":
 		return output.ErrJQNotSupported("the auth token command")
 	case "hey completion":
 		return output.ErrJQNotSupported("the completion command")
 	case "hey skill":
 		return output.ErrJQNotSupported("the skill display command")
-	case "hey tui":
+	case "hey tui", "hey hey":
 		return output.ErrJQNotSupported("the interactive app")
 	default:
 		return nil

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -11,10 +11,18 @@ type tuiCommand struct {
 }
 
 func newTuiCommand() *tuiCommand {
-	c := &tuiCommand{}
-	c.cmd = &cobra.Command{
-		Use:   "tui",
-		Short: "Launch the interactive terminal UI",
+	return &tuiCommand{cmd: newTuiRunner("tui", false)}
+}
+
+func newHeyCommand() *tuiCommand {
+	return &tuiCommand{cmd: newTuiRunner("hey", true)}
+}
+
+func newTuiRunner(use string, hidden bool) *cobra.Command {
+	return &cobra.Command{
+		Use:    use,
+		Short:  "Launch the interactive terminal UI",
+		Hidden: hidden,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := requireAuth(); err != nil {
 				return err
@@ -22,5 +30,4 @@ func newTuiCommand() *tuiCommand {
 			return tui.Run(rootSDK, sdk, cfg.AccountID)
 		},
 	}
-	return c
 }

--- a/internal/cmd/tui_test.go
+++ b/internal/cmd/tui_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "testing"
+
+func TestHeyAliasIsHiddenTuiCommand(t *testing.T) {
+	root := newRootCmd()
+
+	alias, _, err := root.Find([]string{"hey"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if alias.Name() != "hey" {
+		t.Fatalf("expected the hey alias, got %q", alias.CommandPath())
+	}
+	if !alias.Hidden {
+		t.Error("expected the hey alias to be hidden")
+	}
+
+	tui, _, err := root.Find([]string{"tui"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tui.Hidden {
+		t.Error("expected tui to be listed")
+	}
+	if alias.Short != tui.Short {
+		t.Errorf("alias describes itself as %q, tui as %q", alias.Short, tui.Short)
+	}
+}

--- a/internal/cmd/writeok_test.go
+++ b/internal/cmd/writeok_test.go
@@ -9,10 +9,7 @@ import (
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
-// TestBareHeyShowsHelpWithoutTTY verifies that bare `hey` falls back to help
-// when either stdin or stdout is not a terminal (e.g. `hey | head`, cron,
-// CI pipelines). In test context neither fd is a TTY, covering both gates.
-func TestBareHeyShowsHelpWithoutTTY(t *testing.T) {
+func TestBareHeyShowsHelp(t *testing.T) {
 	root := newRootCmd()
 	var buf bytes.Buffer
 	root.SetOut(&buf)
@@ -28,6 +25,9 @@ func TestBareHeyShowsHelpWithoutTTY(t *testing.T) {
 	}
 	if !strings.Contains(out, "hey <command>") {
 		t.Errorf("expected help to mention 'hey <command>', got:\n%s", out)
+	}
+	if !strings.Contains(out, "hey tui") {
+		t.Errorf("expected help to point at 'hey tui', got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
Bare `hey` used to sniff stdin and stdout and launch the interactive app when both were terminals, help otherwise. That made the most common command in the CLI do two unrelated things depending on where it ran.

Now bare `hey` always prints the help. `hey tui` launches the interactive app, and `hey hey` does the same as a hidden command — a real hidden registration rather than a cobra alias, so it stays out of `hey tui --help` and out of `hey commands`.

Also here:

- Root help gains an INTERACTIVE section listing `tui`, and the usage line points at `hey tui`.
- `--jq` no longer errors on bare `hey` (it prints help, there is nothing to filter); it still errors on `hey tui` and `hey hey`.
- README's TUI section says `hey tui`.
- `writeok_test.go`'s bare-hey test lost its now-stale "without TTY" premise; `tui_test.go` covers the hidden alias.

`hey hey` is deliberately undocumented.