### PR TITLE
Stop stretching inline images past their own pixels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,9 +91,9 @@ To add a new section: implement the `sectionView` interface in a new file, add a
 
 The TUI renders inline images using the Kitty graphics protocol's Unicode Placeholder extension (`internal/tui/kitty.go`). This works because Bubble Tea's cell-based renderer corrupts raw APC escape sequences, but Unicode placeholders are regular text that survives rendering. The approach has three steps:
 
-1. **Upload** — image data is sent to the terminal via `tea.Raw()` with `a=t` (transmit only) and `q=2` (suppress response), then a virtual placement is created with `U=1`.
-2. **Display** — U+10EEEE placeholder characters with combining diacritics (encoding row/column) are placed in the viewport content. The image ID is encoded in the foreground color.
-3. **Sizing** — `image.DecodeConfig` reads dimensions without full decoding; terminal cell count accounts for ~2:1 height:width cell ratio.
+1. **Upload** — image data is sent to the terminal via `tea.Raw()` with `a=t` (transmit only) and `q=2` (suppress response), then a virtual placement is created with `U=1`. The upload declares `f=100`, which means PNG, so `pngEncoded` re-encodes anything else first: a JPEG or a GIF handed over under that format code is dropped by the terminal and the thread shows a gap where its image was.
+2. **Display** — U+10EEEE placeholder characters with combining diacritics (encoding row/column) are placed in the viewport content. The image ID is encoded in the foreground color, so ids come from `nextImageID`: they start at `0x010101` to keep every color byte non-zero, stay inside three bytes, and are never reused. Reusing an id replaces the image the terminal holds under it while the placement drawn for the old geometry is still on screen, and the new image renders clipped into the old one's cells.
+3. **Sizing** — `image.DecodeConfig` reads dimensions without full decoding. The terminal stretches the image over the cells it is placed in and scales each cell on its own, so an image placed in more cells than its pixels cover comes out smeared and seamed rather than merely soft. `imageDimensions` therefore treats the image's own size as the ceiling, and a tall image gives up columns instead of its proportions when it hits `maxImageRows`.
 
 This works in Kitty and Ghostty. Other terminals show the text content normally (placeholders are invisible).
 

--- a/internal/tui/journal.go
+++ b/internal/tui/journal.go
@@ -58,8 +58,8 @@ func (v *journalView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.topicViewport.SetContent(v.topicContent)
 		v.topicViewport.GotoTop()
 		var uploadCmds []tea.Cmd
-		for i, imgData := range msg.images {
-			imageID := i + 1
+		for _, imgData := range msg.images {
+			imageID := nextImageID()
 			cols, rows := imageDimensions(imgData, v.vc.width-4)
 			v.topicContent += "\n\n" + renderImagePlaceholder(imageID, cols, rows)
 			v.topicViewport.SetContent(v.topicContent)

--- a/internal/tui/kitty.go
+++ b/internal/tui/kitty.go
@@ -7,9 +7,10 @@ import (
 	"image"
 	_ "image/gif"  // register GIF decoder for image.DecodeConfig
 	_ "image/jpeg" // register JPEG decoder
-	_ "image/png"  // register PNG decoder
+	"image/png"
 	"math"
 	"strings"
+	"sync/atomic"
 )
 
 // Diacritics for encoding row/column indices in Kitty unicode placeholders.
@@ -30,10 +31,45 @@ var diacritics = []rune{
 
 const placeholder = '\U0010EEEE'
 
+const (
+	maxImageCols = 60
+	maxImageRows = 40
+
+	// A cell for terminals that report their window without pixel dimensions.
+	// Only the ratio and the order of magnitude matter here: they keep an image
+	// from being blown up far past the pixels it actually has.
+	cellWidthPixels  = 10
+	cellHeightPixels = 20
+)
+
+// The first id hands the placeholder's foreground color a non-zero byte in every
+// position: a color like rgb(0,0,1) reads as a palette index to some terminals,
+// which then lose the image the cell belongs to. Ids stay under 0xFFFFFF so three
+// bytes of color can carry them without a fourth diacritic per cell.
+const (
+	firstImageID = 0x010101
+	lastImageID  = 0xFFFFFF
+)
+
+var imageIDs atomic.Int64
+
+// nextImageID hands out an id that no earlier image has used. Reusing one replaces
+// the image the terminal holds under it while the placement drawn for the old
+// geometry is still on screen, which renders the new image clipped into the old
+// image's cells.
+func nextImageID() int {
+	id := firstImageID + imageIDs.Add(1)
+	if id > lastImageID {
+		imageIDs.Store(0)
+		id = firstImageID
+	}
+	return int(id)
+}
+
 // kittyUploadAndPlace returns escape sequences to upload image data and create
 // a virtual Unicode placement. The result should be sent via tea.Raw().
 func kittyUploadAndPlace(data []byte, id, cols, rows int) string {
-	encoded := base64.StdEncoding.EncodeToString(data)
+	encoded := base64.StdEncoding.EncodeToString(pngEncoded(data))
 	const chunkSize = 4096
 
 	if len(encoded) == 0 {
@@ -99,8 +135,33 @@ func renderImagePlaceholder(id, cols, rows int) string {
 	return b.String()
 }
 
-// imageDimensions calculates display size in terminal cells for an image.
-// Terminal cells are roughly 2:1 (height:width ratio).
+// pngEncoded returns data the terminal will read the way the upload describes it.
+// The upload declares f=100, which is PNG, so a JPEG or a GIF sent as-is is dropped
+// by the terminal and the email shows an empty gap where its image was. Anything
+// that is not already a PNG is re-encoded, at the fastest compression setting since
+// this runs while the thread is being drawn.
+func pngEncoded(data []byte) []byte {
+	if len(data) == 0 || bytes.HasPrefix(data, []byte("\x89PNG\r\n\x1a\n")) {
+		return data
+	}
+
+	decoded, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return data
+	}
+
+	var encoded bytes.Buffer
+	encoder := png.Encoder{CompressionLevel: png.BestSpeed}
+	if err := encoder.Encode(&encoded, decoded); err != nil {
+		return data
+	}
+	return encoded.Bytes()
+}
+
+// imageDimensions calculates display size in terminal cells for an image. The
+// terminal scales the image to fill the cells it is placed in, one cell at a time,
+// so a small image stretched over many cells comes out smeared and seamed rather
+// than merely soft -- an image never gets more cells than its own pixels cover.
 func imageDimensions(data []byte, maxCols int) (cols, rows int) {
 	cfg, _, err := image.DecodeConfig(bytes.NewReader(data))
 	if err != nil || cfg.Width == 0 || cfg.Height == 0 {
@@ -111,9 +172,18 @@ func imageDimensions(data []byte, maxCols int) (cols, rows int) {
 		return maxCols, 10
 	}
 
-	cols = min(maxCols, 60)
-	// Divide by 2 because terminal cells are ~2x taller than wide
-	rows = max(int(math.Round(float64(cols)*float64(cfg.Height)/float64(cfg.Width)/2.0)), 1)
-	rows = min(rows, 40)
+	naturalCols := int(math.Ceil(float64(cfg.Width) / cellWidthPixels))
+	cols = max(min(maxCols, maxImageCols, naturalCols), 1)
+	rows = imageRows(cols, cfg)
+
+	if rows > maxImageRows {
+		cols = max(cols*maxImageRows/rows, 1)
+		rows = maxImageRows
+	}
 	return cols, rows
+}
+
+func imageRows(cols int, cfg image.Config) int {
+	pixelsPerCol := float64(cfg.Width) / float64(cols)
+	return max(int(math.Round(float64(cfg.Height)/pixelsPerCol*cellWidthPixels/cellHeightPixels)), 1)
 }

--- a/internal/tui/kitty_test.go
+++ b/internal/tui/kitty_test.go
@@ -1,6 +1,11 @@
 package tui
 
 import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
 	"strings"
 	"testing"
 )
@@ -65,6 +70,104 @@ func TestRenderImagePlaceholderZero(t *testing.T) {
 	if result != "" {
 		t.Errorf("zero dimensions should return empty string, got %q", result)
 	}
+}
+
+func TestImageDimensionsStaysWithinTheImagesOwnPixels(t *testing.T) {
+	// A logo the size of the one Sentry puts at the top of its notifications.
+	cols, rows := imageDimensions(pngImage(t, 234, 64), 100)
+	if cols != 24 || rows != 3 {
+		t.Errorf("dimensions = (%d, %d), want (24, 3)", cols, rows)
+	}
+
+	// An icon must not be blown up over half the thread either.
+	cols, rows = imageDimensions(pngImage(t, 32, 32), 100)
+	if cols != 4 || rows != 2 {
+		t.Errorf("dimensions = (%d, %d), want (4, 2)", cols, rows)
+	}
+}
+
+func TestImageDimensionsCaps(t *testing.T) {
+	cols, rows := imageDimensions(pngImage(t, 2000, 1000), 100)
+	if cols != maxImageCols || rows != 15 {
+		t.Errorf("wide image = (%d, %d), want (%d, 15)", cols, rows, maxImageCols)
+	}
+
+	cols, rows = imageDimensions(pngImage(t, 2000, 1000), 30)
+	if cols != 30 || rows != 7 {
+		t.Errorf("narrow viewport = (%d, %d), want (30, 7)", cols, rows)
+	}
+
+	// A tall screenshot loses columns rather than its proportions.
+	cols, rows = imageDimensions(pngImage(t, 600, 4000), 100)
+	if cols != 12 || rows != maxImageRows {
+		t.Errorf("tall image = (%d, %d), want (12, %d)", cols, rows, maxImageRows)
+	}
+}
+
+func TestPngEncodedRewritesWhatTheTerminalWouldDrop(t *testing.T) {
+	original := pngImage(t, 40, 20)
+	if !bytes.Equal(pngEncoded(original), original) {
+		t.Error("a PNG should be passed through untouched")
+	}
+
+	encoded := pngEncoded(jpegImage(t, 40, 20))
+	if !bytes.HasPrefix(encoded, []byte("\x89PNG\r\n\x1a\n")) {
+		t.Error("a JPEG should be re-encoded as PNG")
+	}
+
+	config, format, err := image.DecodeConfig(bytes.NewReader(encoded))
+	if err != nil || format != "png" || config.Width != 40 || config.Height != 20 {
+		t.Errorf("re-encoded image = %s %dx%d, err %v", format, config.Width, config.Height, err)
+	}
+
+	if got := pngEncoded([]byte("not an image")); string(got) != "not an image" {
+		t.Errorf("undecodable data should be left alone, got %q", got)
+	}
+}
+
+func TestNextImageID(t *testing.T) {
+	first, second := nextImageID(), nextImageID()
+	if first == second {
+		t.Error("ids must not repeat")
+	}
+	for _, id := range []int{first, second} {
+		if id>>16&0xFF == 0 || id>>8&0xFF == 0 || id&0xFF == 0 {
+			t.Errorf("id %#x has a zero color byte", id)
+		}
+		if id > lastImageID {
+			t.Errorf("id %#x needs more than three bytes of color", id)
+		}
+	}
+}
+
+func pngImage(t *testing.T, width, height int) []byte {
+	t.Helper()
+
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, filledImage(width, height)); err != nil {
+		t.Fatalf("encoding PNG: %v", err)
+	}
+	return encoded.Bytes()
+}
+
+func jpegImage(t *testing.T, width, height int) []byte {
+	t.Helper()
+
+	var encoded bytes.Buffer
+	if err := jpeg.Encode(&encoded, filledImage(width, height), nil); err != nil {
+		t.Fatalf("encoding JPEG: %v", err)
+	}
+	return encoded.Bytes()
+}
+
+func filledImage(width, height int) image.Image {
+	filled := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := range height {
+		for x := range width {
+			filled.Set(x, y, color.RGBA{R: uint8(x % 256), G: uint8(y % 256), B: 128, A: 255})
+		}
+	}
+	return filled
 }
 
 func TestImageDimensionsFallback(t *testing.T) {

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -275,9 +275,8 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.attachmentCursor = 0
 		var imageContent strings.Builder
 		var uploadCmds []tea.Cmd
-		for i, imgData := range msg.images {
-			imageID := i + 1
-			rendered := v.vc.imageRenderer.render(imgData, imageID, v.vc.width-4)
+		for _, imgData := range msg.images {
+			rendered := v.vc.imageRenderer.render(imgData, nextImageID(), v.vc.width-4)
 			if rendered.content != "" {
 				imageContent.WriteString("\n\n")
 				imageContent.WriteString(rendered.content)


### PR DESCRIPTION
Inline images in the TUI came out smeared and seamed — the SENTRY wordmark in a Sentry notification renders twice over itself, the Slack icon in the same email is a blurry mess with offset blocks.

The three images in that email are 234x64, 32x32 and 60x60 PNGs. `imageDimensions` ignored that and handed every image `min(maxCols, 60)` columns, so the 32px icon got a 60x30 cell box — a 20x blowup. The terminal fills a placement by scaling **each cell on its own**, so at that ratio the per-cell rounding repeats and drops source columns. The result reads as corruption rather than blur.

Reproduced by fetching those exact images out of the message and rendering them through these functions in Ghostty: at today's `60x8` the wordmark is mangled the same way; at natural size it is crisp.

## What changed

- An image's own size is the ceiling. Rows follow from a real cell ratio, and a tall image gives up columns instead of its proportions when it hits `maxImageRows`.
- `pngEncoded` re-encodes anything that is not already a PNG before upload. Every upload declares `f=100`, which means PNG, and a JPEG or a GIF handed over under that code is dropped by the terminal without a word — verified with a JPEG probe that drew a blank gap. The fetcher accepts JPEG and GIF, so those emails were showing nothing where an image belonged.
- `nextImageID` hands out ids once. They were per-view indices reset for every topic and shared with the journal; reusing an id replaces the image the terminal holds under it while the placement drawn for the old geometry is still on screen, and the new image renders clipped into the old one's cells (confirmed with a two-upload probe). Ids start at `0x010101` so no byte of the placeholder's foreground color is zero — some terminals read `rgb(0,0,1)` as a palette index and lose the image.

## Notes

`AGENTS.md`'s inline-images section now says why each of those three constraints exists, so the next change does not undo one of them.

Left alone: ids are never reused, so a long session keeps uploading images without deleting the old ones. Kitty and Ghostty evict their own image cache, so this is not unbounded — but deleting a topic's images when it closes would be tidier if we want it.

Tests cover the sizing ceiling, the caps, the PNG rewrite and the ids. `make test` and `make lint` are clean.
