### PR TITLE
Add thread sharing commands

### DIFF
--- a/.surface
+++ b/.surface
@@ -172,6 +172,7 @@ hey setup omarchy
 hey setup omarchy --no-notify
 hey setup omarchy --notify
 hey setup omarchy --remove
+hey share
 hey skill
 hey skill install
 hey spam
@@ -202,6 +203,7 @@ hey todo uncomplete
 hey trash
 hey tui
 hey unseen
+hey unshare
 hey upgrade
 hey version
 hey watch

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -35,6 +35,9 @@ The remaining HTML-reading gaps use the SDK's authenticated HTML helper and are 
 | `/calendars/{id}/recordings.json` | GET | SDK `Calendars().GetRecordings` | `hey recordings <calendar-id>`, `hey todo list`, `hey timetrack list`, `hey journal list` | covered |
 | `/topics/{id}/entries` | GET (HTML) | SDK `GetHTML` | `hey threads <id>` | gap: SDK Entry lacks body |
 | `/topics/{id}/entries.json` | GET | SDK `Topics().GetEntries` | `hey attachments <topic-id>` | covered |
+| `/topics/{id}/publication` | POST | SDK `Publications().Create` | `hey share <thread-id>` | covered |
+| `/topics/{id}/publication.json` | GET | SDK `Publications().Create` readback | `hey share <thread-id>` | covered |
+| `/topics/{id}/publication` | DELETE | SDK `Publications().Delete` | `hey unshare <thread-id>` | covered |
 | `/messages/{id}.json` | GET | SDK `Messages().Get` | `hey attachments <topic-id>`, `hey attachments save <id>` | covered |
 | `/entries/drafts.json` | GET | SDK `Entries().ListDrafts` | `hey drafts` | covered |
 | `/rails/active_storage/direct_uploads.json` | POST | SDK `Attachments().Upload` | `hey compose --attach`, `hey reply --attach`, `hey bulk-reply send --attach` | covered |

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ hey screener deny 91 --spam        # turn them away and mark what they sent as s
 hey screener history               # who has already been screened
 hey screener clear                 # empty the queue without deciding
 hey threads 123                    # read a full email thread
+hey share 123                      # get a sharing link for a thread
+hey unshare 123                    # turn off the sharing link
 hey attachments 123                # list files attached to the thread
 hey attachments save 456:1         # save a file using its attachment ID
 hey reply 123 -m "Thanks!"        # reply to a thread (or omit -m to open $EDITOR)
@@ -267,6 +269,8 @@ hey stop-ignoring 12345            # resume attention for a thread
 ```
 
 Email bodies come back as Markdown. `hey threads` and the TUI render that Markdown for the terminal — headings, emphasis, lists, quotes, tables and code survive, and links keep their URLs and stay clickable where the terminal supports it. `--json` carries the same Markdown in `body`, so an agent reading a thread sees the structure a human sees rather than a flattened wall of text. `--html` still returns HEY's original HTML.
+
+`hey share <thread_id>` gets a sharing link for a thread. Anyone with the link can see the entire thread and future emails or replies sent to it. `hey unshare <thread_id>` turns off the sharing link.
 
 Search accepts free text plus `--required`, `--any`, `--none`, `--exact`, `--from`, `--to`, `--subject`, `--date`, `--in`, `--label`, and `--attachment`. Use `--page` for one page or `--all` to fetch up to 100 pages; capped searches report the next page for continuation. Search results include `topic_id` for reading the thread and the matching message summaries. Results with an active box item also include `id` for organization actions.
 

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -21,7 +21,7 @@ var curatedCategories = []struct {
 	},
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "labels", "label", "search", "contacts", "screener", "threads", "attachments", "compose", "reply", "bulk-reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"},
+		names:   []string{"boxes", "box", "labels", "label", "search", "contacts", "screener", "threads", "share", "unshare", "attachments", "compose", "reply", "bulk-reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -103,6 +103,8 @@ EMAIL
   contacts       Manage contacts
   screener       Decide who gets to email you
   threads        Read a thread
+  share          Get a sharing link for an email thread
+  unshare        Turn off an email thread's sharing link
   attachments    List and save files from a thread
   compose        Write and send a new email
   reply          Reply to a thread

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -165,6 +165,8 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newContactsCommand().cmd)
 	root.AddCommand(newScreenerCommand().cmd)
 	root.AddCommand(newThreadsCommand().cmd)
+	root.AddCommand(newShareCommand().cmd)
+	root.AddCommand(newUnshareCommand().cmd)
 	root.AddCommand(newAttachmentsCommand().cmd)
 	root.AddCommand(newReplyCommand().cmd)
 	root.AddCommand(newBulkReplyCommand().cmd)

--- a/internal/cmd/share.go
+++ b/internal/cmd/share.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type shareCommand struct {
+	cmd *cobra.Command
+}
+
+func newShareCommand() *shareCommand {
+	shareCommand := &shareCommand{}
+	shareCommand.cmd = &cobra.Command{
+		Use:   "share <thread-id>",
+		Short: "Get a sharing link for an email thread",
+		Long:  "Get a sharing link for an email thread. Anyone with the link can see the entire thread and future emails or replies sent to it.",
+		Example: `  hey share 12345
+  hey share 12345 --json`,
+		Annotations: map[string]string{
+			"agent_notes": "Accepts the topic_id from hey box, hey label, or hey search output. Returns the sharing link in the url field.",
+		},
+		RunE: shareCommand.run,
+		Args: usageExactOneArg(),
+	}
+
+	return shareCommand
+}
+
+func (c *shareCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	threadID, err := parsePositiveID(args[0], "thread")
+	if err != nil {
+		return err
+	}
+
+	publication, err := sdk.Publications().Create(cmd.Context(), threadID)
+	if err != nil {
+		return convertSDKError(err)
+	}
+	if publication == nil || !publication.Published || publication.Url == "" {
+		return output.ErrAPI(0, "HEY did not return a sharing link")
+	}
+
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Sharing link: %s\n", terminalSafeText(publication.Url))
+		return nil
+	}
+
+	return writeOK(publication, output.WithSummary("Sharing link turned on"))
+}
+
+type unshareCommand struct {
+	cmd *cobra.Command
+}
+
+func newUnshareCommand() *unshareCommand {
+	unshareCommand := &unshareCommand{}
+	unshareCommand.cmd = &cobra.Command{
+		Use:     "unshare <thread-id>",
+		Short:   "Turn off an email thread's sharing link",
+		Long:    "Turn off the sharing link for an email thread.",
+		Example: `  hey unshare 12345`,
+		Annotations: map[string]string{
+			"agent_notes": "Accepts the topic_id from hey box, hey label, or hey search output. The thread remains in HEY.",
+		},
+		RunE: unshareCommand.run,
+		Args: usageExactOneArg(),
+	}
+
+	return unshareCommand
+}
+
+func (c *unshareCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	threadID, err := parsePositiveID(args[0], "thread")
+	if err != nil {
+		return err
+	}
+
+	if err := sdk.Publications().Delete(cmd.Context(), threadID); err != nil {
+		return convertSDKError(err)
+	}
+
+	if writer.IsStyled() {
+		fmt.Fprintln(cmd.OutOrStdout(), "Sharing link turned off.")
+		return nil
+	}
+
+	return writeOK(nil, output.WithSummary("Sharing link turned off"))
+}

--- a/internal/cmd/share_test.go
+++ b/internal/cmd/share_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestShareCommand(t *testing.T) {
+	var requests atomic.Int32
+	handler := sharingHandler(t, &requests, `{"published":true,"url":"https://public.hey.com/p/abc123"}`)
+
+	response, err := runJSONCommand(t, handler, "share", "42")
+	if err != nil {
+		t.Fatalf("execute share: %v", err)
+	}
+	if requests.Load() != 2 {
+		t.Errorf("requests = %d, want 2", requests.Load())
+	}
+	if response.Summary != "Sharing link turned on" {
+		t.Errorf("summary = %q, want Sharing link turned on", response.Summary)
+	}
+	data, ok := response.Data.(map[string]any)
+	if !ok || data["published"] != true || data["url"] != "https://public.hey.com/p/abc123" {
+		t.Errorf("data = %#v", response.Data)
+	}
+}
+
+func TestShareCommandStyledOutputIncludesSharingLink(t *testing.T) {
+	var requests atomic.Int32
+	handler := sharingHandler(t, &requests, `{"published":true,"url":"https://public.hey.com/p/abc123"}`)
+
+	output, err := runStyledCommand(t, handler, "share", "42")
+	if err != nil {
+		t.Fatalf("execute share: %v", err)
+	}
+	if output != "Sharing link: https://public.hey.com/p/abc123\n" {
+		t.Errorf("output = %q", output)
+	}
+}
+
+func TestUnshareCommand(t *testing.T) {
+	var requests atomic.Int32
+	handler := sharingHandler(t, &requests, "")
+
+	response, err := runJSONCommand(t, handler, "unshare", "42")
+	if err != nil {
+		t.Fatalf("execute unshare: %v", err)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d, want 1", requests.Load())
+	}
+	if response.Summary != "Sharing link turned off" {
+		t.Errorf("summary = %q, want Sharing link turned off", response.Summary)
+	}
+}
+
+func TestSharingCommandValidationMakesNoRequest(t *testing.T) {
+	for _, command := range []string{"share", "unshare"} {
+		t.Run(command, func(t *testing.T) {
+			var requests atomic.Int32
+			_, err := runJSONCommand(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				requests.Add(1)
+			}), command, "not-a-thread")
+			if err == nil || !strings.Contains(err.Error(), "invalid thread ID") {
+				t.Fatalf("error = %v, want invalid thread ID", err)
+			}
+			if requests.Load() != 0 {
+				t.Errorf("requests = %d, want 0", requests.Load())
+			}
+		})
+	}
+}
+
+func TestShareCommandRequiresSharingLink(t *testing.T) {
+	var requests atomic.Int32
+	handler := sharingHandler(t, &requests, `{"published":false}`)
+
+	_, err := runJSONCommand(t, handler, "share", "42")
+	if err == nil || !strings.Contains(err.Error(), "did not return a sharing link") {
+		t.Fatalf("error = %v, want missing sharing link error", err)
+	}
+}
+
+func sharingHandler(t *testing.T, requests *atomic.Int32, publication string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/topics/42/publication":
+			if contentType := r.Header.Get("Content-Type"); contentType != "application/x-www-form-urlencoded" {
+				t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", contentType)
+			}
+			w.Header().Set("Location", "/topics/42/publication/edit")
+			w.WriteHeader(http.StatusSeeOther)
+		case r.Method == http.MethodGet && r.URL.Path == "/topics/42/publication.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, publication)
+		case r.Method == http.MethodDelete && r.URL.Path == "/topics/42/publication":
+			w.Header().Set("Location", "/topics/42")
+			w.WriteHeader(http.StatusSeeOther)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	})
+}

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -17,6 +17,8 @@ triggers:
   - hey search
   - hey contacts
   - hey threads
+  - hey share
+  - hey unshare
   - hey reply
   - hey forward
   - hey compose
@@ -57,6 +59,8 @@ triggers:
   - send email
   - reply to email
   - forward email
+  - share email thread
+  - turn off sharing link
   - compose email
   - list mailboxes
   - search email
@@ -146,6 +150,8 @@ hey boxes --quiet --jq '.[].name'
 | Set private contact note | `hey contacts note set <id> "Prefers email"` |
 | Delete private contact note | `hey contacts note delete <id>` |
 | Read email thread | `hey threads <topic_id> --json` |
+| Get a sharing link | `hey share <thread_id>` |
+| Turn off a sharing link | `hey unshare <thread_id>` |
 | Reply to email | `hey reply <topic_id> -m "Thanks!"` |
 | Forward email | `hey forward <topic_id> --to alice@example.com -m "For your review"` |
 | Compose email | `hey compose --to user@example.com --subject "Hello"` |
@@ -199,6 +205,8 @@ Want to read email?
 ├── Need available refinements? → hey search filters --json
 ├── List or view contacts? → hey contacts list --json / hey contacts show <id> --json
 ├── Read full thread? → hey threads <topic_id> --json
+├── Get a sharing link? → hey share <thread_id>
+├── Turn off the sharing link? → hey unshare <thread_id>
 ├── Mark as seen? → hey seen <id>
 ├── Mark as unseen? → hey unseen <id>
 ├── Move to another box? → hey move <id> --to <box>
@@ -308,9 +316,13 @@ HEY hides contacts instead of permanently deleting them. A hidden contact leaves
 ```bash
 hey threads <topic_id> --json                 # Read full email thread
 hey threads <topic_id> --html                 # Read with raw HTML content
+hey share <thread_id>                         # Get a sharing link
+hey unshare <thread_id>                       # Turn off the sharing link
 ```
 
-**ID note:** Every email thread returned by `hey box` or `hey label` has an `id` (its box item ID) and a `topic_id` (its thread ID). `hey seen`, `hey unseen`, `hey move`, `hey label add`, `hey label remove`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring` expect `id`. `hey threads`, `hey attachments`, `hey reply`, and `hey forward` expect `topic_id`. The `app_url` field also contains the thread ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
+`hey share` returns a URL that shows the entire thread and future emails or replies sent to it. Anyone with the link can open it. `hey unshare` turns off the sharing link.
+
+**ID note:** Every email thread returned by `hey box` or `hey label` has an `id` (its box item ID) and a `topic_id` (its thread ID). `hey seen`, `hey unseen`, `hey move`, `hey label add`, `hey label remove`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring` expect `id`. `hey threads`, `hey share`, `hey unshare`, `hey attachments`, `hey reply`, and `hey forward` expect `topic_id`. The `app_url` field also contains the thread ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
 
 ### Email - Attachments
 

--- a/tests/smoke/share_test.go
+++ b/tests/smoke/share_test.go
@@ -1,0 +1,117 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestShareAndUnshare(t *testing.T) {
+	subject := fmt.Sprintf("Sharing link smoke test %s", uniqueID())
+	stdout, stderr, code := hey(t, "compose",
+		"--to", "alex@example.com",
+		"--subject", subject,
+		"-m", "This controlled thread verifies sharing link management.",
+		"--json",
+	)
+	if code != 0 {
+		t.Skipf("could not create a controlled thread (exit %d): %s", code, stderr)
+	}
+
+	var composeResp Response
+	if err := json.Unmarshal([]byte(stdout), &composeResp); err != nil {
+		t.Fatalf("failed to parse compose response: %v", err)
+	}
+
+	threadID, err := findSentThread(subject)
+	if err != nil {
+		t.Fatalf("could not find controlled thread: %v", err)
+	}
+	needsCleanup := false
+	cleanupMustSucceed := false
+	t.Cleanup(func() {
+		if !needsCleanup {
+			return
+		}
+		_, cleanupErr, cleanupCode := hey(t, "unshare", threadID, "--json")
+		if cleanupCode != 0 && cleanupMustSucceed {
+			t.Errorf("could not turn off controlled sharing link (exit %d): %s", cleanupCode, cleanupErr)
+		}
+	})
+
+	// The SDK publishes first and reads the link back second. Enable cleanup before
+	// running the command so a failed readback cannot leave the controlled thread shared.
+	needsCleanup = true
+	stdout, stderr, code = hey(t, "share", threadID, "--json")
+	if code != 0 {
+		t.Skipf("sharing links are unavailable on this server (exit %d): %s", code, stderr)
+	}
+	cleanupMustSucceed = true
+	var shareResp Response
+	if err := json.Unmarshal([]byte(stdout), &shareResp); err != nil {
+		t.Fatalf("failed to parse share response: %v", err)
+	}
+	sharing := dataAs[struct {
+		Published bool   `json:"published"`
+		URL       string `json:"url"`
+	}](t, shareResp)
+	if !sharing.Published || sharing.URL == "" {
+		t.Errorf("sharing = %+v, want a sharing link", sharing)
+	}
+
+	stdout, stderr, code = hey(t, "unshare", threadID, "--json")
+	if code != 0 {
+		t.Fatalf("turning off the sharing link failed (exit %d): %s", code, stderr)
+	}
+	needsCleanup = false
+	var unshareResp Response
+	if err := json.Unmarshal([]byte(stdout), &unshareResp); err != nil {
+		t.Fatalf("failed to parse unshare response: %v", err)
+	}
+	if unshareResp.Summary != "Sharing link turned off" {
+		t.Errorf("summary = %q, want Sharing link turned off", unshareResp.Summary)
+	}
+}
+
+func TestSharingCommandsRequireThreadID(t *testing.T) {
+	heyFail(t, "share", "--json")
+	heyFail(t, "unshare", "--json")
+}
+
+func findSentThread(subject string) (string, error) {
+	for range 10 {
+		req, err := http.NewRequest(http.MethodGet, baseURL+"/topics/sent.json", nil)
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: sessionCookie})
+		resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+		if err != nil {
+			return "", err
+		}
+		var sent struct {
+			Topics []struct {
+				ID   int64  `json:"id"`
+				Name string `json:"name"`
+			} `json:"topics"`
+		}
+		decodeErr := json.NewDecoder(resp.Body).Decode(&sent)
+		_ = resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			return "", fmt.Errorf("GET /topics/sent.json returned HTTP %d", resp.StatusCode)
+		}
+		if decodeErr != nil {
+			return "", decodeErr
+		}
+		for _, topic := range sent.Topics {
+			if topic.Name == subject {
+				return fmt.Sprint(topic.ID), nil
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return "", fmt.Errorf("sent thread %q did not appear", subject)
+}


### PR DESCRIPTION
## Summary

Adds user-facing thread sharing commands that match Haystack’s web UI terminology:

- `hey share <thread-id>` gets a sharing link and returns its URL.
- `hey unshare <thread-id>` turns off the sharing link.

Both commands use the typed SDK publication service, validate thread IDs, and support styled and structured output. Help, the CLI surface snapshot, README examples, API coverage, and the bundled agent skill are updated alongside them.

## Tests

- `GOWORK=off make check`
- `GOWORK=off make build`
- `GOWORK=off make test-smoke`

The smoke test creates a controlled thread, exercises both commands, and arranges best-effort cleanup before sharing so a failed link readback cannot leave the thread shared.

## Scope

No Haystack or hey-sdk changes are required; hey-sdk v0.7.0 already provides `Publications().Create` and `Publications().Delete`.

Basecamp: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892862
