### PR TITLE
Add time track category management to the CLI and TUI

### DIFF
--- a/.surface
+++ b/.surface
@@ -163,6 +163,11 @@ hey spam
 hey stop-ignoring
 hey threads
 hey timetrack
+hey timetrack categories
+hey timetrack category
+hey timetrack category create
+hey timetrack category delete
+hey timetrack category rename
 hey timetrack current
 hey timetrack list
 hey timetrack list --all

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -61,6 +61,10 @@ The remaining HTML-reading gaps use the SDK's authenticated HTML helper and are 
 | `/calendar/ongoing_time_track.json` | GET | SDK `TimeTracks().GetOngoing` | `hey timetrack current` | covered |
 | `/calendar/ongoing_time_track.json` | POST | SDK `TimeTracks().Start` | `hey timetrack start` | covered |
 | `/calendar/time_tracks/{id}.json` | PUT | SDK `TimeTracks().Stop` | `hey timetrack stop` | covered |
+| `/calendar/time_tracks/categories.json` | GET | SDK `TimeTracks().Categories` | `hey timetrack categories`, Calendar TUI `c` | covered |
+| `/calendar/time_tracks/categories` | POST | SDK `TimeTracks().CreateCategory` | `hey timetrack category create`, Calendar TUI `c` | covered |
+| `/calendar/time_tracks/categories/{id}` | PATCH | SDK `TimeTracks().UpdateCategory` | `hey timetrack category rename`, Calendar TUI `c` | covered |
+| `/calendar/time_tracks/categories/{id}` | DELETE | SDK `TimeTracks().DeleteCategory` | `hey timetrack category delete`, Calendar TUI `c` | covered |
 | `/calendar/todos.json` | POST | SDK `CalendarTodos().Create` | `hey todo add` | covered |
 | `/calendar/todos/{id}/completions.json` | POST | SDK `CalendarTodos().Complete` | `hey todo complete <id>` | covered |
 | `/calendar/todos/{id}/completions.json` | DELETE | SDK `CalendarTodos().Uncomplete` | `hey todo uncomplete <id>` | covered |

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Thread attachments always appear with their filename, media type, and size. Use 
 
 Press Shift+O to open Contacts. Use Enter to view a contact, `a` to add, `e` to edit, `n` to edit the private note, `x` twice to delete a note, `h` to hide, and `u` to show the most recently hidden contact again. Escape or `q` goes back.
 
+Press Shift+C to open Calendar, then `c` to manage time track categories. Create a category with `n`, rename the selected category with Enter or `r`, and press `x` twice to delete it. Time tracks in a deleted category become uncategorized.
+
 ## CLI Commands
 
 Structured data commands support `--json` for full output and `--jq '<expression>'` to
@@ -332,6 +334,10 @@ hey timetrack start                # start tracking
 hey timetrack stop                 # stop tracking
 hey timetrack current              # show active track
 hey timetrack list                 # list all tracks
+hey timetrack categories           # list categories
+hey timetrack category create "Client work"
+hey timetrack category rename 123 "Planning"
+hey timetrack category delete 123
 ```
 
 ### Journal

--- a/internal/cmd/calendar_commands_test.go
+++ b/internal/cmd/calendar_commands_test.go
@@ -351,3 +351,105 @@ func TestTimetrackListCommand(t *testing.T) {
 		t.Errorf("notice = %q", response.Notice)
 	}
 }
+
+func TestTimetrackCategoriesCommand(t *testing.T) {
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/calendar/time_tracks/categories.json" {
+			t.Errorf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"id":31,"title":"Client work"},{"id":32,"title":"Planning"}]`)
+	}), "timetrack", "categories")
+	if err != nil {
+		t.Fatalf("execute timetrack categories: %v", err)
+	}
+	if response.Summary != "2 time track categories" {
+		t.Errorf("summary = %q", response.Summary)
+	}
+	if len(response.Breadcrumbs) != 1 || response.Breadcrumbs[0].Action != "create" {
+		t.Errorf("breadcrumbs = %#v", response.Breadcrumbs)
+	}
+}
+
+func TestTimetrackCategoryMutations(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		method      string
+		path        string
+		title       string
+		wantSummary string
+	}{
+		{
+			name:        "create",
+			args:        []string{"timetrack", "category", "create", "Client work"},
+			method:      http.MethodPost,
+			path:        "/calendar/time_tracks/categories",
+			title:       "Client work",
+			wantSummary: `Time track category "Client work" created`,
+		},
+		{
+			name:        "rename",
+			args:        []string{"timetrack", "category", "rename", "31", "Planning"},
+			method:      http.MethodPatch,
+			path:        "/calendar/time_tracks/categories/31",
+			title:       "Planning",
+			wantSummary: `Time track category 31 renamed to "Planning"`,
+		},
+		{
+			name:        "delete",
+			args:        []string{"timetrack", "category", "delete", "31"},
+			method:      http.MethodDelete,
+			path:        "/calendar/time_tracks/categories/31",
+			wantSummary: "Time track category 31 deleted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tt.method || r.URL.Path != tt.path {
+					t.Errorf("request = %s %s, want %s %s", r.Method, r.URL.Path, tt.method, tt.path)
+				}
+				if tt.title != "" {
+					if err := r.ParseForm(); err != nil {
+						t.Fatalf("parse form: %v", err)
+					}
+					if got := r.Form.Get("category[title]"); got != tt.title {
+						t.Errorf("category title = %q, want %q", got, tt.title)
+					}
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}), tt.args...)
+			if err != nil {
+				t.Fatalf("execute %s: %v", tt.name, err)
+			}
+			if response.Summary != tt.wantSummary {
+				t.Errorf("summary = %q, want %q", response.Summary, tt.wantSummary)
+			}
+			if len(response.Breadcrumbs) != 1 || response.Breadcrumbs[0].Action != "list" {
+				t.Errorf("breadcrumbs = %#v", response.Breadcrumbs)
+			}
+		})
+	}
+}
+
+func TestTimetrackCategoryMutationValidationMakesNoRequest(t *testing.T) {
+	var requests atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+	})
+
+	for _, args := range [][]string{
+		{"timetrack", "category", "create", "   "},
+		{"timetrack", "category", "rename", "invalid", "Planning"},
+		{"timetrack", "category", "delete", "0"},
+	} {
+		if _, err := runJSONCommand(t, handler, args...); err == nil {
+			t.Errorf("%v: expected validation error", args)
+		}
+	}
+	if requests.Load() != 0 {
+		t.Errorf("requests = %d, want 0", requests.Load())
+	}
+}

--- a/internal/cmd/calendar_commands_test.go
+++ b/internal/cmd/calendar_commands_test.go
@@ -371,6 +371,43 @@ func TestTimetrackCategoriesCommand(t *testing.T) {
 	}
 }
 
+func TestTimetrackCategoryStyledOutputSanitizesTitles(t *testing.T) {
+	dangerous := "Client\x1b]52;c;secret\a\nForged"
+	assertSafe := func(t *testing.T, stdout string) {
+		t.Helper()
+		if strings.Contains(stdout, "\x1b]52") || strings.ContainsRune(stdout, '\a') || strings.Contains(stdout, "\nForged") {
+			t.Errorf("styled category output retained terminal controls: %q", stdout)
+		}
+	}
+
+	t.Run("list", func(t *testing.T) {
+		stdout, err := runStyledCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": 31, "title": dangerous}})
+		}), "timetrack", "categories")
+		if err != nil {
+			t.Fatalf("execute timetrack categories: %v", err)
+		}
+		assertSafe(t, stdout)
+	})
+
+	t.Run("mutation", func(t *testing.T) {
+		stdout, err := runStyledCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			if got := r.Form.Get("category[title]"); got != dangerous {
+				t.Errorf("category title = %q, want unchanged %q", got, dangerous)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}), "timetrack", "category", "create", dangerous)
+		if err != nil {
+			t.Fatalf("execute category create: %v", err)
+		}
+		assertSafe(t, stdout)
+	})
+}
+
 func TestTimetrackCategoryMutations(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/cmd/timetrack.go
+++ b/internal/cmd/timetrack.go
@@ -292,7 +292,7 @@ func (c *timetrackCategoriesCommand) run(cmd *cobra.Command, args []string) erro
 		table := newTable(cmd.OutOrStdout())
 		table.addRow([]string{"ID", "Title"})
 		for _, category := range categories {
-			table.addRow([]string{fmt.Sprintf("%d", category.Id), category.Title})
+			table.addRow([]string{fmt.Sprintf("%d", category.Id), terminalSafeText(category.Title)})
 		}
 		table.print()
 		return nil
@@ -433,7 +433,7 @@ func (c *timetrackCategoryDeleteCommand) run(cmd *cobra.Command, args []string) 
 
 func writeTimetrackCategoryMutation(cmd *cobra.Command, summary string) error {
 	if writer.IsStyled() {
-		fmt.Fprintln(cmd.OutOrStdout(), summary+".")
+		fmt.Fprintln(cmd.OutOrStdout(), terminalSafeText(summary)+".")
 		return nil
 	}
 	return writeOK(nil,

--- a/internal/cmd/timetrack.go
+++ b/internal/cmd/timetrack.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -18,7 +19,7 @@ func newTimetrackCommand() *timetrackCommand {
 		Use:   "timetrack",
 		Short: "Track time",
 		Annotations: map[string]string{
-			"agent_notes": "Subcommands: start, stop, current, list. Use current to check if tracking is active before start/stop.",
+			"agent_notes": "Subcommands: start, stop, current, list, categories, category. Use current to check if tracking is active before start/stop.",
 		},
 	}
 
@@ -26,6 +27,8 @@ func newTimetrackCommand() *timetrackCommand {
 	timetrackCommand.cmd.AddCommand(newTimetrackStopCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackCurrentCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackListCommand().cmd)
+	timetrackCommand.cmd.AddCommand(newTimetrackCategoriesCommand().cmd)
+	timetrackCommand.cmd.AddCommand(newTimetrackCategoryCommand().cmd)
 
 	return timetrackCommand
 }
@@ -248,6 +251,197 @@ func (c *timetrackListCommand) run(cmd *cobra.Command, args []string) error {
 			Action:      "start",
 			Command:     "hey timetrack start",
 			Description: "Start time tracking",
+		}),
+	)
+}
+
+// categories
+
+type timetrackCategoriesCommand struct {
+	cmd *cobra.Command
+}
+
+func newTimetrackCategoriesCommand() *timetrackCategoriesCommand {
+	timetrackCategoriesCommand := &timetrackCategoriesCommand{}
+	timetrackCategoriesCommand.cmd = &cobra.Command{
+		Use:   "categories",
+		Short: "List time track categories",
+		Example: `  hey timetrack categories
+  hey timetrack categories --json`,
+		RunE: timetrackCategoriesCommand.run,
+	}
+	return timetrackCategoriesCommand
+}
+
+func (c *timetrackCategoriesCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	categories, err := sdk.TimeTracks().Categories(cmd.Context())
+	if err != nil {
+		return convertSDKError(err)
+	}
+
+	if writer.IsStyled() {
+		if len(categories) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No time track categories.")
+			return nil
+		}
+
+		table := newTable(cmd.OutOrStdout())
+		table.addRow([]string{"ID", "Title"})
+		for _, category := range categories {
+			table.addRow([]string{fmt.Sprintf("%d", category.Id), category.Title})
+		}
+		table.print()
+		return nil
+	}
+
+	return writeOK(categories,
+		output.WithSummary(fmt.Sprintf("%d time track categories", len(categories))),
+		output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "create",
+			Command:     "hey timetrack category create <title>",
+			Description: "Create a time track category",
+		}),
+	)
+}
+
+// category
+
+type timetrackCategoryCommand struct {
+	cmd *cobra.Command
+}
+
+func newTimetrackCategoryCommand() *timetrackCategoryCommand {
+	timetrackCategoryCommand := &timetrackCategoryCommand{}
+	timetrackCategoryCommand.cmd = &cobra.Command{
+		Use:   "category",
+		Short: "Manage time track categories",
+	}
+	timetrackCategoryCommand.cmd.AddCommand(newTimetrackCategoryCreateCommand().cmd)
+	timetrackCategoryCommand.cmd.AddCommand(newTimetrackCategoryRenameCommand().cmd)
+	timetrackCategoryCommand.cmd.AddCommand(newTimetrackCategoryDeleteCommand().cmd)
+	return timetrackCategoryCommand
+}
+
+type timetrackCategoryCreateCommand struct {
+	cmd *cobra.Command
+}
+
+func newTimetrackCategoryCreateCommand() *timetrackCategoryCreateCommand {
+	timetrackCategoryCreateCommand := &timetrackCategoryCreateCommand{}
+	timetrackCategoryCreateCommand.cmd = &cobra.Command{
+		Use:     "create <title>",
+		Short:   "Create a time track category",
+		Example: `  hey timetrack category create "Client work"`,
+		RunE:    timetrackCategoryCreateCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return timetrackCategoryCreateCommand
+}
+
+func (c *timetrackCategoryCreateCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	title := strings.TrimSpace(args[0])
+	if title == "" {
+		return output.ErrUsage("category title is required")
+	}
+	if err := sdk.TimeTracks().CreateCategory(cmd.Context(), title); err != nil {
+		return convertSDKError(err)
+	}
+	return writeTimetrackCategoryMutation(cmd, fmt.Sprintf("Time track category %q created", title))
+}
+
+type timetrackCategoryRenameCommand struct {
+	cmd *cobra.Command
+}
+
+func newTimetrackCategoryRenameCommand() *timetrackCategoryRenameCommand {
+	timetrackCategoryRenameCommand := &timetrackCategoryRenameCommand{}
+	timetrackCategoryRenameCommand.cmd = &cobra.Command{
+		Use:     "rename <id> <title>",
+		Short:   "Rename a time track category",
+		Example: `  hey timetrack category rename 123 "Planning"`,
+		RunE:    timetrackCategoryRenameCommand.run,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 2 {
+				return nil
+			}
+			if len(args) == 0 {
+				return usageErrorf("%s", cleanUseLine(cmd.UseLine()))
+			}
+			return fmt.Errorf("expected 2 arguments, got %d", len(args))
+		},
+	}
+	return timetrackCategoryRenameCommand
+}
+
+func (c *timetrackCategoryRenameCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	categoryID, err := parsePositiveID(args[0], "category")
+	if err != nil {
+		return err
+	}
+	title := strings.TrimSpace(args[1])
+	if title == "" {
+		return output.ErrUsage("category title is required")
+	}
+	if err := sdk.TimeTracks().UpdateCategory(cmd.Context(), categoryID, title); err != nil {
+		return convertSDKError(err)
+	}
+	return writeTimetrackCategoryMutation(cmd, fmt.Sprintf("Time track category %d renamed to %q", categoryID, title))
+}
+
+type timetrackCategoryDeleteCommand struct {
+	cmd *cobra.Command
+}
+
+func newTimetrackCategoryDeleteCommand() *timetrackCategoryDeleteCommand {
+	timetrackCategoryDeleteCommand := &timetrackCategoryDeleteCommand{}
+	timetrackCategoryDeleteCommand.cmd = &cobra.Command{
+		Use:     "delete <id>",
+		Short:   "Delete a time track category",
+		Example: `  hey timetrack category delete 123`,
+		RunE:    timetrackCategoryDeleteCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return timetrackCategoryDeleteCommand
+}
+
+func (c *timetrackCategoryDeleteCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	categoryID, err := parsePositiveID(args[0], "category")
+	if err != nil {
+		return err
+	}
+	if err := sdk.TimeTracks().DeleteCategory(cmd.Context(), categoryID); err != nil {
+		return convertSDKError(err)
+	}
+	return writeTimetrackCategoryMutation(cmd, fmt.Sprintf("Time track category %d deleted", categoryID))
+}
+
+func writeTimetrackCategoryMutation(cmd *cobra.Command, summary string) error {
+	if writer.IsStyled() {
+		fmt.Fprintln(cmd.OutOrStdout(), summary+".")
+		return nil
+	}
+	return writeOK(nil,
+		output.WithSummary(summary),
+		output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "list",
+			Command:     "hey timetrack categories",
+			Description: "List time track categories",
 		}),
 	)
 }

--- a/internal/tui/calendar.go
+++ b/internal/tui/calendar.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"time"
 
 	"charm.land/bubbles/v2/viewport"
@@ -28,6 +29,16 @@ type identityLoadedMsg struct {
 	firstWeekDay time.Weekday
 }
 
+type timeTrackCategoriesLoadedMsg struct {
+	categories []generated.TimeTrackCategory
+	err        error
+}
+
+type timeTrackCategorySavedMsg struct {
+	summary string
+	err     error
+}
+
 // --- Calendar section view ---
 
 type calendarView struct {
@@ -53,6 +64,8 @@ type calendarView struct {
 	topicContent  string
 	inThread      bool
 	loading       bool
+
+	timeTrackCategories *timeTrackCategoryManager
 }
 
 func newCalendarView(vc *viewContext) *calendarView {
@@ -107,6 +120,31 @@ func (v *calendarView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.topicViewport.SetContent(v.topicContent)
 		v.topicViewport.GotoTop()
 		return nil, true
+
+	case timeTrackCategoriesLoadedMsg:
+		v.loading = false
+		if v.timeTrackCategories == nil {
+			return nil, true
+		}
+		if msg.err != nil {
+			v.timeTrackCategories.status = "Could not load categories: " + msg.err.Error()
+			return nil, true
+		}
+		v.timeTrackCategories.setCategories(msg.categories)
+		return nil, true
+
+	case timeTrackCategorySavedMsg:
+		v.loading = false
+		if v.timeTrackCategories == nil {
+			return nil, true
+		}
+		if msg.err != nil {
+			v.timeTrackCategories.status = msg.err.Error()
+			return nil, true
+		}
+		v.timeTrackCategories.status = msg.summary
+		v.loading = true
+		return v.fetchTimeTrackCategories(), true
 	}
 
 	if v.inThread {
@@ -119,6 +157,9 @@ func (v *calendarView) Update(msg tea.Msg) (tea.Cmd, bool) {
 }
 
 func (v *calendarView) View() string {
+	if v.timeTrackCategories != nil {
+		return v.timeTrackCategories.view(v.vc.styles, v.vc.width, v.vc.height)
+	}
 	if v.inThread {
 		return v.topicViewport.View()
 	}
@@ -126,11 +167,15 @@ func (v *calendarView) View() string {
 }
 
 func (v *calendarView) HelpBindings() []helpBinding {
+	if v.timeTrackCategories != nil {
+		return v.timeTrackCategories.helpBindings()
+	}
 	if v.inThread {
 		return nil
 	}
 	return []helpBinding{
 		{"v", v.viewMode.next().String() + " view"},
+		{"c", "time categories"},
 	}
 }
 
@@ -162,6 +207,9 @@ func (v *calendarView) SubnavRight() tea.Cmd {
 }
 
 func (v *calendarView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
+	if v.timeTrackCategories != nil {
+		return v.handleTimeTrackCategoryKey(msg)
+	}
 	if v.inThread {
 		var cmd tea.Cmd
 		v.topicViewport, cmd = v.topicViewport.Update(msg)
@@ -169,6 +217,10 @@ func (v *calendarView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	switch msg.String() {
+	case "c":
+		v.timeTrackCategories = newTimeTrackCategoryManager()
+		v.loading = true
+		return v.fetchTimeTrackCategories()
 	case "v":
 		v.viewMode = v.viewMode.next()
 		if v.calIndex >= 0 && v.calIndex < len(v.calendars) {
@@ -185,9 +237,73 @@ func (v *calendarView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 	return cmd
 }
 
+func (v *calendarView) handleTimeTrackCategoryKey(msg tea.KeyPressMsg) tea.Cmd {
+	manager := v.timeTrackCategories
+	if v.loading {
+		return nil
+	}
+	if manager.mode != timeTrackCategoryBrowse {
+		switch msg.Key().Code {
+		case tea.KeyEscape:
+			manager.cancelEdit()
+			return nil
+		case tea.KeyEnter:
+			title, ok := manager.title()
+			if !ok {
+				return nil
+			}
+			mode := manager.mode
+			selected := manager.selected()
+			manager.cancelEdit()
+			v.loading = true
+			if mode == timeTrackCategoryCreate {
+				return v.createTimeTrackCategory(title)
+			}
+			if selected != nil {
+				return v.renameTimeTrackCategory(selected.Id, title)
+			}
+			v.loading = false
+			manager.status = "Choose a category to rename"
+			return nil
+		default:
+			return manager.update(msg)
+		}
+	}
+
+	switch msg.String() {
+	case "esc", "q":
+		v.timeTrackCategories = nil
+		return nil
+	case "n":
+		return manager.startCreate()
+	case "enter", "r":
+		return manager.startRename()
+	case "x":
+		selected := manager.selected()
+		if selected == nil {
+			manager.status = "Choose a category to delete"
+			return nil
+		}
+		if !manager.confirmingDelete {
+			manager.confirmingDelete = true
+			manager.status = ""
+			return nil
+		}
+		manager.confirmingDelete = false
+		v.loading = true
+		return v.deleteTimeTrackCategory(selected.Id, selected.Title)
+	default:
+		manager.move(msg.Key())
+		return nil
+	}
+}
+
 func (v *calendarView) InThread() bool { return v.inThread }
 func (v *calendarView) ExitThread()    { v.inThread = false }
 func (v *calendarView) Loading() bool  { return v.loading }
+func (v *calendarView) CapturingInput() bool {
+	return v.timeTrackCategories != nil
+}
 
 func (v *calendarView) Resize(width, height int) {
 	v.contentVP.SetWidth(width)
@@ -308,5 +424,36 @@ func (v *calendarView) fetchRecordings(calID int64) tea.Cmd {
 			}
 		}
 		return recordingsLoadedMsg{recordings: all}
+	}
+}
+
+func (v *calendarView) fetchTimeTrackCategories() tea.Cmd {
+	return func() tea.Msg {
+		if v.vc.sdk == nil || v.vc.ctx == nil {
+			return timeTrackCategoriesLoadedMsg{err: fmt.Errorf("time track categories are unavailable")}
+		}
+		categories, err := v.vc.sdk.TimeTracks().Categories(v.vc.ctx)
+		return timeTrackCategoriesLoadedMsg{categories: categories, err: err}
+	}
+}
+
+func (v *calendarView) createTimeTrackCategory(title string) tea.Cmd {
+	return func() tea.Msg {
+		err := v.vc.sdk.TimeTracks().CreateCategory(v.vc.ctx, title)
+		return timeTrackCategorySavedMsg{summary: fmt.Sprintf("Created %q", title), err: err}
+	}
+}
+
+func (v *calendarView) renameTimeTrackCategory(categoryID int64, title string) tea.Cmd {
+	return func() tea.Msg {
+		err := v.vc.sdk.TimeTracks().UpdateCategory(v.vc.ctx, categoryID, title)
+		return timeTrackCategorySavedMsg{summary: fmt.Sprintf("Renamed category to %q", title), err: err}
+	}
+}
+
+func (v *calendarView) deleteTimeTrackCategory(categoryID int64, title string) tea.Cmd {
+	return func() tea.Msg {
+		err := v.vc.sdk.TimeTracks().DeleteCategory(v.vc.ctx, categoryID)
+		return timeTrackCategorySavedMsg{summary: fmt.Sprintf("Deleted %q", title), err: err}
 	}
 }

--- a/internal/tui/calendar_test.go
+++ b/internal/tui/calendar_test.go
@@ -214,10 +214,13 @@ func TestCalendarViewInThread(t *testing.T) {
 func TestCalendarViewHelpBindingsShowsViewToggle(t *testing.T) {
 	v := calendarWithRecordings()
 	bindings := v.HelpBindings()
-	if len(bindings) != 1 {
-		t.Fatalf("expected 1 binding, got %d", len(bindings))
+	if len(bindings) != 2 {
+		t.Fatalf("expected 2 bindings, got %d", len(bindings))
 	}
 	if bindings[0].key != "v" {
 		t.Errorf("binding key = %q, want \"v\"", bindings[0].key)
+	}
+	if bindings[1].key != "c" {
+		t.Errorf("binding key = %q, want \"c\"", bindings[1].key)
 	}
 }

--- a/internal/tui/time_track_categories.go
+++ b/internal/tui/time_track_categories.go
@@ -1,0 +1,191 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+type timeTrackCategoryEditMode int
+
+const (
+	timeTrackCategoryBrowse timeTrackCategoryEditMode = iota
+	timeTrackCategoryCreate
+	timeTrackCategoryRename
+)
+
+type timeTrackCategoryManager struct {
+	categories       []generated.TimeTrackCategory
+	cursor           int
+	mode             timeTrackCategoryEditMode
+	input            textinput.Model
+	status           string
+	confirmingDelete bool
+}
+
+func newTimeTrackCategoryManager() *timeTrackCategoryManager {
+	input := textinput.New()
+	input.Prompt = ""
+	input.Placeholder = "Category title…"
+	return &timeTrackCategoryManager{input: input}
+}
+
+func (m *timeTrackCategoryManager) selected() *generated.TimeTrackCategory {
+	if m.cursor < 0 || m.cursor >= len(m.categories) {
+		return nil
+	}
+	return &m.categories[m.cursor]
+}
+
+func (m *timeTrackCategoryManager) setCategories(categories []generated.TimeTrackCategory) {
+	selectedID := int64(0)
+	if selected := m.selected(); selected != nil {
+		selectedID = selected.Id
+	}
+	m.categories = categories
+	m.cursor = min(m.cursor, max(len(categories)-1, 0))
+	for i := range categories {
+		if categories[i].Id == selectedID {
+			m.cursor = i
+			break
+		}
+	}
+	m.confirmingDelete = false
+}
+
+func (m *timeTrackCategoryManager) startCreate() tea.Cmd {
+	m.mode = timeTrackCategoryCreate
+	m.confirmingDelete = false
+	m.status = ""
+	m.input.SetValue("")
+	return m.input.Focus()
+}
+
+func (m *timeTrackCategoryManager) startRename() tea.Cmd {
+	selected := m.selected()
+	if selected == nil {
+		m.status = "Choose a category to rename"
+		return nil
+	}
+	m.mode = timeTrackCategoryRename
+	m.confirmingDelete = false
+	m.status = ""
+	m.input.SetValue(selected.Title)
+	m.input.CursorEnd()
+	return m.input.Focus()
+}
+
+func (m *timeTrackCategoryManager) cancelEdit() {
+	m.mode = timeTrackCategoryBrowse
+	m.status = ""
+	m.input.Blur()
+}
+
+func (m *timeTrackCategoryManager) title() (string, bool) {
+	title := strings.TrimSpace(m.input.Value())
+	if title == "" {
+		m.status = "Enter a category title"
+		return "", false
+	}
+	return title, true
+}
+
+func (m *timeTrackCategoryManager) update(msg tea.Msg) tea.Cmd {
+	if m.mode == timeTrackCategoryBrowse {
+		return nil
+	}
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	return cmd
+}
+
+func (m *timeTrackCategoryManager) move(key tea.Key) {
+	switch key.Code {
+	case tea.KeyUp:
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case tea.KeyDown:
+		if m.cursor < len(m.categories)-1 {
+			m.cursor++
+		}
+	}
+	m.confirmingDelete = false
+}
+
+func (m *timeTrackCategoryManager) view(styles styles, width, height int) string {
+	contentWidth := max(width-4, 1)
+	var b strings.Builder
+
+	if m.mode != timeTrackCategoryBrowse {
+		title := "Create time track category"
+		if m.mode == timeTrackCategoryRename {
+			title = "Rename time track category"
+		}
+		b.WriteString(styles.title.Render(title))
+		b.WriteString("\n\n")
+		b.WriteString(styleMuted.Render("Title: "))
+		m.input.SetWidth(max(contentWidth-9, 10))
+		b.WriteString(m.input.View())
+		if m.status != "" {
+			b.WriteString("\n\n")
+			b.WriteString(lipgloss.NewStyle().Foreground(colorError).Render(m.status))
+		}
+		return b.String()
+	}
+
+	b.WriteString(styles.title.Render("Time track categories"))
+	b.WriteString("\n")
+	b.WriteString(styleMuted.Render("Categories organize completed time tracks."))
+	b.WriteString("\n\n")
+
+	if len(m.categories) == 0 {
+		b.WriteString(styleMuted.Render("No categories yet. Press n to create one."))
+		b.WriteString("\n")
+	} else {
+		visibleRows := max(height-7, 1)
+		start := 0
+		if m.cursor >= visibleRows {
+			start = m.cursor - visibleRows + 1
+		}
+		end := min(start+visibleRows, len(m.categories))
+		for i := start; i < end; i++ {
+			category := m.categories[i]
+			prefix := "  "
+			line := fmt.Sprintf("%d  %s", category.Id, terminalSafeFolderText(category.Title))
+			line = truncateStr(line, max(contentWidth-2, 1))
+			if i == m.cursor {
+				prefix = "› "
+				line = styles.title.Render(line)
+			}
+			fmt.Fprintf(&b, "%s%s\n", prefix, line)
+		}
+	}
+
+	if m.confirmingDelete {
+		b.WriteString("\n")
+		b.WriteString(lipgloss.NewStyle().Foreground(colorError).Render("Press x again to delete this category. Its time tracks will become uncategorized."))
+	} else if m.status != "" {
+		b.WriteString("\n")
+		b.WriteString(styleMuted.Render(terminalSafeFolderText(m.status)))
+	}
+	return b.String()
+}
+
+func (m *timeTrackCategoryManager) helpBindings() []helpBinding {
+	if m.mode != timeTrackCategoryBrowse {
+		return []helpBinding{{"enter", "save"}, {"esc", "cancel"}}
+	}
+	return []helpBinding{
+		{"↑↓", "select"},
+		{"n", "new"},
+		{"enter/r", "rename"},
+		{"x", "delete"},
+		{"esc/q", "back"},
+	}
+}

--- a/internal/tui/time_track_categories.go
+++ b/internal/tui/time_track_categories.go
@@ -75,7 +75,7 @@ func (m *timeTrackCategoryManager) startRename() tea.Cmd {
 	m.mode = timeTrackCategoryRename
 	m.confirmingDelete = false
 	m.status = ""
-	m.input.SetValue(selected.Title)
+	m.input.SetValue(terminalSafeFolderText(selected.Title))
 	m.input.CursorEnd()
 	return m.input.Focus()
 }

--- a/internal/tui/time_track_categories_test.go
+++ b/internal/tui/time_track_categories_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 )
 
@@ -190,5 +191,12 @@ func TestTimeTrackCategoryManagerValidatesAndConfirms(t *testing.T) {
 	rendered := manager.view(newStyles(), 80, 20)
 	if strings.Contains(rendered, dangerous) || strings.Contains(rendered, "\x1b]52") || strings.ContainsRune(rendered, '\a') {
 		t.Errorf("category status retained terminal controls: %q", rendered)
+	}
+
+	manager.setCategories([]generated.TimeTrackCategory{{Id: 31, Title: dangerous}})
+	manager.startRename()
+	prefill := manager.input.Value()
+	if strings.Contains(prefill, "\x1b]52") || strings.ContainsRune(prefill, '\a') {
+		t.Errorf("rename input retained terminal controls: %q", prefill)
 	}
 }

--- a/internal/tui/time_track_categories_test.go
+++ b/internal/tui/time_track_categories_test.go
@@ -1,0 +1,194 @@
+package tui
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+)
+
+type timeTrackCategoryRequest struct {
+	method string
+	path   string
+	title  string
+}
+
+func timeTrackCategoryView(t *testing.T) (*calendarView, *[]timeTrackCategoryRequest) {
+	t.Helper()
+	requests := &[]timeTrackCategoryRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := timeTrackCategoryRequest{method: r.Method, path: r.URL.Path}
+		if r.Method != http.MethodGet {
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("parse category form: %v", err)
+			}
+			request.title = r.Form.Get("category[title]")
+		}
+		*requests = append(*requests, request)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/calendar/time_tracks/categories.json":
+			_, _ = w.Write([]byte(`[{"id":31,"title":"Client work"},{"id":32,"title":"Planning"}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/calendar/time_tracks/categories":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPatch && r.URL.Path == "/calendar/time_tracks/categories/31":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && r.URL.Path == "/calendar/time_tracks/categories/31":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	vc := testVC()
+	vc.ctx = context.Background()
+	vc.sdk = hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "t"}, hey.WithMaxRetries(0))
+	view := newCalendarView(vc)
+	view.Resize(80, 30)
+	return view, requests
+}
+
+func finishTimeTrackCategoryMutation(t *testing.T, view *calendarView, cmd tea.Cmd) {
+	t.Helper()
+	msg := cmd()
+	refresh, consumed := view.Update(msg)
+	if !consumed || refresh == nil {
+		t.Fatal("category mutation should be consumed and refresh categories")
+	}
+	_, consumed = view.Update(refresh())
+	if !consumed {
+		t.Fatal("category refresh should be consumed")
+	}
+}
+
+func TestCalendarTimeTrackCategoriesLoadAndClose(t *testing.T) {
+	view, requests := timeTrackCategoryView(t)
+	cmd := view.HandleContentKey(keyPress("c"))
+	if cmd == nil || !view.CapturingInput() || !view.Loading() {
+		t.Fatal("c should open and load the time track category manager")
+	}
+	_, consumed := view.Update(cmd())
+	if !consumed || view.Loading() {
+		t.Fatal("category response should finish loading")
+	}
+	if got := plainText(view.View()); !strings.Contains(got, "Client work") || !strings.Contains(got, "Planning") {
+		t.Errorf("category manager view = %q", got)
+	}
+	if len(*requests) != 1 || (*requests)[0].path != "/calendar/time_tracks/categories.json" {
+		t.Errorf("requests = %#v", *requests)
+	}
+
+	view.HandleContentKey(keyPress("q"))
+	if view.CapturingInput() {
+		t.Error("q should close the category manager")
+	}
+}
+
+func TestCalendarTimeTrackCategoriesBlockKeysWhileLoading(t *testing.T) {
+	view, _ := timeTrackCategoryView(t)
+	load := view.HandleContentKey(keyPress("c"))
+	view.HandleContentKey(keyPress("n"))
+	view.HandleContentKey(keyPress("q"))
+	if view.timeTrackCategories == nil || view.timeTrackCategories.mode != timeTrackCategoryBrowse {
+		t.Fatal("the category manager should ignore actions until its initial load finishes")
+	}
+	_, _ = view.Update(load())
+
+	view.HandleContentKey(keyPress("n"))
+	view.timeTrackCategories.input.SetValue("Research")
+	create := view.HandleContentKey(keyPress("enter"))
+	if create == nil || !view.Loading() {
+		t.Fatal("saving a category should enter a loading state")
+	}
+	view.HandleContentKey(keyPress("n"))
+	view.HandleContentKey(keyPress("q"))
+	view.HandleContentKey(keyPress("x"))
+	if view.timeTrackCategories == nil || view.timeTrackCategories.mode != timeTrackCategoryBrowse || view.timeTrackCategories.confirmingDelete {
+		t.Fatal("the category manager should ignore actions while a mutation is in flight")
+	}
+	finishTimeTrackCategoryMutation(t, view, create)
+}
+
+func TestCalendarTimeTrackCategoryMutations(t *testing.T) {
+	view, requests := timeTrackCategoryView(t)
+	_, _ = view.Update(view.HandleContentKey(keyPress("c"))())
+
+	view.HandleContentKey(keyPress("n"))
+	if view.timeTrackCategories.mode != timeTrackCategoryCreate {
+		t.Fatal("n should open category creation")
+	}
+	view.timeTrackCategories.input.SetValue("Research")
+	create := view.HandleContentKey(keyPress("enter"))
+	if create == nil {
+		t.Fatal("enter should create the category")
+	}
+	finishTimeTrackCategoryMutation(t, view, create)
+
+	view.HandleContentKey(keyPress("enter"))
+	if view.timeTrackCategories.mode != timeTrackCategoryRename {
+		t.Fatal("enter should open category rename")
+	}
+	view.timeTrackCategories.input.SetValue("Customer work")
+	rename := view.HandleContentKey(keyPress("enter"))
+	if rename == nil {
+		t.Fatal("enter should rename the category")
+	}
+	finishTimeTrackCategoryMutation(t, view, rename)
+
+	if cmd := view.HandleContentKey(keyPress("x")); cmd != nil || !view.timeTrackCategories.confirmingDelete {
+		t.Fatal("first x should confirm category deletion")
+	}
+	remove := view.HandleContentKey(keyPress("x"))
+	if remove == nil {
+		t.Fatal("second x should delete the category")
+	}
+	finishTimeTrackCategoryMutation(t, view, remove)
+
+	want := []timeTrackCategoryRequest{
+		{method: http.MethodGet, path: "/calendar/time_tracks/categories.json"},
+		{method: http.MethodPost, path: "/calendar/time_tracks/categories", title: "Research"},
+		{method: http.MethodGet, path: "/calendar/time_tracks/categories.json"},
+		{method: http.MethodPatch, path: "/calendar/time_tracks/categories/31", title: "Customer work"},
+		{method: http.MethodGet, path: "/calendar/time_tracks/categories.json"},
+		{method: http.MethodDelete, path: "/calendar/time_tracks/categories/31"},
+		{method: http.MethodGet, path: "/calendar/time_tracks/categories.json"},
+	}
+	if len(*requests) != len(want) {
+		t.Fatalf("requests = %#v, want %#v", *requests, want)
+	}
+	for i := range want {
+		if (*requests)[i] != want[i] {
+			t.Errorf("request %d = %#v, want %#v", i, (*requests)[i], want[i])
+		}
+	}
+}
+
+func TestTimeTrackCategoryManagerValidatesAndConfirms(t *testing.T) {
+	manager := newTimeTrackCategoryManager()
+	manager.startCreate()
+	manager.input.SetValue("   ")
+	if _, ok := manager.title(); ok || manager.status != "Enter a category title" {
+		t.Errorf("empty category state = ok:%v status:%q", ok, manager.status)
+	}
+
+	manager.cancelEdit()
+	manager.confirmingDelete = true
+	view := plainText(manager.view(newStyles(), 80, 20))
+	if !strings.Contains(view, "will become uncategorized") {
+		t.Errorf("delete confirmation = %q", view)
+	}
+
+	manager.confirmingDelete = false
+	dangerous := "Saved \x1b]52;c;secret\a"
+	manager.status = dangerous
+	rendered := manager.view(newStyles(), 80, 20)
+	if strings.Contains(rendered, dangerous) || strings.Contains(rendered, "\x1b]52") || strings.ContainsRune(rendered, '\a') {
+		t.Errorf("category status retained terminal controls: %q", rendered)
+	}
+}

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -173,6 +173,8 @@ hey boxes --quiet --jq '.[].name'
 | Stop time tracking | `hey timetrack stop` |
 | Current timer | `hey timetrack current --json` |
 | List time entries | `hey timetrack list --json` |
+| List time track categories | `hey timetrack categories --json` |
+| Create time track category | `hey timetrack category create "Client work"` |
 | List journal entries | `hey journal list --json` |
 | Read journal entry | `hey journal read 2024-03-15 --json` |
 | Write journal entry | `hey journal write "Today was great"` |
@@ -442,6 +444,10 @@ hey timetrack start                           # Start timer
 hey timetrack stop                            # Stop timer
 hey timetrack current --json                  # Show current timer
 hey timetrack list --json                     # List time entries
+hey timetrack categories --json               # List categories
+hey timetrack category create "Client work"   # Create a category
+hey timetrack category rename 123 "Planning"  # Rename a category
+hey timetrack category delete 123              # Delete a category
 ```
 
 ### Journal

--- a/tests/smoke/timetrack_test.go
+++ b/tests/smoke/timetrack_test.go
@@ -90,6 +90,47 @@ func TestTimetrackListAll(t *testing.T) {
 	_ = resp
 }
 
+func TestTimetrackCategories(t *testing.T) {
+	title := "Client work " + uniqueID()
+	_, stderr, code := hey(t, "timetrack", "category", "create", title)
+	if code != 0 {
+		t.Skipf("timetrack category create unavailable (exit %d): %s", code, stderr)
+	}
+
+	categoryID := findTimeTrackCategory(t, title)
+	t.Cleanup(func() {
+		hey(t, "timetrack", "category", "delete", categoryID)
+	})
+
+	renamed := "Planning " + uniqueID()
+	_, stderr, code = hey(t, "timetrack", "category", "rename", categoryID, renamed)
+	if code != 0 {
+		t.Fatalf("timetrack category rename failed (exit %d): %s", code, stderr)
+	}
+	findTimeTrackCategory(t, renamed)
+
+	_, stderr, code = hey(t, "timetrack", "category", "delete", categoryID)
+	if code != 0 {
+		t.Fatalf("timetrack category delete failed (exit %d): %s", code, stderr)
+	}
+}
+
+func findTimeTrackCategory(t *testing.T, title string) string {
+	t.Helper()
+	resp := heyJSON(t, "timetrack", "categories")
+	type Category struct {
+		ID    json.Number `json:"id"`
+		Title string      `json:"title"`
+	}
+	for _, category := range dataAs[[]Category](t, resp) {
+		if category.Title == title {
+			return category.ID.String()
+		}
+	}
+	t.Fatalf("time track category %q not found", title)
+	return ""
+}
+
 func TestTimetrackCurrentNoActive(t *testing.T) {
 	// Stop any existing time track first.
 	hey(t, "timetrack", "stop")


### PR DESCRIPTION
<!-- pr-review-readiness-head: 2fb9cb1a9a0070d3749ba184219f7bd5f48361a1 -->

HEY users can now list and manage time-track categories from both scripts and the Calendar TUI, so category setup no longer requires the web app. This covers category management only; assigning a category while starting or stopping a timer remains deferred behind the SDK contract tracked in #205.

**Review readiness:** ✅ Yes  
**Risk:** 🟡 Medium — category deletion is destructive, but the TUI requires confirmation and HEY preserves affected tracks as uncategorized.  
**Decision:** None

<details>
<summary>✅ Change — category management is available in the CLI and Calendar TUI</summary>

### Before

```text
timetrack user
└── wants to organize completed tracks
    └── ❌ leaves the CLI/TUI for the HEY web app
```

### After

```text
timetrack user
└── lists categories in the CLI or opens Calendar → c
    ├── ✅ creates and renames categories
    └── ✅ deletes with an explicit TUI confirmation  ← CHANGED
```

The CLI adds `hey timetrack categories` and `hey timetrack category create|rename|delete`. The Calendar TUI uses the SDK's existing typed category methods, blocks overlapping writes while requests are in flight, refreshes after each mutation, and sanitizes server-provided status text before rendering it.

</details>

<details>
<summary>✅ Evidence — automated checks and a development-server interaction cover the workflow</summary>

- ✅ [TUI interaction recording](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892922#__recording_10225280892) — opens category management, creates “Client work,” refreshes the list, and reports success against the HEY development server. The temporary category was deleted afterward.
- ✅ CLI request tests cover list/create/rename/delete paths, nested form payloads, structured summaries, and validation without network calls.
- ✅ TUI tests cover load, create, rename, confirmed delete, refresh, blocked overlapping actions, and terminal-control sanitization.
- ✅ Smoke coverage creates, discovers, renames, and deletes a real category on the development server.

```text
GOWORK=off make check       # PASS
GOWORK=off make test-smoke  # PASS; time-track category lifecycle passed
```

</details>

<details>
<summary>✅ Scope — category CRUD is included; timer assignment remains separate</summary>

Included:
- CLI list/create/rename/delete commands and JSON output.
- Calendar TUI category manager and documented shortcuts.
- Unit, request, TUI, and smoke coverage; README, agent skill, API coverage, and CLI surface updates.

Preserved:
- Existing start, stop, current, and list behavior.
- Existing time tracks when a category is deleted; HEY moves them to Uncategorized.
- Existing API and SDK dependencies; there are no new packages, configuration, schema, or runtime services.

Deferred:
- `timetrack start/stop --category`. The API accepts `category_title`, while the released SDK update shape still sends `category`; #205 tracks that contract correction.

</details>

<details>
<summary>➖ Delivery — no migration, configuration, or rollout ordering</summary>

No migration, backfill, feature flag, configuration, credential, or deployment ordering is required. Rollback is a normal revert; category data remains server-owned and compatible with older CLI versions.

</details>

<details>
<summary>✅ Review decision — no unresolved decision; focus on command shape and TUI state boundaries</summary>

Suggested focus:
1. Whether the plural list command plus singular mutation group is the desired CLI shape.
2. The Calendar TUI's loading/mutation gate and confirmed deletion flow.

Known limitation: assigning categories to timer entries is intentionally outside this PR and remains tracked in #205.

</details>

<details>
<summary>✅ Review path — start with command behavior, then TUI state and proof</summary>

1. [internal/cmd/timetrack.go](https://github.com/basecamp/hey-cli/blob/2fb9cb1a9a0070d3749ba184219f7bd5f48361a1/internal/cmd/timetrack.go) — CLI command tree, validation, SDK calls, and output.
2. [internal/tui/calendar.go](https://github.com/basecamp/hey-cli/blob/2fb9cb1a9a0070d3749ba184219f7bd5f48361a1/internal/tui/calendar.go) and [time_track_categories.go](https://github.com/basecamp/hey-cli/blob/2fb9cb1a9a0070d3749ba184219f7bd5f48361a1/internal/tui/time_track_categories.go) — Calendar integration, request gating, interaction state, and rendering.
3. [CLI tests](https://github.com/basecamp/hey-cli/blob/2fb9cb1a9a0070d3749ba184219f7bd5f48361a1/internal/cmd/calendar_commands_test.go), [TUI tests](https://github.com/basecamp/hey-cli/blob/2fb9cb1a9a0070d3749ba184219f7bd5f48361a1/internal/tui/time_track_categories_test.go), and [smoke test](https://github.com/basecamp/hey-cli/blob/2fb9cb1a9a0070d3749ba184219f7bd5f48361a1/tests/smoke/timetrack_test.go) — behavior proof.
4. [.surface](https://github.com/basecamp/hey-cli/blob/2fb9cb1a9a0070d3749ba184219f7bd5f48361a1/.surface), [API-COVERAGE.md](https://github.com/basecamp/hey-cli/blob/2fb9cb1a9a0070d3749ba184219f7bd5f48361a1/API-COVERAGE.md), [README.md](https://github.com/basecamp/hey-cli/blob/2fb9cb1a9a0070d3749ba184219f7bd5f48361a1/README.md), and [skills/hey/SKILL.md](https://github.com/basecamp/hey-cli/blob/2fb9cb1a9a0070d3749ba184219f7bd5f48361a1/skills/hey/SKILL.md) — public surface and documentation.

**Origin and supporting links:** [Basecamp card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892922) · #205

</details>
