### PR TITLE
Show Bubbled Up as its own section in the TUI

### DIFF
--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -39,7 +39,7 @@ type contentList struct {
 
 func (c *contentList) setPostings(postings []models.Posting) {
 	if !c.hideSeenState {
-		postings = partitionSeen(postings)
+		postings = partitionSections(postings)
 	}
 	c.postings = postings
 	c.cursor = 0
@@ -53,7 +53,7 @@ func (c *contentList) setPostings(postings []models.Posting) {
 // still there. A posting that left the box takes the cursor or its selection with it.
 func (c *contentList) refreshPostings(postings []models.Posting) {
 	if !c.hideSeenState {
-		postings = partitionSeen(postings)
+		postings = partitionSections(postings)
 	}
 	var cursorID int64
 	if posting := c.selectedPosting(); posting != nil {
@@ -87,22 +87,61 @@ func (c *contentList) keepSelected() {
 	c.selected = remaining
 }
 
-// partitionSeen orders unseen postings before seen ones, keeping the
-// relative order inside each group. This forms the "New for You" and
-// "Previously Seen" sections, as in the HEY web app.
-func partitionSeen(postings []models.Posting) []models.Posting {
-	ordered := make([]models.Posting, 0, len(postings))
-	for _, p := range postings {
-		if !p.Seen {
-			ordered = append(ordered, p)
-		}
+// postingSection is the group a posting belongs to in the Imbox. On the server
+// a posting's read state is one of unseen, bubbled up or seen, and the web app
+// stacks the sections in that order.
+type postingSection int
+
+const (
+	sectionBubbledUp postingSection = iota
+	sectionNewForYou
+	sectionPreviouslySeen
+)
+
+var postingSections = []postingSection{sectionBubbledUp, sectionNewForYou, sectionPreviouslySeen}
+
+func sectionOf(p models.Posting) postingSection {
+	switch {
+	case p.BubbledUp:
+		return sectionBubbledUp
+	case !p.Seen:
+		return sectionNewForYou
+	default:
+		return sectionPreviouslySeen
 	}
-	for _, p := range postings {
-		if p.Seen {
-			ordered = append(ordered, p)
+}
+
+func (s postingSection) label() string {
+	switch s {
+	case sectionBubbledUp:
+		return "Bubbled Up"
+	case sectionNewForYou:
+		return "New for You"
+	default:
+		return "Previously Seen"
+	}
+}
+
+// partitionSections groups postings by section, keeping the relative order
+// inside each group.
+func partitionSections(postings []models.Posting) []models.Posting {
+	ordered := make([]models.Posting, 0, len(postings))
+	for _, section := range postingSections {
+		for _, p := range postings {
+			if sectionOf(p) == section {
+				ordered = append(ordered, p)
+			}
 		}
 	}
 	return ordered
+}
+
+// markSeen moves a posting into "Previously Seen", clearing the bubbled up
+// state the way Postings::SeenController does.
+func (c *contentList) markSeen(index int) {
+	c.postings[index].Seen = true
+	c.postings[index].BubbledUp = false
+	c.resort()
 }
 
 // resort re-partitions the list after a posting changes its seen state and
@@ -115,7 +154,7 @@ func (c *contentList) resort() {
 	if p := c.selectedPosting(); p != nil {
 		id = p.ID
 	}
-	c.postings = partitionSeen(c.postings)
+	c.postings = partitionSections(c.postings)
 	for i := range c.postings {
 		if c.postings[i].ID == id {
 			c.cursor = i
@@ -167,11 +206,9 @@ func (c *contentList) sectionLabelAt(index int) string {
 	if c.hideSeenState || index < 0 || index >= len(c.postings) {
 		return ""
 	}
-	if index == 0 && !c.postings[index].Seen {
-		return "New for You"
-	}
-	if c.postings[index].Seen && (index == 0 || !c.postings[index-1].Seen) {
-		return "Previously Seen"
+	section := sectionOf(c.postings[index])
+	if index == 0 || sectionOf(c.postings[index-1]) != section {
+		return section.label()
 	}
 	return ""
 }
@@ -250,8 +287,8 @@ func (c *contentList) view() string {
 
 	// Every row uses the same styles: bold bright subject; date, sender and
 	// excerpt in the faint secondary style. Read state shows as the section a
-	// row sits in ("New for You" / "Previously Seen") plus the alert dot; the
-	// cursor row renders bold on top of the base styles.
+	// row sits in ("Bubbled Up" / "New for You" / "Previously Seen") plus the
+	// alert dot; the cursor row renders bold on top of the base styles.
 	subjectBase := lipgloss.NewStyle().Foreground(colorBright).Bold(true)
 	dateBase := styleMuted
 	senderBase := styleMuted

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -483,8 +483,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 				}
 				v.postingList.ensureVisible()
 			case postingActionSeen:
-				v.postingList.postings[idx].Seen = true
-				v.postingList.resort()
+				v.postingList.markSeen(idx)
 			case postingActionIgnore:
 				v.postingList.postings[idx].Muted = true
 			case postingActionStopIgnoring:
@@ -506,8 +505,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		}
 		if msg.boxID == v.currentBoxID() && msg.sourceKind == v.currentSourceKind() {
 			if idx := v.postingIndex(msg.postingID); idx >= 0 {
-				v.postingList.postings[idx].Seen = true
-				v.postingList.resort()
+				v.postingList.markSeen(idx)
 			}
 		}
 		return nil, true
@@ -1497,10 +1495,12 @@ func (v *mailView) openSelected() tea.Cmd {
 
 // markPostingSeen marks a thread as seen once it has been opened, the way the
 // web app beacons an observation after it renders a topic. A thread that is
-// already seen costs no request.
+// already seen costs no request, and a bubbled up one is left alone: reading it
+// does not dismiss it, only the seen key does. The server draws the same line
+// in Posting#observed.
 func (v *mailView) markPostingSeen(boxID, postingID int64) tea.Cmd {
 	opened := v.openedPosting(postingID)
-	if opened == nil || opened.Seen {
+	if opened == nil || opened.Seen || opened.BubbledUp {
 		return nil
 	}
 	sourceKind := v.currentSourceKind()
@@ -1727,6 +1727,7 @@ func sdkPostingToModel(p generated.Posting) models.Posting {
 		Kind:                  p.Kind,
 		Name:                  p.Name,
 		Seen:                  p.Seen,
+		BubbledUp:             p.BubbledUp,
 		Bundled:               p.Bundled,
 		Muted:                 p.Muted,
 		Summary:               p.Summary,

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -319,6 +319,42 @@ func TestMailViewMarksOpenedThreadSeen(t *testing.T) {
 	}
 }
 
+func TestMailViewLeavesBubbledUpThreadAloneWhenOpened(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.postingList.postings[0].BubbledUp = true
+
+	loaded := runCmd(v.HandleContentKey(keyPress("enter"))).(topicLoadedMsg)
+	cmd, _ := v.Update(loaded)
+	if cmd != nil {
+		t.Errorf("opening a bubbled up thread should not mark it seen: %#v", runCmd(cmd))
+	}
+	if recorded.path == "/postings/seen.json" {
+		t.Error("opening a bubbled up thread hit the mark seen endpoint")
+	}
+	if !v.postingList.postings[v.postingIndex(100)].BubbledUp {
+		t.Error("reading a bubbled up thread should leave it in its section")
+	}
+}
+
+func TestMailViewSeenKeyDismissesBubbledUpThread(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.postingList.postings[0].BubbledUp = true
+
+	done := runCmd(v.HandleContentKey(keyPress("e"))).(postingActionDoneMsg)
+	if done.err != nil {
+		t.Fatalf("marking a bubbled up thread seen failed: %v", done.err)
+	}
+	if recorded.path != "/postings/seen.json" {
+		t.Errorf("request path = %q, want /postings/seen.json", recorded.path)
+	}
+
+	v.Update(done)
+	posting := v.postingList.postings[v.postingIndex(100)]
+	if !posting.Seen || posting.BubbledUp {
+		t.Errorf("the seen key should dismiss a bubbled up thread: seen %v bubbled up %v", posting.Seen, posting.BubbledUp)
+	}
+}
+
 func TestMailViewLeavesSeenThreadAloneWhenOpened(t *testing.T) {
 	v, recorded := mailWithTestServer(t, http.StatusNoContent)
 	v.postingList.postings[0].Seen = true

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -742,6 +742,52 @@ func TestContentListMovesSeenPostingToItsSection(t *testing.T) {
 	}
 }
 
+func TestContentListOpensWithTheBubbledUpSection(t *testing.T) {
+	cl := &contentList{}
+	cl.setPostings([]models.Posting{
+		{ID: 1, Name: "Weekly release notes", CreatedAt: "2026-08-20T10:00:00Z"},
+		{ID: 2, Name: "Standup notes", CreatedAt: "2026-08-19T10:00:00Z", Seen: true},
+		{ID: 3, Name: "Invoice for July hosting", CreatedAt: "2026-08-18T09:00:00Z", BubbledUp: true},
+	})
+	cl.setSize(80, 20)
+
+	if cl.postings[0].ID != 3 || cl.postings[1].ID != 1 || cl.postings[2].ID != 2 {
+		t.Errorf("bubbled up postings should sort above the unseen and seen ones: %+v", cl.postings)
+	}
+
+	lines := strings.Split(stripANSI(cl.view()), "\n")
+	if !strings.HasPrefix(lines[0], "Bubbled Up") {
+		t.Errorf("the list should open with the bubbled up header: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "Invoice for July hosting") || !strings.Contains(lines[1], "●") {
+		t.Errorf("a bubbled up row should show the unread dot: %q", lines[1])
+	}
+	if !strings.HasPrefix(lines[3], "New for You") || !strings.HasPrefix(lines[6], "Previously Seen") {
+		t.Errorf("the other sections should follow with their headers: %q / %q", lines[3], lines[6])
+	}
+}
+
+func TestContentListMovesSeenBubbledUpPostingToItsSection(t *testing.T) {
+	cl := &contentList{}
+	cl.setPostings([]models.Posting{
+		{ID: 1, Name: "Invoice for July hosting", CreatedAt: "2026-08-20T10:00:00Z", BubbledUp: true},
+		{ID: 2, Name: "Weekly release notes", CreatedAt: "2026-08-19T10:00:00Z"},
+	})
+	cl.setSize(80, 20)
+
+	cl.markSeen(0)
+
+	if cl.postings[0].ID != 2 || cl.postings[1].ID != 1 {
+		t.Errorf("a seen bubbled up posting should move below the unseen ones: %+v", cl.postings)
+	}
+	if cl.postings[1].BubbledUp {
+		t.Error("marking a bubbled up posting seen should clear its bubbled up state")
+	}
+	if got := cl.selectedPosting(); got == nil || got.ID != 1 {
+		t.Errorf("cursor should follow the moved posting: %+v", got)
+	}
+}
+
 func TestContentListAlignsDateColumn(t *testing.T) {
 	long := models.Posting{
 		ID:        300,


### PR DESCRIPTION
The TUI's Imbox was missing the Bubbled Up section the web app opens with.

HEY's `seen` column is a three-state enum — `bubbled_up: -1`, `unseen: 0`, `seen: 1` — and the imbox listing orders by it, so bubbled up threads were already arriving at the top of the list. The TUI only knew about two states and lumped them into "New for You".

`postingSection` now splits the three, in the order `POSTING_ORDER` stacks them in haystack, and both the sort and the section headers read from `sectionOf` so they can't drift apart. `models.Posting.BubbledUp` existed but nothing ever filled it in.

On reading: opening a bubbled up thread leaves it where it is, the same line the server draws in `Posting#observed` (`seen!(at) unless bubbled_up?`) — a bubbled up thread stays put until you dismiss it. The seen key (`e`) does dismiss it, since `Postings::SeenController` calls `seen!` with no exemption, and `markSeen` clears the bubbled up state locally so the row drops into "Previously Seen" right away rather than at the next refetch.
