### PR TITLE
Add time tracking export command

### DIFF
--- a/.surface
+++ b/.surface
@@ -185,6 +185,9 @@ hey timetrack category create
 hey timetrack category delete
 hey timetrack category rename
 hey timetrack current
+hey timetrack export
+hey timetrack export --force
+hey timetrack export --output
 hey timetrack list
 hey timetrack list --all
 hey timetrack list --limit

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -67,6 +67,7 @@ The remaining HTML-reading gaps use the SDK's authenticated HTML helper and are 
 | `/calendar/ongoing_time_track.json` | GET | SDK `TimeTracks().GetOngoing` | `hey timetrack current` | covered |
 | `/calendar/ongoing_time_track.json` | POST | SDK `TimeTracks().Start` | `hey timetrack start` | covered |
 | `/calendar/time_tracks/{id}.json` | PUT | SDK `TimeTracks().Stop` | `hey timetrack stop` | covered |
+| `/calendar/time_tracks/exports` | GET | SDK `TimeTracks().Export` | `hey timetrack export` | covered |
 | `/calendar/time_tracks/categories.json` | GET | SDK `TimeTracks().Categories` | `hey timetrack categories`, Calendar TUI `c` | covered |
 | `/calendar/time_tracks/categories` | POST | SDK `TimeTracks().CreateCategory` | `hey timetrack category create`, Calendar TUI `c` | covered |
 | `/calendar/time_tracks/categories/{id}` | PATCH | SDK `TimeTracks().UpdateCategory` | `hey timetrack category rename`, Calendar TUI `c` | covered |

--- a/README.md
+++ b/README.md
@@ -360,11 +360,15 @@ hey timetrack start                # start tracking
 hey timetrack stop                 # stop tracking
 hey timetrack current              # show active track
 hey timetrack list                 # list all tracks
+hey timetrack export > tracked-time.csv
+hey timetrack export --output tracked-time.csv
 hey timetrack categories           # list categories
 hey timetrack category create "Client work"
 hey timetrack category rename 123 "Planning"
 hey timetrack category delete 123
 ```
+
+The time tracking export contains every completed entry, newest first, with Start, End, Duration, Category, and Notes columns. Ongoing time tracking is excluded. `--output` preserves an existing file unless `--force` is set.
 
 ### Journal
 

--- a/internal/attachments/save.go
+++ b/internal/attachments/save.go
@@ -1,6 +1,7 @@
 package attachments
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -58,19 +59,31 @@ func PortableFilename(filename string) (string, error) {
 	return filename, nil
 }
 
+// SaveBytes safely writes data to destination. Existing paths are preserved unless force is set.
+func SaveBytes(destination string, data []byte, force bool) (int64, error) {
+	return Save(context.Background(), byteDownloader(data), destination, "", force)
+}
+
+type byteDownloader []byte
+
+func (data byteDownloader) DownloadBlob(_ context.Context, _ string, writer io.Writer) (int64, http.Header, error) {
+	written, err := io.Copy(writer, bytes.NewReader(data))
+	return written, nil, err
+}
+
 func Save(ctx context.Context, downloader Downloader, destination, sourceURL string, force bool) (int64, error) {
 	if !force {
 		if _, err := os.Lstat(destination); err == nil {
 			return 0, apierr.ErrUsage(fmt.Sprintf("destination already exists: %s (use --force to replace it)", destination))
 		} else if !os.IsNotExist(err) {
-			return 0, apierr.ErrAPI(0, fmt.Sprintf("could not inspect attachment destination: %v", err))
+			return 0, apierr.ErrAPI(0, fmt.Sprintf("could not inspect destination: %v", err))
 		}
 	}
 
 	directory := filepath.Dir(destination)
-	temporary, err := os.CreateTemp(directory, ".hey-attachment-*")
+	temporary, err := os.CreateTemp(directory, ".hey-file-*")
 	if err != nil {
-		return 0, apierr.ErrAPI(0, fmt.Sprintf("could not create temporary attachment file: %v", err))
+		return 0, apierr.ErrAPI(0, fmt.Sprintf("could not create temporary file: %v", err))
 	}
 	temporaryPath := temporary.Name()
 	defer func() { _ = os.Remove(temporaryPath) }()
@@ -81,19 +94,19 @@ func Save(ctx context.Context, downloader Downloader, destination, sourceURL str
 		return written, err
 	}
 	if err := temporary.Close(); err != nil {
-		return written, apierr.ErrAPI(0, fmt.Sprintf("could not close attachment file: %v", err))
+		return written, apierr.ErrAPI(0, fmt.Sprintf("could not close temporary file: %v", err))
 	}
 
 	if force {
 		if err := replaceFile(temporaryPath, destination); err != nil {
-			return written, apierr.ErrAPI(0, fmt.Sprintf("could not replace attachment file: %v", err))
+			return written, apierr.ErrAPI(0, fmt.Sprintf("could not replace file: %v", err))
 		}
 		return written, nil
 	}
 	if err := commitFileNoReplace(temporaryPath, destination); os.IsExist(err) {
 		return written, apierr.ErrUsage(fmt.Sprintf("destination already exists: %s (use --force to replace it)", destination))
 	} else if err != nil {
-		return written, apierr.ErrAPI(0, fmt.Sprintf("could not save attachment file: %v", err))
+		return written, apierr.ErrAPI(0, fmt.Sprintf("could not save file: %v", err))
 	}
 	return written, nil
 }

--- a/internal/attachments/save_test.go
+++ b/internal/attachments/save_test.go
@@ -60,6 +60,18 @@ func TestDestinationPreservesPortableFilenameBehavior(t *testing.T) {
 	}
 }
 
+func TestSaveBytesWritesContentSafely(t *testing.T) {
+	destination := filepath.Join(t.TempDir(), "tracked-time.csv")
+	written, err := SaveBytes(destination, []byte("Start,End\n09:00,10:00\n"), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != int64(len("Start,End\n09:00,10:00\n")) {
+		t.Errorf("written = %d", written)
+	}
+	assertFileContent(t, destination, "Start,End\n09:00,10:00\n")
+}
+
 func TestSavePreservesExistingFileUnlessForced(t *testing.T) {
 	destination := filepath.Join(t.TempDir(), "quarterly-report.pdf")
 	if err := os.WriteFile(destination, []byte("keep me"), 0o600); err != nil {
@@ -149,7 +161,7 @@ func assertNoTemporaryFiles(t *testing.T, directory string) {
 		t.Fatal(err)
 	}
 	for _, entry := range entries {
-		if strings.HasPrefix(entry.Name(), ".hey-attachment-") {
+		if strings.HasPrefix(entry.Name(), ".hey-file-") {
 			t.Errorf("temporary file was not removed: %s", entry.Name())
 		}
 	}

--- a/internal/cmd/testdata/time-tracking-export.csv
+++ b/internal/cmd/testdata/time-tracking-export.csv
@@ -1,0 +1,3 @@
+Start,End,Duration,Category,Notes
+2026-08-20 09:00,2026-08-20 11:00,2 hrs,Client work,Planning call
+2026-08-19 14:30,2026-08-19 15:15,45 mins,Uncategorized,"Reviewed budget, timeline, and next steps"

--- a/internal/cmd/timetrack.go
+++ b/internal/cmd/timetrack.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	safefiles "github.com/basecamp/hey-cli/internal/attachments"
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
@@ -19,7 +22,7 @@ func newTimetrackCommand() *timetrackCommand {
 		Use:   "timetrack",
 		Short: "Track time",
 		Annotations: map[string]string{
-			"agent_notes": "Subcommands: start, stop, current, list, categories, category. Use current to check if tracking is active before start/stop.",
+			"agent_notes": "Subcommands: start, stop, current, list, export, categories, category. Use current to check if tracking is active before start/stop. Export writes CSV to stdout or safely saves it with --output.",
 		},
 	}
 
@@ -27,6 +30,7 @@ func newTimetrackCommand() *timetrackCommand {
 	timetrackCommand.cmd.AddCommand(newTimetrackStopCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackCurrentCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackListCommand().cmd)
+	timetrackCommand.cmd.AddCommand(newTimetrackExportCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackCategoriesCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackCategoryCommand().cmd)
 
@@ -253,6 +257,97 @@ func (c *timetrackListCommand) run(cmd *cobra.Command, args []string) error {
 			Description: "Start time tracking",
 		}),
 	)
+}
+
+// export
+
+type timetrackExportCommand struct {
+	cmd    *cobra.Command
+	output string
+	force  bool
+}
+
+type timeTrackExportResult struct {
+	Path     string `json:"path"`
+	ByteSize int64  `json:"byte_size"`
+}
+
+func newTimetrackExportCommand() *timetrackExportCommand {
+	timetrackExportCommand := &timetrackExportCommand{}
+	timetrackExportCommand.cmd = &cobra.Command{
+		Use:   "export",
+		Short: "Export completed time tracks as CSV",
+		Long:  "Export every completed time track as CSV, newest first. Without --output, the CSV is written directly to stdout. With --output, the command safely saves the CSV and returns file metadata.",
+		Example: `  hey timetrack export > time-tracking.csv
+  hey timetrack export --output time-tracking.csv
+  hey timetrack export --output time-tracking.csv --force`,
+		Annotations: map[string]string{
+			"agent_notes": "Writes HEY's CSV unchanged to stdout. Use --output to save it to a file; existing paths are preserved unless --force is set. The columns are Start, End, Duration, Category, and Notes.",
+		},
+		RunE: timetrackExportCommand.run,
+		Args: cobra.NoArgs,
+	}
+
+	timetrackExportCommand.cmd.Flags().StringVarP(&timetrackExportCommand.output, "output", "o", "", "Save CSV to this file instead of stdout")
+	timetrackExportCommand.cmd.Flags().BoolVar(&timetrackExportCommand.force, "force", false, "Replace an existing output file")
+
+	return timetrackExportCommand
+}
+
+func (c *timetrackExportCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	if c.output == "" {
+		if c.force {
+			return output.ErrUsage("--force requires --output")
+		}
+		if timetrackExportStructuredOutputRequested(cmd) {
+			return output.ErrUsage("output formatting flags require --output for time track exports")
+		}
+	} else if err := ensureTimetrackExportDestination(c.output, c.force); err != nil {
+		return err
+	}
+
+	data, err := sdk.TimeTracks().Export(cmd.Context())
+	if err != nil {
+		return convertSDKError(err)
+	}
+
+	if c.output == "" {
+		if _, writeErr := cmd.OutOrStdout().Write(data); writeErr != nil {
+			return output.ErrAPI(0, fmt.Sprintf("could not write time track export: %v", writeErr))
+		}
+		return nil
+	}
+
+	destination := filepath.Clean(c.output)
+	written, err := safefiles.SaveBytes(destination, data, c.force)
+	if err != nil {
+		return err
+	}
+	result := timeTrackExportResult{Path: destination, ByteSize: written}
+	if writer.IsStyled() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Exported time tracks to %s (%s)\n", terminalSafeText(destination), formatByteSize(written))
+		return nil
+	}
+	return writeOK(result, output.WithSummary(fmt.Sprintf("Time tracks exported to %s", destination)))
+}
+
+func timetrackExportStructuredOutputRequested(cmd *cobra.Command) bool {
+	return jsonFlag || idsOnly || countFlag || markdownF || styledFlag || agentFlag || statsFlag || cmd.Flags().Changed("jq")
+}
+
+func ensureTimetrackExportDestination(destination string, force bool) error {
+	if force {
+		return nil
+	}
+	if _, err := os.Lstat(destination); err == nil {
+		return output.ErrUsage(fmt.Sprintf("destination already exists: %s (use --force to replace it)", destination))
+	} else if !os.IsNotExist(err) {
+		return output.ErrAPI(0, fmt.Sprintf("could not inspect destination: %v", err))
+	}
+	return nil
 }
 
 // categories

--- a/internal/cmd/timetrack_export_test.go
+++ b/internal/cmd/timetrack_export_test.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestTimetrackExportWritesServerCSVToStdout(t *testing.T) {
+	csv := timeTrackCSVFixture(t)
+	var requests atomic.Int32
+	stdout, err := runFormattedCommand(t, timeTrackExportHandler(t, &requests), nil, "timetrack", "export")
+	if err != nil {
+		t.Fatalf("execute timetrack export: %v", err)
+	}
+	if stdout != csv {
+		t.Errorf("stdout = %q, want server CSV", stdout)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestTimetrackExportSavesCSV(t *testing.T) {
+	csv := timeTrackCSVFixture(t)
+	destination := filepath.Join(t.TempDir(), "tracked-time.csv")
+	var requests atomic.Int32
+	response, err := runJSONCommand(t, timeTrackExportHandler(t, &requests), "timetrack", "export", "--output", destination)
+	if err != nil {
+		t.Fatalf("execute timetrack export: %v", err)
+	}
+
+	data, ok := response.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("data = %#v, want export metadata", response.Data)
+	}
+	if data["path"] != destination || data["byte_size"] != float64(len(csv)) {
+		t.Errorf("data = %#v", data)
+	}
+	if response.Summary != "Time tracks exported to "+destination {
+		t.Errorf("summary = %q", response.Summary)
+	}
+	contents, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != csv {
+		t.Errorf("saved CSV = %q", contents)
+	}
+}
+
+func TestTimetrackExportPreservesExistingFileWithoutRequest(t *testing.T) {
+	destination := filepath.Join(t.TempDir(), "tracked-time.csv")
+	if err := os.WriteFile(destination, []byte("keep me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var requests atomic.Int32
+	_, err := runJSONCommand(t, timeTrackExportHandler(t, &requests), "timetrack", "export", "--output", destination)
+	if err == nil || !strings.Contains(err.Error(), "use --force") {
+		t.Fatalf("error = %v, want existing destination error", err)
+	}
+	if requests.Load() != 0 {
+		t.Errorf("requests = %d, want 0", requests.Load())
+	}
+	contents, readErr := os.ReadFile(destination)
+	if readErr != nil || string(contents) != "keep me" {
+		t.Errorf("existing file = %q, %v", contents, readErr)
+	}
+}
+
+func TestTimetrackExportForceReplacesExistingFile(t *testing.T) {
+	csv := timeTrackCSVFixture(t)
+	destination := filepath.Join(t.TempDir(), "tracked-time.csv")
+	if err := os.WriteFile(destination, []byte("old export"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var requests atomic.Int32
+	if _, err := runJSONCommand(t, timeTrackExportHandler(t, &requests), "timetrack", "export", "--output", destination, "--force"); err != nil {
+		t.Fatalf("execute timetrack export --force: %v", err)
+	}
+	contents, err := os.ReadFile(destination)
+	if err != nil || string(contents) != csv {
+		t.Errorf("replaced file = %q, %v", contents, err)
+	}
+}
+
+func TestTimetrackExportFetchFailurePreservesExistingFile(t *testing.T) {
+	destination := filepath.Join(t.TempDir(), "tracked-time.csv")
+	if err := os.WriteFile(destination, []byte("old export"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "export unavailable", http.StatusBadRequest)
+	}), "timetrack", "export", "--output", destination, "--force")
+	if err == nil {
+		t.Fatal("expected export error")
+	}
+	contents, readErr := os.ReadFile(destination)
+	if readErr != nil || string(contents) != "old export" {
+		t.Errorf("existing file = %q, %v", contents, readErr)
+	}
+}
+
+func TestTimetrackExportValidatesRawOutputFlagsWithoutRequest(t *testing.T) {
+	for _, args := range [][]string{
+		{"timetrack", "export", "--force"},
+		{"timetrack", "export"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var requests atomic.Int32
+			_, err := runJSONCommand(t, timeTrackExportHandler(t, &requests), args...)
+			if err == nil {
+				t.Fatal("expected usage error")
+			}
+			if requests.Load() != 0 {
+				t.Errorf("requests = %d, want 0", requests.Load())
+			}
+		})
+	}
+
+	t.Run("styled", func(t *testing.T) {
+		var requests atomic.Int32
+		_, err := runFormattedCommand(t, timeTrackExportHandler(t, &requests), []string{"--styled"}, "timetrack", "export")
+		if err == nil {
+			t.Fatal("expected usage error")
+		}
+		if requests.Load() != 0 {
+			t.Errorf("requests = %d, want 0", requests.Load())
+		}
+	})
+}
+
+func timeTrackExportHandler(t *testing.T, requests *atomic.Int32) http.Handler {
+	t.Helper()
+	csv := timeTrackCSVFixture(t)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Method != http.MethodGet || r.URL.Path != "/calendar/time_tracks/exports" {
+			t.Errorf("request = %s %s, want GET /calendar/time_tracks/exports", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if accept := r.Header.Get("Accept"); accept != "text/csv" {
+			t.Errorf("Accept = %q, want text/csv", accept)
+		}
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = io.WriteString(w, csv)
+	})
+}
+
+func timeTrackCSVFixture(t *testing.T) string {
+	t.Helper()
+	contents, err := os.ReadFile("testdata/time-tracking-export.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(contents)
+}

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -182,6 +182,8 @@ hey boxes --quiet --jq '.[].name'
 | Stop time tracking | `hey timetrack stop` |
 | Current timer | `hey timetrack current --json` |
 | List time entries | `hey timetrack list --json` |
+| Export completed time entries | `hey timetrack export > tracked-time.csv` |
+| Save a time tracking export | `hey timetrack export --output tracked-time.csv --json` |
 | List time track categories | `hey timetrack categories --json` |
 | Create time track category | `hey timetrack category create "Client work"` |
 | List journal entries | `hey journal list --json` |
@@ -464,6 +466,8 @@ hey timetrack start                           # Start timer
 hey timetrack stop                            # Stop timer
 hey timetrack current --json                  # Show current timer
 hey timetrack list --json                     # List time entries
+hey timetrack export > tracked-time.csv        # Write the complete CSV export
+hey timetrack export -o tracked-time.csv       # Safely save the CSV to a file
 hey timetrack categories --json               # List categories
 hey timetrack category create "Client work"   # Create a category
 hey timetrack category rename 123 "Planning"  # Rename a category

--- a/tests/smoke/timetrack_test.go
+++ b/tests/smoke/timetrack_test.go
@@ -1,7 +1,11 @@
 package smoke_test
 
 import (
+	"encoding/csv"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -88,6 +92,46 @@ func TestTimetrackListLimit(t *testing.T) {
 func TestTimetrackListAll(t *testing.T) {
 	resp := heyJSON(t, "timetrack", "list", "--all")
 	_ = resp
+}
+
+func TestTimetrackExport(t *testing.T) {
+	stdout, stderr, code := hey(t, "timetrack", "export")
+	if code != 0 {
+		t.Fatalf("timetrack export failed (exit %d): %s", code, stderr)
+	}
+	assertTimeTrackExportCSV(t, stdout)
+
+	destination := filepath.Join(t.TempDir(), "tracked-time.csv")
+	output, stderr, code := hey(t, "timetrack", "export", "--output", destination, "--json")
+	if code != 0 {
+		t.Fatalf("timetrack export --output failed (exit %d): %s", code, stderr)
+	}
+	var response Response
+	if err := json.Unmarshal([]byte(output), &response); err != nil {
+		t.Fatalf("parse export response: %v", err)
+	}
+	assertContains(t, response.Summary, destination)
+
+	contents, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read time track export: %v", err)
+	}
+	assertTimeTrackExportCSV(t, string(contents))
+}
+
+func assertTimeTrackExportCSV(t *testing.T, contents string) {
+	t.Helper()
+	rows, err := csv.NewReader(strings.NewReader(contents)).ReadAll()
+	if err != nil {
+		t.Fatalf("parse time track CSV: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("time track export has no header")
+	}
+	want := []string{"Start", "End", "Duration", "Category", "Notes"}
+	if strings.Join(rows[0], ",") != strings.Join(want, ",") {
+		t.Errorf("CSV header = %v, want %v", rows[0], want)
+	}
 }
 
 func TestTimetrackCategories(t *testing.T) {


### PR DESCRIPTION
<!-- pr-review-readiness-head: 35460bbf188abe1014de823b1022c6677b354629 -->

Give people and scripts immediate access to HEY’s complete time tracking CSV from the CLI. The command exports completed entries only and leaves HEY data unchanged.

**Review readiness:** ✅ Yes  
**Risk:** 🟡 Medium — the new command can write personal tracking data to a caller-selected path and replace it only with explicit `--force`.  
**Decision:** None

<details>
<summary>✅ Change — completed time tracks can be exported to stdout or safely saved</summary>

### Before

```text
Person or script needs tracked-time CSV
└── Opens HEY’s desktop web UI
    └── ❌ No CLI export workflow
```

### After

```text
Person or script needs tracked-time CSV
├── `hey timetrack export`
│   └── ✅ Receives HEY’s CSV unchanged on stdout  ← CHANGED
└── `hey timetrack export --output tracked-time.csv`
    ├── ✅ Saves through the existing race-safe file commit path
    └── ✅ Preserves existing paths unless `--force` is explicit
```

The command calls the typed `TimeTracks().Export` SDK operation. HEY generates all completed entries newest first with Start, End, Duration, Category, and Notes columns.

</details>

<details>
<summary>✅ Evidence — unit, live smoke, and representative CSV coverage</summary>

- ✅ Command tests cover byte-for-byte stdout, saved-file metadata and content, collision refusal before the request, forced replacement, API-failure preservation, and raw-output flag validation.
- ✅ Safe-file tests cover writing in-memory export data through the same hardened commit path used for attachments.
- ✅ Live smoke coverage exercises both stdout and `--output` against the HEY development server and parses the resulting CSV header.
- ✅ [Representative CSV artifact](https://github.com/basecamp/hey-cli/blob/35460bbf188abe1014de823b1022c6677b354629/internal/cmd/testdata/time-tracking-export.csv) shows the generated columns, categorized and uncategorized entries, and CSV quoting.

```text
GOWORK=off make check      PASS
GOWORK=off make build      PASS
GOWORK=off make test-smoke PASS (one pre-existing attachment-send skip)
git diff --check           PASS
```

</details>

<details>
<summary>✅ Scope — CLI export, safety, tests, and discoverability only</summary>

Included: `hey timetrack export`, `--output`/`--force`, safe in-memory file commits, unit and smoke tests, README examples, API coverage, CLI surface, and the bundled HEY skill.

The web export remains immediate and unchanged. This PR adds no TUI action, server behavior, SDK changes, filters, background jobs, migrations, dependencies, or HEY data mutations.

</details>

<details>
<summary>✅ Delivery — no deployment prerequisites or data changes</summary>

No feature flags, configuration, migrations, backfills, deploy ordering, or cleanup are required. Failures return without modifying HEY; output files are committed only after the complete CSV has been received. Rollback is the single commit.

</details>

<details>
<summary>✅ Review decision — focus on stdout/output semantics and replacement safety</summary>

Start with whether raw stdout plus explicit file output is the right scripting contract, then verify that existing-path preservation and `--force` behavior match other saved-file workflows.

</details>

<details>
<summary>✅ Review path — command, safety helper, evidence, then documentation</summary>

1. [`internal/cmd/timetrack.go`](https://github.com/basecamp/hey-cli/blob/35460bbf188abe1014de823b1022c6677b354629/internal/cmd/timetrack.go) — command contract and SDK flow.
2. [`internal/cmd/timetrack_export_test.go`](https://github.com/basecamp/hey-cli/blob/35460bbf188abe1014de823b1022c6677b354629/internal/cmd/timetrack_export_test.go) and [`tests/smoke/timetrack_test.go`](https://github.com/basecamp/hey-cli/blob/35460bbf188abe1014de823b1022c6677b354629/tests/smoke/timetrack_test.go) — behavioral and live-server evidence.
3. [`internal/attachments/save.go`](https://github.com/basecamp/hey-cli/blob/35460bbf188abe1014de823b1022c6677b354629/internal/attachments/save.go) — generalized safe byte saving used by exports and attachments.
4. [`README.md`](https://github.com/basecamp/hey-cli/blob/35460bbf188abe1014de823b1022c6677b354629/README.md), [`API-COVERAGE.md`](https://github.com/basecamp/hey-cli/blob/35460bbf188abe1014de823b1022c6677b354629/API-COVERAGE.md), [`.surface`](https://github.com/basecamp/hey-cli/blob/35460bbf188abe1014de823b1022c6677b354629/.surface), and [`skills/hey/SKILL.md`](https://github.com/basecamp/hey-cli/blob/35460bbf188abe1014de823b1022c6677b354629/skills/hey/SKILL.md) — discoverability and documented coverage.

**Origin and supporting links:** [Basecamp card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892911)

</details>
