### PR TITLE
Add collection management to CLI and TUI

### DIFF
--- a/.surface
+++ b/.surface
@@ -43,6 +43,22 @@ hey bulk-reply send --attach
 hey bulk-reply send --message
 hey bulk-reply undo
 hey calendars
+hey collection
+hey collection --all
+hey collection --limit
+hey collection --page
+hey collection add
+hey collection add --to
+hey collection create
+hey collection create --summary
+hey collection remove
+hey collection remove --from
+hey collection update
+hey collection update --name
+hey collection update --summary
+hey collections
+hey collections --all
+hey collections --limit
 hey commands
 hey completion
 hey compose

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -18,6 +18,12 @@ The remaining HTML-reading gaps use the SDK's authenticated HTML helper and are 
 | `/postings/filings.json` | POST | SDK `Postings().File` | `hey label add`, TUI `g` | covered |
 | `/postings/filings.json` | DELETE | SDK `Postings().Unfile` | `hey label remove`, TUI `g` | covered |
 | `/postings/folders.json` | POST | SDK `Postings().CreateFolder` | `hey label create`, TUI `g` | covered |
+| `/collections.json` | GET | SDK `Collections().List` | `hey collections`, Mail TUI navigation | covered |
+| `/collections/{id}.json` | GET | SDK `Collections().GetPage` | `hey collection <id>`, Mail TUI collections | covered |
+| `/collections` | POST | SDK `Collections().Create` | `hey collection create` | covered |
+| `/collections/{id}.json` | PATCH | SDK `Collections().Update` | `hey collection update` | covered |
+| `/topics/{id}/collecting` | POST | SDK `Collections().AddTopic` | `hey collection add`, TUI `k` | covered |
+| `/topics/{id}/collecting` | DELETE | SDK `Collections().RemoveTopic` | `hey collection remove`, TUI `k` | covered |
 | `/advanced_search.json` | GET | SDK `Search().Search` | `hey search`, TUI `/` | covered |
 | `/advanced_search_filters.json` | GET | SDK `Search().Filters` | `hey search filters` | covered |
 | `/contacts.json` | GET | SDK `Contacts().List` | `hey contacts list`, Contacts TUI | covered |

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ and individual email addresses.
 Switching cancels requests from the previous account and reloads the active section;
 Calendar and Journal remain identity-wide.
 
-Navigate between Mail, Contacts, Calendar, and Journal. Mail navigation includes HEY boxes followed by your labels. Use `n` and `p` to page through a label. Use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `g` to add, create, or remove labels, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press `b` to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with `u` while HEY's undo window remains open. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
+Navigate between Mail, Contacts, Calendar, and Journal. Mail navigation includes HEY boxes plus separate Labels and Collections tabs. Press Shift+L or Shift+K to choose one, then use `n` and `p` to page through its threads. Use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `g` to manage labels, `k` to add or remove the selected thread from collections, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press `b` to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with `u` while HEY's undo window remains open. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
 
 The mail list follows the server. HEY tells the TUI when a box changed over the same
 Action Cable connection `hey watch` uses, and the box on screen is read again a moment
@@ -235,6 +235,12 @@ hey label add 12345 --to 789        # add a label to a thread
 hey label create "Travel receipts" 12345  # create and add a label
 hey label remove 12345 --from 789   # remove one label
 hey label remove 12345 --from all   # remove every label
+hey collections                     # list collections and their IDs
+hey collection 321 --all            # list every thread in a collection
+hey collection create "Kitchen remodel" --summary "Plans and decisions"
+hey collection update 321 --name "Kitchen renovation"
+hey collection add 987 --to 321      # add a topic ID to a collection
+hey collection remove 987 --from 321 # remove a topic ID from a collection
 hey search "quarterly planning"    # search threads and matching messages
 hey search --from jane@example.com --date last_30_days  # refine a search
 hey search filters                 # list available refinement values
@@ -293,7 +299,11 @@ The Screener is where first-time senders wait. `hey screener list` returns clear
 
 `--attach` is repeatable on `hey compose`, `hey reply`, and `hey bulk-reply send`, and attachment-only messages are supported. The CLI validates and uploads every file before sending the email. `hey attachments <topic_id>` returns stable message-and-position IDs such as `456:1`; pass an ID to `hey attachments save`. Saving uses the original filename by default, accepts `--output` for a file or directory, and preserves existing files unless `--force` is set.
 
-Organization actions take the `id` values returned by `hey box --json`, `hey label --json`, or `hey search --json`. Label IDs come from `hey labels`; `hey label` returns `next_page` and `total_count`, accepts `--page <next_page>` for continuation, and supports `--all` for complete traversal. HEY creates a label while adding it to at least one thread, so `hey label create` requires thread item IDs. Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
+Organization actions take the `id` values returned by `hey box --json`, `hey label --json`, or `hey search --json`. Label IDs come from `hey labels`; `hey label` returns `next_page` and `total_count`, accepts `--page <next_page>` for continuation, and supports `--all` for complete traversal. HEY creates a label while adding it to at least one thread, so `hey label create` requires thread item IDs.
+
+Collection IDs come from `hey collections`. `hey collection` returns both each posting `id` and its `topic_id`, plus `next_page` and `total_count`. Collection membership commands take `topic_id`; posting organization commands continue to take `id`. Creating a collection returns a confirmed mutation, and `hey collections` provides its ID for subsequent commands. Collection updates accept a non-empty name, summary, or both.
+
+Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 
 ### Watching for changes
 

--- a/internal/cmd/collection.go
+++ b/internal/cmd/collection.go
@@ -73,6 +73,9 @@ func (c *collectionsCommand) run(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	}
+	if stderrNotice := paginationNoticeForStderr(writer.EffectiveFormat(), notice); stderrNotice != "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), stderrNotice)
+	}
 
 	return writeOK(collections,
 		output.WithSummary(fmt.Sprintf("%d %s", len(collections), collectionNoun(len(collections)))),
@@ -175,6 +178,12 @@ func (c *collectionCommand) run(cmd *cobra.Command, args []string) error {
 	case output.FormatStyled:
 		return writeStyledCollection(cmd, collection, notice)
 	case output.FormatIDs, output.FormatCount:
+		if stderrNotice := paginationNoticeForStderr(writer.EffectiveFormat(), notice); stderrNotice != "" {
+			fmt.Fprintln(cmd.ErrOrStderr(), stderrNotice)
+		}
+		if nextPage != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "next_page: %s\n", terminalSafeText(nextPage))
+		}
 		return writeOK(collection.Postings)
 	case output.FormatMarkdown:
 		return writeMarkdownCollection(cmd, collection, nextPage, total, notice)

--- a/internal/cmd/collection.go
+++ b/internal/cmd/collection.go
@@ -1,0 +1,533 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type collectionsCommand struct {
+	cmd   *cobra.Command
+	limit int
+	all   bool
+}
+
+func newCollectionsCommand() *collectionsCommand {
+	collectionsCommand := &collectionsCommand{}
+	collectionsCommand.cmd = &cobra.Command{
+		Use:   "collections",
+		Short: "List your email collections",
+		Annotations: map[string]string{
+			"agent_notes": "Returns collection IDs and names. Use an ID with hey collection and hey collection add/remove/update.",
+		},
+		Example: `  hey collections
+  hey collections --limit 10
+  hey collections --json`,
+		RunE: collectionsCommand.run,
+	}
+
+	collectionsCommand.cmd.Flags().IntVar(&collectionsCommand.limit, "limit", 0, "Maximum number of collections to show")
+	collectionsCommand.cmd.Flags().BoolVar(&collectionsCommand.all, "all", false, "Show all results (override --limit)")
+
+	return collectionsCommand
+}
+
+func (c *collectionsCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	result, err := sdk.Collections().List(cmd.Context())
+	if err != nil {
+		return convertSDKError(err)
+	}
+
+	collections := make([]generated.Collection, 0)
+	if result != nil {
+		collections = append(collections, (*result)...)
+	}
+	total := len(collections)
+	if c.limit > 0 && !c.all && len(collections) > c.limit {
+		collections = collections[:c.limit]
+	}
+	notice := output.TruncationNotice(len(collections), total)
+
+	if writer.IsStyled() {
+		table := newTable(cmd.OutOrStdout())
+		table.addRow([]string{"ID", "Name"})
+		for _, collection := range collections {
+			table.addRow([]string{fmt.Sprintf("%d", collection.Id), terminalSafeText(collection.Name)})
+		}
+		table.print()
+		if notice != "" {
+			fmt.Fprintln(cmd.OutOrStdout(), notice)
+		}
+		return nil
+	}
+
+	return writeOK(collections,
+		output.WithSummary(fmt.Sprintf("%d %s", len(collections), collectionNoun(len(collections)))),
+		output.WithNotice(notice),
+		output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "view",
+			Command:     "hey collection <id>",
+			Description: "View email threads in a collection",
+		}),
+	)
+}
+
+type collectionCommand struct {
+	cmd   *cobra.Command
+	limit int
+	all   bool
+	page  string
+}
+
+type collectionOutput struct {
+	ID         int64                     `json:"id"`
+	Name       string                    `json:"name,omitempty"`
+	AppURL     string                    `json:"app_url,omitempty"`
+	CreatedAt  *time.Time                `json:"created_at,omitempty"`
+	UpdatedAt  *time.Time                `json:"updated_at,omitempty"`
+	Postings   []collectionPostingOutput `json:"postings"`
+	NextPage   string                    `json:"next_page,omitempty"`
+	TotalCount int                       `json:"total_count"`
+}
+
+type collectionPostingOutput struct {
+	generated.Posting
+	TopicID int64 `json:"topic_id,omitempty"`
+}
+
+type collectionPostingMarkdown struct {
+	ID      int64  `json:"id"`
+	TopicID int64  `json:"topic_id,omitempty"`
+	From    string `json:"from,omitempty"`
+	Summary string `json:"summary,omitempty"`
+	Date    string `json:"date,omitempty"`
+}
+
+func newCollectionCommand() *collectionCommand {
+	collectionCommand := &collectionCommand{}
+	collectionCommand.cmd = &cobra.Command{
+		Use:   "collection <id>",
+		Short: "View and manage an email collection",
+		Annotations: map[string]string{
+			"agent_notes": "The ID comes from hey collections. Detail returns posting IDs for organization actions and topic_id for reading threads and collection membership changes.",
+		},
+		Example: `  hey collection 123
+  hey collection 123 --page next-cursor
+  hey collection 123 --all
+  hey collection 123 --json`,
+		RunE: collectionCommand.run,
+		Args: usageExactOneArg(),
+	}
+
+	collectionCommand.cmd.Flags().IntVar(&collectionCommand.limit, "limit", 0, "Maximum number of threads to show")
+	collectionCommand.cmd.Flags().BoolVar(&collectionCommand.all, "all", false, "Fetch all results (override --limit)")
+	collectionCommand.cmd.Flags().StringVar(&collectionCommand.page, "page", "", "Continue from a next_page cursor")
+	collectionCommand.cmd.AddCommand(newCollectionAddCommand().cmd)
+	collectionCommand.cmd.AddCommand(newCollectionCreateCommand().cmd)
+	collectionCommand.cmd.AddCommand(newCollectionRemoveCommand().cmd)
+	collectionCommand.cmd.AddCommand(newCollectionUpdateCommand().cmd)
+
+	return collectionCommand
+}
+
+func (c *collectionCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	collectionID, err := parsePositiveID(args[0], "collection")
+	if err != nil {
+		return err
+	}
+
+	var params *generated.GetCollectionParams
+	if c.page != "" {
+		params = &generated.GetCollectionParams{Page: &c.page}
+	}
+	page, err := sdk.Collections().GetPage(cmd.Context(), collectionID, params)
+	if err != nil {
+		return convertSDKError(err)
+	}
+	if page == nil || page.Collection == nil {
+		return output.ErrNotFound("collection", args[0])
+	}
+
+	collection, nextPage, total, err := paginateCollection(cmd.Context(), collectionID, page, c.limit, c.all)
+	if err != nil {
+		return err
+	}
+	notice := collectionTruncationNotice(len(collection.Postings), total, nextPage != "", c.all, c.page != "")
+
+	switch writer.EffectiveFormat() {
+	case output.FormatStyled:
+		return writeStyledCollection(cmd, collection, notice)
+	case output.FormatIDs, output.FormatCount:
+		return writeOK(collection.Postings)
+	case output.FormatMarkdown:
+		return writeMarkdownCollection(cmd, collection, nextPage, total, notice)
+	default:
+		return writeOK(makeCollectionOutput(collection, nextPage, total),
+			output.WithSummary(fmt.Sprintf("%d %s in %s", len(collection.Postings), threadNoun(len(collection.Postings)), collection.Name)),
+			output.WithNotice(notice),
+			output.WithBreadcrumbs(
+				output.Breadcrumb{Action: "read", Command: "hey threads <topic-id>", Description: "Read an email thread"},
+				output.Breadcrumb{Action: "add_to_collection", Command: "hey collection add <topic-id> --to <collection-id>", Description: "Add a thread to a collection"},
+				output.Breadcrumb{Action: "remove_from_collection", Command: "hey collection remove <topic-id> --from <collection-id>", Description: "Remove a thread from a collection"},
+			),
+		)
+	}
+}
+
+func writeStyledCollection(cmd *cobra.Command, collection *generated.CollectionWithPostings, notice string) error {
+	fmt.Fprintf(cmd.OutOrStdout(), "Collection: %s\n\n", terminalSafeText(collection.Name))
+	table := newTable(cmd.OutOrStdout())
+	table.addRow([]string{"ID", "Thread", "From", "Summary", "Date"})
+	for _, posting := range collection.Postings {
+		topicID := ""
+		if id := resolvePostingTopicID(posting); id != 0 {
+			topicID = fmt.Sprintf("%d", id)
+		}
+		table.addRow([]string{
+			fmt.Sprintf("%d", posting.Id),
+			topicID,
+			terminalSafeText(posting.Creator.Name),
+			truncate(terminalSafeText(posting.Summary), 60),
+			formatDate(posting.CreatedAt),
+		})
+	}
+	table.print()
+	if notice != "" {
+		fmt.Fprintln(cmd.OutOrStdout(), notice)
+	}
+	return nil
+}
+
+func writeMarkdownCollection(cmd *cobra.Command, collection *generated.CollectionWithPostings, nextPage string, total int, notice string) error {
+	fmt.Fprintf(cmd.OutOrStdout(), "# %s\n\n", markdownSafeText(collection.Name))
+	rows := make([]collectionPostingMarkdown, len(collection.Postings))
+	for i, posting := range collection.Postings {
+		rows[i] = collectionPostingMarkdown{
+			ID:      posting.Id,
+			TopicID: resolvePostingTopicID(posting),
+			From:    posting.Creator.Name,
+			Summary: posting.Summary,
+			Date:    formatDate(posting.CreatedAt),
+		}
+	}
+	if err := writeOK(rows); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "\n**Total threads:** %d\n", total)
+	if nextPage != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "**Next page:** `%s`\n", terminalSafeText(nextPage))
+	}
+	if notice != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n", markdownSafeText(notice))
+	}
+	return nil
+}
+
+type collectionCreateCommand struct {
+	cmd     *cobra.Command
+	summary string
+}
+
+func newCollectionCreateCommand() *collectionCreateCommand {
+	collectionCreateCommand := &collectionCreateCommand{}
+	collectionCreateCommand.cmd = &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a collection",
+		Example: `  hey collection create "Kitchen remodel"
+  hey collection create "Project Apollo" --summary "Messages and decisions for the project"`,
+		RunE: collectionCreateCommand.run,
+		Args: usageExactOneArg(),
+	}
+	collectionCreateCommand.cmd.Flags().StringVar(&collectionCreateCommand.summary, "summary", "", "Description shown with the collection")
+	return collectionCreateCommand
+}
+
+func (c *collectionCreateCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	name := strings.TrimSpace(args[0])
+	if name == "" {
+		return output.ErrUsage("collection name is required")
+	}
+	accountID, _ := sdk.AccountID()
+	if err := sdk.Collections().Create(cmd.Context(), hey.CreateCollectionParams{
+		Name:      name,
+		Summary:   strings.TrimSpace(c.summary),
+		AccountID: accountID,
+	}); err != nil {
+		return convertSDKError(err)
+	}
+
+	return writeCollectionMutation(cmd, fmt.Sprintf("Collection %q created", name), output.Breadcrumb{
+		Action:      "list",
+		Command:     "hey collections",
+		Description: "Find the new collection ID",
+	})
+}
+
+type collectionUpdateCommand struct {
+	cmd     *cobra.Command
+	name    string
+	summary string
+}
+
+func newCollectionUpdateCommand() *collectionUpdateCommand {
+	collectionUpdateCommand := &collectionUpdateCommand{}
+	collectionUpdateCommand.cmd = &cobra.Command{
+		Use:     "update <id>",
+		Aliases: []string{"edit"},
+		Short:   "Update a collection",
+		Example: `  hey collection update 123 --name "Kitchen renovation"
+  hey collection update 123 --summary "Invoices and contractor decisions"`,
+		RunE: collectionUpdateCommand.run,
+		Args: usageExactOneArg(),
+	}
+	collectionUpdateCommand.cmd.Flags().StringVar(&collectionUpdateCommand.name, "name", "", "New collection name")
+	collectionUpdateCommand.cmd.Flags().StringVar(&collectionUpdateCommand.summary, "summary", "", "New collection description")
+	return collectionUpdateCommand
+}
+
+func (c *collectionUpdateCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	collectionID, err := parsePositiveID(args[0], "collection")
+	if err != nil {
+		return err
+	}
+	nameChanged := cmd.Flags().Changed("name")
+	summaryChanged := cmd.Flags().Changed("summary")
+	if !nameChanged && !summaryChanged {
+		return output.ErrUsage("at least one of --name or --summary is required")
+	}
+
+	params := hey.UpdateCollectionParams{}
+	if nameChanged {
+		params.Name = strings.TrimSpace(c.name)
+		if params.Name == "" {
+			return output.ErrUsage("collection name is required")
+		}
+	}
+	if summaryChanged {
+		params.Summary = strings.TrimSpace(c.summary)
+		if params.Summary == "" {
+			return output.ErrUsage("collection summary is required")
+		}
+	}
+	if err := sdk.Collections().Update(cmd.Context(), collectionID, params); err != nil {
+		return convertSDKError(err)
+	}
+
+	return writeCollectionMutation(cmd, fmt.Sprintf("Collection %d updated", collectionID))
+}
+
+type collectionAddCommand struct {
+	cmd *cobra.Command
+	to  string
+}
+
+func newCollectionAddCommand() *collectionAddCommand {
+	collectionAddCommand := &collectionAddCommand{}
+	collectionAddCommand.cmd = &cobra.Command{
+		Use:   "add <topic-id>...",
+		Short: "Add email threads to a collection",
+		Example: `  hey collection add 501 --to 123
+  hey collection add 501 502 --to 123`,
+		RunE: collectionAddCommand.run,
+		Args: usageMinOneArg(),
+	}
+	collectionAddCommand.cmd.Flags().StringVar(&collectionAddCommand.to, "to", "", "Collection ID (required)")
+	return collectionAddCommand
+}
+
+func (c *collectionAddCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(c.to) == "" {
+		return output.ErrUsage("collection is required (use --to <collection-id>)")
+	}
+	collectionID, err := parsePositiveID(c.to, "collection")
+	if err != nil {
+		return err
+	}
+	topicIDs, err := parsePositiveTopicIDs(args)
+	if err != nil {
+		return err
+	}
+	for _, topicID := range topicIDs {
+		if err := sdk.Collections().AddTopic(cmd.Context(), topicID, collectionID); err != nil {
+			return convertSDKError(err)
+		}
+	}
+
+	summary := fmt.Sprintf("%d %s added to collection %d", len(topicIDs), threadNoun(len(topicIDs)), collectionID)
+	return writeCollectionMutation(cmd, summary)
+}
+
+type collectionRemoveCommand struct {
+	cmd  *cobra.Command
+	from string
+}
+
+func newCollectionRemoveCommand() *collectionRemoveCommand {
+	collectionRemoveCommand := &collectionRemoveCommand{}
+	collectionRemoveCommand.cmd = &cobra.Command{
+		Use:   "remove <topic-id>...",
+		Short: "Remove email threads from a collection",
+		Example: `  hey collection remove 501 --from 123
+  hey collection remove 501 502 --from 123`,
+		RunE: collectionRemoveCommand.run,
+		Args: usageMinOneArg(),
+	}
+	collectionRemoveCommand.cmd.Flags().StringVar(&collectionRemoveCommand.from, "from", "", "Collection ID (required)")
+	return collectionRemoveCommand
+}
+
+func (c *collectionRemoveCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(c.from) == "" {
+		return output.ErrUsage("collection is required (use --from <collection-id>)")
+	}
+	collectionID, err := parsePositiveID(c.from, "collection")
+	if err != nil {
+		return err
+	}
+	topicIDs, err := parsePositiveTopicIDs(args)
+	if err != nil {
+		return err
+	}
+	for _, topicID := range topicIDs {
+		if err := sdk.Collections().RemoveTopic(cmd.Context(), topicID, collectionID); err != nil {
+			return convertSDKError(err)
+		}
+	}
+
+	summary := fmt.Sprintf("%d %s removed from collection %d", len(topicIDs), threadNoun(len(topicIDs)), collectionID)
+	return writeCollectionMutation(cmd, summary)
+}
+
+func paginateCollection(ctx context.Context, collectionID int64, first *hey.CollectionPage, limit int, all bool) (*generated.CollectionWithPostings, string, int, error) {
+	collection := *first.Collection
+	collection.Postings = append([]generated.Posting(nil), first.Collection.Postings...)
+	nextPage := first.NextPage
+	total := max(first.TotalCount, len(collection.Postings))
+
+	needMore := all || (limit > 0 && len(collection.Postings) < limit)
+	for page := 1; page <= maxAdditionalPages && needMore && nextPage != ""; page++ {
+		cursor := nextPage
+		result, err := sdk.Collections().GetPage(ctx, collectionID, &generated.GetCollectionParams{Page: &cursor})
+		if err != nil {
+			return nil, "", 0, convertSDKError(err)
+		}
+		if result == nil || result.Collection == nil {
+			return nil, "", 0, fmt.Errorf("collection %d page %q returned no data", collectionID, cursor)
+		}
+		collection.Postings = append(collection.Postings, result.Collection.Postings...)
+		nextPage = result.NextPage
+		total = max(total, result.TotalCount, len(collection.Postings))
+		needMore = all || (limit > 0 && len(collection.Postings) < limit)
+	}
+
+	if limit > 0 && !all && len(collection.Postings) > limit {
+		collection.Postings = collection.Postings[:limit]
+		nextPage = ""
+	}
+	return &collection, nextPage, total, nil
+}
+
+func collectionTruncationNotice(shown, total int, hasMore, all, fromCursor bool) string {
+	if all {
+		if hasMore {
+			return fmt.Sprintf("Showing %d results. Pagination limit reached; continue with --page using next_page.", shown)
+		}
+		if shown < total {
+			if fromCursor {
+				return fmt.Sprintf("Showing %d remaining results from this cursor (%d threads in the collection).", shown, total)
+			}
+			return fmt.Sprintf("Showing %d of %d results; HEY returned no additional page cursor.", shown, total)
+		}
+		return ""
+	}
+	if shown < total {
+		return fmt.Sprintf("Showing %d of %d results. Use --all to see everything.", shown, total)
+	}
+	if hasMore {
+		return fmt.Sprintf("Showing %d results. More available; use --all to fetch all.", shown)
+	}
+	return ""
+}
+
+func makeCollectionOutput(collection *generated.CollectionWithPostings, nextPage string, total int) collectionOutput {
+	postings := make([]collectionPostingOutput, len(collection.Postings))
+	for i, posting := range collection.Postings {
+		postings[i] = collectionPostingOutput{Posting: posting, TopicID: resolvePostingTopicID(posting)}
+	}
+	return collectionOutput{
+		ID:         collection.Id,
+		Name:       collection.Name,
+		AppURL:     collection.AppUrl,
+		CreatedAt:  nonZeroTime(collection.CreatedAt),
+		UpdatedAt:  nonZeroTime(collection.UpdatedAt),
+		Postings:   postings,
+		NextPage:   nextPage,
+		TotalCount: total,
+	}
+}
+
+func writeCollectionMutation(cmd *cobra.Command, summary string, breadcrumbs ...output.Breadcrumb) error {
+	if writer.IsStyled() {
+		fmt.Fprintln(cmd.OutOrStdout(), terminalSafeText(summary)+".")
+		return nil
+	}
+	options := []output.ResponseOption{output.WithSummary(summary)}
+	if len(breadcrumbs) > 0 {
+		options = append(options, output.WithBreadcrumbs(breadcrumbs...))
+	}
+	return writeOK(nil, options...)
+}
+
+func parsePositiveTopicIDs(values []string) ([]int64, error) {
+	ids := make([]int64, len(values))
+	seen := make(map[int64]bool, len(values))
+	for i, value := range values {
+		id, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || id <= 0 {
+			return nil, output.ErrUsage(fmt.Sprintf("invalid topic ID: %s", value))
+		}
+		if seen[id] {
+			return nil, output.ErrUsage(fmt.Sprintf("duplicate topic ID: %d", id))
+		}
+		seen[id] = true
+		ids[i] = id
+	}
+	return ids, nil
+}
+
+func collectionNoun(count int) string {
+	if count == 1 {
+		return "collection"
+	}
+	return "collections"
+}

--- a/internal/cmd/collection_test.go
+++ b/internal/cmd/collection_test.go
@@ -1,0 +1,356 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestCollectionsCommand(t *testing.T) {
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/collections.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[
+			{"id":12,"name":"Kitchen remodel","app_url":"/collections/12"},
+			{"id":34,"name":"Project Apollo","app_url":"/collections/34"}
+		]`)
+	}), "collections", "--limit", "1")
+	if err != nil {
+		t.Fatalf("execute collections: %v", err)
+	}
+	if response.Summary != "1 collection" || response.Notice != "Showing 1 of 2 results. Use --all to see everything." {
+		t.Errorf("response = %#v", response)
+	}
+	collections, ok := response.Data.([]any)
+	if !ok || len(collections) != 1 {
+		t.Fatalf("data = %#v, want one collection", response.Data)
+	}
+	collection := collections[0].(map[string]any)
+	if collection["id"] != float64(12) || collection["name"] != "Kitchen remodel" {
+		t.Errorf("collection = %#v", collection)
+	}
+}
+
+func TestCollectionsCommandOutputFormats(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"id":12,"name":"Kitchen remodel"},{"id":34,"name":"Project Apollo"}]`)
+	})
+	ids, err := runFormattedCommand(t, handler, []string{"--ids-only"}, "collections")
+	if err != nil || ids != "12\n34\n" {
+		t.Errorf("ids output = %q, err = %v", ids, err)
+	}
+	count, err := runFormattedCommand(t, handler, []string{"--count"}, "collections")
+	if err != nil || count != "2\n" {
+		t.Errorf("count output = %q, err = %v", count, err)
+	}
+	markdown, err := runFormattedCommand(t, handler, []string{"--markdown"}, "collections")
+	if err != nil || !strings.Contains(markdown, "| id |") || !strings.Contains(markdown, "Kitchen remodel") {
+		t.Errorf("markdown output = %q, err = %v", markdown, err)
+	}
+	styled, err := runStyledCommand(t, handler, "collections")
+	if err != nil || !strings.Contains(styled, "Kitchen remodel") || !strings.Contains(styled, "Project Apollo") {
+		t.Errorf("styled output = %q, err = %v", styled, err)
+	}
+}
+
+func TestCollectionsCommandPreservesEmptyList(t *testing.T) {
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}), "collections")
+	if err != nil {
+		t.Fatalf("execute collections: %v", err)
+	}
+	collections, ok := response.Data.([]any)
+	if !ok || len(collections) != 0 || response.Summary != "0 collections" {
+		t.Errorf("response = %#v, want an empty collection list", response)
+	}
+}
+
+func TestCollectionCommand(t *testing.T) {
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/collections/12.json" {
+			t.Errorf("request = %s %s, want GET /collections/12.json", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("page"); got != "current-cursor" {
+			t.Errorf("page = %q, want current-cursor", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "2")
+		_, _ = io.WriteString(w, `{"id":12,"name":"Kitchen remodel","postings":[
+			{"id":101,"kind":"topic","summary":"Cabinet estimate","app_url":"https://app.hey.com/topics/501","creator":{"name":"Jane Doe"},"created_at":"2026-08-20T09:30:00Z"},
+			{"id":102,"kind":"topic","summary":"Tile samples"}
+		]}`)
+	}), "collection", "12", "--page", "current-cursor", "--limit", "1")
+	if err != nil {
+		t.Fatalf("execute collection: %v", err)
+	}
+	if response.Summary != "1 thread in Kitchen remodel" || response.Notice != "Showing 1 of 2 results. Use --all to see everything." {
+		t.Errorf("response = %#v", response)
+	}
+	collection := response.Data.(map[string]any)
+	if collection["id"] != float64(12) || collection["name"] != "Kitchen remodel" || collection["total_count"] != float64(2) {
+		t.Errorf("collection = %#v", collection)
+	}
+	postings := collection["postings"].([]any)
+	posting := postings[0].(map[string]any)
+	if posting["id"] != float64(101) || posting["topic_id"] != float64(501) {
+		t.Errorf("posting = %#v", posting)
+	}
+}
+
+func TestCollectionCommandEmptyPreservesCollectionAndCount(t *testing.T) {
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "0")
+		_, _ = io.WriteString(w, `{"id":12,"name":"Kitchen remodel","postings":[]}`)
+	}), "collection", "12")
+	if err != nil {
+		t.Fatalf("execute empty collection: %v", err)
+	}
+	collection := response.Data.(map[string]any)
+	postings, ok := collection["postings"].([]any)
+	if !ok || len(postings) != 0 || collection["total_count"] != float64(0) {
+		t.Errorf("empty collection contract = %#v", collection)
+	}
+}
+
+func TestCollectionCommandReturnsContinuation(t *testing.T) {
+	var requests atomic.Int32
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "3")
+		w.Header().Set("Link", "<http://"+r.Host+"/collections/12.json?page=next-cursor>; rel=\"next\"")
+		_, _ = io.WriteString(w, `{"id":12,"name":"Kitchen remodel","postings":[{"id":101,"kind":"topic"},{"id":102,"kind":"topic"}]}`)
+	}), "collection", "12")
+	if err != nil {
+		t.Fatalf("execute collection: %v", err)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d, want first page only", requests.Load())
+	}
+	collection := response.Data.(map[string]any)
+	if collection["next_page"] != "next-cursor" || collection["total_count"] != float64(3) {
+		t.Errorf("pagination metadata = %#v", collection)
+	}
+}
+
+func TestCollectionCommandFetchesAllPages(t *testing.T) {
+	var requests atomic.Int32
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "2")
+		if request == 1 {
+			w.Header().Set("Link", "<http://"+r.Host+"/collections/12.json?page=next-cursor>; rel=\"next\"")
+			_, _ = io.WriteString(w, `{"id":12,"name":"Kitchen remodel","postings":[{"id":101,"kind":"topic"}]}`)
+			return
+		}
+		if got := r.URL.Query().Get("page"); got != "next-cursor" {
+			t.Errorf("page = %q, want next-cursor", got)
+		}
+		_, _ = io.WriteString(w, `{"id":12,"name":"Kitchen remodel","postings":[{"id":102,"kind":"topic"}]}`)
+	}), "collection", "12", "--all")
+	if err != nil {
+		t.Fatalf("execute collection --all: %v", err)
+	}
+	collection := response.Data.(map[string]any)
+	if requests.Load() != 2 || len(collection["postings"].([]any)) != 2 || collection["next_page"] != nil {
+		t.Errorf("requests = %d, collection = %#v", requests.Load(), collection)
+	}
+}
+
+func TestCollectionCommandOutputFormats(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "2")
+		_, _ = io.WriteString(w, `{"id":12,"name":"Kitchen remodel","postings":[
+			{"id":101,"kind":"topic","summary":"Cabinet estimate","app_url":"https://app.hey.com/topics/501","creator":{"name":"Jane Doe"}},
+			{"id":102,"kind":"topic","summary":"Tile samples","app_url":"https://app.hey.com/topics/502"}
+		]}`)
+	})
+
+	ids, err := runFormattedCommand(t, handler, []string{"--ids-only"}, "collection", "12")
+	if err != nil || ids != "101\n102\n" {
+		t.Errorf("ids output = %q, err = %v", ids, err)
+	}
+	count, err := runFormattedCommand(t, handler, []string{"--count"}, "collection", "12")
+	if err != nil || count != "2\n" {
+		t.Errorf("count output = %q, err = %v", count, err)
+	}
+	markdown, err := runFormattedCommand(t, handler, []string{"--markdown"}, "collection", "12")
+	if err != nil {
+		t.Fatalf("markdown collection: %v", err)
+	}
+	for _, want := range []string{"# Kitchen remodel", "| id |", "topic_id", "Cabinet estimate", "**Total threads:** 2"} {
+		if !strings.Contains(markdown, want) {
+			t.Errorf("markdown %q does not contain %q", markdown, want)
+		}
+	}
+	styled, err := runStyledCommand(t, handler, "collection", "12")
+	if err != nil {
+		t.Fatalf("styled collection: %v", err)
+	}
+	for _, want := range []string{"Collection: Kitchen remodel", "Thread", "Jane Doe", "Cabinet estimate", "501"} {
+		if !strings.Contains(styled, want) {
+			t.Errorf("styled output %q does not contain %q", styled, want)
+		}
+	}
+}
+
+func TestCollectionMutationCommands(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		method      string
+		path        string
+		wantSummary string
+		check       func(*testing.T, *http.Request)
+	}{
+		{
+			name: "create", args: []string{"collection", "create", "Kitchen remodel", "--summary", "Plans and decisions"},
+			method: http.MethodPost, path: "/collections", wantSummary: `Collection "Kitchen remodel" created`,
+			check: func(t *testing.T, r *http.Request) {
+				if err := r.ParseForm(); err != nil {
+					t.Fatal(err)
+				}
+				if r.Form.Get("collection[name]") != "Kitchen remodel" || r.Form.Get("collection[summary]") != "Plans and decisions" {
+					t.Errorf("form = %v", r.Form)
+				}
+			},
+		},
+		{
+			name: "update", args: []string{"collection", "update", "12", "--name", "Kitchen renovation", "--summary", "Contractor decisions"},
+			method: http.MethodPatch, path: "/collections/12.json", wantSummary: "Collection 12 updated",
+			check: func(t *testing.T, r *http.Request) {
+				var body struct {
+					Collection struct {
+						Name    string `json:"name"`
+						Summary string `json:"summary"`
+					} `json:"collection"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				if body.Collection.Name != "Kitchen renovation" || body.Collection.Summary != "Contractor decisions" {
+					t.Errorf("body = %#v", body)
+				}
+			},
+		},
+		{
+			name: "add", args: []string{"collection", "add", "501", "--to", "12"},
+			method: http.MethodPost, path: "/topics/501/collecting", wantSummary: "1 thread added to collection 12",
+			check: func(t *testing.T, r *http.Request) {
+				if r.URL.Query().Get("collection_id") != "12" {
+					t.Errorf("query = %s", r.URL.RawQuery)
+				}
+			},
+		},
+		{
+			name: "remove", args: []string{"collection", "remove", "501", "--from", "12"},
+			method: http.MethodDelete, path: "/topics/501/collecting", wantSummary: "1 thread removed from collection 12",
+			check: func(t *testing.T, r *http.Request) {
+				if r.URL.Query().Get("collection_id") != "12" {
+					t.Errorf("query = %s", r.URL.RawQuery)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tt.method || r.URL.Path != tt.path {
+					t.Errorf("request = %s %s, want %s %s", r.Method, r.URL.Path, tt.method, tt.path)
+					http.NotFound(w, r)
+					return
+				}
+				tt.check(t, r)
+				w.WriteHeader(http.StatusNoContent)
+			}), tt.args...)
+			if err != nil {
+				t.Fatalf("execute mutation: %v", err)
+			}
+			if response.Summary != tt.wantSummary {
+				t.Errorf("summary = %q, want %q", response.Summary, tt.wantSummary)
+			}
+		})
+	}
+}
+
+func TestCollectionMutationHandlesMultipleTopics(t *testing.T) {
+	var paths []string
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path+"?"+r.URL.RawQuery)
+		w.WriteHeader(http.StatusNoContent)
+	}), "collection", "add", "501", "502", "--to", "12")
+	if err != nil {
+		t.Fatalf("execute add: %v", err)
+	}
+	want := []string{"/topics/501/collecting?collection_id=12", "/topics/502/collecting?collection_id=12"}
+	if strings.Join(paths, "|") != strings.Join(want, "|") || response.Summary != "2 threads added to collection 12" {
+		t.Errorf("paths = %v, response = %#v", paths, response)
+	}
+}
+
+func TestCollectionValidationMakesNoRequest(t *testing.T) {
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{args: []string{"collection", "invalid"}, want: "invalid collection ID"},
+		{args: []string{"collection", "create", "   "}, want: "collection name is required"},
+		{args: []string{"collection", "update", "12"}, want: "at least one"},
+		{args: []string{"collection", "update", "12", "--name", "   "}, want: "collection name is required"},
+		{args: []string{"collection", "update", "12", "--summary", "   "}, want: "collection summary is required"},
+		{args: []string{"collection", "add", "501"}, want: "collection is required"},
+		{args: []string{"collection", "add", "bad", "--to", "12"}, want: "invalid topic ID"},
+		{args: []string{"collection", "add", "501", "501", "--to", "12"}, want: "duplicate topic ID"},
+		{args: []string{"collection", "remove", "501"}, want: "collection is required"},
+		{args: []string{"collection", "remove", "501", "--from", "bad"}, want: "invalid collection ID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
+			var requests atomic.Int32
+			_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				http.Error(w, "unexpected request", http.StatusInternalServerError)
+			}), tt.args...)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+			if requests.Load() != 0 {
+				t.Errorf("requests = %d, want 0", requests.Load())
+			}
+		})
+	}
+}
+
+func TestCollectionCreateOmitsUnselectedAccount(t *testing.T) {
+	var form url.Values
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		form = r.Form
+		w.WriteHeader(http.StatusNoContent)
+	}), "collection", "create", "Kitchen remodel")
+	if err != nil {
+		t.Fatalf("execute create: %v", err)
+	}
+	if form.Has("account_id") || form.Has("collection[summary]") {
+		t.Errorf("form = %v, want only the required name", form)
+	}
+}

--- a/internal/cmd/collection_test.go
+++ b/internal/cmd/collection_test.go
@@ -209,6 +209,29 @@ func TestCollectionCommandOutputFormats(t *testing.T) {
 	}
 }
 
+func TestCollectionDataOnlyFormatsReportPaginationOnStderr(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "3")
+		w.Header().Set("Link", "<http://"+r.Host+"/collections/12.json?page=next-cursor>; rel=\"next\"")
+		_, _ = io.WriteString(w, `{"id":12,"name":"Kitchen remodel","postings":[{"id":101,"kind":"topic"},{"id":102,"kind":"topic"}]}`)
+	})
+
+	for _, format := range []string{"--ids-only", "--count"} {
+		t.Run(format, func(t *testing.T) {
+			_, stderr, err := runFormattedCommandWithStderr(t, handler, []string{format}, "collection", "12")
+			if err != nil {
+				t.Fatalf("collection %s: %v", format, err)
+			}
+			for _, want := range []string{"notice: Showing 2 of 3 results", "next_page: next-cursor"} {
+				if !strings.Contains(stderr, want) {
+					t.Errorf("stderr %q does not contain %q", stderr, want)
+				}
+			}
+		})
+	}
+}
+
 func TestCollectionMutationCommands(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/cmd/drafts_test.go
+++ b/internal/cmd/drafts_test.go
@@ -16,6 +16,12 @@ func runStyledCommand(t *testing.T, handler http.Handler, args ...string) (strin
 
 func runFormattedCommand(t *testing.T, handler http.Handler, formatArgs []string, args ...string) (string, error) {
 	t.Helper()
+	stdout, _, err := runFormattedCommandWithStderr(t, handler, formatArgs, args...)
+	return stdout, err
+}
+
+func runFormattedCommandWithStderr(t *testing.T, handler http.Handler, formatArgs []string, args ...string) (string, string, error) {
+	t.Helper()
 	previousColorDisabled := colorDisabled
 	colorDisabled = false
 	t.Cleanup(func() { colorDisabled = previousColorDisabled })
@@ -40,7 +46,7 @@ func runFormattedCommand(t *testing.T, handler http.Handler, formatArgs []string
 	root.SetArgs(append(rootArgs, args...))
 
 	err := root.Execute()
-	return stdout.String(), err
+	return stdout.String(), stderr.String(), err
 }
 
 func TestDraftsCommandLimitsResults(t *testing.T) {

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -21,7 +21,7 @@ var curatedCategories = []struct {
 	},
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "labels", "label", "search", "contacts", "screener", "threads", "share", "unshare", "attachments", "compose", "reply", "bulk-reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"},
+		names:   []string{"boxes", "box", "labels", "label", "collections", "collection", "search", "contacts", "screener", "threads", "share", "unshare", "attachments", "compose", "reply", "bulk-reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -99,6 +99,8 @@ EMAIL
   box            List email threads in a box
   labels         List your email labels
   label          View and manage an email label
+  collections    List your email collections
+  collection     View and manage an email collection
   search         Search email threads and messages
   contacts       Manage contacts
   screener       Decide who gets to email you

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -161,6 +161,8 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newBoxCommand().cmd)
 	root.AddCommand(newLabelsCommand().cmd)
 	root.AddCommand(newLabelCommand().cmd)
+	root.AddCommand(newCollectionsCommand().cmd)
+	root.AddCommand(newCollectionCommand().cmd)
 	root.AddCommand(newSearchCommand().cmd)
 	root.AddCommand(newContactsCommand().cmd)
 	root.AddCommand(newScreenerCommand().cmd)

--- a/internal/models/box.go
+++ b/internal/models/box.go
@@ -20,28 +20,35 @@ type Folder struct {
 	AppURL string `json:"app_url"`
 }
 
+type Collection struct {
+	ID     int64  `json:"id"`
+	Name   string `json:"name"`
+	AppURL string `json:"app_url"`
+}
+
 type Posting struct {
-	ID                    int64       `json:"id"`
-	CreatedAt             string      `json:"created_at"`
-	UpdatedAt             string      `json:"updated_at"`
-	ObservedAt            string      `json:"observed_at"`
-	Kind                  string      `json:"kind"`
-	Name                  string      `json:"name"`
-	Seen                  bool        `json:"seen"`
-	Bundled               bool        `json:"bundled"`
-	Muted                 bool        `json:"muted"`
-	Summary               string      `json:"summary"`
-	EntryKind             string      `json:"entry_kind"`
-	IncludesAttachments   bool        `json:"includes_attachments"`
-	BubbledUp             bool        `json:"bubbled_up"`
-	AppURL                string      `json:"app_url"`
-	Creator               Contact     `json:"creator"`
-	AlternativeSenderName string      `json:"alternative_sender_name"`
-	VisibleEntryCount     int32       `json:"visible_entry_count"`
-	Extenzions            []Extenzion `json:"extenzions,omitempty"`
-	Folders               []Folder    `json:"folders,omitempty"`
-	TopicID               int64       `json:"topic_id"`
-	Topic                 *Topic      `json:"topic,omitempty"`
+	ID                    int64        `json:"id"`
+	CreatedAt             string       `json:"created_at"`
+	UpdatedAt             string       `json:"updated_at"`
+	ObservedAt            string       `json:"observed_at"`
+	Kind                  string       `json:"kind"`
+	Name                  string       `json:"name"`
+	Seen                  bool         `json:"seen"`
+	Bundled               bool         `json:"bundled"`
+	Muted                 bool         `json:"muted"`
+	Summary               string       `json:"summary"`
+	EntryKind             string       `json:"entry_kind"`
+	IncludesAttachments   bool         `json:"includes_attachments"`
+	BubbledUp             bool         `json:"bubbled_up"`
+	AppURL                string       `json:"app_url"`
+	Creator               Contact      `json:"creator"`
+	AlternativeSenderName string       `json:"alternative_sender_name"`
+	VisibleEntryCount     int32        `json:"visible_entry_count"`
+	Extenzions            []Extenzion  `json:"extenzions,omitempty"`
+	Folders               []Folder     `json:"folders,omitempty"`
+	Collections           []Collection `json:"collections,omitempty"`
+	TopicID               int64        `json:"topic_id"`
+	Topic                 *Topic       `json:"topic,omitempty"`
 }
 
 // Extenzion is a HEY extension (group/list) through which a topic was received.

--- a/internal/tui/collections.go
+++ b/internal/tui/collections.go
@@ -1,0 +1,205 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/basecamp/hey-cli/internal/models"
+)
+
+const mailSourceKindCollection = "collection"
+
+// collectionNavPicker chooses a collection to open from the Collections tab.
+type collectionNavPicker struct {
+	sourceIndexes []int
+	names         []string
+	cursor        int
+}
+
+func newCollectionNavPicker(sources []models.Box, currentIndex int) *collectionNavPicker {
+	picker := &collectionNavPicker{}
+	for i, source := range sources {
+		if source.Kind != mailSourceKindCollection {
+			continue
+		}
+		if i == currentIndex {
+			picker.cursor = len(picker.sourceIndexes)
+		}
+		picker.sourceIndexes = append(picker.sourceIndexes, i)
+		picker.names = append(picker.names, terminalSafeCollectionText(source.Name))
+	}
+	return picker
+}
+
+func (p *collectionNavPicker) selectedSourceIndex() int {
+	if p.cursor < 0 || p.cursor >= len(p.sourceIndexes) {
+		return -1
+	}
+	return p.sourceIndexes[p.cursor]
+}
+
+func (p *collectionNavPicker) update(msg tea.KeyPressMsg) {
+	switch msg.Key().Code {
+	case tea.KeyUp:
+		if p.cursor > 0 {
+			p.cursor--
+		}
+	case tea.KeyDown:
+		if p.cursor < len(p.sourceIndexes)-1 {
+			p.cursor++
+		}
+	}
+}
+
+func (p *collectionNavPicker) overlay(base string, width, height int) string {
+	modal := p.view(width, height)
+	x := max((width-lipgloss.Width(modal))/2, 0)
+	y := max((height-lipgloss.Height(modal))/2, 0)
+	compositor := lipgloss.NewCompositor(
+		lipgloss.NewLayer(base).Z(0),
+		lipgloss.NewLayer(modal).X(x).Y(y).Z(1),
+	)
+	canvas := lipgloss.NewCanvas(width, height)
+	compositor.Draw(canvas, canvas.Bounds())
+	return canvas.Render()
+}
+
+func (p *collectionNavPicker) view(width, height int) string {
+	contentWidth := max(width-6, 1)
+	title := lipgloss.NewStyle().Foreground(colorChrome).Bold(true).Render(truncateToWidth("Collections", contentWidth))
+	selected := lipgloss.NewStyle().Foreground(colorActive).Bold(true)
+
+	maxRows := max(height-6, 1)
+	start := 0
+	if p.cursor >= maxRows {
+		start = p.cursor - maxRows + 1
+	}
+	rows := make([]string, 0, maxRows)
+	for i := start; i < min(start+maxRows, len(p.names)); i++ {
+		name := truncateToWidth(p.names[i], max(contentWidth-2, 1))
+		if i == p.cursor {
+			rows = append(rows, selected.Render("› "+name))
+		} else {
+			rows = append(rows, "  "+name)
+		}
+	}
+
+	body := title + "\n\n" + strings.Join(rows, "\n")
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorChrome).
+		Padding(0, 2).
+		Render(body)
+}
+
+func (p *collectionNavPicker) helpBindings() []helpBinding {
+	return []helpBinding{{"↑/↓", "choose"}, {"enter", "open"}, {"esc", "cancel"}}
+}
+
+// collectionMembershipPicker toggles the selected thread in an existing collection.
+type collectionMembershipPicker struct {
+	posting     models.Posting
+	collections []models.Collection
+	cursor      int
+	offset      int
+	height      int
+}
+
+func newCollectionMembershipPicker(posting models.Posting, sources []models.Box) *collectionMembershipPicker {
+	collections := make([]models.Collection, 0)
+	for _, source := range sources {
+		if source.Kind == mailSourceKindCollection {
+			collections = append(collections, models.Collection{ID: source.ID, Name: source.Name, AppURL: source.AppURL})
+		}
+	}
+	return &collectionMembershipPicker{posting: posting, collections: collections}
+}
+
+func (p *collectionMembershipPicker) selected() *models.Collection {
+	if p.cursor < 0 || p.cursor >= len(p.collections) {
+		return nil
+	}
+	return &p.collections[p.cursor]
+}
+
+func (p *collectionMembershipPicker) postingHasCollection(collectionID int64) bool {
+	for _, collection := range p.posting.Collections {
+		if collection.ID == collectionID {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *collectionMembershipPicker) update(msg tea.KeyPressMsg) {
+	switch msg.Key().Code {
+	case tea.KeyUp:
+		if p.cursor > 0 {
+			p.cursor--
+		}
+	case tea.KeyDown:
+		if p.cursor < len(p.collections)-1 {
+			p.cursor++
+		}
+	}
+	p.ensureVisible()
+}
+
+func (p *collectionMembershipPicker) resize(height int) {
+	p.height = height
+	p.ensureVisible()
+}
+
+func (p *collectionMembershipPicker) visibleRows() int {
+	return max(p.height-5, 1)
+}
+
+func (p *collectionMembershipPicker) ensureVisible() {
+	if p.cursor < p.offset {
+		p.offset = p.cursor
+	}
+	rows := p.visibleRows()
+	if p.cursor >= p.offset+rows {
+		p.offset = p.cursor - rows + 1
+	}
+}
+
+func (p *collectionMembershipPicker) view(styles styles, width int) string {
+	contentWidth := max(width-4, 1)
+	var body strings.Builder
+	body.WriteString(styles.title.Render("Thread collections"))
+	if p.posting.Summary != "" {
+		fmt.Fprintf(&body, "\n%s", truncateStr(p.posting.Summary, contentWidth))
+	}
+	body.WriteString("\n\n")
+	end := min(p.offset+p.visibleRows(), len(p.collections))
+	for i := p.offset; i < end; i++ {
+		collection := p.collections[i]
+		prefix := "  "
+		if i == p.cursor {
+			prefix = "› "
+		}
+		mark := "[ ]"
+		if p.postingHasCollection(collection.ID) {
+			mark = "[x]"
+		}
+		label := mark + " " + terminalSafeCollectionText(collection.Name)
+		label = truncateStr(label, max(contentWidth-lipgloss.Width(prefix), 1))
+		if i == p.cursor {
+			label = styles.title.Render(label)
+		}
+		fmt.Fprintf(&body, "%s%s\n", prefix, label)
+	}
+	return body.String()
+}
+
+func (p *collectionMembershipPicker) helpBindings() []helpBinding {
+	return []helpBinding{{"↑↓", "select"}, {"enter", "toggle"}, {"esc", "cancel"}}
+}
+
+func terminalSafeCollectionText(value string) string {
+	return terminalSafeFolderText(value)
+}

--- a/internal/tui/collections_test.go
+++ b/internal/tui/collections_test.go
@@ -1,0 +1,678 @@
+package tui
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/models"
+)
+
+func TestCollectionNavPickerConstrainsAndSanitizesNames(t *testing.T) {
+	picker := newCollectionNavPicker([]models.Box{{
+		ID:   12,
+		Kind: mailSourceKindCollection,
+		Name: "Kitchen remodel\x1b]2;owned\a\nwith every contractor decision and invoice",
+	}}, 0)
+
+	const width = 32
+	view := stripANSI(picker.overlay("", width, 10))
+	if !strings.Contains(view, "Collections") || strings.Contains(view, "\x1b]2;owned") {
+		t.Errorf("picker should identify collections and sanitize controls: %q", view)
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if lipgloss.Width(line) > width {
+			t.Errorf("picker line width = %d, want at most %d: %q", lipgloss.Width(line), width, line)
+		}
+	}
+}
+
+func TestCollectionMembershipPickerShowsCurrentMembership(t *testing.T) {
+	picker := newCollectionMembershipPicker(models.Posting{
+		ID:          100,
+		Summary:     "Cabinet estimate",
+		Collections: []models.Collection{{ID: 12, Name: "Kitchen remodel"}},
+	}, []models.Box{
+		{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"},
+		{ID: 34, Kind: mailSourceKindCollection, Name: "Project Apollo"},
+	})
+	picker.resize(20)
+	view := stripANSI(picker.view(newStyles(), 80))
+	for _, want := range []string{"Thread collections", "Cabinet estimate", "[x] Kitchen remodel", "[ ] Project Apollo"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("picker view %q does not contain %q", view, want)
+		}
+	}
+}
+
+func TestMailViewLoadsAndPagesCollections(t *testing.T) {
+	var collectionQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/boxes.json":
+			_, _ = w.Write([]byte(`[{"id":1,"kind":"imbox","name":"Imbox"}]`))
+		case "/my/navigation.json":
+			_, _ = w.Write([]byte(`{"items":[]}`))
+		case "/collections.json":
+			_, _ = w.Write([]byte(`[{"id":12,"name":"Kitchen remodel","app_url":"/collections/12"}]`))
+		case "/collections/12.json":
+			collectionQueries = append(collectionQueries, r.URL.Query().Get("page"))
+			w.Header().Set("X-Total-Count", "2")
+			if r.URL.Query().Get("page") == "next-cursor" {
+				_, _ = w.Write([]byte(`{"id":12,"name":"Kitchen remodel","postings":[{"id":101,"kind":"topic","summary":"Second page","app_url":"/topics/502","collections":[{"id":12,"name":"Kitchen remodel"}]}]}`))
+				return
+			}
+			w.Header().Set("Link", "<http://"+r.Host+"/collections/12.json?page=next-cursor>; rel=\"next\"")
+			_, _ = w.Write([]byte(`{"id":12,"name":"Kitchen remodel","postings":[{"id":100,"kind":"topic","summary":"First page","app_url":"/topics/501","collections":[{"id":12,"name":"Kitchen remodel"}]}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "test-token"}, hey.WithMaxRetries(0))
+	vc := testVC()
+	vc.sdk = client
+	v := newMailView(vc)
+
+	loaded := runCmd(v.Init()).(mailSourcesLoadedMsg)
+	v.Update(loaded)
+	if len(v.boxes) != 2 || v.boxes[1].Kind != mailSourceKindCollection {
+		t.Fatalf("sources = %+v", v.boxes)
+	}
+	if cmd := v.SubnavRight(); cmd != nil || v.collections == nil {
+		t.Fatal("right from the last box should open Collections")
+	}
+	first := runCmd(v.HandleContentKey(keyPress("enter"))).(postingsLoadedMsg)
+	v.Update(first)
+	if v.currentSourceKind() != mailSourceKindCollection || len(v.postingList.postings) != 1 {
+		t.Fatalf("collection source = %q postings = %+v", v.currentSourceKind(), v.postingList.postings)
+	}
+	posting := v.postingList.postings[0]
+	if posting.ResolveTopicID() != 501 || len(posting.Collections) != 1 || posting.Collections[0].ID != 12 {
+		t.Errorf("posting = %+v", posting)
+	}
+	if v.notice != "Collection page 1 — 2 threads total" || v.folderNextPage != "next-cursor" {
+		t.Errorf("page state = notice:%q next:%q", v.notice, v.folderNextPage)
+	}
+
+	second := runCmd(v.HandleContentKey(keyPress("n"))).(postingsLoadedMsg)
+	v.Update(second)
+	if len(v.folderPageHistory) != 1 || v.postingList.postings[0].Summary != "Second page" {
+		t.Errorf("second page = history:%v postings:%+v", v.folderPageHistory, v.postingList.postings)
+	}
+	previous := runCmd(v.HandleContentKey(keyPress("p"))).(postingsLoadedMsg)
+	v.Update(previous)
+	if len(v.folderPageHistory) != 0 || v.postingList.postings[0].Summary != "First page" {
+		t.Errorf("previous page = history:%v postings:%+v", v.folderPageHistory, v.postingList.postings)
+	}
+	if fmt.Sprint(collectionQueries) != "[ next-cursor ]" {
+		t.Errorf("collection page queries = %q", collectionQueries)
+	}
+}
+
+func TestMailViewCollectionMembershipAddsAndRemoves(t *testing.T) {
+	t.Run("add", func(t *testing.T) {
+		v, recorded := mailWithTestServer(t, http.StatusNoContent)
+		v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+		v.postingList.postings[0].AppURL = "/topics/501"
+
+		v.HandleContentKey(keyPress("k"))
+		if v.collectionPicker == nil || !v.CapturingInput() {
+			t.Fatal("collection picker should capture input")
+		}
+		done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
+		if recorded.method != http.MethodPost || recorded.path != "/topics/501/collecting" || recorded.rawQueries[len(recorded.rawQueries)-1] != "collection_id=12" {
+			t.Errorf("request = %s %s?%v", recorded.method, recorded.path, recorded.rawQueries)
+		}
+		v.Update(done)
+		if v.pendingMutations != 0 || v.notice != "Added to collection Kitchen remodel" {
+			t.Errorf("mutation state = pending:%d notice:%q", v.pendingMutations, v.notice)
+		}
+		if memberships := v.postingList.postings[0].Collections; len(memberships) != 1 || memberships[0].ID != 12 {
+			t.Errorf("memberships = %+v", memberships)
+		}
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		v, recorded := mailWithTestServer(t, http.StatusNoContent)
+		collection := models.Collection{ID: 12, Name: "Kitchen remodel"}
+		v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: collection.Name})
+		v.postingList.postings[0].AppURL = "/topics/501"
+		v.postingList.postings[0].Collections = []models.Collection{collection}
+
+		v.HandleContentKey(keyPress("k"))
+		done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
+		if recorded.method != http.MethodDelete || recorded.path != "/topics/501/collecting" || recorded.rawQueries[len(recorded.rawQueries)-1] != "collection_id=12" {
+			t.Errorf("request = %s %s?%v", recorded.method, recorded.path, recorded.rawQueries)
+		}
+		v.Update(done)
+		if len(v.postingList.postings[0].Collections) != 0 || v.notice != "Removed from collection Kitchen remodel" {
+			t.Errorf("posting = %+v notice = %q", v.postingList.postings[0], v.notice)
+		}
+	})
+}
+
+func TestMailViewCollectionMembershipFailureKeepsState(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusBadRequest)
+	collection := models.Collection{ID: 12, Name: "Kitchen remodel"}
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: collection.Name})
+	v.postingList.postings[0].AppURL = "/topics/501"
+	v.postingList.postings[0].Collections = []models.Collection{collection}
+
+	v.HandleContentKey(keyPress("k"))
+	done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
+	v.Update(done)
+	if v.pendingMutations != 0 || len(v.postingList.postings[0].Collections) != 1 {
+		t.Errorf("failed mutation changed state: pending:%d posting:%+v", v.pendingMutations, v.postingList.postings[0])
+	}
+	if !strings.Contains(v.notice, "Could not update collections") {
+		t.Errorf("notice = %q", v.notice)
+	}
+}
+
+func TestMailViewCollectionMembershipRequiresTopicID(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+
+	if cmd := v.HandleContentKey(keyPress("k")); cmd != nil {
+		t.Fatal("unresolved posting should not start a mutation")
+	}
+	if v.collectionPicker != nil || v.notice != "This item does not identify an email thread" || len(recorded.requests) != 0 {
+		t.Errorf("picker = %v notice = %q requests = %v", v.collectionPicker != nil, v.notice, recorded.requests)
+	}
+}
+
+func TestMailViewCollectionDiscoveryFailurePreservesKnownCollections(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	v.sourceRequestID = 1
+
+	v.Update(mailSourcesLoadedMsg{
+		requestID:     1,
+		sources:       testBoxes(),
+		collectionErr: fmt.Errorf("collections unavailable"),
+	})
+	if sourceIndex(v.boxes, 12, mailSourceKindCollection) == 0 || v.collectionDiscoveryErr == "" {
+		t.Errorf("sources = %+v error = %q", v.boxes, v.collectionDiscoveryErr)
+	}
+	if !strings.Contains(v.notice, "press k to retry") {
+		t.Errorf("notice = %q", v.notice)
+	}
+}
+
+func TestMailViewCollectionMutationIgnoresStaleSource(t *testing.T) {
+	v := mailWithPostings()
+	v.pendingMutations = 1
+	v.Update(collectionActionDoneMsg{
+		action:     "Added to collection Kitchen remodel",
+		sourceID:   99,
+		sourceKind: mailSourceKindCollection,
+		postingID:  100,
+		collection: models.Collection{ID: 12, Name: "Kitchen remodel"},
+		added:      true,
+	})
+	if v.pendingMutations != 0 || len(v.postingList.postings[0].Collections) != 0 || v.notice != "" {
+		t.Errorf("stale completion changed current source: pending:%d posting:%+v notice:%q", v.pendingMutations, v.postingList.postings[0], v.notice)
+	}
+}
+
+func TestMailViewCollectionIgnoresBoxLiveRefreshes(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	v.boxIndex = len(v.boxes) - 1
+	if cmd := v.boxChanged(AnyBoxChanged); cmd != nil || v.liveRefreshDue {
+		t.Errorf("collection should not follow box live updates: command:%v due:%v", cmd != nil, v.liveRefreshDue)
+	}
+}
+
+func TestMailViewCollectionNamedImboxIsNotAnImbox(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Imbox"})
+	v.boxIndex = len(v.boxes) - 1
+	if v.currentBoxIsImbox() {
+		t.Fatal("a collection named Imbox should remain a flat collection view")
+	}
+}
+
+func TestMailViewCollectionNavigationShortcut(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	if cmd := v.handleBoxShortcut("K"); cmd == nil || v.collections == nil {
+		t.Fatal("K should open the Collections picker")
+	}
+	items, _, _, _ := v.SubnavItems()
+	last := items[len(items)-1]
+	if last.label != "Collections" || last.shortcut != "K" {
+		t.Errorf("collections tab = %+v", last)
+	}
+}
+
+func TestMailViewRemovingFromCurrentCollectionRefreshesIt(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusNoContent)
+	collection := models.Collection{ID: 12, Name: "Kitchen remodel"}
+	v.boxes = []models.Box{{ID: 12, Kind: mailSourceKindCollection, Name: collection.Name}}
+	v.boxIndex = 0
+	v.postingList.postings[0].AppURL = "/topics/501"
+	v.postingList.postings[0].Collections = []models.Collection{collection}
+
+	v.HandleContentKey(keyPress("k"))
+	done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
+	refresh, consumed := v.Update(done)
+	if !consumed || refresh == nil || v.activeRequestKind != mailRequestPostings || v.postingIndex(100) >= 0 {
+		t.Errorf("current collection removal should update then refresh: consumed:%v refresh:%v kind:%v postings:%+v", consumed, refresh != nil, v.activeRequestKind, v.postingList.postings)
+	}
+}
+
+func TestMailViewCollectionPendingMutationBlocksAccountSwitch(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusNoContent)
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	v.postingList.postings[0].AppURL = "/topics/501"
+	v.HandleContentKey(keyPress("k"))
+	cmd := v.HandleContentKey(keyPress("enter"))
+	if cmd == nil || !v.AccountSwitchBlocked() {
+		t.Fatal("collection write should block account switching until completion")
+	}
+	v.Update(runCmd(cmd))
+	if v.AccountSwitchBlocked() {
+		t.Fatal("collection write completion should release account switching")
+	}
+}
+
+func TestMailViewCollectionDiscoveryRetryKey(t *testing.T) {
+	v := mailWithPostings()
+	v.collectionDiscoveryErr = "unavailable"
+	cmd := v.HandleContentKey(keyPress("k"))
+	if cmd == nil || !v.loading || v.notice != "Retrying collections…" {
+		t.Errorf("retry = cmd:%v loading:%v notice:%q", cmd != nil, v.loading, v.notice)
+	}
+}
+
+func TestMailViewCollectionActionUsesTopicNotPostingID(t *testing.T) {
+	var path string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	client := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "test-token"}, hey.WithMaxRetries(0))
+	vc := testVC()
+	vc.sdk = client
+	v := newMailView(vc)
+	v.boxes = []models.Box{{ID: 1, Kind: "imbox", Name: "Imbox"}, {ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"}}
+	v.postingList.setPostings([]models.Posting{{ID: 100, AppURL: "/topics/501"}})
+
+	v.HandleContentKey(keyPress("k"))
+	done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
+	if path != "/topics/501/collecting" || done.postingID != 100 {
+		t.Errorf("path = %q posting ID = %d", path, done.postingID)
+	}
+}
+
+func TestMailViewCollectionPageHelpUsesPreviousInsteadOfPaperTrail(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	v.boxIndex = len(v.boxes) - 1
+	v.folderPageHistory = []string{""}
+	previous, paperTrail := 0, 0
+	for _, binding := range v.HelpBindings() {
+		if binding.key != "p" {
+			continue
+		}
+		if binding.desc == "previous page" {
+			previous++
+		}
+		if binding.desc == "paper trail" {
+			paperTrail++
+		}
+	}
+	if previous != 1 || paperTrail != 0 {
+		t.Errorf("bindings = %v", v.HelpBindings())
+	}
+}
+
+func TestMailViewCollectionMoveKeepsCollectionMembership(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusNoContent)
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	v.boxIndex = len(v.boxes) - 1
+	v.postingList.setPostings([]models.Posting{{ID: 100, Collections: []models.Collection{{ID: 12, Name: "Kitchen remodel"}}}})
+
+	v.startMove()
+	if v.movePicker == nil {
+		t.Fatal("move picker should offer mailbox destinations")
+	}
+	done := runCmd(v.movePostingToBox(100, models.Box{ID: 2, Kind: "feedbox", Name: "The Feed"})).(postingActionDoneMsg)
+	if done.effect != postingActionNone {
+		t.Errorf("collection move effect = %v, want no row removal", done.effect)
+	}
+}
+
+func TestCollectionSourceIdentityDistinguishesCollidingIDs(t *testing.T) {
+	sources := []models.Box{
+		{ID: 12, Kind: "imbox", Name: "Imbox"},
+		{ID: 12, Kind: mailSourceKindFolder, Name: "Receipts"},
+		{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"},
+	}
+	if got := sourceIndex(sources, 12, mailSourceKindCollection); got != 2 {
+		t.Errorf("collection source index = %d, want 2", got)
+	}
+}
+
+func TestMailViewCollectionPickerEscapeMakesNoRequest(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	v.postingList.postings[0].AppURL = "/topics/501"
+	v.HandleContentKey(keyPress("k"))
+	if cmd := v.HandleContentKey(keyPress("esc")); cmd != nil {
+		t.Fatal("escape should not return a command")
+	}
+	if v.collectionPicker != nil || len(recorded.requests) != 0 {
+		t.Errorf("picker = %v requests = %v", v.collectionPicker != nil, recorded.requests)
+	}
+}
+
+func TestMailViewCollectionDiscoveryStaleResultIgnored(t *testing.T) {
+	v := mailWithPostings()
+	v.sourceRequestID = 2
+	v.Update(mailSourcesLoadedMsg{requestID: 1, sources: []models.Box{{ID: 12, Kind: mailSourceKindCollection, Name: "Stale"}}})
+	if len(v.boxes) != len(testBoxes()) {
+		t.Errorf("stale discovery replaced sources: %+v", v.boxes)
+	}
+}
+
+func TestMailViewCollectionMembershipListScrolls(t *testing.T) {
+	collections := make([]models.Box, 0, 20)
+	for id := int64(1); id <= 20; id++ {
+		collections = append(collections, models.Box{ID: id, Kind: mailSourceKindCollection, Name: fmt.Sprintf("Collection %02d", id)})
+	}
+	picker := newCollectionMembershipPicker(models.Posting{ID: 100}, collections)
+	picker.resize(8)
+	for range 19 {
+		picker.update(keyPress("down"))
+	}
+	view := stripANSI(picker.view(newStyles(), 40))
+	if strings.Contains(view, "Collection 01") || !strings.Contains(view, "Collection 20") {
+		t.Errorf("scrolled picker = %q", view)
+	}
+}
+
+func TestMailViewCollectionCompletionFromWrongKindIgnored(t *testing.T) {
+	v := mailWithPostings()
+	v.pendingMutations = 1
+	v.Update(collectionActionDoneMsg{
+		sourceID:   v.currentBoxID(),
+		sourceKind: mailSourceKindCollection,
+		postingID:  100,
+		collection: models.Collection{ID: 12, Name: "Kitchen remodel"},
+		added:      true,
+	})
+	if len(v.postingList.postings[0].Collections) != 0 {
+		t.Errorf("wrong-kind completion changed current posting: %+v", v.postingList.postings[0])
+	}
+}
+
+func TestMailViewCollectionDiscoveryErrorDoesNotHideLabels(t *testing.T) {
+	v := mailWithPostings()
+	v.sourceRequestID = 1
+	v.Update(mailSourcesLoadedMsg{
+		requestID:     1,
+		sources:       append(testBoxes(), models.Box{ID: 7, Kind: mailSourceKindFolder, Name: "Receipts"}),
+		collectionErr: fmt.Errorf("collections unavailable"),
+	})
+	if !v.hasLabels() || v.hasCollections() {
+		t.Errorf("sources = %+v", v.boxes)
+	}
+}
+
+func TestMailViewCollectionSourceDoesNotAppearAsMoveDestination(t *testing.T) {
+	posting := models.Posting{ID: 100}
+	boxes := []models.Box{
+		{ID: 1, Kind: "imbox", Name: "Imbox"},
+		{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"},
+	}
+	picker := newMovePicker(posting, boxes, boxes[0])
+	if len(picker.destinations) != 0 {
+		t.Errorf("move destinations = %+v", picker.destinations)
+	}
+}
+
+func TestMailViewCollectionNoticeSanitizesName(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusNoContent)
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen\x1b]2;owned\a\nremodel"})
+	v.postingList.postings[0].AppURL = "/topics/501"
+	v.HandleContentKey(keyPress("k"))
+	done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
+	v.Update(done)
+	if strings.Contains(v.notice, "\x1b") || strings.Contains(v.notice, "\nremodel") {
+		t.Errorf("unsafe collection notice = %q", v.notice)
+	}
+}
+
+func TestMailViewCollectionPageMessageRejectsWrongSource(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	v.boxIndex = len(v.boxes) - 1
+	v.activeRequestID = 3
+	_, consumed := v.Update(postingsLoadedMsg{
+		requestID:  3,
+		boxID:      12,
+		sourceKind: mailSourceKindFolder,
+		postings:   []models.Posting{{ID: 999}},
+	})
+	if !consumed || len(v.postingList.postings) != 2 {
+		t.Errorf("wrong-kind page replaced postings: %+v", v.postingList.postings)
+	}
+}
+
+func TestMailViewCollectionEmptySourceStillPages(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	v.boxIndex = len(v.boxes) - 1
+	v.activeRequestID = 1
+	v.Update(postingsLoadedMsg{requestID: 1, boxID: 12, sourceKind: mailSourceKindCollection, totalCount: 0})
+	if v.notice != "Collection page 1" || len(v.postingList.postings) != 0 {
+		t.Errorf("empty collection state = notice:%q postings:%+v", v.notice, v.postingList.postings)
+	}
+}
+
+func TestMailViewCollectionPickerNoCollections(t *testing.T) {
+	v := mailWithPostings()
+	v.postingList.postings[0].AppURL = "/topics/501"
+	v.HandleContentKey(keyPress("k"))
+	if v.collectionPicker != nil || v.notice != "No collections available" {
+		t.Errorf("picker = %v notice = %q", v.collectionPicker != nil, v.notice)
+	}
+}
+
+func TestMailViewCollectionNavigationFromLabels(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes,
+		models.Box{ID: 7, Kind: mailSourceKindFolder, Name: "Receipts"},
+		models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"},
+	)
+	v.boxIndex = len(v.boxes) - 2
+	if cmd := v.SubnavRight(); cmd != nil || v.collections == nil {
+		t.Fatal("right from Labels should open Collections")
+	}
+	v.collections = nil
+	v.boxIndex = len(v.boxes) - 1
+	if cmd := v.SubnavLeft(); cmd != nil || v.labels == nil {
+		t.Fatal("left from Collections should open Labels")
+	}
+}
+
+func TestMailViewCollectionActionErrorReleasesPendingMutation(t *testing.T) {
+	v := mailWithPostings()
+	v.pendingMutations = 1
+	v.Update(collectionActionDoneMsg{
+		sourceID:   v.currentBoxID(),
+		sourceKind: v.currentSourceKind(),
+		postingID:  100,
+		collection: models.Collection{ID: 12, Name: "Kitchen remodel"},
+		err:        fmt.Errorf("unavailable"),
+	})
+	if v.pendingMutations != 0 || !strings.Contains(v.notice, "unavailable") {
+		t.Errorf("pending = %d notice = %q", v.pendingMutations, v.notice)
+	}
+}
+
+func TestMailViewCollectionMembershipToggleUsesKnownState(t *testing.T) {
+	posting := models.Posting{Collections: []models.Collection{{ID: 12, Name: "Kitchen remodel"}}}
+	picker := newCollectionMembershipPicker(posting, []models.Box{{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"}})
+	selected := picker.selected()
+	if selected == nil || !picker.postingHasCollection(selected.ID) {
+		t.Fatal("known membership should select removal behavior")
+	}
+}
+
+func TestMailViewCollectionNavigationSelection(t *testing.T) {
+	sources := []models.Box{
+		{ID: 1, Kind: "imbox", Name: "Imbox"},
+		{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"},
+		{ID: 34, Kind: mailSourceKindCollection, Name: "Project Apollo"},
+	}
+	picker := newCollectionNavPicker(sources, 2)
+	if picker.selectedSourceIndex() != 2 {
+		t.Errorf("selected source = %d, want 2", picker.selectedSourceIndex())
+	}
+	picker.update(keyPress("up"))
+	if picker.selectedSourceIndex() != 1 {
+		t.Errorf("selected source after up = %d, want 1", picker.selectedSourceIndex())
+	}
+}
+
+func TestMailViewCollectionMembershipCompletionUpdatesExactPosting(t *testing.T) {
+	v := mailWithPostings()
+	v.pendingMutations = 1
+	collection := models.Collection{ID: 12, Name: "Kitchen remodel"}
+	v.Update(collectionActionDoneMsg{
+		sourceID:   v.currentBoxID(),
+		sourceKind: v.currentSourceKind(),
+		postingID:  101,
+		collection: collection,
+		added:      true,
+	})
+	if len(v.postingList.postings[0].Collections) != 0 || len(v.postingList.postings[1].Collections) != 1 {
+		t.Errorf("postings = %+v", v.postingList.postings)
+	}
+}
+
+func TestMailViewCollectionMembershipDoesNotDuplicate(t *testing.T) {
+	v := mailWithPostings()
+	collection := models.Collection{ID: 12, Name: "Kitchen remodel"}
+	v.postingList.postings[0].Collections = []models.Collection{collection}
+	v.updatePostingCollection(0, collection, true)
+	if len(v.postingList.postings[0].Collections) != 1 {
+		t.Errorf("memberships = %+v", v.postingList.postings[0].Collections)
+	}
+}
+
+func TestMailViewCollectionMembershipRemoveUnknownIsStable(t *testing.T) {
+	v := mailWithPostings()
+	v.updatePostingCollection(0, models.Collection{ID: 12, Name: "Kitchen remodel"}, false)
+	if len(v.postingList.postings[0].Collections) != 0 {
+		t.Errorf("memberships = %+v", v.postingList.postings[0].Collections)
+	}
+}
+
+func TestMailViewCollectionNavigationHelp(t *testing.T) {
+	picker := newCollectionNavPicker([]models.Box{{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"}}, 0)
+	bindings := picker.helpBindings()
+	if len(bindings) != 3 || bindings[1].desc != "open" {
+		t.Errorf("bindings = %+v", bindings)
+	}
+}
+
+func TestMailViewCollectionMembershipHelp(t *testing.T) {
+	picker := newCollectionMembershipPicker(models.Posting{}, nil)
+	bindings := picker.helpBindings()
+	if len(bindings) != 3 || bindings[1].desc != "toggle" {
+		t.Errorf("bindings = %+v", bindings)
+	}
+}
+
+func TestMailViewCollectionListErrorNoticeIsRecoverable(t *testing.T) {
+	v := mailWithPostings()
+	v.collectionDiscoveryErr = "unavailable"
+	bindings := v.HelpBindings()
+	found := false
+	for _, binding := range bindings {
+		if binding.key == "k" && binding.desc == "retry collections" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("bindings = %+v", bindings)
+	}
+}
+
+func TestMailViewCollectionTabSelectedWhenOpen(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	v.boxIndex = len(v.boxes) - 1
+	items, selected, label, _ := v.SubnavItems()
+	if selected != len(items)-1 || items[selected].label != "Collections" || !strings.Contains(label, "Kitchen remodel") {
+		t.Errorf("items = %+v selected = %d label = %q", items, selected, label)
+	}
+}
+
+func TestMailViewCollectionPaginationNoticeSanitizesNameInHeader(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen\nremodel"})
+	v.boxIndex = len(v.boxes) - 1
+	_, _, label, _ := v.SubnavItems()
+	if strings.Contains(label, "\n") {
+		t.Errorf("unsafe collection header = %q", label)
+	}
+}
+
+func TestMailViewCollectionsAndLabelsStaySeparate(t *testing.T) {
+	v := mailWithPostings()
+	v.boxes = append(v.boxes,
+		models.Box{ID: 12, Kind: mailSourceKindFolder, Name: "Receipts"},
+		models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"},
+	)
+	labels := newLabelPicker(v.boxes, 0)
+	collections := newCollectionNavPicker(v.boxes, 0)
+	if len(labels.names) != 1 || labels.names[0] != "Receipts" || len(collections.names) != 1 || collections.names[0] != "Kitchen remodel" {
+		t.Errorf("labels = %v collections = %v", labels.names, collections.names)
+	}
+}
+
+func TestMailViewCollectionActionCompletionMessageCarriesIdentity(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusNoContent)
+	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
+	v.postingList.postings[0].AppURL = "/topics/501"
+	v.HandleContentKey(keyPress("k"))
+	done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
+	if done.sourceID != v.currentBoxID() || done.sourceKind != v.currentSourceKind() || done.collection.ID != 12 || !done.added {
+		t.Errorf("completion = %+v", done)
+	}
+}
+
+func TestMailViewCollectionMutationUsesOneRequest(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	client := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "test-token"}, hey.WithMaxRetries(0))
+	vc := testVC()
+	vc.sdk = client
+	v := newMailView(vc)
+	v.boxes = []models.Box{{ID: 1, Kind: "imbox", Name: "Imbox"}, {ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"}}
+	v.postingList.setPostings([]models.Posting{{ID: 100, AppURL: "/topics/501"}})
+	v.HandleContentKey(keyPress("k"))
+	runCmd(v.HandleContentKey(keyPress("enter")))
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d, want 1", requests.Load())
+	}
+}

--- a/internal/tui/folders.go
+++ b/internal/tui/folders.go
@@ -14,6 +14,10 @@ import (
 
 const mailSourceKindFolder = "folder"
 
+func isOrganizedMailSource(kind string) bool {
+	return kind == mailSourceKindFolder || kind == mailSourceKindCollection
+}
+
 type folderPickerChoice int
 
 const (

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -47,6 +47,7 @@ type mailSourcesLoadedMsg struct {
 	screenerCount  int
 	screenerStream string
 	folderErr      error
+	collectionErr  error
 }
 
 type postingsLoadedMsg struct {
@@ -147,6 +148,16 @@ type folderActionDoneMsg struct {
 	err        error
 }
 
+type collectionActionDoneMsg struct {
+	action     string
+	sourceID   int64
+	sourceKind string
+	postingID  int64
+	collection models.Collection
+	added      bool
+	err        error
+}
+
 // --- Mail section view ---
 
 type mailView struct {
@@ -171,25 +182,28 @@ type mailView struct {
 	inThread         bool
 	loading          bool
 
-	compose            *composeForm    // non-nil while a message, reply or forward is being written
-	bulkReply          *bulkReplyForm  // non-nil while a bulk reply is being previewed or written
-	movePicker         *movePicker     // non-nil while a destination box is being selected
-	folderPicker       *folderPicker   // non-nil while folder labels are being managed
-	labels             *labelPicker    // non-nil while a label is being chosen
-	searchForm         *mailSearchForm // non-nil while a search query is being entered
-	searchList         contentList
-	searchActive       bool
-	searchQuery        string
-	searchPage         int
-	screenerCount      int    // senders waiting in The Screener
-	lastBulkReplyID    int64  // delayed delivery currently available for undo
-	pendingMutations   int    // writes that must finish before changing the account context
-	notice             string // one-shot confirmation shown above the posting list
-	activeRequestID    uint64 // identifies the only mail read allowed to update the view
-	activeRequestKind  mailRequestKind
-	sourceRequestID    uint64
-	folderDiscoveryErr string
-	requestCancel      context.CancelFunc
+	compose                *composeForm                // non-nil while a message, reply or forward is being written
+	bulkReply              *bulkReplyForm              // non-nil while a bulk reply is being previewed or written
+	movePicker             *movePicker                 // non-nil while a destination box is being selected
+	folderPicker           *folderPicker               // non-nil while folder labels are being managed
+	collectionPicker       *collectionMembershipPicker // non-nil while collection membership is being managed
+	labels                 *labelPicker                // non-nil while a label is being chosen
+	collections            *collectionNavPicker        // non-nil while a collection is being chosen
+	searchForm             *mailSearchForm             // non-nil while a search query is being entered
+	searchList             contentList
+	searchActive           bool
+	searchQuery            string
+	searchPage             int
+	screenerCount          int    // senders waiting in The Screener
+	lastBulkReplyID        int64  // delayed delivery currently available for undo
+	pendingMutations       int    // writes that must finish before changing the account context
+	notice                 string // one-shot confirmation shown above the posting list
+	activeRequestID        uint64 // identifies the only mail read allowed to update the view
+	activeRequestKind      mailRequestKind
+	sourceRequestID        uint64
+	folderDiscoveryErr     string
+	collectionDiscoveryErr string
+	requestCancel          context.CancelFunc
 
 	liveRequestID   uint64 // identifies the only live re-read allowed to update the list
 	liveRefreshDue  bool   // a re-read is already on its way
@@ -229,13 +243,20 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 					sources = append(sources, source)
 				}
 			}
-			v.notice = "Could not load labels — press g to retry"
 		} else {
 			v.folderDiscoveryErr = ""
-			if v.notice == "Retrying labels…" {
-				v.notice = ""
-			}
 		}
+		if msg.collectionErr != nil {
+			v.collectionDiscoveryErr = msg.collectionErr.Error()
+			for _, source := range v.boxes {
+				if source.Kind == mailSourceKindCollection {
+					sources = append(sources, source)
+				}
+			}
+		} else {
+			v.collectionDiscoveryErr = ""
+		}
+		v.updateSourceDiscoveryNotice()
 		return v.applySources(sources), true
 
 	case boxesLoadedMsg:
@@ -259,7 +280,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		// unread threads with the dot; every other source is one flat list.
 		v.postingList.hideSeenState = !v.currentBoxIsImbox()
 		v.postingList.setPostings(msg.postings)
-		if v.currentSourceKind() == mailSourceKindFolder {
+		if isOrganizedMailSource(v.currentSourceKind()) {
 			v.folderPage = msg.page
 			v.folderPageHistory = msg.pageHistory
 			v.folderNextPage = msg.nextPage
@@ -528,6 +549,29 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			return v.requestPostings(*source), true
 		}
 		return nil, true
+
+	case collectionActionDoneMsg:
+		v.finishMutation()
+		if msg.sourceID != v.currentBoxID() || msg.sourceKind != v.currentSourceKind() {
+			return nil, true
+		}
+		if msg.err != nil {
+			v.notice = "Could not update collections: " + terminalSafeCollectionText(msg.err.Error())
+			return nil, true
+		}
+		v.notice = msg.action
+		if index := v.postingIndex(msg.postingID); index >= 0 {
+			v.updatePostingCollection(index, msg.collection, msg.added)
+			if !msg.added && msg.sourceKind == mailSourceKindCollection && msg.collection.ID == msg.sourceID {
+				v.removePostingAt(index)
+			}
+		}
+		if msg.sourceKind == mailSourceKindCollection && msg.collection.ID == msg.sourceID {
+			if source := v.currentSource(); source != nil {
+				return v.requestPostings(*source), true
+			}
+		}
+		return nil, true
 	}
 
 	// Cursor blinks and other component messages go to the open form. The
@@ -571,9 +615,16 @@ func (v *mailView) View() string {
 	if v.folderPicker != nil {
 		return v.folderPicker.view(v.vc.styles, v.vc.width)
 	}
+	if v.collectionPicker != nil {
+		return v.collectionPicker.view(v.vc.styles, v.vc.width)
+	}
 	if v.labels != nil {
 		base := v.listHeader() + v.postingList.view()
 		return v.labels.overlay(base, v.vc.width, v.vc.height)
+	}
+	if v.collections != nil {
+		base := v.listHeader() + v.postingList.view()
+		return v.collections.overlay(base, v.vc.width, v.vc.height)
 	}
 	if v.inThread {
 		if v.notice != "" {
@@ -597,7 +648,7 @@ func (v *mailView) listHeader() string {
 	if v.notice != "" {
 		lines = append(lines, v.vc.styles.title.Render(v.notice))
 	}
-	if v.liveUpdatesOver {
+	if v.liveUpdatesOver && !isOrganizedMailSource(v.currentSourceKind()) {
 		lines = append(lines, v.vc.styles.title.Render("Not live any more — press ctrl+r to reload"))
 	}
 	if hint := v.screenerHint(); hint != "" {
@@ -623,9 +674,22 @@ func firstTimeSenderNoun(count int) string {
 	return "first-time senders"
 }
 
+func (v *mailView) updateSourceDiscoveryNotice() {
+	switch {
+	case v.folderDiscoveryErr != "" && v.collectionDiscoveryErr != "":
+		v.notice = "Could not load labels or collections — press g or k to retry"
+	case v.folderDiscoveryErr != "":
+		v.notice = "Could not load labels — press g to retry"
+	case v.collectionDiscoveryErr != "":
+		v.notice = "Could not load collections — press k to retry"
+	case v.notice == "Retrying labels…" || v.notice == "Retrying collections…":
+		v.notice = ""
+	}
+}
+
 // CapturingInput reports whether a form or picker is open and wants every key.
 func (v *mailView) CapturingInput() bool {
-	return v.compose != nil || v.bulkReply != nil || v.movePicker != nil || v.folderPicker != nil || v.labels != nil || v.searchForm != nil
+	return v.compose != nil || v.bulkReply != nil || v.movePicker != nil || v.folderPicker != nil || v.collectionPicker != nil || v.labels != nil || v.collections != nil || v.searchForm != nil
 }
 
 func (v *mailView) AccountSwitchBlocked() bool {
@@ -648,8 +712,14 @@ func (v *mailView) HelpBindings() []helpBinding {
 	if v.folderPicker != nil {
 		return v.folderPicker.helpBindings()
 	}
+	if v.collectionPicker != nil {
+		return v.collectionPicker.helpBindings()
+	}
 	if v.labels != nil {
 		return v.labels.helpBindings()
+	}
+	if v.collections != nil {
+		return v.collections.helpBindings()
 	}
 	if v.inThread {
 		bindings := []helpBinding{{"r", "reply"}, {"f", "forward"}}
@@ -674,6 +744,10 @@ func (v *mailView) HelpBindings() []helpBinding {
 	if v.folderDiscoveryErr != "" {
 		folderBinding = helpBinding{"g", "retry labels"}
 	}
+	collectionBinding := helpBinding{"k", "collections"}
+	if v.collectionDiscoveryErr != "" {
+		collectionBinding = helpBinding{"k", "retry collections"}
+	}
 	bindings := []helpBinding{
 		{"/", "search"},
 		{"ctrl+s", "screener"},
@@ -684,12 +758,13 @@ func (v *mailView) HelpBindings() []helpBinding {
 		{"f", "forward"},
 		{"m", "move"},
 		folderBinding,
+		collectionBinding,
 		{"e", "seen"},
 		{"l", "reply later"},
 		{"a", "set aside"},
 		{"d", "feed"},
 	}
-	if v.currentSourceKind() != mailSourceKindFolder {
+	if !isOrganizedMailSource(v.currentSourceKind()) {
 		bindings = append(bindings, helpBinding{"p", "paper trail"})
 	}
 	bindings = append(bindings,
@@ -697,7 +772,7 @@ func (v *mailView) HelpBindings() []helpBinding {
 		helpBinding{"s", "spam"},
 		ignoreBinding,
 	)
-	if v.currentSourceKind() == mailSourceKindFolder {
+	if isOrganizedMailSource(v.currentSourceKind()) {
 		if v.folderNextPage != "" {
 			bindings = append(bindings, helpBinding{"n", "next page"})
 		}
@@ -723,14 +798,13 @@ func (v *mailView) SubnavItems() ([]navItem, int, string, bool) {
 	label := "Mail"
 	if v.boxIndex >= 0 && v.boxIndex < len(v.boxes) {
 		label = v.boxes[v.boxIndex].Name
-		if v.boxes[v.boxIndex].Kind == mailSourceKindFolder {
+		if isOrganizedMailSource(v.boxes[v.boxIndex].Kind) {
 			label = terminalSafeFolderText(label)
 			label = fmt.Sprintf("%s (page %d)", label, len(v.folderPageHistory)+1)
 		}
 	}
 
-	// The tab row shows the known boxes plus one Labels tab; the labels
-	// themselves live in a modal picker.
+	// Labels and Collections each use one tab whose modal chooses the source.
 	tabIndexes := v.tabBoxIndexes()
 	boxes := make([]models.Box, len(tabIndexes))
 	selected := 0
@@ -747,15 +821,20 @@ func (v *mailView) SubnavItems() ([]navItem, int, string, bool) {
 			selected = len(items) - 1
 		}
 	}
+	if v.hasCollections() {
+		items = append(items, navItem{shortcut: "K", label: "Collections"})
+		if v.currentSourceKind() == mailSourceKindCollection {
+			selected = len(items) - 1
+		}
+	}
 	return items, selected, label, true
 }
 
-// tabBoxIndexes returns the indexes into v.boxes shown as their own tabs —
-// every source except labels.
+// tabBoxIndexes returns the sources shown as their own tabs.
 func (v *mailView) tabBoxIndexes() []int {
 	indexes := make([]int, 0, len(v.boxes))
-	for i, b := range v.boxes {
-		if b.Kind != mailSourceKindFolder {
+	for i, source := range v.boxes {
+		if !isOrganizedMailSource(source.Kind) {
 			indexes = append(indexes, i)
 		}
 	}
@@ -763,8 +842,16 @@ func (v *mailView) tabBoxIndexes() []int {
 }
 
 func (v *mailView) hasLabels() bool {
-	for _, b := range v.boxes {
-		if b.Kind == mailSourceKindFolder {
+	return v.hasSourceKind(mailSourceKindFolder)
+}
+
+func (v *mailView) hasCollections() bool {
+	return v.hasSourceKind(mailSourceKindCollection)
+}
+
+func (v *mailView) hasSourceKind(kind string) bool {
+	for _, source := range v.boxes {
+		if source.Kind == kind {
 			return true
 		}
 	}
@@ -775,17 +862,30 @@ func (v *mailView) openLabels() {
 	v.labels = newLabelPicker(v.boxes, v.boxIndex)
 }
 
+func (v *mailView) openCollections() {
+	v.collections = newCollectionNavPicker(v.boxes, v.boxIndex)
+}
+
 func (v *mailView) SubnavLeft() tea.Cmd {
 	if v.searchActive || v.searchForm != nil {
 		return nil
 	}
 	tabIndexes := v.tabBoxIndexes()
-	if v.currentSourceKind() == mailSourceKindFolder {
-		// From the Labels tab, step back to the last box tab.
-		if len(tabIndexes) == 0 {
+	switch v.currentSourceKind() {
+	case mailSourceKindCollection:
+		if v.hasLabels() {
+			v.openLabels()
 			return nil
 		}
-		return v.switchBox(tabIndexes[len(tabIndexes)-1])
+		if len(tabIndexes) > 0 {
+			return v.switchBox(tabIndexes[len(tabIndexes)-1])
+		}
+		return nil
+	case mailSourceKindFolder:
+		if len(tabIndexes) > 0 {
+			return v.switchBox(tabIndexes[len(tabIndexes)-1])
+		}
+		return nil
 	}
 	for i, boxIndex := range tabIndexes {
 		if boxIndex == v.boxIndex && i > 0 {
@@ -799,9 +899,16 @@ func (v *mailView) SubnavRight() tea.Cmd {
 	if v.searchActive || v.searchForm != nil {
 		return nil
 	}
-	if v.currentSourceKind() == mailSourceKindFolder {
-		// Already on the Labels tab: reopen the picker.
-		v.openLabels()
+	switch v.currentSourceKind() {
+	case mailSourceKindFolder:
+		if v.hasCollections() {
+			v.openCollections()
+		} else {
+			v.openLabels()
+		}
+		return nil
+	case mailSourceKindCollection:
+		v.openCollections()
 		return nil
 	}
 	tabIndexes := v.tabBoxIndexes()
@@ -814,6 +921,8 @@ func (v *mailView) SubnavRight() tea.Cmd {
 		}
 		if v.hasLabels() {
 			v.openLabels()
+		} else if v.hasCollections() {
+			v.openCollections()
 		}
 		return nil
 	}
@@ -895,6 +1004,23 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		return nil
 	}
 
+	if v.collections != nil {
+		switch msg.Key().Code {
+		case tea.KeyEscape:
+			v.collections = nil
+			return nil
+		case tea.KeyEnter:
+			index := v.collections.selectedSourceIndex()
+			v.collections = nil
+			if index < 0 {
+				return nil
+			}
+			return v.switchBox(index)
+		}
+		v.collections.update(msg)
+		return nil
+	}
+
 	if v.folderPicker != nil {
 		picker := v.folderPicker
 		if msg.Key().Code == tea.KeyEscape {
@@ -936,6 +1062,33 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 			}
 		}
 		return picker.handleKey(msg)
+	}
+
+	if v.collectionPicker != nil {
+		picker := v.collectionPicker
+		if msg.Key().Code == tea.KeyEscape {
+			v.collectionPicker = nil
+			return nil
+		}
+		if msg.Key().Code == tea.KeyEnter {
+			collection := picker.selected()
+			if collection == nil {
+				return nil
+			}
+			topicID := picker.posting.ResolveTopicID()
+			if topicID == 0 {
+				v.collectionPicker = nil
+				v.notice = "This item does not identify an email thread"
+				return nil
+			}
+			v.collectionPicker = nil
+			if picker.postingHasCollection(collection.ID) {
+				return v.removePostingFromCollection(picker.posting.ID, topicID, *collection)
+			}
+			return v.addPostingToCollection(picker.posting.ID, topicID, *collection)
+		}
+		picker.update(msg)
+		return nil
 	}
 
 	if v.inThread {
@@ -996,7 +1149,7 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 	case tea.KeyEnter:
 		return v.openSelected()
 	default:
-		if v.currentSourceKind() == mailSourceKindFolder {
+		if isOrganizedMailSource(v.currentSourceKind()) {
 			switch msg.String() {
 			case "n":
 				return v.nextFolderPage()
@@ -1021,6 +1174,8 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 			return nil
 		case "g":
 			return v.startFolderPicker()
+		case "k":
+			return v.startCollectionPicker()
 		case "ctrl+r":
 			return v.reloadPostings()
 		default:
@@ -1051,6 +1206,7 @@ func (v *mailView) ExitThread() {
 		v.compose = nil
 		v.movePicker = nil
 		v.folderPicker = nil
+		v.collectionPicker = nil
 		v.cancelRequest()
 		return
 	}
@@ -1111,6 +1267,9 @@ func (v *mailView) Resize(width, height int) {
 	if v.folderPicker != nil {
 		v.folderPicker.resize(width, height)
 	}
+	if v.collectionPicker != nil {
+		v.collectionPicker.resize(height)
+	}
 	v.postingList.setSize(width, height)
 	v.searchList.setSize(width, height)
 	v.topicViewport.SetWidth(width)
@@ -1119,10 +1278,20 @@ func (v *mailView) Resize(width, height int) {
 
 // handleBoxShortcut handles number-key shortcuts for switching boxes.
 func (v *mailView) handleBoxShortcut(key string) tea.Cmd {
-	if key == "L" && v.hasLabels() && !v.CapturingInput() {
-		v.openLabels()
-		// A no-op command tells the caller the key was handled.
-		return func() tea.Msg { return nil }
+	if v.CapturingInput() {
+		return nil
+	}
+	switch key {
+	case "L":
+		if v.hasLabels() {
+			v.openLabels()
+			return func() tea.Msg { return nil }
+		}
+	case "K":
+		if v.hasCollections() {
+			v.openCollections()
+			return func() tea.Msg { return nil }
+		}
 	}
 	return v.switchBox(boxForShortcut(key, v.boxes))
 }
@@ -1162,7 +1331,7 @@ func (v *mailView) currentBoxIsImbox() bool {
 		return false
 	}
 	return strings.EqualFold(source.Kind, hey.BoxKindImbox) ||
-		(source.Kind != mailSourceKindFolder && strings.EqualFold(source.Name, "Imbox"))
+		(!isOrganizedMailSource(source.Kind) && strings.EqualFold(source.Name, "Imbox"))
 }
 
 func (v *mailView) currentSourceKind() string {
@@ -1296,11 +1465,11 @@ func (v *mailView) refreshBox(boxID int64) tea.Cmd {
 	return v.fetchBoxRefresh(v.vc.ctx, v.liveRequestID, *v.currentSource())
 }
 
-// showsBox reports whether the list on screen is that box's. Labels page through their
-// own feed rather than a box's, and a change that names no box stands for all of them.
+// showsBox reports whether the list on screen is that box's. Labels and collections page
+// through their own feeds, and a change that names no box stands for every actual box.
 func (v *mailView) showsBox(boxID int64) bool {
 	source := v.currentSource()
-	if source == nil || source.Kind == mailSourceKindFolder {
+	if source == nil || isOrganizedMailSource(source.Kind) {
 		return false
 	}
 	return boxID == AnyBoxChanged || boxID == source.ID
@@ -1338,7 +1507,7 @@ func (v *mailView) noteFailure(what string, err error) {
 
 func (v *mailView) nextFolderPage() tea.Cmd {
 	source := v.currentSource()
-	if source == nil || source.Kind != mailSourceKindFolder || v.folderNextPage == "" {
+	if source == nil || !isOrganizedMailSource(source.Kind) || v.folderNextPage == "" {
 		return nil
 	}
 	history := append(append([]string(nil), v.folderPageHistory...), v.folderPage)
@@ -1347,7 +1516,7 @@ func (v *mailView) nextFolderPage() tea.Cmd {
 
 func (v *mailView) previousFolderPage() tea.Cmd {
 	source := v.currentSource()
-	if source == nil || source.Kind != mailSourceKindFolder || len(v.folderPageHistory) == 0 {
+	if source == nil || !isOrganizedMailSource(source.Kind) || len(v.folderPageHistory) == 0 {
 		return nil
 	}
 	last := len(v.folderPageHistory) - 1
@@ -1365,10 +1534,14 @@ func (v *mailView) resetFolderPagination() {
 
 func (v *mailView) folderPageNotice() string {
 	page := len(v.folderPageHistory) + 1
-	if v.folderTotalCount > 0 {
-		return fmt.Sprintf("Label page %d — %d threads total", page, v.folderTotalCount)
+	name := "Label"
+	if v.currentSourceKind() == mailSourceKindCollection {
+		name = "Collection"
 	}
-	return fmt.Sprintf("Label page %d", page)
+	if v.folderTotalCount > 0 {
+		return fmt.Sprintf("%s page %d — %d threads total", name, page, v.folderTotalCount)
+	}
+	return fmt.Sprintf("%s page %d", name, page)
 }
 
 func (v *mailView) startSearch() tea.Cmd {
@@ -1397,6 +1570,20 @@ func (v *mailView) postingIndex(postingID int64) int {
 		}
 	}
 	return -1
+}
+
+func (v *mailView) removePostingAt(index int) {
+	if index < 0 || index >= len(v.postingList.postings) {
+		return
+	}
+	v.postingList.postings = append(v.postingList.postings[:index], v.postingList.postings[index+1:]...)
+	if v.postingList.cursor > index {
+		v.postingList.cursor--
+	}
+	if v.postingList.cursor >= len(v.postingList.postings) && v.postingList.cursor > 0 {
+		v.postingList.cursor--
+	}
+	v.postingList.ensureVisible()
 }
 
 func (v *mailView) moveAttachmentCursor(delta int) {
@@ -1590,6 +1777,77 @@ func (v *mailView) doFolderAction(label string, created bool, fn func() error) t
 	}
 }
 
+func (v *mailView) startCollectionPicker() tea.Cmd {
+	if v.collectionDiscoveryErr != "" {
+		v.notice = "Retrying collections…"
+		return v.requestSources()
+	}
+	selected := v.postingList.selectedPosting()
+	if selected == nil {
+		return nil
+	}
+	if selected.ResolveTopicID() == 0 {
+		v.notice = "This item does not identify an email thread"
+		return nil
+	}
+	picker := newCollectionMembershipPicker(*selected, v.boxes)
+	if len(picker.collections) == 0 {
+		v.notice = "No collections available"
+		return nil
+	}
+	picker.resize(v.vc.height)
+	v.collectionPicker = picker
+	return nil
+}
+
+func (v *mailView) addPostingToCollection(postingID, topicID int64, collection models.Collection) tea.Cmd {
+	label := "Added to collection " + terminalSafeCollectionText(collection.Name)
+	return v.doCollectionAction(label, postingID, topicID, collection, true)
+}
+
+func (v *mailView) removePostingFromCollection(postingID, topicID int64, collection models.Collection) tea.Cmd {
+	label := "Removed from collection " + terminalSafeCollectionText(collection.Name)
+	return v.doCollectionAction(label, postingID, topicID, collection, false)
+}
+
+func (v *mailView) doCollectionAction(label string, postingID, topicID int64, collection models.Collection, added bool) tea.Cmd {
+	sourceID, sourceKind := v.currentSourceIdentity()
+	v.pendingMutations++
+	return func() tea.Msg {
+		var err error
+		if added {
+			err = v.vc.sdk.Collections().AddTopic(v.vc.ctx, topicID, collection.ID)
+		} else {
+			err = v.vc.sdk.Collections().RemoveTopic(v.vc.ctx, topicID, collection.ID)
+		}
+		return collectionActionDoneMsg{
+			action:     label,
+			sourceID:   sourceID,
+			sourceKind: sourceKind,
+			postingID:  postingID,
+			collection: collection,
+			added:      added,
+			err:        err,
+		}
+	}
+}
+
+func (v *mailView) updatePostingCollection(index int, collection models.Collection, added bool) {
+	memberships := v.postingList.postings[index].Collections
+	for i, membership := range memberships {
+		if membership.ID != collection.ID {
+			continue
+		}
+		if !added {
+			v.postingList.postings[index].Collections = append(memberships[:i], memberships[i+1:]...)
+		}
+		return
+	}
+	if added {
+		v.postingList.postings[index].Collections = append(memberships, collection)
+	}
+}
+
 func (v *mailView) movePostingToBox(postingID int64, destination models.Box) tea.Cmd {
 	return v.doPostingAction("Thread moved to "+destination.Name, v.boxMoveEffect(), v.currentBoxID(), postingID, func() error {
 		return v.vc.sdk.Postings().Move(v.vc.ctx, destination.ID, postingID)
@@ -1674,7 +1932,7 @@ func (v *mailView) moveSelectedToKnownBox(name, kind string, boxID, postingID in
 }
 
 func (v *mailView) boxMoveEffect() postingActionEffect {
-	if v.currentSourceKind() == mailSourceKindFolder {
+	if isOrganizedMailSource(v.currentSourceKind()) {
 		return postingActionNone
 	}
 	return postingActionRemove
@@ -1720,6 +1978,10 @@ func sdkPostingToModel(p generated.Posting) models.Posting {
 	for i, folder := range p.Folders {
 		folders[i] = models.Folder{ID: folder.Id, Name: folder.Name, AppURL: folder.AppUrl}
 	}
+	collections := make([]models.Collection, len(p.Collections))
+	for i, collection := range p.Collections {
+		collections[i] = models.Collection{ID: collection.Id, Name: collection.Name, AppURL: collection.AppUrl}
+	}
 	return models.Posting{
 		ID:                    p.Id,
 		CreatedAt:             formatTimestamp(p.CreatedAt),
@@ -1737,6 +1999,7 @@ func sdkPostingToModel(p generated.Posting) models.Posting {
 		VisibleEntryCount:     p.VisibleEntryCount,
 		Extenzions:            sdkExtenzionsToModel(p.Extenzions),
 		Folders:               folders,
+		Collections:           collections,
 		Creator: models.Contact{
 			ID:           p.Creator.Id,
 			Name:         p.Creator.Name,
@@ -1847,7 +2110,13 @@ func (v *mailView) fetchSources(requestID uint64) tea.Cmd {
 				boxes = append(boxes, models.Box{ID: label.ID, Kind: mailSourceKindFolder, Name: label.Name, AppURL: label.AppURL})
 			}
 		}
-		message := mailSourcesLoadedMsg{requestID: requestID, sources: boxes, folderErr: folderErr}
+		collections, collectionErr := v.vc.sdk.Collections().List(v.vc.ctx)
+		if collectionErr == nil && collections != nil {
+			for _, collection := range *collections {
+				boxes = append(boxes, models.Box{ID: collection.Id, Kind: mailSourceKindCollection, Name: collection.Name, AppURL: collection.AppUrl})
+			}
+		}
+		message := mailSourcesLoadedMsg{requestID: requestID, sources: boxes, folderErr: folderErr, collectionErr: collectionErr}
 		if screener, err := v.vc.sdk.Clearances().Summary(v.vc.ctx); err == nil && screener != nil {
 			message.screenerCount = int(screener.PendingClearancesCount)
 			message.screenerStream = screener.SignedStreamName
@@ -1867,7 +2136,8 @@ func (v *mailView) fetchPostings(ctx context.Context, requestID uint64, source m
 	return func() tea.Msg {
 		var sdkPostings []generated.Posting
 		message := postingsLoadedMsg{requestID: requestID, boxID: source.ID, sourceKind: source.Kind, page: page, pageHistory: history}
-		if source.Kind == mailSourceKindFolder {
+		switch source.Kind {
+		case mailSourceKindFolder:
 			var params *generated.GetFolderParams
 			if page != "" {
 				params = &generated.GetFolderParams{Page: &page}
@@ -1884,7 +2154,24 @@ func (v *mailView) fetchPostings(ctx context.Context, requestID uint64, source m
 					sdkPostings = result.Folder.Postings
 				}
 			}
-		} else {
+		case mailSourceKindCollection:
+			var params *generated.GetCollectionParams
+			if page != "" {
+				params = &generated.GetCollectionParams{Page: &page}
+			}
+			result, err := v.vc.sdk.Collections().GetPage(ctx, source.ID, params)
+			if err != nil {
+				message.err = err
+				return message
+			}
+			if result != nil {
+				message.nextPage = result.NextPage
+				message.totalCount = result.TotalCount
+				if result.Collection != nil {
+					sdkPostings = result.Collection.Postings
+				}
+			}
+		default:
 			box, err := v.vc.sdk.Boxes().Get(ctx, source.ID, nil)
 			if err != nil {
 				message.err = err

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -643,6 +643,8 @@ func TestMailViewLoadsFolderSourcesAndPostings(t *testing.T) {
 			_, _ = w.Write([]byte(`[{"id":1,"kind":"imbox","name":"Imbox"}]`))
 		case "/my/navigation.json":
 			_, _ = w.Write([]byte(`{"items":[{"title":"Labels","menu_items":[{"title":"All Labels","app_url":"/folders"},{"title":"Receipts","app_url":"/folders/12"}]}]}`))
+		case "/collections.json":
+			_, _ = w.Write([]byte(`[]`))
 		case "/folders/12.json":
 			_, _ = w.Write([]byte(`{"id":12,"name":"Receipts","postings":[{"id":100,"kind":"topic","summary":"Hotel receipt","folders":[{"id":12,"name":"Receipts"}]}]}`))
 		default:
@@ -697,6 +699,8 @@ func TestMailViewFolderPagination(t *testing.T) {
 			_, _ = w.Write([]byte(`[{"id":1,"kind":"imbox","name":"Imbox"}]`))
 		case "/my/navigation.json":
 			_, _ = w.Write([]byte(`{"items":[{"title":"Labels","menu_items":[{"title":"Receipts","app_url":"/folders/12"}]}]}`))
+		case "/collections.json":
+			_, _ = w.Write([]byte(`[]`))
 		case "/folders/12.json":
 			folderQueries = append(folderQueries, r.URL.Query().Get("page"))
 			w.Header().Set("X-Total-Count", "2")
@@ -765,6 +769,8 @@ func TestMailViewFolderDiscoveryFailurePreservesMailAndRetries(t *testing.T) {
 			_, _ = w.Write([]byte(`{"items":[{"title":"Labels","menu_items":[{"title":"Receipts","app_url":"/folders/12"}]}]}`))
 		case "/boxes/1.json":
 			_, _ = w.Write([]byte(`{"id":1,"kind":"imbox","name":"Imbox","postings":[]}`))
+		case "/collections.json":
+			_, _ = w.Write([]byte(`[]`))
 		default:
 			http.NotFound(w, r)
 		}

--- a/internal/tui/move.go
+++ b/internal/tui/move.go
@@ -22,7 +22,7 @@ func newMovePicker(posting models.Posting, boxes []models.Box, currentSource mod
 	destinations := make([]models.Box, 0, len(boxes))
 	for _, box := range boxes {
 		isCurrentSource := box.ID == currentSource.ID && box.Kind == currentSource.Kind
-		if box.Kind == mailSourceKindFolder || isCurrentSource || strings.EqualFold(box.Kind, hey.BoxKindBubbleUp) || strings.EqualFold(box.Name, "Bubble Up") {
+		if isOrganizedMailSource(box.Kind) || isCurrentSource || strings.EqualFold(box.Kind, hey.BoxKindBubbleUp) || strings.EqualFold(box.Name, "Bubble Up") {
 			continue
 		}
 		destinations = append(destinations, box)

--- a/internal/tui/nav.go
+++ b/internal/tui/nav.go
@@ -87,7 +87,7 @@ func orderBoxes(boxes []models.Box) []models.Box {
 	for _, spec := range knownBoxes {
 		for _, b := range boxes {
 			key := sourceKey{id: b.ID, kind: b.Kind}
-			if b.Kind != mailSourceKindFolder && strings.EqualFold(b.Name, spec.name) && !used[key] {
+			if !isOrganizedMailSource(b.Kind) && strings.EqualFold(b.Name, spec.name) && !used[key] {
 				ordered = append(ordered, b)
 				used[key] = true
 				break
@@ -110,13 +110,13 @@ func boxNavItems(boxes []models.Box) []navItem {
 	for i, b := range boxes {
 		shortcut := ""
 		for _, spec := range knownBoxes {
-			if b.Kind != mailSourceKindFolder && strings.EqualFold(b.Name, spec.name) {
+			if !isOrganizedMailSource(b.Kind) && strings.EqualFold(b.Name, spec.name) {
 				shortcut = spec.key
 				break
 			}
 		}
 		label := b.Name
-		if b.Kind == mailSourceKindFolder {
+		if isOrganizedMailSource(b.Kind) {
 			label = terminalSafeFolderText(label)
 		}
 		items[i] = navItem{shortcut: shortcut, label: label}
@@ -129,7 +129,7 @@ func boxForShortcut(key string, boxes []models.Box) int {
 	for _, spec := range knownBoxes {
 		if spec.key == key {
 			for i, b := range boxes {
-				if b.Kind != mailSourceKindFolder && strings.EqualFold(b.Name, spec.name) {
+				if !isOrganizedMailSource(b.Kind) && strings.EqualFold(b.Name, spec.name) {
 					return i
 				}
 			}

--- a/internal/tui/translate_test.go
+++ b/internal/tui/translate_test.go
@@ -20,8 +20,10 @@ func TestSDKPostingToModel(t *testing.T) {
 		Kind: "topic", Name: "Life insurance", Seen: true, Bundled: true, Muted: true,
 		Summary: "the summary", EntryKind: "message", AppUrl: "https://app.hey.com/topics/21",
 		AlternativeSenderName: "Copilot", VisibleEntryCount: 3,
-		Extenzions: []generated.Extenzion{{Id: 7, Name: "receipts"}},
-		Creator:    generated.Contact{Id: 42, Name: "Jane Dawson", EmailAddress: "jane@example.com"},
+		Extenzions:  []generated.Extenzion{{Id: 7, Name: "receipts"}},
+		Folders:     []generated.Folder{{Id: 8, Name: "Receipts", AppUrl: "/folders/8"}},
+		Collections: []generated.Collection{{Id: 9, Name: "Kitchen remodel", AppUrl: "/collections/9"}},
+		Creator:     generated.Contact{Id: 42, Name: "Jane Dawson", EmailAddress: "jane@example.com"},
 	})
 
 	if got.ID != 1233065884 || got.Name != "Life insurance" || got.Kind != "topic" {
@@ -41,6 +43,12 @@ func TestSDKPostingToModel(t *testing.T) {
 	}
 	if len(got.Extenzions) != 1 || got.Extenzions[0].Name != "receipts" {
 		t.Errorf("extenzions = %+v", got.Extenzions)
+	}
+	if len(got.Folders) != 1 || got.Folders[0].ID != 8 {
+		t.Errorf("folders = %+v", got.Folders)
+	}
+	if len(got.Collections) != 1 || got.Collections[0].ID != 9 || got.Collections[0].Name != "Kitchen remodel" {
+		t.Errorf("collections = %+v", got.Collections)
 	}
 	if got.Creator.ID != 42 || got.Creator.Name != "Jane Dawson" || got.Creator.EmailAddress != "jane@example.com" {
 		t.Errorf("creator = %+v", got.Creator)

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -2,7 +2,7 @@
 name: hey
 description: |
   Interact with HEY via the HEY CLI. Read and send emails, manage contacts,
-  boxes, labels, calendars, todos, habits, time tracking, and journal entries. Use for ANY
+  boxes, labels, collections, calendars, todos, habits, time tracking, and journal entries. Use for ANY
   HEY-related question or action.
 triggers:
   # Direct invocations
@@ -14,6 +14,8 @@ triggers:
   - hey box
   - hey labels
   - hey label
+  - hey collections
+  - hey collection
   - hey search
   - hey contacts
   - hey threads
@@ -98,7 +100,7 @@ argument-hint: "[command] [args...]"
 
 # /hey - HEY Email Workflow Command
 
-CLI for HEY: mailboxes, labels, email threads, contacts, replies, compose, calendars, todos, habits, time tracking, and journal entries.
+CLI for HEY: mailboxes, labels, collections, email threads, contacts, replies, compose, calendars, todos, habits, time tracking, and journal entries.
 
 ## Agent Invariants
 
@@ -136,6 +138,12 @@ hey boxes --quiet --jq '.[].name'
 | Add a label to a thread | `hey label add <id> --to <label_id>` |
 | Create and add a label | `hey label create "Travel receipts" <id>` |
 | Remove labels | `hey label remove <id> --from <label_id\|all>` |
+| List collections | `hey collections --json` |
+| List collection threads | `hey collection <collection_id> --all --json` |
+| Create a collection | `hey collection create "Kitchen remodel"` |
+| Update a collection | `hey collection update <collection_id> --name "Kitchen renovation"` |
+| Add a thread to a collection | `hey collection add <topic_id> --to <collection_id>` |
+| Remove a thread from a collection | `hey collection remove <topic_id> --from <collection_id>` |
 | Search email | `hey search "quarterly planning" --json` |
 | List search filters | `hey search filters --json` |
 | List contacts | `hey contacts list --json` |
@@ -203,6 +211,8 @@ Want to read email?
 ├── List emails in box? → hey box <name|id> --json
 ├── List labels or labeled email? → hey labels --json / hey label <label_id> --json
 ├── Add, create, or remove a label? → hey label add|create|remove
+├── List collections or collection threads? → hey collections --json / hey collection <collection_id> --json
+├── Create, update, add to, or remove from a collection? → hey collection create|update|add|remove
 ├── Search threads and messages? → hey search <query> --json
 ├── Need available refinements? → hey search filters --json
 ├── List or view contacts? → hey contacts list --json / hey contacts show <id> --json
@@ -276,6 +286,19 @@ hey label remove 12345 --from all              # Remove every label
 
 Label mutations take box item IDs from `hey box`, `hey label`, or active `hey search` results. Label IDs come from `hey labels`. `hey label` returns `next_page` and `total_count`; pass `--page <next_page>` to continue or `--all` to fetch every page. HEY creates a label while adding it to at least one thread, so `label create` requires one or more thread item IDs.
 
+### Email - Collections
+
+```bash
+hey collections --json                                      # List collections and stable IDs
+hey collection 321 --all --json                             # List every thread in a collection
+hey collection create "Kitchen remodel" --summary "Plans and decisions"
+hey collection update 321 --name "Kitchen renovation"
+hey collection add 987 --to 321                             # Add a topic ID
+hey collection remove 987 --from 321                        # Remove a topic ID
+```
+
+Collection IDs come from `hey collections`. `hey collection` returns posting `id`, thread `topic_id`, `next_page`, and `total_count`; pass `--page <next_page>` to continue or `--all` to fetch every page. Collection membership commands take `topic_id`. Creating a collection confirms the mutation, and listing collections provides its ID for later commands.
+
 ### Email - Search
 
 ```bash
@@ -324,7 +347,7 @@ hey unshare <thread_id>                       # Turn off the sharing link
 
 `hey share` returns a URL that shows the entire thread and future emails or replies sent to it. Anyone with the link can open it. `hey unshare` turns off the sharing link.
 
-**ID note:** Every email thread returned by `hey box` or `hey label` has an `id` (its box item ID) and a `topic_id` (its thread ID). `hey seen`, `hey unseen`, `hey move`, `hey label add`, `hey label remove`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring` expect `id`. `hey threads`, `hey share`, `hey unshare`, `hey attachments`, `hey reply`, and `hey forward` expect `topic_id`. The `app_url` field also contains the thread ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
+**ID note:** Every email thread returned by `hey box`, `hey label`, or `hey collection` has an `id` (its box item ID) and a `topic_id` (its thread ID). `hey seen`, `hey unseen`, `hey move`, `hey label add`, `hey label remove`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring` expect `id`. `hey threads`, `hey share`, `hey unshare`, `hey attachments`, `hey reply`, `hey forward`, `hey collection add`, and `hey collection remove` expect `topic_id`. The `app_url` field also contains the thread ID as a fallback (e.g. `https://app.hey.com/topics/123` → `123`).
 
 ### Email - Attachments
 

--- a/tests/smoke/collections_test.go
+++ b/tests/smoke/collections_test.go
@@ -1,0 +1,299 @@
+package smoke_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/chromedp"
+)
+
+type smokeCollection struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestCollectionsAndCollection(t *testing.T) {
+	response := heyJSON(t, "collections")
+	collections := dataAs[[]smokeCollection](t, response)
+	if response.Summary == "" {
+		t.Error("collections response omitted summary")
+	}
+	if len(collections) == 0 {
+		t.Skip("no collections available for collection detail validation")
+	}
+
+	collection := collections[0]
+	detail := heyJSON(t, "collection", strconv.FormatInt(collection.ID, 10), "--limit", "2")
+	data := dataAs[struct {
+		ID         int64  `json:"id"`
+		Name       string `json:"name"`
+		Postings   []any  `json:"postings"`
+		TotalCount int    `json:"total_count"`
+	}](t, detail)
+	if data.ID != collection.ID || data.Name != collection.Name || data.Postings == nil {
+		t.Errorf("collection detail = %+v, want %+v with postings", data, collection)
+	}
+
+	page := html.UnescapeString(fetchHTML(t, baseURL+"/collections/"+strconv.FormatInt(collection.ID, 10)))
+	if !strings.Contains(page, collection.Name) {
+		t.Errorf("collection page does not contain %q", collection.Name)
+	}
+}
+
+func TestCollectionOutputFormats(t *testing.T) {
+	collections := dataAs[[]smokeCollection](t, heyJSON(t, "collections"))
+	if len(collections) == 0 {
+		t.Skip("no collections available for output validation")
+	}
+	id := strconv.FormatInt(collections[0].ID, 10)
+	for _, args := range [][]string{
+		{"collections", "--quiet"},
+		{"collections", "--ids-only"},
+		{"collections", "--count"},
+		{"collections", "--markdown"},
+		{"collections", "--styled"},
+		{"collection", id, "--quiet"},
+		{"collection", id, "--ids-only"},
+		{"collection", id, "--count"},
+		{"collection", id, "--markdown"},
+		{"collection", id, "--styled"},
+	} {
+		_, stderr, code := hey(t, args...)
+		if code != 0 {
+			t.Errorf("hey %s failed (exit %d): %s", strings.Join(args, " "), code, stderr)
+		}
+	}
+}
+
+func TestCollectionMutations(t *testing.T) {
+	uid := uniqueID()
+	subject := fmt.Sprintf("Disposable collection test %s", uid)
+	_, stderr, code := hey(t, "compose",
+		"--to", smokeEmail,
+		"--subject", subject,
+		"-m", "This disposable thread verifies collection membership.",
+		"--json",
+	)
+	if code != 0 {
+		t.Skipf("could not create a disposable thread (exit %d): %s", code, stderr)
+	}
+	t.Cleanup(func() { cleanupThreadBySubject(t, subject) })
+
+	postingID, topicID, accountID, err := waitForPostingAndTopicIDsBySubject(t, subject)
+	if err != nil {
+		t.Fatalf("could not find disposable thread: %v", err)
+	}
+	if postingID == 0 || topicID == 0 || accountID == 0 {
+		t.Skip("disposable thread did not expose posting, topic, and account IDs")
+	}
+
+	collectionName := "Smoke collection " + uid
+	_, stderr, code = hey(t, "collection", "create", collectionName, "--summary", "Disposable collection smoke coverage", "--account", strconv.FormatInt(accountID, 10), "--json")
+	if code != 0 {
+		t.Skipf("collection creation unavailable (exit %d): %s", code, stderr)
+	}
+
+	collectionID, err := findCollectionIDByName(t, collectionName)
+	if err != nil {
+		t.Fatalf("could not list created collection: %v", err)
+	}
+	if collectionID == 0 {
+		t.Fatalf("created collection %q was not listed", collectionName)
+	}
+	t.Cleanup(func() { cleanupCollection(t, collectionID) })
+
+	updatedName := collectionName + " updated"
+	collectionWriteJSON(t, "collection", "update", strconv.FormatInt(collectionID, 10), "--name", updatedName)
+	if updatedID, err := findCollectionIDByName(t, updatedName); err != nil || updatedID != collectionID {
+		t.Fatalf("updated collection lookup = %d, %v; want %d", updatedID, err, collectionID)
+	}
+
+	collectionWriteJSON(t, "collection", "add", strconv.FormatInt(topicID, 10), "--to", strconv.FormatInt(collectionID, 10))
+	assertCollectionContainsPosting(t, collectionID, postingID, topicID, true)
+	collectionWriteJSON(t, "collection", "remove", strconv.FormatInt(topicID, 10), "--from", strconv.FormatInt(collectionID, 10))
+	assertCollectionContainsPosting(t, collectionID, postingID, topicID, false)
+}
+
+func collectionWriteJSON(t *testing.T, args ...string) Response {
+	t.Helper()
+	args = append(args, "--json")
+	stdout, stderr, code := hey(t, args...)
+	if code != 0 {
+		t.Skipf("collection write unavailable (exit %d): %s", code, stderr)
+	}
+	var response Response
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("invalid collection response: %v: %s", err, stdout)
+	}
+	return response
+}
+
+func assertCollectionContainsPosting(t *testing.T, collectionID, postingID, topicID int64, want bool) {
+	t.Helper()
+	collection := dataAs[struct {
+		Postings []struct {
+			ID      int64 `json:"id"`
+			TopicID int64 `json:"topic_id"`
+		} `json:"postings"`
+	}](t, heyJSON(t, "collection", strconv.FormatInt(collectionID, 10), "--all"))
+	found := false
+	for _, item := range collection.Postings {
+		if item.ID == postingID && item.TopicID == topicID {
+			found = true
+			break
+		}
+	}
+	if found != want {
+		t.Errorf("collection %d contains posting %d/topic %d = %v, want %v", collectionID, postingID, topicID, found, want)
+	}
+}
+
+func waitForPostingAndTopicIDsBySubject(t *testing.T, subject string) (int64, int64, int64, error) {
+	t.Helper()
+	var lastErr error
+	for range 10 {
+		postingID, topicID, accountID, err := findPostingAndTopicIDsBySubject(t, subject)
+		if err == nil && postingID != 0 && topicID != 0 && accountID != 0 {
+			return postingID, topicID, accountID, nil
+		}
+		lastErr = err
+		time.Sleep(500 * time.Millisecond)
+	}
+	return 0, 0, 0, lastErr
+}
+
+func findPostingAndTopicIDsBySubject(t *testing.T, subject string) (int64, int64, int64, error) {
+	t.Helper()
+	stdout, stderr, code := hey(t, "box", "imbox", "--all", "--json")
+	if code != 0 {
+		return 0, 0, 0, fmt.Errorf("list Imbox (exit %d): %s", code, stderr)
+	}
+	var response Response
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		return 0, 0, 0, fmt.Errorf("decode Imbox response: %w", err)
+	}
+	var box struct {
+		Postings []struct {
+			ID        int64  `json:"id"`
+			AccountID int64  `json:"account_id"`
+			Name      string `json:"name"`
+			AppURL    string `json:"app_url"`
+		} `json:"postings"`
+	}
+	if err := json.Unmarshal(response.Data, &box); err != nil {
+		return 0, 0, 0, fmt.Errorf("decode Imbox data: %w", err)
+	}
+	for _, posting := range box.Postings {
+		if posting.Name != subject {
+			continue
+		}
+		topicID, err := topicIDFromAppURL(posting.AppURL)
+		if err != nil {
+			return posting.ID, 0, posting.AccountID, err
+		}
+		return posting.ID, topicID, posting.AccountID, nil
+	}
+	return 0, 0, 0, nil
+}
+
+func topicIDFromAppURL(appURL string) (int64, error) {
+	parsed, err := url.Parse(appURL)
+	if err != nil {
+		return 0, err
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	for i := len(parts) - 2; i >= 0; i-- {
+		if parts[i] == "topics" {
+			return strconv.ParseInt(parts[i+1], 10, 64)
+		}
+	}
+	return 0, fmt.Errorf("posting app URL %q has no topic ID", appURL)
+}
+
+func findCollectionIDByName(t *testing.T, name string) (int64, error) {
+	t.Helper()
+	stdout, stderr, code := hey(t, "collections", "--all", "--json")
+	if code != 0 {
+		return 0, fmt.Errorf("list collections (exit %d): %s", code, stderr)
+	}
+	var response Response
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		return 0, fmt.Errorf("decode collections response: %w", err)
+	}
+	var collections []smokeCollection
+	if err := json.Unmarshal(response.Data, &collections); err != nil {
+		return 0, fmt.Errorf("decode collections data: %w", err)
+	}
+	for _, collection := range collections {
+		if collection.Name == name {
+			return collection.ID, nil
+		}
+	}
+	return 0, nil
+}
+
+func cleanupCollection(t *testing.T, collectionID int64) {
+	t.Helper()
+	ctx, ctxCancel, allocCancel := newBrowserContext()
+	defer ctxCancel()
+	defer allocCancel()
+
+	tCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		t.Errorf("parse base URL: %v", err)
+		return
+	}
+	path := fmt.Sprintf("/collections/%d", collectionID)
+	selector := fmt.Sprintf(`form[action$="%s"] input[type="submit"]`, path)
+	if err := chromedp.Run(tCtx,
+		network.SetCookie("session_token", sessionCookie).
+			WithDomain(parsed.Hostname()).
+			WithPath("/").
+			WithHTTPOnly(true),
+		chromedp.Navigate(baseURL+path+"/status"),
+		chromedp.WaitVisible(selector, chromedp.ByQuery),
+		chromedp.Click(selector, chromedp.ByQuery),
+		chromedp.WaitNotPresent(selector, chromedp.ByQuery),
+	); err != nil {
+		t.Errorf("could not delete disposable collection %d: %v", collectionID, err)
+		return
+	}
+	for range 5 {
+		collections := dataAs[[]smokeCollection](t, heyJSON(t, "collections", "--all"))
+		found := false
+		for _, collection := range collections {
+			if collection.ID == collectionID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Errorf("disposable collection %d remains after cleanup", collectionID)
+}
+
+func TestCollectionMutationValidation(t *testing.T) {
+	for _, args := range [][]string{
+		{"collection", "create", "   "},
+		{"collection", "update", "12"},
+		{"collection", "add", "501"},
+		{"collection", "add", "invalid", "--to", "12"},
+		{"collection", "remove", "501"},
+		{"collection", "remove", "invalid", "--from", "12"},
+	} {
+		heyFail(t, args...)
+	}
+}


### PR DESCRIPTION
Adds complete collection browsing and management to the CLI and Mail TUI so collections no longer require the web app. The CLI uses topic IDs for collection membership while preserving posting IDs for existing organization actions.

## What changed

- Adds `hey collections` and paginated `hey collection <id>` reads with styled, JSON, quiet, IDs-only, count, Markdown, and jq-compatible output.
- Adds `hey collection create`, `update`, `add`, and `remove` through the typed HEY SDK.
- Adds a separate Collections tab and picker to the Mail TUI, with forward/back pagination.
- Adds a `k` membership picker that reflects current membership and adds or removes the selected thread from existing collections.
- Updates local membership immediately after successful writes, refreshes the active collection after removals, preserves state on failures, and rejects stale cross-source completions.
- Keeps Labels and Collections separate when IDs or names collide, and excludes both from box moves and box live-refresh handling.
- Updates command discovery, README/skill documentation, API coverage, unit tests, and development-server smoke coverage.

## Scope

- Membership changes target the cursor-selected thread, matching existing TUI move and label actions; Space-marked bulk collection changes are not included.
- Collection deletion is not included because the released SDK has no delete operation. The requested create, update, add, and remove workflows are covered.
- HEY's typed collection responses do not return summaries, so summaries are accepted for create/update but are not displayed by list/detail reads.
- `hey-sdk/go` v0.9.0 is already pinned on main and includes the collection detail operation released in v0.8.0; no dependency change is needed here.

## Validation

- `GOWORK=off make check` — passed
- `GOWORK=off go test -race ./internal/cmd ./internal/tui` — passed
- `GOWORK=off make coverage` — passed at 76.2% repository coverage (70.8% floor)
- `GOWORK=off make test-smoke` — passed against `app.hey.localhost:3003`, including collection list/detail, every requested output mode, create/update/add/remove lifecycle, validation, and cleanup

## Delivery and risk

No migration, backfill, configuration, feature flag, or deploy ordering is required. Risk is medium because this extends the shared Mail TUI source and modal state machine. Review focus: the posting-ID/topic-ID boundary in `internal/cmd/collection.go`, and source identity, pagination, membership, and live-refresh boundaries in `internal/tui/mail.go`.

Basecamp card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892839

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end collection browsing and management to the CLI and Mail TUI so collections no longer require the web app. Data-only JSON now includes collection pagination so scripts can detect remaining pages.

The CLI adds `collections` and `collection <id>` with pagination and styled/JSON/quiet/IDs-only/count/Markdown/jq-compatible output. It supports `collection create|update|add|remove`, returns pagination metadata on list and detail reads, and uses topic IDs for membership while existing org actions keep posting IDs. The TUI adds a Collections tab and picker, a `k` membership picker that reflects membership, forward/back pagination, immediate local membership updates after successful writes, refreshes the active collection after removals, and rejects stale cross-source completions. Labels and Collections remain separate even when IDs or names collide; both are excluded from box moves and live-refresh handling. API coverage adds list/detail/create/update and add/remove via the typed SDK; unit and smoke tests cover all paths.

- Review focus
  - Posting-ID/topic-ID boundary in `internal/cmd/collection.go`.
  - Source identity, pagination, membership, and live-refresh boundaries in `internal/tui/mail.go`.
  - Data-only pagination fields on collection list/detail outputs.

- Rollout
  - No migration, config, feature flags, or deploy ordering. Risk is medium due to shared Mail TUI state-machine changes.
  - Known gaps: bulk collection changes (Space selection) and collection deletion are not included; create/update accept summaries but list/detail do not display them.

<sup>Written for commit 48e3a6f9bf7e05f0ff3f2eb8b8483f62026f5641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

