### PR TITLE
TUI: follow mail and The Screener live

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ section: ctrl+s from the mail list swaps it in as the active view, it captures e
 while it is open, and it asks to be closed again with `screenerClosedMsg`.
 The rest of `internal/tui/` is shared infrastructure: `tui.go` (model and
 router), `section_view.go` (the interface), plus `nav.go`, `content.go`, `help.go`,
-`styles.go`, `loading.go`, `kitty.go`, `html.go` and `calendar_views.go`. Read the directory rather than a
+`styles.go`, `loading.go`, `kitty.go`, `html.go`, `live.go` and `calendar_views.go`. Read the directory rather than a
 table here.
 
 To add a new section: implement the `sectionView` interface in a new file, add a field and constructor call in `newModel`, and add a case in `switchSection`.
@@ -151,6 +151,45 @@ missed broadcast costs nothing, and a 409 means catch up in full instead. A read
 fails leaves the cursor where it was and is retried on a doubling backoff, so a change
 isn't lost with the notification that announced it, and a subscription that closes without
 the watch being interrupted is an error rather than a quiet exit.
+
+The TUI's mail list follows the same channel and wants less from it. `internal/cmd/tui_watch.go`
+subscribes and relays the changed box IDs down a channel; `internal/tui/live.go` defines
+that contract as `tui.MailWatcher`, so the TUI never sees cable or auth, and a test hands
+it a plain channel. There is no cursor: the doorbell says which box changed and
+`mailView.refreshBox` reads that box again in full, which is what the list renders anyway.
+A reconnect sends `tui.AnyBoxChanged`, standing for the changes broadcast while the
+connection was down.
+
+`internal/tui/live.go` is also where the two delays live. `liveRefreshDelay` collects one
+delivery's changes into a single re-read — a thread rings the doorbell once per posting.
+`liveRetryDelay` is how long a re-read waits when a form or a picker is open over the list,
+or a write hasn't landed: the change is held rather than dropped, because a re-read
+replaces what the reader is looking at. `contentList.refreshPostings` is what makes that
+safe — unlike `setPostings` it keeps the cursor on its posting and keeps a selection —
+and the re-read has its own request lane (`liveRequestID`, `postingsRefreshedMsg`) so it
+can never be confused with a read the user asked for, or show the spinner.
+
+The watch outlives the view context, which a mail account switch throws away; that is what
+`model.watchCtx` is for. When the stream closes for good the mail list says so and stays
+saying so until ctrl+r reads the box again.
+
+The Screener is told over a different stream, because haystack has no channel for it:
+`Clearance::Broadcasting` re-renders the Screener's own button over a Turbo stream, and
+`clearances/index.jbuilder` serves that stream's signed name next to the pending count.
+So the TUI subscribes to `Turbo::StreamsChannel` with `signed_stream_name` (that is
+`tui.ScreenerWatcher`, and the name is why the watch can only be opened after a read).
+What HEY broadcasts there is markup for the web app — nothing is parsed out of it, the
+arrival is the whole message, and the count is read again behind it. The SDK's
+`Clearances().Summary` is that read: the same cheap request as `PendingCount`, keeping
+the stream name it used to throw away.
+
+The doorbell always re-reads the count, wherever the user is, because the mail list is
+where The Screener announces itself. When The Screener is what's on screen the queue is
+re-read too, through `screenerPane.refreshRows` — the same keep-your-place trick as the
+mail list — and held while a decision is in flight or the clear-everything question is up.
+On the history tab nothing is read; the pending pane is just marked unloaded, which is
+what `switchTab` already looks at. Both watches share one websocket
+(`tuiCableClient` in `internal/cmd/tui_watch.go`): two subscriptions, one authorization.
 
 ### API documentation
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ Calendar and Journal remain identity-wide.
 
 Navigate between Mail, Contacts, Calendar, and Journal. Mail navigation includes HEY boxes followed by your labels. Use `n` and `p` to page through a label. Use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `g` to add, create, or remove labels, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press `b` to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with `u` while HEY's undo window remains open. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
 
+The mail list follows the server. HEY tells the TUI when a box changed over the same
+Action Cable connection `hey watch` uses, and the box on screen is read again a moment
+later, keeping your place in the list and anything you had selected. A change that arrives
+while a form or a picker is open waits for it to close. Press Ctrl+R to read the box again
+yourself; if the connection goes away for good, the list says so and Ctrl+R is how you
+catch up.
+
+The Screener keeps up too. When a first-time sender writes, the count above the threads
+changes on its own, and if you have The Screener open the new sender appears in the queue
+without moving your place in it.
+
 Press Ctrl+S from the mail list to open The Screener. When senders are waiting, the mail
 list says so above the threads. In The Screener, `y` screens the selected sender in and `n`
 screens them out, Tab moves to Screener History and back, `[` and `]` page through either

--- a/go.mod
+++ b/go.mod
@@ -118,3 +118,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 )
+
+replace github.com/basecamp/hey-sdk/go => /home/stanko/Work/basecamp/hey-sdk/go

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/actioncable-go v0.0.0-20260819125529-39dd29b8e4d1
-	github.com/basecamp/hey-sdk/go v0.7.0
+	github.com/basecamp/hey-sdk/go v0.9.0
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gofrs/flock v0.13.0
@@ -118,5 +118,3 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 )
-
-replace github.com/basecamp/hey-sdk/go => /home/stanko/Work/basecamp/hey-sdk/go

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/actioncable-go v0.0.0-20260819125529-39dd29b8e4d1 h1:aNCaFvx7FosjImt1A3TM3aWizOgWGHtKUoQ4RTa6Mx8=
 github.com/basecamp/actioncable-go v0.0.0-20260819125529-39dd29b8e4d1/go.mod h1:9+DEydJMniIKraEsd4fDJpFEnqlLUJ6XhAswxRBaITk=
-github.com/basecamp/hey-sdk/go v0.7.0 h1:dp73t131XpVWcLgqTGgkn+CLrb0MVHdp5qkqUpXtPZI=
-github.com/basecamp/hey-sdk/go v0.7.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
+github.com/basecamp/hey-sdk/go v0.9.0 h1:f1TWkQpc1FnrNknCZfCeViJFfecbhzc/vnOby96JbFE=
+github.com/basecamp/hey-sdk/go v0.9.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -27,7 +27,7 @@ func newTuiRunner(use string, hidden bool) *cobra.Command {
 			if err := requireAuth(); err != nil {
 				return err
 			}
-			return tui.Run(rootSDK, sdk, cfg.AccountID)
+			return tui.Run(rootSDK, sdk, cfg.AccountID, tuiWatchers())
 		},
 	}
 }

--- a/internal/cmd/tui_watch.go
+++ b/internal/cmd/tui_watch.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"context"
+	"sync"
+
+	actioncable "github.com/basecamp/actioncable-go"
+
+	"github.com/basecamp/hey-cli/internal/cable"
+	"github.com/basecamp/hey-cli/internal/tui"
+)
+
+const turboStreamsChannel = "Turbo::StreamsChannel"
+
+// mailChangeBacklog is how many notifications wait to be read before the reconnect
+// catch-up is dropped instead of blocking the cable client's own goroutine. A full
+// backlog means a re-read is already coming.
+const mailChangeBacklog = 16
+
+// tuiWatchers are the streams `hey tui` follows to stay live.
+func tuiWatchers() tui.Watchers {
+	return tui.Watchers{Mail: watchMailChanges, Screener: watchScreenerChanges}
+}
+
+// watchMailChanges opens the stream of changed boxes the TUI follows, over the same
+// cable subscription `hey watch` listens on. The notification is a doorbell — it names
+// the box and nothing else — and that is all the TUI wants: it re-reads the box it is
+// showing rather than following individual postings, so there is no cursor to keep.
+//
+// The stream closes when ctx is done, or when the connection is gone for good, which is
+// how the TUI hears that its list has stopped being live.
+func watchMailChanges(ctx context.Context) (<-chan int64, error) {
+	client, err := tuiCableClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// A reconnect stands for every box: the changes broadcast while the connection was
+	// down were missed, and the box on screen has to be read again to find them.
+	changes := make(chan int64, mailChangeBacklog)
+	subscription, err := client.Subscribe(ctx, actioncable.Identifier{Channel: changesChannel},
+		actioncable.OnConnected(func(reconnected bool) {
+			if reconnected {
+				select {
+				case changes <- tui.AnyBoxChanged:
+				default:
+				}
+			}
+		}))
+	if err != nil {
+		return nil, err
+	}
+
+	go relayMailChanges(ctx, subscription, changes)
+
+	return changes, nil
+}
+
+func relayMailChanges(ctx context.Context, subscription *actioncable.Subscription, changes chan<- int64) {
+	defer close(changes)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case message, open := <-subscription.Messages():
+			if !open {
+				return
+			}
+			var notification struct {
+				BoxID int64 `json:"box_id"`
+			}
+			if err := message.Unmarshal(&notification); err != nil {
+				continue
+			}
+			select {
+			case changes <- notification.BoxID:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// watchScreenerChanges opens the stream that says The Screener changed. HEY re-renders the
+// Screener's own button over a Turbo stream whenever a clearance is created or decided,
+// and serves the signed name of that stream with the pending count. What it broadcasts is
+// markup for the web app, so nothing is read out of it: the arrival is the whole message,
+// and the TUI reads the count again behind it.
+func watchScreenerChanges(ctx context.Context, signedStreamName string) (<-chan struct{}, error) {
+	client, err := tuiCableClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	changes := make(chan struct{}, 1)
+	subscription, err := client.Subscribe(ctx, actioncable.Identifier{
+		Channel: turboStreamsChannel,
+		Params:  actioncable.Params{"signed_stream_name": signedStreamName},
+	}, actioncable.OnConnected(func(reconnected bool) {
+		if reconnected {
+			ringScreener(changes)
+		}
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	go relayScreenerChanges(ctx, subscription, changes)
+
+	return changes, nil
+}
+
+func relayScreenerChanges(ctx context.Context, subscription *actioncable.Subscription, changes chan struct{}) {
+	defer close(changes)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, open := <-subscription.Messages():
+			if !open {
+				return
+			}
+			ringScreener(changes)
+		}
+	}
+}
+
+// ringScreener drops the ring when one is already waiting: they all say the same thing,
+// and it must not block the cable client's own goroutine.
+func ringScreener(changes chan struct{}) {
+	select {
+	case changes <- struct{}{}:
+	default:
+	}
+}
+
+// tuiCable is the one connection the TUI's watches share — two subscriptions over one
+// websocket, authorized once. It is opened by whichever watch needs it first and closed
+// when that watch's context is done, which is the TUI's own lifetime.
+var tuiCable struct {
+	sync.Mutex
+	client *actioncable.Client
+}
+
+func tuiCableClient(ctx context.Context) (*actioncable.Client, error) {
+	tuiCable.Lock()
+	defer tuiCable.Unlock()
+
+	if tuiCable.client != nil {
+		return tuiCable.client, nil
+	}
+
+	client, err := cable.Dial(ctx, cfg.BaseURL, authMgr)
+	if err != nil {
+		return nil, watchDialError(err)
+	}
+	tuiCable.client = client
+
+	go func() {
+		<-ctx.Done()
+		tuiCable.Lock()
+		defer tuiCable.Unlock()
+		_ = client.Close()
+		tuiCable.client = nil
+	}()
+
+	return client, nil
+}

--- a/internal/tui/accounts_test.go
+++ b/internal/tui/accounts_test.go
@@ -56,7 +56,7 @@ func TestUnavailableSelectedAccountFailsClosedAndAllowsRecovery(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 	root := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "token"}, hey.WithMaxRetries(0))
-	m := newModelWithMailAccounts(root, root, "99")
+	m := newModelWithMailAccounts(root, root, "99", Watchers{})
 
 	loaded := loadMailAccounts(t.Context(), root, "99")().(mailAccountsLoadedMsg)
 	if !loaded.selectedUnavailable {
@@ -83,7 +83,7 @@ func TestAccountDiscoveryFailureCanRetry(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 	root := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "token"}, hey.WithMaxRetries(0))
-	m := newModelWithMailAccounts(root, root, "all")
+	m := newModelWithMailAccounts(root, root, "all", Watchers{})
 	m.loading = false
 
 	failed := loadMailAccounts(t.Context(), root, "all")().(mailAccountsLoadedMsg)
@@ -179,7 +179,7 @@ func TestAccountSwitchRebuildsViewsAndCancelsOldGeneration(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 	root := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "token"}, hey.WithMaxRetries(0))
-	m := newModelWithMailAccounts(root, root, "all")
+	m := newModelWithMailAccounts(root, root, "all", Watchers{})
 	m.mailAccounts = []mailAccountChoice{
 		{label: "All Accounts"},
 		{id: 1, label: "jane@example.com"},
@@ -227,7 +227,7 @@ func TestFailedAccountSwitchPreservesCurrentViews(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 	root := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "token"}, hey.WithMaxRetries(0))
-	m := newModelWithMailAccounts(root, root, "all")
+	m := newModelWithMailAccounts(root, root, "all", Watchers{})
 	m.mailAccounts = []mailAccountChoice{{label: "All Accounts"}, {id: 1, label: "jane@example.com"}, {id: 2, label: "missing@example.com"}}
 	m.mailAccountPicker = true
 	m.mailAccountCursor = 2

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -47,6 +47,46 @@ func (c *contentList) setPostings(postings []models.Posting) {
 	c.clearSelected()
 }
 
+// refreshPostings replaces the list with a newly read one while the user is looking at
+// it, so the reader keeps their place: the cursor stays on the posting it was on, the
+// window stays where it was scrolled to, and a multi-selection keeps every row that is
+// still there. A posting that left the box takes the cursor or its selection with it.
+func (c *contentList) refreshPostings(postings []models.Posting) {
+	if !c.hideSeenState {
+		postings = partitionSeen(postings)
+	}
+	var cursorID int64
+	if posting := c.selectedPosting(); posting != nil {
+		cursorID = posting.ID
+	}
+
+	c.postings = postings
+	c.cursor = 0
+	for i := range c.postings {
+		if c.postings[i].ID == cursorID {
+			c.cursor = i
+			break
+		}
+	}
+	c.keepSelected()
+	c.scrollOff = min(c.scrollOff, max(len(c.postings)-1, 0))
+	c.ensureVisible()
+}
+
+// keepSelected drops the postings that are no longer in the list from the selection.
+func (c *contentList) keepSelected() {
+	if len(c.selected) == 0 {
+		return
+	}
+	remaining := make(map[int64]struct{}, len(c.selected))
+	for _, posting := range c.postings {
+		if _, wasSelected := c.selected[posting.ID]; wasSelected {
+			remaining[posting.ID] = struct{}{}
+		}
+	}
+	c.selected = remaining
+}
+
 // partitionSeen orders unseen postings before seen ones, keeping the
 // relative order inside each group. This forms the "New for You" and
 // "Previously Seen" sections, as in the HEY web app.

--- a/internal/tui/live.go
+++ b/internal/tui/live.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	"context"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// Watchers are the streams the TUI follows to stay live. Both are optional: without them
+// a list is the snapshot it was read as.
+type Watchers struct {
+	Mail     MailWatcher
+	Screener ScreenerWatcher
+}
+
+// MailWatcher opens the stream of boxes that changed, so the TUI is told when to re-read
+// a box instead of polling for it. The stream closes when ctx is done, or when whatever
+// is behind it has given up for good — which is what tells the TUI it isn't live any more.
+type MailWatcher func(ctx context.Context) (<-chan int64, error)
+
+// ScreenerWatcher opens the stream that says The Screener changed. HEY signs the stream
+// name and serves it alongside the pending count, so a watcher can only be opened once
+// that name has been read — there is nothing to subscribe to before then.
+type ScreenerWatcher func(ctx context.Context, signedStreamName string) (<-chan struct{}, error)
+
+// AnyBoxChanged stands for "something changed, we don't know what" — a watcher sends it
+// after a reconnect, where the changes broadcast while it was away were missed.
+const AnyBoxChanged int64 = 0
+
+// liveRefreshDelay collects one delivery's changes into a single re-read: a thread lands
+// as several postings, and each one rings the doorbell separately.
+//
+// liveRetryDelay is how long a re-read waits when it can't be applied yet, because a form
+// or a picker is open over the list. Nothing is read until it closes, but the change is
+// held onto rather than dropped.
+const (
+	liveRefreshDelay = 500 * time.Millisecond
+	liveRetryDelay   = 2 * time.Second
+)
+
+// mailWatchStartedMsg carries the stream a watcher opened, or the reason there isn't one.
+type mailWatchStartedMsg struct {
+	changes <-chan int64
+	err     error
+}
+
+// mailChangedMsg reports one changed box, or a stream that has closed.
+type mailChangedMsg struct {
+	boxID  int64
+	closed bool
+}
+
+// mailRefreshDueMsg is the re-read a change asked for, once its delay has passed.
+type mailRefreshDueMsg struct{ boxID int64 }
+
+func startMailWatchCmd(ctx context.Context, watch MailWatcher) tea.Cmd {
+	if watch == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		changes, err := watch(ctx)
+		return mailWatchStartedMsg{changes: changes, err: err}
+	}
+}
+
+// waitForMailChangeCmd blocks until the next box changes, then reports it once. The
+// handler re-arms it, the way watchThemeCmd is re-armed.
+func waitForMailChangeCmd(changes <-chan int64) tea.Cmd {
+	if changes == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		boxID, open := <-changes
+		if !open {
+			return mailChangedMsg{closed: true}
+		}
+		return mailChangedMsg{boxID: boxID}
+	}
+}
+
+func refreshMailLaterCmd(boxID int64, delay time.Duration) tea.Cmd {
+	return tea.Tick(delay, func(time.Time) tea.Msg { return mailRefreshDueMsg{boxID: boxID} })
+}
+
+// --- The Screener ---
+
+// screenerWatchStartedMsg carries the stream a watcher opened, or the reason there isn't one.
+type screenerWatchStartedMsg struct {
+	changes <-chan struct{}
+	err     error
+}
+
+// screenerChangedMsg reports that someone arrived in or left The Screener, or that the
+// stream has closed. HEY broadcasts the Screener's own rendering, so the message says
+// nothing the TUI can use: it is a doorbell and the count is read again behind it.
+type screenerChangedMsg struct{ closed bool }
+
+// screenerRefreshDueMsg is the re-read a Screener change asked for, once its delay has passed.
+type screenerRefreshDueMsg struct{}
+
+func startScreenerWatchCmd(ctx context.Context, watch ScreenerWatcher, signedStreamName string) tea.Cmd {
+	if watch == nil || signedStreamName == "" {
+		return nil
+	}
+	return func() tea.Msg {
+		changes, err := watch(ctx, signedStreamName)
+		return screenerWatchStartedMsg{changes: changes, err: err}
+	}
+}
+
+func waitForScreenerChangeCmd(changes <-chan struct{}) tea.Cmd {
+	if changes == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		_, open := <-changes
+		return screenerChangedMsg{closed: !open}
+	}
+}
+
+func refreshScreenerLaterCmd(delay time.Duration) tea.Cmd {
+	return tea.Tick(delay, func(time.Time) tea.Msg { return screenerRefreshDueMsg{} })
+}

--- a/internal/tui/live_test.go
+++ b/internal/tui/live_test.go
@@ -1,0 +1,477 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/models"
+)
+
+// --- The changes stream ---
+
+func TestWaitForMailChangeReportsTheChangedBox(t *testing.T) {
+	changes := make(chan int64, 1)
+	changes <- 7
+
+	msg := waitForMailChangeCmd(changes)()
+	changed, ok := msg.(mailChangedMsg)
+	if !ok {
+		t.Fatalf("msg = %#v, want mailChangedMsg", msg)
+	}
+	if changed.boxID != 7 || changed.closed {
+		t.Errorf("changed = %+v, want box 7 and an open stream", changed)
+	}
+}
+
+func TestWaitForMailChangeReportsAClosedStream(t *testing.T) {
+	changes := make(chan int64)
+	close(changes)
+
+	if changed := waitForMailChangeCmd(changes)().(mailChangedMsg); !changed.closed {
+		t.Errorf("changed = %+v, want a closed stream", changed)
+	}
+	if cmd := waitForMailChangeCmd(nil); cmd != nil {
+		t.Error("nothing to wait on should be no command")
+	}
+}
+
+func TestStartMailWatchCarriesTheStreamOrTheReason(t *testing.T) {
+	changes := make(chan int64)
+	opened := startMailWatchCmd(context.Background(), func(context.Context) (<-chan int64, error) {
+		return changes, nil
+	})().(mailWatchStartedMsg)
+	if opened.changes == nil || opened.err != nil {
+		t.Errorf("opened = %+v, want the stream", opened)
+	}
+
+	refused := startMailWatchCmd(context.Background(), func(context.Context) (<-chan int64, error) {
+		return nil, errors.New("cable server said no")
+	})().(mailWatchStartedMsg)
+	if refused.err == nil {
+		t.Error("a watcher that fails should say why")
+	}
+
+	if cmd := startMailWatchCmd(context.Background(), nil); cmd != nil {
+		t.Error("no watcher should be no command")
+	}
+}
+
+// --- The model side ---
+
+func TestModelListensForMailChanges(t *testing.T) {
+	m := newModel()
+	m.mailView.boxes = orderBoxes(testBoxes())
+	changes := make(chan int64, 1)
+
+	updated, cmd := m.Update(mailWatchStartedMsg{changes: changes})
+	m = updated.(model)
+	if m.mailChanges == nil {
+		t.Fatal("the model should hold on to the stream")
+	}
+	if cmd == nil {
+		t.Fatal("the model should wait for the first change")
+	}
+
+	updated, _ = m.Update(mailChangedMsg{boxID: m.mailView.currentBoxID()})
+	m = updated.(model)
+	if !m.mailView.liveRefreshDue {
+		t.Error("a change to the box on screen should arm a re-read")
+	}
+}
+
+func TestModelSaysWhenLiveUpdatesStopped(t *testing.T) {
+	m := newModel()
+	m.mailView.boxes = orderBoxes(testBoxes())
+	m.mailView.Update(currentPostingsLoaded(m.mailView, testPostings()))
+	m.mailChanges = make(chan int64)
+
+	updated, cmd := m.Update(mailChangedMsg{closed: true})
+	m = updated.(model)
+	if cmd != nil {
+		t.Error("a closed stream should not be waited on again")
+	}
+	if m.mailChanges != nil {
+		t.Error("the closed stream should be let go of")
+	}
+	if !strings.Contains(m.mailView.View(), "ctrl+r") {
+		t.Errorf("the list should say it stopped following the server:\n%s", m.mailView.View())
+	}
+
+	if cmd := m.mailView.reloadPostings(); cmd == nil {
+		t.Fatal("ctrl+r should read the box again")
+	}
+	if strings.Contains(m.mailView.View(), "Not live") {
+		t.Error("a reload should take the standing word back down")
+	}
+}
+
+func TestModelReportsAWatcherThatNeverStarted(t *testing.T) {
+	m := newModel()
+	m.vc.width = 80
+	m.mailView.boxes = orderBoxes(testBoxes())
+
+	updated, _ := m.Update(mailWatchStartedMsg{err: errors.New("cable server said no")})
+	m = updated.(model)
+	if !strings.Contains(m.mailView.notice, "cable server said no") {
+		t.Errorf("notice = %q, want the reason there are no live updates", m.mailView.notice)
+	}
+}
+
+// --- The doorbell ---
+
+func TestMailViewArmsOneReReadPerRing(t *testing.T) {
+	v := mailWithPostings()
+
+	if cmd := v.boxChanged(v.currentBoxID()); cmd == nil {
+		t.Fatal("a change to the box on screen should arm a re-read")
+	}
+	if cmd := v.boxChanged(v.currentBoxID()); cmd != nil {
+		t.Error("a second ring should join the re-read already on its way")
+	}
+	if cmd := v.boxChanged(AnyBoxChanged); cmd != nil {
+		t.Error("a reconnect should join it too")
+	}
+}
+
+func TestMailViewIgnoresChangesItIsNotShowing(t *testing.T) {
+	v := mailWithPostings()
+
+	if cmd := v.boxChanged(v.currentBoxID() + 1000); cmd != nil {
+		t.Error("another box's change should not read the box on screen")
+	}
+	if !v.showsBox(AnyBoxChanged) {
+		t.Error("a reconnect stands for the box on screen")
+	}
+
+	v.boxes = append(v.boxes, models.Box{ID: 900, Kind: mailSourceKindFolder, Name: "Receipts"})
+	v.boxIndex = len(v.boxes) - 1
+	if cmd := v.boxChanged(900); cmd != nil {
+		t.Error("a label pages through its own feed, not a box's")
+	}
+}
+
+func TestMailViewHoldsAReReadWhileAFormIsOpen(t *testing.T) {
+	v, recorded := mailWithBoxServer(t, `[{"id":100,"summary":"Hello world","created_at":"2025-03-01T10:00:00Z"}]`)
+	v.startMove()
+
+	cmd := v.refreshBox(v.currentBoxID())
+	if cmd == nil {
+		t.Fatal("the change should be held onto, not dropped")
+	}
+	if !v.liveRefreshDue {
+		t.Error("a held change should still be due")
+	}
+	if len(recorded.paths) != 0 {
+		t.Errorf("nothing should have been read yet, got %v", recorded.paths)
+	}
+
+	v.movePicker = nil
+	if cmd := v.refreshBox(v.currentBoxID()); cmd == nil {
+		t.Fatal("closing the picker should let the re-read through")
+	}
+}
+
+func TestMailViewReReadKeepsTheReadersPlace(t *testing.T) {
+	v, recorded := mailWithBoxServer(t, `[
+		{"id":102,"summary":"Just arrived","created_at":"2025-03-01T11:00:00Z","creator":{"id":12,"name":"Carol Danvers"}},
+		{"id":100,"summary":"Hello world","created_at":"2025-03-01T10:00:00Z","creator":{"id":10,"name":"Alice Chen"}},
+		{"id":101,"summary":"Meeting notes","created_at":"2025-03-01T09:00:00Z","seen":true,"creator":{"id":11,"name":"Bob Lee"}}
+	]`)
+	v.postingList.cursor = 1 // Meeting notes, the seen one at the bottom
+	v.postingList.toggleSelected()
+
+	cmd := v.refreshBox(v.currentBoxID())
+	if cmd == nil {
+		t.Fatal("the box on screen should be re-read")
+	}
+	msg := cmd()
+	if _, consumed := v.Update(msg); !consumed {
+		t.Fatalf("msg = %#v, want a re-read the mail view takes", msg)
+	}
+
+	if len(v.postingList.postings) != 3 {
+		t.Fatalf("postings = %d, want the three the server answered", len(v.postingList.postings))
+	}
+	if v.postingList.postings[0].ID != 102 {
+		t.Errorf("first posting = %d, want the one that just arrived", v.postingList.postings[0].ID)
+	}
+	if selected := v.postingList.selectedPosting(); selected == nil || selected.ID != 101 {
+		t.Errorf("cursor = %+v, want it still on Meeting notes", selected)
+	}
+	if ids := v.postingList.selectedIDs(); len(ids) != 1 || ids[0] != 101 {
+		t.Errorf("selection = %v, want Meeting notes still selected", ids)
+	}
+	if paths := recorded.paths; len(paths) != 1 || !strings.HasSuffix(paths[0], "/boxes/1.json") {
+		t.Errorf("read = %v, want the one box", paths)
+	}
+	if v.loading {
+		t.Error("a re-read is not the user waiting on something")
+	}
+}
+
+func TestMailViewReadsTheBoxWhenTheDelayIsUp(t *testing.T) {
+	v, _ := mailWithBoxServer(t, `[{"id":100,"summary":"Hello world","created_at":"2025-03-01T10:00:00Z"}]`)
+	v.boxChanged(v.currentBoxID())
+
+	cmd, consumed := v.Update(mailRefreshDueMsg{boxID: v.currentBoxID()})
+	if !consumed {
+		t.Fatal("the mail view should take the re-read it asked for")
+	}
+	if cmd == nil {
+		t.Fatal("the delay being up should read the box")
+	}
+	if v.liveRefreshDue {
+		t.Error("the re-read is no longer due once it is on its way")
+	}
+}
+
+func TestMailViewIgnoresAReReadOfAnotherBox(t *testing.T) {
+	v := mailWithPostings()
+	v.liveRequestID = 3
+
+	v.Update(postingsRefreshedMsg{requestID: 3, boxID: v.currentBoxID() + 1, sourceKind: v.currentSourceKind(), postings: nil})
+	if len(v.postingList.postings) != 2 {
+		t.Error("a re-read of a box that is no longer on screen should be dropped")
+	}
+
+	v.Update(postingsRefreshedMsg{requestID: 2, boxID: v.currentBoxID(), sourceKind: v.currentSourceKind(), postings: nil})
+	if len(v.postingList.postings) != 2 {
+		t.Error("a re-read the view has moved on from should be dropped")
+	}
+}
+
+func TestMailViewSaysWhenAReReadFails(t *testing.T) {
+	v := mailWithPostings()
+
+	v.Update(postingsRefreshedMsg{requestID: v.liveRequestID, boxID: v.currentBoxID(), sourceKind: v.currentSourceKind(), err: errors.New("box unreachable")})
+	if !strings.Contains(v.notice, "box unreachable") {
+		t.Errorf("notice = %q, want the reason the re-read failed", v.notice)
+	}
+	if len(v.postingList.postings) != 2 {
+		t.Error("a failed re-read should leave the list as it was")
+	}
+}
+
+func TestMailViewReloadsOnCtrlR(t *testing.T) {
+	v := mailWithPostings()
+
+	if cmd := v.HandleContentKey(keyPress("ctrl+r")); cmd == nil {
+		t.Fatal("ctrl+r should read the box again")
+	}
+	if !v.loading {
+		t.Error("a reload the user asked for should show as loading")
+	}
+	if !hasHelpBinding(v.HelpBindings(), "ctrl+r") {
+		t.Error("the help should offer the reload")
+	}
+}
+
+// --- Keeping the reader's place ---
+
+func TestContentListRefreshDropsWhatLeftTheBox(t *testing.T) {
+	list := contentList{hideSeenState: true, width: 80, height: 20}
+	list.setPostings(testPostings())
+	list.cursor = 1
+	if !list.toggleSelected() {
+		t.Fatal("the posting under the cursor should end up selected")
+	}
+
+	list.refreshPostings([]models.Posting{testPostings()[0]})
+	if list.cursor != 0 {
+		t.Errorf("cursor = %d, want the top once its posting left", list.cursor)
+	}
+	if ids := list.selectedIDs(); len(ids) != 0 {
+		t.Errorf("selection = %v, want the posting that left dropped", ids)
+	}
+}
+
+// --- The Screener's stream ---
+
+func TestWaitForScreenerChangeReportsTheRingAndTheClose(t *testing.T) {
+	changes := make(chan struct{}, 1)
+	changes <- struct{}{}
+	if changed := waitForScreenerChangeCmd(changes)().(screenerChangedMsg); changed.closed {
+		t.Error("a ring is not a closed stream")
+	}
+
+	close(changes)
+	if changed := waitForScreenerChangeCmd(changes)().(screenerChangedMsg); !changed.closed {
+		t.Error("a closed stream should say so")
+	}
+	if cmd := waitForScreenerChangeCmd(nil); cmd != nil {
+		t.Error("nothing to wait on should be no command")
+	}
+}
+
+func TestModelOpensTheScreenerStreamOnlyWhenItsNameChanges(t *testing.T) {
+	m := newModel()
+	m.watchScreener = func(context.Context, string) (<-chan struct{}, error) {
+		return make(chan struct{}), nil
+	}
+
+	if cmd := m.startScreenerWatch(""); cmd != nil {
+		t.Error("there is nothing to subscribe to without a name")
+	}
+	if cmd := m.startScreenerWatch("stream-one"); cmd == nil {
+		t.Fatal("the first name HEY serves should open the stream")
+	}
+	if cmd := m.startScreenerWatch("stream-one"); cmd != nil {
+		t.Error("every count read carries the name; the same one should not reopen it")
+	}
+	if cmd := m.startScreenerWatch("stream-two"); cmd == nil {
+		t.Error("a new name should open the stream again")
+	}
+}
+
+func TestModelSaysWhenTheScreenerStreamCloses(t *testing.T) {
+	m := newModel()
+	m.screenerStream = "stream-one"
+	m.screenerChanges = make(chan struct{})
+
+	updated, cmd := m.Update(screenerChangedMsg{closed: true})
+	m = updated.(model)
+	if cmd != nil {
+		t.Error("a closed stream should not be waited on again")
+	}
+	if m.screenerChanges != nil || m.screenerStream != "" {
+		t.Error("the closed stream and its name should be let go of, so the next count read reopens it")
+	}
+	if !strings.Contains(m.mailView.notice, "stopped updating live") {
+		t.Errorf("notice = %q, want the Screener's own word", m.mailView.notice)
+	}
+}
+
+func TestModelRingsTheScreenerOnce(t *testing.T) {
+	m := newModel()
+
+	if cmd := m.screenerChanged(); cmd == nil {
+		t.Fatal("a Screener change should arm a re-read")
+	}
+	if cmd := m.screenerChanged(); cmd != nil {
+		t.Error("screening a queue in one go should still cost one re-read")
+	}
+}
+
+func TestModelReadsTheScreenerCountWhereverTheUserIs(t *testing.T) {
+	m := newModel()
+	m.mailView.boxes = orderBoxes(testBoxes())
+	m.screenerRefreshDue = true
+
+	if cmd := m.refreshScreener(); cmd == nil {
+		t.Fatal("the count should be read again even with The Screener closed")
+	}
+	if m.screenerRefreshDue {
+		t.Error("the re-read is no longer due once it is on its way")
+	}
+}
+
+func TestModelHoldsTheScreenerReadWhileADecisionIsInFlight(t *testing.T) {
+	view, _ := loadedScreener(t)
+	m := newModel()
+	m.screenerView = view
+	m.activeView = view
+	view.mutations = 1
+
+	if cmd := m.refreshScreener(); cmd == nil {
+		t.Fatal("the change should be held onto, not dropped")
+	}
+	if !m.screenerRefreshDue {
+		t.Error("a held change should still be due")
+	}
+}
+
+func TestScreenerRefreshKeepsTheCursorOnItsSender(t *testing.T) {
+	view, state := loadedScreener(t)
+	view.pending.cursor = 1 // Bob Smith
+
+	state.mu.Lock()
+	state.pending = `{"pending_clearances_count":3,"clearances":[
+		{"id":93,"status":"pending","petitioner":{"id":15,"name":"Nora Vance","email_address":"nora@example.com"},
+		 "most_recent_entry":{"id":503,"subject":"Just arrived","summary":"Are you around?","topic_id":702}},
+		{"id":91,"status":"pending","petitioner":{"id":11,"name":"Jane Doe","email_address":"jane@example.com"},
+		 "most_recent_entry":{"id":501,"subject":"Quarterly planning","summary":"Can we meet Thursday?","topic_id":700}},
+		{"id":92,"status":"pending","petitioner":{"id":12,"name":"Bob Smith","email_address":"bob@example.org"},
+		 "most_recent_entry":{"id":502,"subject":"Invoice 4102","summary":"Attached for your records","topic_id":701}}
+	]}`
+	state.mu.Unlock()
+
+	cmd, held := view.refreshPending()
+	if held || cmd == nil {
+		t.Fatalf("refresh = cmd:%v held:%v, want the queue read again", cmd != nil, held)
+	}
+	msg := runCmd(cmd)
+	if _, consumed := view.Update(msg); !consumed {
+		t.Fatalf("msg = %#v, want a re-read The Screener takes", msg)
+	}
+
+	if view.pendingCount != 3 || len(view.pending.rows) != 3 {
+		t.Fatalf("pending = count:%d rows:%d, want 3 and 3", view.pendingCount, len(view.pending.rows))
+	}
+	if selected := view.pending.selected(); selected == nil || selected.id != 92 {
+		t.Errorf("cursor = %+v, want it still on Bob Smith", selected)
+	}
+}
+
+func TestScreenerRefreshHoldsWhileDeciding(t *testing.T) {
+	view, _ := loadedScreener(t)
+
+	view.mutations = 1
+	if cmd, held := view.refreshPending(); !held || cmd != nil {
+		t.Errorf("refresh = cmd:%v held:%v, want it held while a decision is in flight", cmd != nil, held)
+	}
+
+	view.mutations = 0
+	view.confirmingClear = true
+	if cmd, held := view.refreshPending(); !held || cmd != nil {
+		t.Errorf("refresh = cmd:%v held:%v, want it held while the question is up", cmd != nil, held)
+	}
+}
+
+func TestScreenerRefreshMarksTheQueueStaleFromHistory(t *testing.T) {
+	view, _ := loadedScreener(t)
+	view.tab = screenerHistoryTab
+
+	cmd, held := view.refreshPending()
+	if cmd != nil || held {
+		t.Errorf("refresh = cmd:%v held:%v, want nothing read while history is up", cmd != nil, held)
+	}
+	if view.pending.loaded {
+		t.Error("the queue should be read again when it is next looked at")
+	}
+}
+
+// --- Helpers ---
+
+type recordedReads struct{ paths []string }
+
+// mailWithBoxServer answers the box on screen with postings, and records what was read.
+func mailWithBoxServer(t *testing.T, postingsJSON string) (*mailView, *recordedReads) {
+	t.Helper()
+
+	recorded := &recordedReads{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorded.paths = append(recorded.paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"kind":"imbox","name":"Imbox","postings":` + postingsJSON + `}`))
+	}))
+	t.Cleanup(server.Close)
+
+	vc := testVC()
+	vc.ctx = context.Background()
+	vc.sdk = hey.NewClient(
+		&hey.Config{BaseURL: server.URL},
+		&hey.StaticTokenProvider{Token: "test-token"},
+		hey.WithMaxRetries(0),
+	)
+	v := newMailView(vc)
+	v.Resize(vc.width, vc.height)
+	v.boxes = orderBoxes(testBoxes())
+	v.Update(currentPostingsLoaded(v, testPostings()))
+	return v, recorded
+}

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -40,10 +40,13 @@ const (
 type boxesLoadedMsg []models.Box
 
 type mailSourcesLoadedMsg struct {
-	requestID     uint64
-	sources       []models.Box
-	screenerCount int
-	folderErr     error
+	requestID uint64
+	sources   []models.Box
+	// screenerCount is what The Screener holds, and screenerStream is the signed stream
+	// name to follow to be told when that changes. HEY serves both from the one read.
+	screenerCount  int
+	screenerStream string
+	folderErr      error
 }
 
 type postingsLoadedMsg struct {
@@ -56,6 +59,17 @@ type postingsLoadedMsg struct {
 	totalCount  int
 	postings    []models.Posting
 	err         error
+}
+
+// postingsRefreshedMsg is a box re-read after it changed underneath the reader. It has
+// its own lane so it can never be mistaken for a read the user asked for, and so a list
+// that is on screen is updated in place rather than replaced.
+type postingsRefreshedMsg struct {
+	requestID  uint64
+	boxID      int64
+	sourceKind string
+	postings   []models.Posting
+	err        error
 }
 
 type topicLoadedMsg struct {
@@ -176,6 +190,10 @@ type mailView struct {
 	sourceRequestID    uint64
 	folderDiscoveryErr string
 	requestCancel      context.CancelFunc
+
+	liveRequestID   uint64 // identifies the only live re-read allowed to update the list
+	liveRefreshDue  bool   // a re-read is already on its way
+	liveUpdatesOver bool   // the changes stream closed, so the list is a snapshot again
 }
 
 func newMailView(vc *viewContext) *mailView {
@@ -250,6 +268,20 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 				v.notice = v.folderPageNotice()
 			}
 		}
+		return nil, true
+
+	case mailRefreshDueMsg:
+		return v.refreshBox(msg.boxID), true
+
+	case postingsRefreshedMsg:
+		if msg.requestID != v.liveRequestID || msg.boxID != v.currentBoxID() || msg.sourceKind != v.currentSourceKind() {
+			return nil, true
+		}
+		if msg.err != nil {
+			v.notice = "Could not refresh mail: " + msg.err.Error()
+			return nil, true
+		}
+		v.postingList.refreshPostings(msg.postings)
 		return nil, true
 
 	case searchResultsLoadedMsg:
@@ -560,12 +592,15 @@ func (v *mailView) View() string {
 	return v.listHeader() + v.postingList.view()
 }
 
-// listHeader carries the one-shot notice and the Screener's standing invitation above
-// the posting list.
+// listHeader carries the one-shot notice, the standing word that the list has stopped
+// following the server, and the Screener's standing invitation above the posting list.
 func (v *mailView) listHeader() string {
 	var lines []string
 	if v.notice != "" {
 		lines = append(lines, v.vc.styles.title.Render(v.notice))
+	}
+	if v.liveUpdatesOver {
+		lines = append(lines, v.vc.styles.title.Render("Not live any more — press ctrl+r to reload"))
 	}
 	if hint := v.screenerHint(); hint != "" {
 		lines = append(lines, centerText(v.vc.styles.pill.Render(hint), v.vc.width), "")
@@ -672,6 +707,7 @@ func (v *mailView) HelpBindings() []helpBinding {
 			bindings = append(bindings, helpBinding{"p", "previous page"})
 		}
 	}
+	bindings = append(bindings, helpBinding{"ctrl+r", "reload"})
 	if v.lastBulkReplyID != 0 {
 		bindings = append(bindings, helpBinding{"u", "undo bulk reply"})
 	}
@@ -987,6 +1023,8 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 			return nil
 		case "g":
 			return v.startFolderPicker()
+		case "ctrl+r":
+			return v.reloadPostings()
 		default:
 			return v.handlePostingAction(msg.String())
 		}
@@ -1219,6 +1257,85 @@ func (v *mailView) requestPostings(source models.Box) tea.Cmd {
 func (v *mailView) requestPostingsPage(source models.Box, page string, history []string) tea.Cmd {
 	requestID, ctx := v.beginRequest(mailRequestPostings)
 	return v.fetchPostings(ctx, requestID, source, page, append([]string(nil), history...))
+}
+
+// reloadPostings reads the box on screen again, on the user's say-so. It is how a list
+// that stopped being live is caught up, and how anything else is put right.
+func (v *mailView) reloadPostings() tea.Cmd {
+	source := v.currentSource()
+	if source == nil {
+		return nil
+	}
+	v.liveUpdatesOver = false
+	return v.requestPostings(*source)
+}
+
+// boxChanged is the doorbell: something arrived in, left, or was changed in a box. Only
+// the box on screen is worth re-reading, and one re-read is armed at a time — a delivery
+// rings once per posting, and a catch-up after a reconnect rings for everything at once.
+func (v *mailView) boxChanged(boxID int64) tea.Cmd {
+	if v.liveRefreshDue || !v.showsBox(boxID) {
+		return nil
+	}
+	v.liveRefreshDue = true
+	return refreshMailLaterCmd(boxID, liveRefreshDelay)
+}
+
+// refreshBox re-reads the box, unless something is open over the list — a form, a picker,
+// a write that hasn't landed. Then the change waits: it is the reader's place in the list
+// that a re-read would disturb, and holding onto it costs a timer rather than the change.
+func (v *mailView) refreshBox(boxID int64) tea.Cmd {
+	v.liveRefreshDue = false
+	if !v.showsBox(boxID) {
+		return nil
+	}
+	if v.CapturingInput() || v.pendingMutations > 0 {
+		v.liveRefreshDue = true
+		return refreshMailLaterCmd(boxID, liveRetryDelay)
+	}
+
+	v.liveRequestID++
+	return v.fetchBoxRefresh(v.vc.ctx, v.liveRequestID, *v.currentSource())
+}
+
+// showsBox reports whether the list on screen is that box's. Labels page through their
+// own feed rather than a box's, and a change that names no box stands for all of them.
+func (v *mailView) showsBox(boxID int64) bool {
+	source := v.currentSource()
+	if source == nil || source.Kind == mailSourceKindFolder {
+		return false
+	}
+	return boxID == AnyBoxChanged || boxID == source.ID
+}
+
+// liveUpdatesStopped stands above the list until the box is read again: what was live is
+// a snapshot now, and a reader has no other way of telling.
+func (v *mailView) liveUpdatesStopped() {
+	v.liveUpdatesOver = true
+	v.liveRefreshDue = false
+}
+
+// liveUpdatesUnavailable is the other way it goes wrong: there was never a stream to
+// begin with, which is worth saying once rather than standing over the list forever.
+func (v *mailView) liveUpdatesUnavailable(err error) {
+	v.noteFailure("Live updates unavailable", err)
+}
+
+// screenerUpdatesUnavailable is said in the mail list because that is where The Screener
+// announces itself — the count above the threads is what stops keeping up.
+func (v *mailView) screenerUpdatesUnavailable(err error) {
+	v.noteFailure("The Screener won't update live", err)
+}
+
+// screenerUpdatesStopped is said once rather than standing over the list: opening The
+// Screener reads the count again anyway, and so does the next look at the labels.
+func (v *mailView) screenerUpdatesStopped() {
+	v.notice = "The Screener stopped updating live"
+}
+
+// noteFailure keeps the reason to a line. `hey watch` is where the whole of it is.
+func (v *mailView) noteFailure(what string, err error) {
+	v.notice = truncateToWidth(what+": "+err.Error(), max(v.vc.width-2, 40))
 }
 
 func (v *mailView) nextFolderPage() tea.Cmd {
@@ -1729,8 +1846,12 @@ func (v *mailView) fetchSources(requestID uint64) tea.Cmd {
 				boxes = append(boxes, models.Box{ID: label.ID, Kind: mailSourceKindFolder, Name: label.Name, AppURL: label.AppURL})
 			}
 		}
-		screenerCount, _ := v.vc.sdk.Clearances().PendingCount(v.vc.ctx)
-		return mailSourcesLoadedMsg{requestID: requestID, sources: boxes, screenerCount: screenerCount, folderErr: folderErr}
+		message := mailSourcesLoadedMsg{requestID: requestID, sources: boxes, folderErr: folderErr}
+		if screener, err := v.vc.sdk.Clearances().Summary(v.vc.ctx); err == nil && screener != nil {
+			message.screenerCount = int(screener.PendingClearancesCount)
+			message.screenerStream = screener.SignedStreamName
+		}
+		return message
 	}
 }
 
@@ -1777,6 +1898,27 @@ func (v *mailView) fetchPostings(ctx context.Context, requestID uint64, source m
 			postings = append(postings, sdkPostingToModel(posting))
 		}
 		message.postings = postings
+		return message
+	}
+}
+
+// fetchBoxRefresh re-reads a box for the live update. It reads the box and nothing else:
+// a label's page, a search and a thread all stay as they were.
+func (v *mailView) fetchBoxRefresh(ctx context.Context, requestID uint64, source models.Box) tea.Cmd {
+	return func() tea.Msg {
+		message := postingsRefreshedMsg{requestID: requestID, boxID: source.ID, sourceKind: source.Kind}
+		box, err := v.vc.sdk.Boxes().Get(ctx, source.ID, nil)
+		if err != nil {
+			message.err = err
+			return message
+		}
+		if box != nil {
+			postings := make([]models.Posting, 0, len(box.Postings))
+			for _, posting := range box.Postings {
+				postings = append(postings, sdkPostingToModel(posting))
+			}
+			message.postings = postings
+		}
 		return message
 	}
 }

--- a/internal/tui/screener.go
+++ b/internal/tui/screener.go
@@ -22,6 +22,17 @@ type screenerPendingLoadedMsg struct {
 	err       error
 }
 
+// screenerPendingRefreshedMsg is the queue read again after someone arrived in or left
+// The Screener while it was open. Its own lane, so it can never be taken for a page the
+// user asked for, and the rows land under the cursor rather than replacing it.
+type screenerPendingRefreshedMsg struct {
+	requestID uint64
+	page      int
+	rows      []screenerRow
+	count     int
+	err       error
+}
+
 type screenerScreenedLoadedMsg struct {
 	requestID uint64
 	page      int
@@ -79,6 +90,28 @@ func (p *screenerPane) setRows(rows []screenerRow, page int) {
 	p.scroll = 0
 	p.page = page
 	p.loaded = true
+}
+
+// refreshRows replaces the rows with a newly read page while someone is working through
+// it: the cursor stays on the sender it was on, and the window stays where it was. A
+// sender who has been dealt with elsewhere takes the cursor with them.
+func (p *screenerPane) refreshRows(rows []screenerRow, page int) {
+	var cursorID int64
+	if row := p.selected(); row != nil {
+		cursorID = row.id
+	}
+
+	p.rows = rows
+	p.page = page
+	p.loaded = true
+	p.cursor = 0
+	for index := range p.rows {
+		if p.rows[index].id == cursorID {
+			p.cursor = index
+			break
+		}
+	}
+	p.scroll = min(p.scroll, max(len(p.rows)-1, 0))
 }
 
 func (p *screenerPane) selected() *screenerRow {
@@ -141,6 +174,7 @@ type screenerView struct {
 	notice          string
 	loading         bool
 	requestID       uint64
+	liveRequestID   uint64 // identifies the only live re-read allowed to update the queue
 	mutations       int
 }
 
@@ -175,6 +209,19 @@ func (v *screenerView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		}
 		v.pendingCount = msg.count
 		v.pending.setRows(msg.rows, msg.page)
+		return nil, true
+
+	case screenerPendingRefreshedMsg:
+		if msg.requestID != v.liveRequestID || v.tab != screenerPendingTab {
+			return nil, true
+		}
+		if msg.err != nil {
+			v.notice = "Could not refresh The Screener: " + msg.err.Error()
+			return nil, true
+		}
+		v.pendingCount = msg.count
+		v.pending.refreshRows(msg.rows, msg.page)
+		v.pending.ensureVisible(v.visibleRows())
 		return nil, true
 
 	case screenerScreenedLoadedMsg:
@@ -384,6 +431,23 @@ func (v *screenerView) requestPending(page int) tea.Cmd {
 	return v.fetchPending(v.requestID, max(page, 1))
 }
 
+// refreshPending is what the doorbell asks of The Screener: read the queue again under
+// the cursor. It waits while a decision is in flight or the clear-everything question is
+// on screen — held says so, and the caller comes back to it. When the queue isn't what
+// is on screen there is nothing to read now, only to mark for the next look at it.
+func (v *screenerView) refreshPending() (cmd tea.Cmd, held bool) {
+	if v.mutations > 0 || v.confirmingClear {
+		return nil, true
+	}
+	if v.tab != screenerPendingTab {
+		v.pending.loaded = false
+		return nil, false
+	}
+
+	v.liveRequestID++
+	return v.fetchPendingRefresh(v.liveRequestID, max(v.pending.page, 1)), false
+}
+
 func (v *screenerView) requestScreened(page int) tea.Cmd {
 	v.requestID++
 	v.loading = true
@@ -483,6 +547,25 @@ func (v *screenerView) fetchPending(requestID uint64, page int) tea.Cmd {
 			return screenerPendingLoadedMsg{requestID: requestID, page: page, err: err}
 		}
 		message := screenerPendingLoadedMsg{requestID: requestID, page: page}
+		if summary != nil {
+			message.count = int(summary.PendingClearancesCount)
+			for _, clearance := range summary.Clearances {
+				message.rows = append(message.rows, pendingScreenerRow(clearance))
+			}
+		}
+		return message
+	}
+}
+
+// fetchPendingRefresh reads the same page fetchPending reads, in the live lane and
+// without the spinner: nobody is waiting on it.
+func (v *screenerView) fetchPendingRefresh(requestID uint64, page int) tea.Cmd {
+	return func() tea.Msg {
+		summary, err := v.vc.sdk.Clearances().Pending(v.vc.ctx, strconv.Itoa(page))
+		if err != nil {
+			return screenerPendingRefreshedMsg{requestID: requestID, page: page, err: err}
+		}
+		message := screenerPendingRefreshedMsg{requestID: requestID, page: page}
 		if summary != nil {
 			message.count = int(summary.PendingClearancesCount)
 			for _, clearance := range summary.Clearances {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -52,6 +52,20 @@ type model struct {
 	// The Screener, opened over the mail section with ctrl+s
 	screenerView *screenerView
 
+	// Live mail updates: the watcher, the stream it opened, and the context that keeps
+	// the stream open. It outlives the view context, which a mail account switch throws
+	// away — the changes stream is the same one whichever account is being read.
+	watchMail    MailWatcher
+	mailChanges  <-chan int64
+	watchCtx     context.Context
+	stopWatching context.CancelFunc
+
+	// The Screener's stream, which can only be opened once HEY has served its name
+	watchScreener      ScreenerWatcher
+	screenerChanges    <-chan struct{}
+	screenerStream     string
+	screenerRefreshDue bool
+
 	// Linked mail accounts
 	mailAccounts            []mailAccountChoice
 	mailAccount             mailAccountChoice
@@ -73,14 +87,15 @@ type model struct {
 }
 
 func newModel() model {
-	return newModelWithMailAccounts(nil, nil, "all")
+	return newModelWithMailAccounts(nil, nil, "all", Watchers{})
 }
 
-func newModelWithMailAccounts(rootSDK, sdk *hey.Client, selected string) model {
+func newModelWithMailAccounts(rootSDK, sdk *hey.Client, selected string, watchers Watchers) model {
 	theme := ResolveTheme()
 	applyTheme(theme)
 	s := newStyles()
-	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel stored, called on ctrl+c
+	ctx, cancel := context.WithCancel(context.Background())            //nolint:gosec // G118: cancel stored, called on ctrl+c
+	watchCtx, stopWatching := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel stored, called on ctrl+c
 	vc := newViewContext(ctx, rootSDK, sdk, s)
 	mv := newMailView(vc)
 	ov := newContactsView(vc)
@@ -107,6 +122,10 @@ func newModelWithMailAccounts(rootSDK, sdk *hey.Client, selected string) model {
 		calendarView:        cv,
 		journalView:         jv,
 		screenerView:        sv,
+		watchMail:           watchers.Mail,
+		watchScreener:       watchers.Screener,
+		watchCtx:            watchCtx,
+		stopWatching:        stopWatching,
 		mailAccounts:        []mailAccountChoice{{label: "All Accounts"}},
 		mailAccount:         account,
 		viewGenerationToken: &atomic.Uint64{},
@@ -139,6 +158,7 @@ func (m model) Init() tea.Cmd {
 		spinnerTick(),
 		tea.RequestBackgroundColor,
 		watchThemeCmd(omarchyWatchDir(userHomeDir())),
+		startMailWatchCmd(m.watchCtx, m.watchMail),
 	)
 }
 
@@ -252,11 +272,67 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case screenerClosedMsg:
 		return m.closeScreener()
 
+	case mailWatchStartedMsg:
+		if msg.err != nil {
+			m.mailView.liveUpdatesUnavailable(msg.err)
+			return m, nil
+		}
+		m.mailChanges = msg.changes
+		return m, waitForMailChangeCmd(m.mailChanges)
+
+	case mailChangedMsg:
+		if msg.closed {
+			m.mailChanges = nil
+			m.mailView.liveUpdatesStopped()
+			return m, nil
+		}
+		// The stream is listened to for as long as the TUI runs, whichever section is
+		// on screen: mail that arrived while the user was in the calendar is there when
+		// they come back.
+		return m, tea.Batch(m.stampViewCmd(m.mailView.boxChanged(msg.boxID)), waitForMailChangeCmd(m.mailChanges))
+
+	case mailRefreshDueMsg, postingsRefreshedMsg:
+		cmd, _ := m.mailView.Update(msg)
+		return m, m.stampViewCmd(cmd)
+
+	case screenerWatchStartedMsg:
+		if msg.err != nil {
+			m.screenerStream = ""
+			m.mailView.screenerUpdatesUnavailable(msg.err)
+			return m, nil
+		}
+		m.screenerChanges = msg.changes
+		return m, waitForScreenerChangeCmd(m.screenerChanges)
+
+	case screenerChangedMsg:
+		if msg.closed {
+			m.screenerChanges = nil
+			// Letting the name go means the next read of the count opens the stream again.
+			m.screenerStream = ""
+			m.mailView.screenerUpdatesStopped()
+			return m, nil
+		}
+		return m, tea.Batch(m.screenerChanged(), waitForScreenerChangeCmd(m.screenerChanges))
+
+	case screenerRefreshDueMsg:
+		return m, m.refreshScreener()
+
+	case screenerPendingRefreshedMsg:
+		cmd, _ := m.screenerView.Update(msg)
+		return m, m.stampViewCmd(cmd)
+
 	case mailSourcesLoadedMsg:
+		// HEY serves The Screener's stream name with its count, so this read is the only
+		// place the watch can be opened from.
+		watch := m.startScreenerWatch(msg.screenerStream)
 		if m.activeView != m.mailView {
 			cmd, _ := m.mailView.Update(msg)
-			return m, m.stampViewCmd(cmd)
+			return m, tea.Batch(m.stampViewCmd(cmd), watch)
 		}
+		cmd, _ := m.activeView.Update(msg)
+		cmd = m.syncLoading(cmd)
+		m.updateHelpBindings()
+		return m, tea.Batch(cmd, watch)
 
 	case screenerCountLoadedMsg:
 		if m.activeView != m.mailView {
@@ -505,6 +581,7 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if key == "ctrl+c" {
 		if m.ctrlCOnce {
 			m.cancel()
+			m.stopWatching()
 			return m, tea.Quit
 		}
 		m.ctrlCOnce = true
@@ -700,6 +777,44 @@ func (m model) closeScreener() (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// startScreenerWatch opens the Screener's stream the first time HEY names it, and again
+// only if the name changes. Every read of the count carries the name, so without this the
+// watch would be reopened on each one.
+func (m *model) startScreenerWatch(signedStreamName string) tea.Cmd {
+	if signedStreamName == "" || signedStreamName == m.screenerStream {
+		return nil
+	}
+	m.screenerStream = signedStreamName
+	return startScreenerWatchCmd(m.watchCtx, m.watchScreener, signedStreamName)
+}
+
+// screenerChanged is the Screener's doorbell. Screening a queue in one go rings it once
+// per sender, so the re-read is delayed and one is armed at a time.
+func (m *model) screenerChanged() tea.Cmd {
+	if m.screenerRefreshDue {
+		return nil
+	}
+	m.screenerRefreshDue = true
+	return refreshScreenerLaterCmd(liveRefreshDelay)
+}
+
+// refreshScreener reads the count again wherever the user is — it is the mail list's
+// standing invitation — and reads the queue again as well when The Screener is what is
+// on screen.
+func (m *model) refreshScreener() tea.Cmd {
+	m.screenerRefreshDue = false
+	if m.activeView != m.screenerView {
+		return m.stampViewCmd(m.mailView.refreshScreenerCount())
+	}
+
+	queue, held := m.screenerView.refreshPending()
+	if held {
+		m.screenerRefreshDue = true
+		return refreshScreenerLaterCmd(liveRetryDelay)
+	}
+	return tea.Batch(m.stampViewCmd(m.mailView.refreshScreenerCount()), m.stampViewCmd(queue))
+}
+
 func (m model) switchSection(sec section) (tea.Model, tea.Cmd) {
 	if sec == m.section || m.hasPendingMutation() {
 		return m, nil
@@ -755,10 +870,10 @@ func formatTimestamp(ts time.Time) string {
 	return ts.UTC().Format("2006-01-02T15:04:05Z")
 }
 
-// Run starts the TUI with the resolved mail account and the identity root client used
-// for interactive account switching.
-func Run(rootSDK, sdk *hey.Client, selected string) error {
-	p := tea.NewProgram(newModelWithMailAccounts(rootSDK, sdk, selected))
+// Run starts the TUI with the resolved mail account, the identity root client used for
+// interactive account switching, and the watchers that tell it when things changed.
+func Run(rootSDK, sdk *hey.Client, selected string, watchers Watchers) error {
+	p := tea.NewProgram(newModelWithMailAccounts(rootSDK, sdk, selected, watchers))
 	_, err := p.Run()
 	return err
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-RwineTy+Yk7TcR+tcWK4oy3vsLTzJrbSgsxkoMtGvP8=";
+  vendorHash = "sha256-2/hjp9RDsDGGHqj6Bxo6n+N6nczCKyZhOI+S3fEIAjw=";
 
   subPackages = [ "cmd/hey" ];
 


### PR DESCRIPTION
The mail list used to be a snapshot of whenever you loaded the box, and The Screener's count only moved when you opened or closed it. The cable connection `hey watch` already uses was sitting right there, so the TUI listens on it now.

## Mail

The doorbell names a box; the box on screen is read again half a second later. `contentList.refreshPostings` is what makes replacing a list safe — the cursor stays on its posting and a multi-selection keeps every row still there, unlike `setPostings`, which resets both. A change that arrives while a form or a picker is open, or while a write hasn't landed, waits on a 2s retry rather than being dropped: a re-read replaces what the reader is looking at.

No cursor is involved. `hey watch` needs `Postings().AllChanges` because it reports every individual change; the TUI renders a whole box page anyway, so re-reading the box is simpler and is exactly what the list shows.

The re-read has its own lane (`liveRequestID`, `postingsRefreshedMsg`) so it can never be taken for a read the user asked for, and never shows the spinner. `ctrl+r` reads the box again by hand — also the way back when the stream drops, which the list says plainly and keeps saying until you reload.

## The Screener

It has no channel of its own: `Clearance::Broadcasting` re-renders the Screener's button over a Turbo stream, and `clearances/index.jbuilder` serves that stream's signed name next to the pending count. So the TUI subscribes to `Turbo::StreamsChannel` with the name it was handed. What comes down it is markup for the web app — nothing is parsed out of it, the arrival is the whole message, and the count is read again behind it.

The count is re-read wherever the user is, because the mail list is where The Screener announces itself. With The Screener open the queue is re-read too, through `screenerPane.refreshRows` — same keep-your-place trick — and held while a decision is in flight or the clear-everything question is up. On the history tab nothing is read; the pending pane is marked unloaded, which `switchTab` already looks at.

Both watches share one websocket: two subscriptions, one authorization, one reconnect story. A reconnect stands for every box, since whatever was broadcast while the connection was down was missed. The watch outlives the view context that a mail account switch throws away.

## Blocked on an SDK release

`go.mod` carries a `replace` pointing at a local hey-sdk checkout, so **CI cannot pass as it stands**. The change there is small: `Clearances().Summary` — the same cheap `/clearances.json` read `PendingCount` already does, returning the whole summary instead of throwing away the `signed_stream_name` HEY sends with it. `PendingCount` becomes a wrapper over it.

Once that's released, the replace comes out and this is green.

The alternative, if a release isn't worth it: call the released `Pending(ctx, "")` at startup instead, which carries the same stream name but drags the first page of the queue along with it — a heavier read on every launch, for a name.

## Not covered

- A thread you're reading doesn't grow new entries live; only the list refreshes.
- Label lists aren't refreshed — the doorbell names a box, and a label pages through its own feed.
- No dev server was running while this was written, so none of it has been watched with real mail landing in it. The behaviour is covered by tests against httptest servers, not by eye.
