### PR TITLE
Mark a thread as seen when the TUI opens it

### DIFF
--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -62,6 +62,7 @@ type topicLoadedMsg struct {
 	requestID   uint64
 	boxID       int64
 	topicID     int64
+	postingID   int64
 	title       string
 	entries     []models.Entry
 	attachments []messageAttachment
@@ -107,6 +108,15 @@ type postingActionDoneMsg struct {
 	sourceKind string
 	postingID  int64
 	effect     postingActionEffect
+	err        error
+}
+
+// postingSeenMsg reports the mark-seen that opening a thread triggers on its
+// own, as the web app does out of band once it has rendered the topic.
+type postingSeenMsg struct {
+	boxID      int64
+	sourceKind string
+	postingID  int64
 	err        error
 }
 
@@ -289,10 +299,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.imageContent = imageContent.String()
 		v.rebuildTopicContent()
 		v.topicViewport.GotoTop()
-		if len(uploadCmds) > 0 {
-			return tea.Batch(uploadCmds...), true
-		}
-		return nil, true
+		return tea.Batch(append(uploadCmds, v.markPostingSeen(msg.boxID, msg.postingID))...), true
 
 	case replyContextLoadedMsg:
 		if msg.requestID != v.activeRequestID || msg.boxID != v.currentBoxID() {
@@ -455,6 +462,20 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		if v.activeRequestKind == mailRequestPostings {
 			if source := v.currentSource(); source != nil {
 				return v.requestPostings(*source), true
+			}
+		}
+		return nil, true
+
+	case postingSeenMsg:
+		v.finishMutation()
+		if msg.err != nil {
+			v.notice = "Could not mark thread as seen: " + msg.err.Error()
+			return nil, true
+		}
+		if msg.boxID == v.currentBoxID() && msg.sourceKind == v.currentSourceKind() {
+			if idx := v.postingIndex(msg.postingID); idx >= 0 {
+				v.postingList.postings[idx].Seen = true
+				v.postingList.resort()
 			}
 		}
 		return nil, true
@@ -1249,9 +1270,9 @@ func (v *mailView) requestSearch(query string, page int) tea.Cmd {
 	return v.fetchSearchResults(ctx, requestID, query, max(page, 1))
 }
 
-func (v *mailView) requestTopic(boxID, topicID int64, title string) tea.Cmd {
+func (v *mailView) requestTopic(boxID, topicID, postingID int64, title string) tea.Cmd {
 	requestID, ctx := v.beginRequest(mailRequestTopic)
-	return v.fetchTopic(ctx, requestID, boxID, topicID, title)
+	return v.fetchTopic(ctx, requestID, boxID, topicID, postingID, title)
 }
 
 func (v *mailView) postingIndex(postingID int64) int {
@@ -1354,7 +1375,36 @@ func (v *mailView) openSelected() tea.Cmd {
 	if v.searchActive {
 		title = selected.Name
 	}
-	return v.requestTopic(v.currentBoxID(), topicID, title)
+	return v.requestTopic(v.currentBoxID(), topicID, selected.ID, title)
+}
+
+// markPostingSeen marks a thread as seen once it has been opened, the way the
+// web app beacons an observation after it renders a topic. A thread that is
+// already seen costs no request.
+func (v *mailView) markPostingSeen(boxID, postingID int64) tea.Cmd {
+	opened := v.openedPosting(postingID)
+	if opened == nil || opened.Seen {
+		return nil
+	}
+	sourceKind := v.currentSourceKind()
+	v.pendingMutations++
+	return func() tea.Msg {
+		err := v.vc.sdk.Postings().MarkSeen(v.vc.ctx, []int64{postingID})
+		return postingSeenMsg{boxID: boxID, sourceKind: sourceKind, postingID: postingID, err: err}
+	}
+}
+
+func (v *mailView) openedPosting(postingID int64) *models.Posting {
+	list := &v.postingList
+	if v.searchActive {
+		list = &v.searchList
+	}
+	for i := range list.postings {
+		if list.postings[i].ID == postingID {
+			return &list.postings[i]
+		}
+	}
+	return nil
 }
 
 // --- Posting actions ---
@@ -1749,7 +1799,7 @@ func (v *mailView) fetchSearchResults(ctx context.Context, requestID uint64, que
 	}
 }
 
-func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topicID int64, title string) tea.Cmd {
+func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topicID, postingID int64, title string) tea.Cmd {
 	return func() tea.Msg {
 		topic, err := v.vc.sdk.Topics().Get(ctx, topicID)
 		if err != nil {
@@ -1817,6 +1867,7 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 			requestID:   requestID,
 			boxID:       boxID,
 			topicID:     topicID,
+			postingID:   postingID,
 			title:       title,
 			entries:     entries,
 			attachments: attachments,

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -284,6 +284,78 @@ func TestMailViewIgnoresUnrelatedMessages(t *testing.T) {
 	}
 }
 
+func TestMailViewMarksOpenedThreadSeen(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+
+	loaded, ok := runCmd(v.HandleContentKey(keyPress("enter"))).(topicLoadedMsg)
+	if !ok || loaded.err != nil || loaded.postingID != 100 {
+		t.Fatalf("opened topic = posting %d error %v", loaded.postingID, loaded.err)
+	}
+
+	cmd, _ := v.Update(loaded)
+	if !v.AccountSwitchBlocked() {
+		t.Fatal("marking the opened thread seen did not block account switching")
+	}
+	seen, ok := runCmd(cmd).(postingSeenMsg)
+	if !ok || seen.err != nil {
+		t.Fatalf("mark seen returned %#v", seen)
+	}
+	if recorded.method != http.MethodPost || recorded.path != "/postings/seen.json" {
+		t.Errorf("request = %s %s, want POST /postings/seen.json", recorded.method, recorded.path)
+	}
+	if len(recorded.body.PostingIDs) != 1 || recorded.body.PostingIDs[0] != 100 {
+		t.Errorf("posting_ids = %v, want [100]", recorded.body.PostingIDs)
+	}
+
+	v.Update(seen)
+	if v.AccountSwitchBlocked() {
+		t.Error("completed mark seen still blocks account switching")
+	}
+	if !v.postingList.postings[v.postingIndex(100)].Seen {
+		t.Error("the opened thread should be seen in the list")
+	}
+	if v.notice != "" {
+		t.Errorf("opening a thread should not announce itself: %q", v.notice)
+	}
+}
+
+func TestMailViewLeavesSeenThreadAloneWhenOpened(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.postingList.postings[0].Seen = true
+
+	loaded, ok := runCmd(v.HandleContentKey(keyPress("enter"))).(topicLoadedMsg)
+	if !ok || loaded.err != nil || loaded.postingID != 100 {
+		t.Fatalf("opened topic = posting %d error %v", loaded.postingID, loaded.err)
+	}
+
+	cmd, _ := v.Update(loaded)
+	if cmd != nil {
+		t.Errorf("opening a seen thread should not mark it again: %#v", runCmd(cmd))
+	}
+	if recorded.path == "/postings/seen.json" {
+		t.Error("opening a seen thread hit the mark seen endpoint")
+	}
+}
+
+func TestMailViewReportsFailureToMarkOpenedThreadSeen(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusInternalServerError)
+
+	loaded := runCmd(v.HandleContentKey(keyPress("enter"))).(topicLoadedMsg)
+	cmd, _ := v.Update(loaded)
+	seen := runCmd(cmd).(postingSeenMsg)
+	if seen.err == nil {
+		t.Fatal("a failed mark seen should carry its error")
+	}
+
+	v.Update(seen)
+	if !strings.HasPrefix(v.notice, "Could not mark thread as seen") {
+		t.Errorf("notice = %q, want the mark seen failure", v.notice)
+	}
+	if v.postingList.postings[v.postingIndex(100)].Seen {
+		t.Error("a failed mark seen should leave the thread unseen")
+	}
+}
+
 // --- Posting actions ---
 
 func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
@@ -1191,7 +1263,7 @@ func TestMailViewDownloadsImageDataOnlyForKittyRenderer(t *testing.T) {
 	vc.sdk = client
 	vc.imageFetcher = newTrustedImageFetcher(client)
 	v := newMailView(vc)
-	loaded := v.fetchTopic(context.Background(), 1, 1, 100, "Latest image")().(topicLoadedMsg)
+	loaded := v.fetchTopic(context.Background(), 1, 1, 100, 500, "Latest image")().(topicLoadedMsg)
 
 	if loaded.err != nil || len(loaded.attachments) != 1 {
 		t.Fatalf("text fallback topic = attachments:%d error:%v", len(loaded.attachments), loaded.err)
@@ -1202,7 +1274,7 @@ func TestMailViewDownloadsImageDataOnlyForKittyRenderer(t *testing.T) {
 
 	vc.imageRenderer = kittyImageRenderer{}
 	v = newMailView(vc)
-	loaded = v.fetchTopic(context.Background(), 2, 1, 100, "Latest image")().(topicLoadedMsg)
+	loaded = v.fetchTopic(context.Background(), 2, 1, 100, 500, "Latest image")().(topicLoadedMsg)
 	if loaded.err != nil || len(loaded.images) != 1 || imageRequests.Load() != 1 {
 		t.Errorf("Kitty topic = images:%d requests:%d error:%v", len(loaded.images), imageRequests.Load(), loaded.err)
 	}
@@ -1244,7 +1316,7 @@ func TestMailViewDoesNotFetchImagesOutsideHEYOrGopher(t *testing.T) {
 	vc.imageFetcher = newTrustedImageFetcher(client)
 	v := newMailView(vc)
 
-	loaded := v.fetchTopic(context.Background(), 1, 1, 100, "Untrusted image")().(topicLoadedMsg)
+	loaded := v.fetchTopic(context.Background(), 1, 1, 100, 500, "Untrusted image")().(topicLoadedMsg)
 
 	if loaded.err != nil {
 		t.Fatalf("fetch topic: %v", loaded.err)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -466,7 +466,7 @@ func TestEscCancelsPendingSearchResultAndPreservesResults(t *testing.T) {
 	m.mailView.searchQuery = "quarterly planning"
 	m.mailView.searchPage = 1
 	m.mailView.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
-	m.mailView.requestTopic(m.mailView.currentBoxID(), 100, "Hello world")
+	m.mailView.requestTopic(m.mailView.currentBoxID(), 100, 10, "Hello world")
 	m.loading = true
 
 	updated, _ := m.Update(keyPress("esc"))
@@ -485,7 +485,7 @@ func TestQExitsSearchDuringPendingResult(t *testing.T) {
 	m.mailView.searchQuery = "quarterly planning"
 	m.mailView.searchPage = 1
 	m.mailView.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
-	m.mailView.requestTopic(m.mailView.currentBoxID(), 100, "Hello world")
+	m.mailView.requestTopic(m.mailView.currentBoxID(), 100, 10, "Hello world")
 	m.loading = true
 
 	updated, _ := m.Update(keyPress("q"))


### PR DESCRIPTION
Opening a thread in the TUI only fetched it. Nothing told the server it had been read, so the only way to mark a thread seen was pressing `e` on the list.

The web app does this out of band: `app/views/topics/show.html.erb` beacons `POST /topics/:id/observation` once it has rendered a topic, and `Topics::ObservationsController` marks it seen. `TopicsController#show` doesn't, so nothing was going to happen on the CLI's behalf.

Opening now carries the posting's id along with the topic load, and once the topic renders the view marks it seen through the same endpoint `e` uses -- no SDK change.

- Marks on a successful load, not on the keypress, so a failed fetch doesn't claim you read something.
- An already-seen thread costs no request.
- It's a real mutation: it blocks account switching while in flight, and the row flips to seen and re-partitions into Previously Seen when the write comes back rather than optimistically.
- Success is silent -- being read is a side effect, not an action you took. A failure says `Could not mark thread as seen: ...` instead of swallowing it.

`hey topic` on the CLI still leaves the seen state alone: agents and scripts reading mail shouldn't quietly clear your Imbox. Happy to make it match if we'd rather.

Three tests cover the mark, the skip for an already-seen thread, and the failure notice. `make test` and `make lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)