### PR TITLE
Add The Screener to the TUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,11 @@ attributes are relative paths requiring authentication via `sdk.Get`.
 
 The TUI uses the `sectionView` interface pattern. Each top-level section (Mail, Calendar, Journal) implements `sectionView` and owns its data, fetch commands, key handling, rendering, and help bindings. The main model delegates to the active view.
 
-Three files implement `sectionView` -- `mail.go`, `calendar.go` and `journal.go`, one per
-section. The rest of `internal/tui/` is shared infrastructure: `tui.go` (model and
+Four files implement `sectionView` -- `mail.go`, `contacts.go`, `calendar.go` and
+`journal.go`, one per section. `screener.go` implements it too, but The Screener is not a
+section: ctrl+s from the mail list swaps it in as the active view, it captures every key
+while it is open, and it asks to be closed again with `screenerClosedMsg`.
+The rest of `internal/tui/` is shared infrastructure: `tui.go` (model and
 router), `section_view.go` (the interface), plus `nav.go`, `content.go`, `help.go`,
 `styles.go`, `loading.go`, `kitty.go`, `html.go` and `calendar_views.go`. Read the directory rather than a
 table here.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ Calendar and Journal remain identity-wide.
 
 Navigate between Mail, Contacts, Calendar, and Journal. Mail navigation includes HEY boxes followed by your labels. Use `n` and `p` to page through a label. Use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `g` to add, create, or remove labels, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press `b` to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with `u` while HEY's undo window remains open. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
 
+Press Ctrl+S from the mail list to open The Screener. When senders are waiting, the mail
+list says so above the threads. In The Screener, `y` screens the selected sender in and `n`
+screens them out, Tab moves to Screener History and back, `[` and `]` page through either
+list, `X` clears the whole Screener after a confirmation, and Escape or `q` returns to mail.
+
 Thread attachments always appear with their filename, media type, and size. Use `[` and `]` to select an attachment, `s` to save it without replacing an existing file, and `o` to download and open it in an external application. Attachments never open automatically. Kitty and Ghostty can show inline images. Foot and other terminals use visible text markers.
 
 Press Shift+O to open Contacts. Use Enter to view a contact, `a` to add, `e` to edit, `n` to edit the private note, `x` twice to delete a note, `h` to hide, and `u` to show the most recently hidden contact again. Escape or `q` goes back.

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -39,9 +39,10 @@ const (
 type boxesLoadedMsg []models.Box
 
 type mailSourcesLoadedMsg struct {
-	requestID uint64
-	sources   []models.Box
-	folderErr error
+	requestID     uint64
+	sources       []models.Box
+	screenerCount int
+	folderErr     error
 }
 
 type postingsLoadedMsg struct {
@@ -108,6 +109,11 @@ type postingActionDoneMsg struct {
 	err        error
 }
 
+type screenerCountLoadedMsg struct {
+	count int
+	err   error
+}
+
 type folderActionDoneMsg struct {
 	action     string
 	sourceID   int64
@@ -149,6 +155,7 @@ type mailView struct {
 	searchActive       bool
 	searchQuery        string
 	searchPage         int
+	screenerCount      int    // senders waiting in The Screener
 	lastBulkReplyID    int64  // delayed delivery currently available for undo
 	pendingMutations   int    // writes that must finish before changing the account context
 	notice             string // one-shot confirmation shown above the posting list
@@ -183,6 +190,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		if msg.requestID != v.sourceRequestID {
 			return nil, true
 		}
+		v.screenerCount = msg.screenerCount
 		sources := msg.sources
 		if msg.folderErr != nil {
 			v.folderDiscoveryErr = msg.folderErr.Error()
@@ -202,6 +210,12 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 
 	case boxesLoadedMsg:
 		return v.applySources([]models.Box(msg)), true
+
+	case screenerCountLoadedMsg:
+		if msg.err == nil {
+			v.screenerCount = msg.count
+		}
+		return nil, true
 
 	case postingsLoadedMsg:
 		if !v.acceptsPostingsLoaded(msg) {
@@ -513,10 +527,37 @@ func (v *mailView) View() string {
 		}
 		return v.searchList.view()
 	}
+	return v.listHeader() + v.postingList.view()
+}
+
+// listHeader carries the one-shot notice and the Screener's standing invitation above
+// the posting list.
+func (v *mailView) listHeader() string {
+	var lines []string
 	if v.notice != "" {
-		return v.vc.styles.title.Render(v.notice) + "\n" + v.postingList.view()
+		lines = append(lines, v.vc.styles.title.Render(v.notice))
 	}
-	return v.postingList.view()
+	if hint := v.screenerHint(); hint != "" {
+		lines = append(lines, centerText(v.vc.styles.pill.Render(hint), v.vc.width), "")
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func (v *mailView) screenerHint() string {
+	if v.screenerCount <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("Screen %d %s · ctrl+s", v.screenerCount, firstTimeSenderNoun(v.screenerCount))
+}
+
+func firstTimeSenderNoun(count int) string {
+	if count == 1 {
+		return "first-time sender"
+	}
+	return "first-time senders"
 }
 
 // CapturingInput reports whether a form or picker is open and wants every key.
@@ -569,6 +610,7 @@ func (v *mailView) HelpBindings() []helpBinding {
 	}
 	bindings := []helpBinding{
 		{"/", "search"},
+		{"ctrl+s", "screener"},
 		{"c", "compose"},
 		{"space", "select"},
 		{"b", "bulk reply"},
@@ -1497,7 +1539,15 @@ func (v *mailView) fetchSources(requestID uint64) tea.Cmd {
 				boxes = append(boxes, models.Box{ID: label.ID, Kind: mailSourceKindFolder, Name: label.Name, AppURL: label.AppURL})
 			}
 		}
-		return mailSourcesLoadedMsg{requestID: requestID, sources: boxes, folderErr: folderErr}
+		screenerCount, _ := v.vc.sdk.Clearances().PendingCount(v.vc.ctx)
+		return mailSourcesLoadedMsg{requestID: requestID, sources: boxes, screenerCount: screenerCount, folderErr: folderErr}
+	}
+}
+
+func (v *mailView) refreshScreenerCount() tea.Cmd {
+	return func() tea.Msg {
+		count, err := v.vc.sdk.Clearances().PendingCount(v.vc.ctx)
+		return screenerCountLoadedMsg{count: count, err: err}
 	}
 }
 

--- a/internal/tui/nav.go
+++ b/internal/tui/nav.go
@@ -224,9 +224,7 @@ func renderNavRow(items []navItem, selected int, focused bool, width int, center
 		}
 		row := strings.Join(parts, sep)
 		if centered {
-			rowWidth := lipgloss.Width(row)
-			pad := max((width-rowWidth)/2, 0)
-			return strings.Repeat(" ", pad) + row
+			return centerText(row, width)
 		}
 		return row
 	}
@@ -301,11 +299,15 @@ func renderNavRow(items []navItem, selected int, focused bool, width int, center
 
 	row := b.String()
 	if centered {
-		rowWidth := lipgloss.Width(row)
-		pad := max((width-rowWidth)/2, 0)
-		return strings.Repeat(" ", pad) + row
+		return centerText(row, width)
 	}
 	return row
+}
+
+// centerText pads text so it sits in the middle of width.
+func centerText(text string, width int) string {
+	pad := max((width-lipgloss.Width(text))/2, 0)
+	return strings.Repeat(" ", pad) + text
 }
 
 // renderHeader renders the full 3-row navigation header.

--- a/internal/tui/screener.go
+++ b/internal/tui/screener.go
@@ -1,0 +1,597 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+)
+
+// --- Screener messages ---
+
+type screenerPendingLoadedMsg struct {
+	requestID uint64
+	page      int
+	rows      []screenerRow
+	count     int
+	err       error
+}
+
+type screenerScreenedLoadedMsg struct {
+	requestID uint64
+	page      int
+	rows      []screenerRow
+	err       error
+}
+
+type screenerDecisionDoneMsg struct {
+	clearanceID int64
+	name        string
+	status      string
+	err         error
+}
+
+type screenerClearedMsg struct{ err error }
+
+// screenerClosedMsg asks the app to put the mail view back on screen.
+type screenerClosedMsg struct{}
+
+// --- Screener panes ---
+
+type screenerTab int
+
+const (
+	screenerPendingTab screenerTab = iota
+	screenerHistoryTab
+)
+
+var screenerTabItems = []navItem{
+	{label: "The Screener"},
+	{label: "Screener History"},
+}
+
+// screenerRow is one sender in either pane: someone waiting to be screened, or
+// someone already screened in or out.
+type screenerRow struct {
+	id       int64
+	name     string
+	email    string
+	detail   string // what they sent, or the address they write from
+	trailing string // their address, or the decision and when it was made
+}
+
+type screenerPane struct {
+	rows   []screenerRow
+	cursor int
+	scroll int
+	page   int
+	loaded bool
+}
+
+func (p *screenerPane) setRows(rows []screenerRow, page int) {
+	p.rows = rows
+	p.cursor = 0
+	p.scroll = 0
+	p.page = page
+	p.loaded = true
+}
+
+func (p *screenerPane) selected() *screenerRow {
+	if p.cursor < 0 || p.cursor >= len(p.rows) {
+		return nil
+	}
+	return &p.rows[p.cursor]
+}
+
+func (p *screenerPane) remove(id int64) {
+	for index, row := range p.rows {
+		if row.id != id {
+			continue
+		}
+		p.rows = append(p.rows[:index], p.rows[index+1:]...)
+		if p.cursor >= len(p.rows) && p.cursor > 0 {
+			p.cursor--
+		}
+		return
+	}
+}
+
+func (p *screenerPane) moveUp(visible int) {
+	if p.cursor > 0 {
+		p.cursor--
+		p.ensureVisible(visible)
+	}
+}
+
+func (p *screenerPane) moveDown(visible int) {
+	if p.cursor < len(p.rows)-1 {
+		p.cursor++
+		p.ensureVisible(visible)
+	}
+}
+
+func (p *screenerPane) ensureVisible(visible int) {
+	if p.cursor < p.scroll {
+		p.scroll = p.cursor
+	}
+	if p.cursor >= p.scroll+visible {
+		p.scroll = p.cursor - visible + 1
+	}
+}
+
+// --- Screener view ---
+
+// screenerView is the full-screen Screener, opened with ctrl+s from the mail list.
+// It captures every key while it is open, so it is a place you are in rather than a
+// picker layered over the mail list.
+type screenerView struct {
+	vc *viewContext
+
+	tab     screenerTab
+	pending screenerPane
+	history screenerPane
+
+	pendingCount    int
+	confirmingClear bool
+	notice          string
+	loading         bool
+	requestID       uint64
+	mutations       int
+}
+
+func newScreenerView(vc *viewContext) *screenerView {
+	return &screenerView{vc: vc}
+}
+
+func (v *screenerView) Init() tea.Cmd {
+	v.notice = ""
+	v.confirmingClear = false
+	v.tab = screenerPendingTab
+	return v.requestPending(1)
+}
+
+func (v *screenerView) Update(msg tea.Msg) (tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case screenerPendingLoadedMsg:
+		if msg.requestID != v.requestID {
+			return nil, true
+		}
+		v.loading = false
+		if msg.err != nil {
+			v.notice = "Could not load The Screener: " + msg.err.Error()
+			return nil, true
+		}
+		if len(msg.rows) == 0 && msg.page > v.pending.page {
+			v.notice = "No more senders waiting"
+			return nil, true
+		}
+		v.pendingCount = msg.count
+		v.pending.setRows(msg.rows, msg.page)
+		return nil, true
+
+	case screenerScreenedLoadedMsg:
+		if msg.requestID != v.requestID {
+			return nil, true
+		}
+		v.loading = false
+		if msg.err != nil {
+			v.notice = "Could not load Screener History: " + msg.err.Error()
+			return nil, true
+		}
+		if len(msg.rows) == 0 && msg.page > v.history.page {
+			v.notice = "No more decisions"
+			return nil, true
+		}
+		v.history.setRows(msg.rows, msg.page)
+		return nil, true
+
+	case screenerDecisionDoneMsg:
+		if v.mutations > 0 {
+			v.mutations--
+		}
+		if msg.err != nil {
+			v.notice = "Could not screen " + msg.name + ": " + msg.err.Error()
+			return nil, true
+		}
+		v.pending.remove(msg.clearanceID)
+		v.pendingCount = max(v.pendingCount-1, 0)
+		v.history.loaded = false
+		v.notice = msg.name + " " + screenedVerb(msg.status)
+		return nil, true
+
+	case screenerClearedMsg:
+		if v.mutations > 0 {
+			v.mutations--
+		}
+		if msg.err != nil {
+			v.notice = "Could not clear The Screener: " + msg.err.Error()
+			return nil, true
+		}
+		v.pending.setRows(nil, 1)
+		v.pendingCount = 0
+		v.notice = "The Screener is clearing. Everyone waiting will be asked about again on their next email."
+		return nil, true
+	}
+	return nil, false
+}
+
+func (v *screenerView) View() string {
+	if v.confirmingClear {
+		return v.clearConfirmationView()
+	}
+
+	var b strings.Builder
+	if v.notice != "" {
+		b.WriteString(v.vc.styles.title.Render(truncateStr(v.notice, max(v.vc.width, 1))) + "\n")
+	}
+	b.WriteString(v.explanation() + "\n")
+
+	pane := v.pane()
+	if len(pane.rows) == 0 {
+		b.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Render("  " + v.emptyMessage()))
+		return b.String()
+	}
+	b.WriteString(renderScreenerRows(pane, v.visibleRows(), v.vc.width))
+	if pane.page > 1 {
+		b.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Render(fmt.Sprintf("  Page %d", pane.page)))
+	}
+	return b.String()
+}
+
+// CapturingInput keeps every key inside the Screener while it is open.
+func (v *screenerView) CapturingInput() bool { return true }
+
+func (v *screenerView) AccountSwitchBlocked() bool { return v.mutations > 0 }
+
+func (v *screenerView) HelpBindings() []helpBinding {
+	if v.confirmingClear {
+		return []helpBinding{
+			{"y", "clear all unscreened email"},
+			{"n/esc", "cancel"},
+		}
+	}
+	bindings := []helpBinding{{"↑↓", "navigate"}}
+	if v.tab == screenerPendingTab {
+		bindings = append(bindings,
+			helpBinding{"y", "screen in"},
+			helpBinding{"n", "screen out"},
+			helpBinding{"tab", "screener history"},
+		)
+	} else {
+		bindings = append(bindings, helpBinding{"tab", "the screener"})
+	}
+	bindings = append(bindings, helpBinding{"X", "clear all"})
+	pane := v.pane()
+	if len(pane.rows) > 0 {
+		bindings = append(bindings, helpBinding{"]", "next page"})
+	}
+	if pane.page > 1 {
+		bindings = append(bindings, helpBinding{"[", "previous page"})
+	}
+	return append(bindings, helpBinding{"esc/q", "back to mail"})
+}
+
+func (v *screenerView) SubnavItems() ([]navItem, int, string, bool) {
+	label := "The Screener"
+	if v.tab == screenerHistoryTab {
+		label = "Screener History"
+	} else if v.pendingCount > 0 {
+		label = fmt.Sprintf("The Screener (%d)", v.pendingCount)
+	}
+	return screenerTabItems, int(v.tab), label, true
+}
+
+func (v *screenerView) SubnavLeft() tea.Cmd  { return v.switchTab(screenerPendingTab) }
+func (v *screenerView) SubnavRight() tea.Cmd { return v.switchTab(screenerHistoryTab) }
+
+func (v *screenerView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
+	if v.confirmingClear {
+		return v.handleClearConfirmationKey(msg)
+	}
+
+	key := msg.String()
+	switch msg.Key().Code {
+	case tea.KeyEscape:
+		return v.close()
+	case tea.KeyTab:
+		return v.switchTab(v.otherTab())
+	case tea.KeyUp:
+		v.pane().moveUp(v.visibleRows())
+		return nil
+	case tea.KeyDown:
+		v.pane().moveDown(v.visibleRows())
+		return nil
+	}
+
+	switch key {
+	case "q":
+		return v.close()
+	case "k":
+		v.pane().moveUp(v.visibleRows())
+	case "j":
+		v.pane().moveDown(v.visibleRows())
+	case "y", "i":
+		return v.screen(hey.ClearanceApproved)
+	case "n":
+		return v.screen(hey.ClearanceDenied)
+	case "X":
+		v.confirmingClear = true
+		v.notice = ""
+	case "]":
+		return v.requestPage(v.pane().page + 1)
+	case "[":
+		if v.pane().page > 1 {
+			return v.requestPage(v.pane().page - 1)
+		}
+	}
+	return nil
+}
+
+// InThread reports the Screener as a detail view so the app treats it as a place
+// you are inside of rather than a list row.
+func (v *screenerView) InThread() bool { return true }
+
+func (v *screenerView) ExitThread() {}
+
+func (v *screenerView) Loading() bool { return v.loading }
+
+func (v *screenerView) Resize(int, int) {}
+
+func (v *screenerView) pane() *screenerPane {
+	if v.tab == screenerHistoryTab {
+		return &v.history
+	}
+	return &v.pending
+}
+
+func (v *screenerView) otherTab() screenerTab {
+	if v.tab == screenerHistoryTab {
+		return screenerPendingTab
+	}
+	return screenerHistoryTab
+}
+
+func (v *screenerView) switchTab(tab screenerTab) tea.Cmd {
+	if tab == v.tab {
+		return nil
+	}
+	v.tab = tab
+	v.notice = ""
+	if v.pane().loaded {
+		return nil
+	}
+	return v.requestPage(1)
+}
+
+func (v *screenerView) requestPage(page int) tea.Cmd {
+	if v.tab == screenerHistoryTab {
+		return v.requestScreened(page)
+	}
+	return v.requestPending(page)
+}
+
+func (v *screenerView) requestPending(page int) tea.Cmd {
+	v.requestID++
+	v.loading = true
+	return v.fetchPending(v.requestID, max(page, 1))
+}
+
+func (v *screenerView) requestScreened(page int) tea.Cmd {
+	v.requestID++
+	v.loading = true
+	return v.fetchScreened(v.requestID, max(page, 1))
+}
+
+func (v *screenerView) screen(status string) tea.Cmd {
+	if v.tab != screenerPendingTab {
+		return nil
+	}
+	row := v.pane().selected()
+	if row == nil {
+		return nil
+	}
+	clearanceID, name := row.id, screenerRowName(*row)
+	v.mutations++
+	v.notice = ""
+	return func() tea.Msg {
+		_, err := v.vc.sdk.Clearances().Screen(v.vc.ctx, clearanceID, status, hey.ScreenOptions{})
+		return screenerDecisionDoneMsg{clearanceID: clearanceID, name: name, status: status, err: err}
+	}
+}
+
+func (v *screenerView) handleClearConfirmationKey(msg tea.KeyPressMsg) tea.Cmd {
+	if msg.Key().Code == tea.KeyEnter || msg.String() == "y" {
+		v.confirmingClear = false
+		v.mutations++
+		return func() tea.Msg {
+			return screenerClearedMsg{err: v.vc.sdk.Clearances().Punt(v.vc.ctx)}
+		}
+	}
+	if msg.Key().Code == tea.KeyEscape || msg.String() == "n" || msg.String() == "q" {
+		v.confirmingClear = false
+	}
+	return nil
+}
+
+func (v *screenerView) close() tea.Cmd {
+	if v.mutations > 0 {
+		return nil
+	}
+	return func() tea.Msg { return screenerClosedMsg{} }
+}
+
+func (v *screenerView) explanation() string {
+	width := max(v.vc.width-2, 20)
+	muted := lipgloss.NewStyle().Foreground(colorMuted)
+	if v.tab == screenerHistoryTab {
+		return muted.Render("  All the contacts you've screened in or out.") + "\n"
+	}
+	lines := wrapText("The people below are trying to email you for the first time. You get to decide if you want to hear from them.", width)
+	var b strings.Builder
+	for _, line := range lines {
+		b.WriteString(muted.Render("  "+line) + "\n")
+	}
+	b.WriteString(v.vc.styles.title.Render("  Want to get emails from them?") + "\n")
+	return b.String()
+}
+
+func (v *screenerView) emptyMessage() string {
+	if v.tab == screenerHistoryTab {
+		return "Nobody has been screened yet"
+	}
+	return "Nobody is waiting to be screened"
+}
+
+func (v *screenerView) visibleRows() int {
+	headerLines := strings.Count(v.explanation(), "\n") + 1
+	if v.notice != "" {
+		headerLines++
+	}
+	return max((v.vc.height-headerLines)/2, 1)
+}
+
+func (v *screenerView) clearConfirmationView() string {
+	width := max(v.vc.width-4, 20)
+	muted := lipgloss.NewStyle().Foreground(colorMuted)
+
+	var b strings.Builder
+	b.WriteString(v.vc.styles.title.Render("Not sure what to do with these?") + "\n\n")
+	for _, line := range wrapText("If you don't want to decide on these senders, you can clear them all.", width) {
+		b.WriteString(line + "\n")
+	}
+	b.WriteString("\n")
+	for _, line := range wrapText("All emails currently in the Screener will go to the trash. You'll be asked to screen each sender again if they email you in the future.", width) {
+		b.WriteString(muted.Render(line) + "\n")
+	}
+	return b.String()
+}
+
+// --- Fetch commands ---
+
+func (v *screenerView) fetchPending(requestID uint64, page int) tea.Cmd {
+	return func() tea.Msg {
+		summary, err := v.vc.sdk.Clearances().Pending(v.vc.ctx, strconv.Itoa(page))
+		if err != nil {
+			return screenerPendingLoadedMsg{requestID: requestID, page: page, err: err}
+		}
+		message := screenerPendingLoadedMsg{requestID: requestID, page: page}
+		if summary != nil {
+			message.count = int(summary.PendingClearancesCount)
+			for _, clearance := range summary.Clearances {
+				message.rows = append(message.rows, pendingScreenerRow(clearance))
+			}
+		}
+		return message
+	}
+}
+
+func (v *screenerView) fetchScreened(requestID uint64, page int) tea.Cmd {
+	return func() tea.Msg {
+		clearances, err := v.vc.sdk.Clearances().Screened(v.vc.ctx, strconv.Itoa(page))
+		if err != nil {
+			return screenerScreenedLoadedMsg{requestID: requestID, page: page, err: err}
+		}
+		message := screenerScreenedLoadedMsg{requestID: requestID, page: page}
+		for _, clearance := range clearances {
+			message.rows = append(message.rows, screenedScreenerRow(clearance))
+		}
+		return message
+	}
+}
+
+// --- Rendering ---
+
+func pendingScreenerRow(clearance generated.Clearance) screenerRow {
+	detail := clearance.MostRecentEntry.Subject
+	if summary := clearance.MostRecentEntry.Summary; summary != "" {
+		if detail == "" {
+			detail = summary
+		} else {
+			detail += " – " + summary
+		}
+	}
+	return screenerRow{
+		id:       clearance.Id,
+		name:     clearance.Petitioner.Name,
+		email:    clearance.Petitioner.EmailAddress,
+		detail:   detail,
+		trailing: clearance.Petitioner.EmailAddress,
+	}
+}
+
+func screenedScreenerRow(clearance generated.Clearance) screenerRow {
+	trailing := screenedVerb(clearance.Status)
+	if decided := formatDisplayDate(formatTimestamp(clearance.UpdatedAt)); decided != "" {
+		trailing += " · " + decided
+	}
+	return screenerRow{
+		id:       clearance.Id,
+		name:     clearance.Petitioner.Name,
+		email:    clearance.Petitioner.EmailAddress,
+		detail:   clearance.Petitioner.EmailAddress,
+		trailing: trailing,
+	}
+}
+
+func screenedVerb(status string) string {
+	if status == hey.ClearanceDenied {
+		return "screened out"
+	}
+	return "screened in"
+}
+
+func screenerRowName(row screenerRow) string {
+	if row.name != "" {
+		return row.name
+	}
+	if row.email != "" {
+		return row.email
+	}
+	return fmt.Sprintf("clearance %d", row.id)
+}
+
+func renderScreenerRows(pane *screenerPane, visible, width int) string {
+	selected := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
+	normal := lipgloss.NewStyle().Foreground(colorBright)
+	muted := lipgloss.NewStyle().Foreground(colorMuted)
+
+	var b strings.Builder
+	end := min(pane.scroll+visible, len(pane.rows))
+	for index := pane.scroll; index < end; index++ {
+		row := pane.rows[index]
+		isCursor := index == pane.cursor
+
+		prefix := "  "
+		if isCursor {
+			prefix = selected.Render("│") + " "
+		}
+
+		trailing := truncateStr(row.trailing, max(width/2, 10))
+		name := truncateStr(screenerRowName(row), max(width-lipgloss.Width(trailing)-6, 10))
+		gap := max(width-4-lipgloss.Width(name)-lipgloss.Width(trailing), 1)
+
+		b.WriteString(prefix)
+		if isCursor {
+			b.WriteString(selected.Render(name))
+		} else {
+			b.WriteString(normal.Render(name))
+		}
+		b.WriteString(strings.Repeat(" ", gap))
+		if trailing != "" {
+			b.WriteString(muted.Render(trailing))
+		}
+		b.WriteString("\n")
+
+		detailPrefix := "    "
+		if isCursor {
+			detailPrefix = selected.Render("│") + "   "
+		}
+		b.WriteString(detailPrefix + muted.Render(truncateStr(row.detail, max(width-6, 10))) + "\n")
+	}
+	return b.String()
+}

--- a/internal/tui/screener_test.go
+++ b/internal/tui/screener_test.go
@@ -1,0 +1,478 @@
+package tui
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+)
+
+// --- Test helpers ---
+
+type screenerRequest struct {
+	method string
+	path   string
+	query  string
+	body   string
+}
+
+type screenerServerState struct {
+	mu         sync.Mutex
+	requests   []screenerRequest
+	pending    string
+	screened   string
+	failScreen bool
+}
+
+func (s *screenerServerState) snapshot() []screenerRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]screenerRequest(nil), s.requests...)
+}
+
+func screenerTestView(t *testing.T) (*screenerView, *screenerServerState) {
+	t.Helper()
+	state := &screenerServerState{
+		pending: `{"pending_clearances_count":2,"clearances":[
+			{"id":91,"status":"pending","petitioner":{"id":11,"name":"Jane Doe","email_address":"jane@example.com"},
+			 "most_recent_entry":{"id":501,"subject":"Quarterly planning","summary":"Can we meet Thursday?","topic_id":700}},
+			{"id":92,"status":"pending","petitioner":{"id":12,"name":"Bob Smith","email_address":"bob@example.org"},
+			 "most_recent_entry":{"id":502,"subject":"Invoice 4102","summary":"Attached for your records","topic_id":701}}
+		]}`,
+		screened: `{"clearances":[
+			{"id":80,"status":"approved","petitioner":{"id":13,"name":"Alice Jones","email_address":"alice@example.com"},"updated_at":"2026-08-18T10:00:00Z"},
+			{"id":81,"status":"denied","petitioner":{"id":14,"name":"Carl Reed","email_address":"carl@example.org"},"updated_at":"2026-08-17T09:00:00Z"}
+		]}`,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := new(bytes.Buffer)
+		_, _ = body.ReadFrom(r.Body)
+		state.mu.Lock()
+		state.requests = append(state.requests, screenerRequest{method: r.Method, path: r.URL.Path, query: r.URL.RawQuery, body: body.String()})
+		pending, screened, failScreen := state.pending, state.screened, state.failScreen
+		state.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/clearances.json":
+			_, _ = w.Write([]byte(pending))
+		case r.Method == http.MethodGet && r.URL.Path == "/my/clearances.json":
+			_, _ = w.Write([]byte(screened))
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/clearances/"):
+			if failScreen {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"error":"Not allowed"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"id":91,"status":"approved","petitioner":{"id":11,"name":"Jane Doe","email_address":"jane@example.com"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/clearances/punt.json":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	vc := testVC()
+	vc.ctx = context.Background()
+	vc.sdk = hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "t"}, hey.WithMaxRetries(0))
+	return newScreenerView(vc), state
+}
+
+// loadedScreener returns a view showing the two senders waiting to be screened.
+func loadedScreener(t *testing.T) (*screenerView, *screenerServerState) {
+	t.Helper()
+	view, state := screenerTestView(t)
+	loaded, ok := runCmd(view.Init()).(screenerPendingLoadedMsg)
+	if !ok {
+		t.Fatalf("Init returned %T, want screenerPendingLoadedMsg", loaded)
+	}
+	view.Update(loaded)
+	return view, state
+}
+
+// --- Loading ---
+
+func TestScreenerLoadsPendingSenders(t *testing.T) {
+	view, _ := loadedScreener(t)
+
+	if view.pendingCount != 2 || len(view.pending.rows) != 2 {
+		t.Fatalf("pending = count:%d rows:%d, want 2 and 2", view.pendingCount, len(view.pending.rows))
+	}
+	first := view.pending.rows[0]
+	if first.id != 91 || first.name != "Jane Doe" || first.detail != "Quarterly planning – Can we meet Thursday?" {
+		t.Errorf("first sender = %+v", first)
+	}
+	if view.loading {
+		t.Error("loading should be false once the senders arrive")
+	}
+}
+
+func TestScreenerViewCarriesHeyWording(t *testing.T) {
+	view, _ := loadedScreener(t)
+	rendered := plainText(view.View())
+
+	for _, want := range []string{
+		"The people below are trying to email you for the first time.",
+		"You get to decide if you want to hear from them.",
+		"Want to get emails from them?",
+		"Jane Doe",
+		"Quarterly planning",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("screener view is missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestScreenerEmptyQueue(t *testing.T) {
+	view, state := screenerTestView(t)
+	state.pending = `{"pending_clearances_count":0,"clearances":[]}`
+	view.Update(runCmd(view.Init()))
+
+	if rendered := view.View(); !strings.Contains(rendered, "Nobody is waiting to be screened") {
+		t.Errorf("empty screener rendered:\n%s", rendered)
+	}
+}
+
+// --- Screening in and out ---
+
+func TestScreenerScreensSenderIn(t *testing.T) {
+	view, state := loadedScreener(t)
+
+	done, ok := runCmd(view.HandleContentKey(keyPress("y"))).(screenerDecisionDoneMsg)
+	if !ok {
+		t.Fatalf("y returned %T, want screenerDecisionDoneMsg", done)
+	}
+	if done.err != nil {
+		t.Fatalf("screening in failed: %v", done.err)
+	}
+	view.Update(done)
+
+	if len(view.pending.rows) != 1 || view.pending.rows[0].id != 92 {
+		t.Errorf("screened sender should leave the queue: %+v", view.pending.rows)
+	}
+	if view.pendingCount != 1 {
+		t.Errorf("pendingCount = %d, want 1", view.pendingCount)
+	}
+	if view.notice != "Jane Doe screened in" {
+		t.Errorf("notice = %q", view.notice)
+	}
+
+	requests := state.snapshot()
+	last := requests[len(requests)-1]
+	if last.method != http.MethodPatch || last.path != "/clearances/91.json" || !strings.Contains(last.body, `"status":"approved"`) {
+		t.Errorf("screen in request = %+v", last)
+	}
+}
+
+func TestScreenerScreensSenderOut(t *testing.T) {
+	view, state := loadedScreener(t)
+	view.HandleContentKey(keyPress("down"))
+
+	done := runCmd(view.HandleContentKey(keyPress("n"))).(screenerDecisionDoneMsg)
+	if done.status != hey.ClearanceDenied || done.name != "Bob Smith" {
+		t.Fatalf("decision = %+v", done)
+	}
+	view.Update(done)
+	if view.notice != "Bob Smith screened out" {
+		t.Errorf("notice = %q", view.notice)
+	}
+
+	requests := state.snapshot()
+	last := requests[len(requests)-1]
+	if last.path != "/clearances/92.json" || !strings.Contains(last.body, `"status":"denied"`) {
+		t.Errorf("screen out request = %+v", last)
+	}
+}
+
+func TestScreenerReportsFailedDecision(t *testing.T) {
+	view, state := loadedScreener(t)
+	state.failScreen = true
+
+	done := runCmd(view.HandleContentKey(keyPress("y"))).(screenerDecisionDoneMsg)
+	if done.err == nil {
+		t.Fatal("a refused decision should carry the error")
+	}
+	view.Update(done)
+
+	if len(view.pending.rows) != 2 {
+		t.Error("a refused decision should leave the queue alone")
+	}
+	if !strings.HasPrefix(view.notice, "Could not screen Jane Doe:") {
+		t.Errorf("notice = %q", view.notice)
+	}
+}
+
+// --- Screener history ---
+
+func TestScreenerTabsOverToPreviousDecisions(t *testing.T) {
+	view, state := loadedScreener(t)
+
+	loaded, ok := runCmd(view.HandleContentKey(keyPress("tab"))).(screenerScreenedLoadedMsg)
+	if !ok {
+		t.Fatalf("tab returned %T, want screenerScreenedLoadedMsg", loaded)
+	}
+	view.Update(loaded)
+
+	if view.tab != screenerHistoryTab {
+		t.Fatal("tab should move to the history pane")
+	}
+	if len(view.history.rows) != 2 {
+		t.Fatalf("history rows = %+v", view.history.rows)
+	}
+	if view.history.rows[0].trailing != "screened in · Aug 18, 2026" || view.history.rows[1].trailing != "screened out · Aug 17, 2026" {
+		t.Errorf("history decisions = %q, %q", view.history.rows[0].trailing, view.history.rows[1].trailing)
+	}
+
+	rendered := plainText(view.View())
+	for _, want := range []string{"All the contacts you've screened in or out.", "Alice Jones", "Aug 18, 2026"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("history view is missing %q:\n%s", want, rendered)
+		}
+	}
+
+	if cmd := view.HandleContentKey(keyPress("tab")); cmd != nil {
+		t.Error("tabbing back to a loaded pane should not refetch")
+	}
+	if view.tab != screenerPendingTab {
+		t.Error("tab should move back to the pending pane")
+	}
+
+	requests := state.snapshot()
+	if requests[len(requests)-1].path != "/my/clearances.json" {
+		t.Errorf("history request = %+v", requests)
+	}
+}
+
+func TestScreenerHistoryDoesNotScreen(t *testing.T) {
+	view, _ := loadedScreener(t)
+	view.Update(runCmd(view.HandleContentKey(keyPress("tab"))))
+
+	if cmd := view.HandleContentKey(keyPress("y")); cmd != nil {
+		t.Error("the history pane should not decide anything")
+	}
+}
+
+// --- Clearing ---
+
+func TestScreenerClearsTheQueueAfterConfirmation(t *testing.T) {
+	view, state := loadedScreener(t)
+
+	view.HandleContentKey(keyPress("X"))
+	if !view.confirmingClear {
+		t.Fatal("X should ask before clearing")
+	}
+	confirmation := plainText(view.View())
+	for _, want := range []string{
+		"Not sure what to do with these?",
+		"you can clear them all",
+		"All emails currently in the Screener will go to the trash.",
+		"You'll be asked to screen each sender again if they email you in the future.",
+	} {
+		if !strings.Contains(confirmation, want) {
+			t.Errorf("confirmation is missing %q:\n%s", want, confirmation)
+		}
+	}
+
+	cleared, ok := runCmd(view.HandleContentKey(keyPress("y"))).(screenerClearedMsg)
+	if !ok || cleared.err != nil {
+		t.Fatalf("clearing returned %#v", cleared)
+	}
+	view.Update(cleared)
+
+	if len(view.pending.rows) != 0 || view.pendingCount != 0 {
+		t.Errorf("clearing should empty the queue: rows:%d count:%d", len(view.pending.rows), view.pendingCount)
+	}
+	if !strings.HasPrefix(view.notice, "The Screener is clearing.") {
+		t.Errorf("notice = %q", view.notice)
+	}
+
+	requests := state.snapshot()
+	last := requests[len(requests)-1]
+	if last.method != http.MethodPost || last.path != "/clearances/punt.json" {
+		t.Errorf("punt request = %+v", last)
+	}
+}
+
+func TestScreenerClearCanBeCanceled(t *testing.T) {
+	view, state := loadedScreener(t)
+	before := len(state.snapshot())
+
+	view.HandleContentKey(keyPress("X"))
+	if cmd := view.HandleContentKey(keyPress("n")); cmd != nil {
+		t.Error("canceling should not clear anything")
+	}
+	if view.confirmingClear {
+		t.Error("n should close the confirmation")
+	}
+	if len(state.snapshot()) != before {
+		t.Error("canceling should not make a request")
+	}
+	if len(view.pending.rows) != 2 {
+		t.Error("canceling should leave the queue alone")
+	}
+}
+
+func TestScreenerOffersClearOnBothPanes(t *testing.T) {
+	view, _ := loadedScreener(t)
+	for _, pane := range []string{"pending", "history"} {
+		if !hasBinding(view.HelpBindings(), "X") {
+			t.Errorf("%s pane does not offer the clear shortcut: %v", pane, view.HelpBindings())
+		}
+		view.Update(runCmd(view.HandleContentKey(keyPress("tab"))))
+	}
+}
+
+// --- Pagination ---
+
+func TestScreenerKeepsQueueWhenNextPageIsEmpty(t *testing.T) {
+	view, state := loadedScreener(t)
+	state.pending = `{"pending_clearances_count":2,"clearances":[]}`
+
+	loaded := runCmd(view.HandleContentKey(keyPress("]"))).(screenerPendingLoadedMsg)
+	if loaded.page != 2 {
+		t.Fatalf("next page = %d, want 2", loaded.page)
+	}
+	view.Update(loaded)
+
+	if len(view.pending.rows) != 2 || view.notice != "No more senders waiting" {
+		t.Errorf("empty next page = rows:%d notice:%q", len(view.pending.rows), view.notice)
+	}
+	if requests := state.snapshot(); !strings.Contains(requests[len(requests)-1].query, "page=2") {
+		t.Errorf("page request = %+v", requests[len(requests)-1])
+	}
+}
+
+// --- Leaving ---
+
+func TestScreenerEscapeAsksToClose(t *testing.T) {
+	view, _ := loadedScreener(t)
+
+	if _, ok := runCmd(view.HandleContentKey(keyPress("esc"))).(screenerClosedMsg); !ok {
+		t.Error("esc should close The Screener")
+	}
+	if _, ok := runCmd(view.HandleContentKey(keyPress("q"))).(screenerClosedMsg); !ok {
+		t.Error("q should close The Screener")
+	}
+}
+
+func TestScreenerStaysOpenWhileADecisionIsInFlight(t *testing.T) {
+	view, _ := loadedScreener(t)
+	view.HandleContentKey(keyPress("y"))
+
+	if cmd := view.HandleContentKey(keyPress("esc")); cmd != nil {
+		t.Error("The Screener should stay open until the decision lands")
+	}
+}
+
+// plainText strips styling and line breaks so a wording assertion reads the sentence
+// rather than the wrapping.
+func plainText(rendered string) string {
+	return strings.Join(strings.Fields(ansi.Strip(rendered)), " ")
+}
+
+func hasBinding(bindings []helpBinding, key string) bool {
+	for _, binding := range bindings {
+		if binding.key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Mail integration ---
+
+func TestMailShowsScreenerInvitation(t *testing.T) {
+	view := mailWithPostings()
+
+	if strings.Contains(view.View(), "first-time") {
+		t.Error("an empty Screener should not be advertised")
+	}
+
+	view.Update(screenerCountLoadedMsg{count: 1})
+	if !strings.Contains(plainText(view.View()), "Screen 1 first-time sender · ctrl+s") {
+		t.Errorf("one waiting sender rendered:\n%s", view.View())
+	}
+
+	view.Update(screenerCountLoadedMsg{count: 3})
+	if !strings.Contains(plainText(view.View()), "Screen 3 first-time senders · ctrl+s") {
+		t.Errorf("three waiting senders rendered:\n%s", view.View())
+	}
+
+	view.Update(screenerCountLoadedMsg{count: 0, err: context.Canceled})
+	if !strings.Contains(plainText(view.View()), "Screen 3 first-time senders") {
+		t.Error("a failed count should leave the last known one alone")
+	}
+}
+
+func TestModelOpensAndClosesScreener(t *testing.T) {
+	m := modelWithBoxes()
+
+	updated, cmd := m.Update(keyPress("ctrl+s"))
+	m = updated.(model)
+	if m.activeView != m.screenerView {
+		t.Fatal("ctrl+s should open The Screener over the mail list")
+	}
+	if cmd == nil {
+		t.Error("opening The Screener should load the queue")
+	}
+	if !hasBinding(m.help.bindings, "X") {
+		t.Errorf("help should offer the clear shortcut: %v", m.help.bindings)
+	}
+
+	updated, _ = m.Update(screenerClosedMsg{})
+	m = updated.(model)
+	if m.activeView != m.mailView {
+		t.Error("closing The Screener should put the mail list back")
+	}
+	if m.section != sectionMail {
+		t.Error("The Screener should not change the section")
+	}
+}
+
+func TestModelKeepsScreenerClosedInsideAThread(t *testing.T) {
+	m := modelWithBoxes()
+	m.mailView.inThread = true
+
+	updated, _ := m.Update(keyPress("ctrl+s"))
+	m = updated.(model)
+	if m.activeView == m.screenerView {
+		t.Error("ctrl+s should do nothing while a thread is open")
+	}
+}
+
+func TestModelRoutesScreenerKeysToTheScreener(t *testing.T) {
+	m := modelWithBoxes()
+	updated, _ := m.Update(keyPress("ctrl+s"))
+	m = updated.(model)
+	m.screenerView.Update(screenerPendingLoadedMsg{
+		requestID: m.screenerView.requestID,
+		page:      1,
+		count:     1,
+		rows:      []screenerRow{{id: 91, name: "Jane Doe", detail: "Quarterly planning"}},
+	})
+	m.loading = false
+
+	updated, _ = m.Update(keyPress("shift+tab"))
+	m = updated.(model)
+	if m.focus != rowContent {
+		t.Error("The Screener should keep tab to itself instead of moving the focus row")
+	}
+
+	updated, _ = m.Update(keyPress("q"))
+	m = updated.(model)
+	if m.activeView != m.screenerView {
+		t.Error("q reaches The Screener, which closes itself through a message")
+	}
+}
+
+var _ tea.Model = model{}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -17,6 +17,7 @@ var (
 type styles struct {
 	app       lipgloss.Style
 	title     lipgloss.Style // bold primary for inline titles
+	pill      lipgloss.Style // filled button, for a call to action above a list
 	entryFrom lipgloss.Style
 	entryDate lipgloss.Style
 	entryBody lipgloss.Style
@@ -30,6 +31,7 @@ func newStyles() styles {
 	return styles{
 		app:       lipgloss.NewStyle().Padding(1, 2),
 		title:     lipgloss.NewStyle().Foreground(colorPrimary).Bold(true),
+		pill:      lipgloss.NewStyle().Foreground(lipgloss.Black).Background(colorPrimary).Bold(true).Padding(0, 1),
 		entryFrom: lipgloss.NewStyle().Foreground(colorPrimary).Bold(true),
 		entryDate: lipgloss.NewStyle().Foreground(colorMuted),
 		entryBody: lipgloss.NewStyle(),

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -48,6 +48,9 @@ type model struct {
 	calendarView *calendarView
 	journalView  *journalView
 
+	// The Screener, opened over the mail section with ctrl+s
+	screenerView *screenerView
+
 	// Linked mail accounts
 	mailAccounts            []mailAccountChoice
 	mailAccount             mailAccountChoice
@@ -80,6 +83,7 @@ func newModelWithMailAccounts(rootSDK, sdk *hey.Client, selected string) model {
 	ov := newContactsView(vc)
 	cv := newCalendarView(vc)
 	jv := newJournalView(vc)
+	sv := newScreenerView(vc)
 	account := mailAccountChoice{label: "All Accounts"}
 	if accountID, err := strconv.ParseInt(selected, 10, 64); err == nil && accountID > 0 {
 		account = mailAccountChoice{id: accountID, label: fmt.Sprintf("Account %d", accountID)}
@@ -98,6 +102,7 @@ func newModelWithMailAccounts(rootSDK, sdk *hey.Client, selected string) model {
 		contactsView:        ov,
 		calendarView:        cv,
 		journalView:         jv,
+		screenerView:        sv,
 		mailAccounts:        []mailAccountChoice{{label: "All Accounts"}},
 		mailAccount:         account,
 		viewGenerationToken: &atomic.Uint64{},
@@ -199,7 +204,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.updateHelpBindings()
 		return m, nil
 
+	case screenerClosedMsg:
+		return m.closeScreener()
+
 	case mailSourcesLoadedMsg:
+		if m.activeView != m.mailView {
+			cmd, _ := m.mailView.Update(msg)
+			return m, m.stampViewCmd(cmd)
+		}
+
+	case screenerCountLoadedMsg:
 		if m.activeView != m.mailView {
 			cmd, _ := m.mailView.Update(msg)
 			return m, m.stampViewCmd(cmd)
@@ -293,6 +307,7 @@ func (m model) applyMailAccount(account mailAccountChoice, client *hey.Client) (
 	m.contactsView = newContactsView(m.vc)
 	m.calendarView = newCalendarView(m.vc)
 	m.journalView = newJournalView(m.vc)
+	m.screenerView = newScreenerView(m.vc)
 	switch m.section {
 	case sectionMail:
 		m.activeView = m.mailView
@@ -468,6 +483,10 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
+	if key == "ctrl+s" && m.canOpenScreener() {
+		return m.openScreener()
+	}
+
 	if key == "ctrl+a" && m.canOpenMailAccountPicker() {
 		if m.mailAccountDiscoveryErr != "" {
 			m.mailAccountDiscoveryErr = ""
@@ -606,6 +625,32 @@ func (m model) handleMailAccountKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, switchMailAccount(m.vc.ctx, m.rootSDK, account, m.mailAccountRequestID)
 	}
 	return m, nil
+}
+
+// canOpenScreener reports whether ctrl+s should open The Screener: from the mail list,
+// with no thread, search or form in the way.
+func (m model) canOpenScreener() bool {
+	return m.section == sectionMail && m.activeView == m.mailView && !m.loading && m.err == nil &&
+		!m.mailView.InThread() && !m.hasPendingMutation()
+}
+
+func (m model) openScreener() (tea.Model, tea.Cmd) {
+	m.activeView = m.screenerView
+	m.activeView.Resize(m.vc.width, m.vc.height)
+	cmd := m.syncLoading(m.activeView.Init())
+	m.updateHelpBindings()
+	return m, cmd
+}
+
+func (m model) closeScreener() (tea.Model, tea.Cmd) {
+	if m.activeView != m.screenerView {
+		return m, nil
+	}
+	m.activeView = m.mailView
+	m.activeView.Resize(m.vc.width, m.vc.height)
+	cmd := m.syncLoading(m.mailView.refreshScreenerCount())
+	m.updateHelpBindings()
+	return m, cmd
 }
 
 func (m model) switchSection(sec section) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
Ctrl+S from the mail list opens The Screener as a full view. The wording is haystack's, so the TUI and the web read the same.

**Deciding.** `y` (or `i`) screens the selected sender in, `n` screens them out — the same letters the web binds. The sender leaves the queue, the count drops, and you get "Jane Doe screened in".

**Previous decisions.** Tab moves over to Screener History and back. Each pane fetches once; `[` and `]` page either list.

**Clearing.** `X` clears the whole Screener behind the punt page's confirmation, word for word: "All emails currently in the Screener will go to the trash. You'll be asked to screen each sender again if they email you in the future." `y` confirms, `n` or Escape backs out. It's on both panes — clearing is about the Screener, not about which pane you're looking at.

**Getting there.** When senders are waiting, the mail list says so in a pill above the threads: `Screen 1 first-time sender · ctrl+s`, from haystack's `Screen #{pluralize(count, "first-time sender")}`. The count rides along with the box load and is read again when The Screener closes. Ctrl+S works from the list whether or not anyone is waiting, and stays out of the way inside a thread, a search, or a form.

`screenerView` implements `sectionView` but is not a section: it swaps in as the active view, captures every key while it is open, and asks to be closed with `screenerClosedMsg`. It won't leave while a decision is still in flight.

Two calls worth a look:

- **History is read-only.** The web has a switch to flip an old decision and the SDK has `Rescreen` for it, but this only shows them.
- **No "screen in to The Feed / Paper Trail" or "mark as spam"** (`d`, `p`, `m` on the web). Screening in to a box needs a box ID The Screener doesn't hold, and spam is harder to undo than a plain deny.

Also pulled the centering math out of `renderNavRow` into `centerText` — it was already written twice there.

Tested against a real account, plus `internal/tui/screener_test.go` covering loading, the wording, both decisions and a refused one, tabbing over, the clear confirmation and its cancel, empty pages, and the model-level open/close.