### PR TITLE
Grow every list as the reader scrolls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,40 @@ table here.
 
 To add a new section: implement the `sectionView` interface in a new file, add a field and constructor call in `newModel`, and add a case in `switchSection`.
 
+### Lists grow as the reader scrolls
+
+Every mail list — a box, a label, a collection, a search — and both of The Screener's panes
+read one page and then grow downwards. There are no page keys: the cursor coming within
+`loadMoreThreshold` of the bottom reads the page below, and so does a list the reader can
+already see the end of, which is why a first page too short to fill the window keeps reading
+until it does.
+
+The pages come from geared_pagination, which is not offset paging: every JSON read carries
+a `Link` header whose `page` is a cursor into the ordering, and the last page carries none.
+`listPaging` in `content.go` holds that cursor, and an empty page ends the list whatever
+cursor came with it. On the SDK side the header is what `Boxes().GetPage`,
+`Clearances().PendingPage`, `Clearances().ScreenedPage` and `Search().SearchPage` exist for —
+`Get`, `Pending`, `Screened` and `Search` throw it away.
+
+Search is the exception to the cursor: `Search::Matches::Page` is a shim over geared's page
+rather than the real thing, and it numbers its pages, so the search results carry
+`searchNextPage int` instead of a `listPaging`. There is nothing to keep a `headIDs` for
+either — search results are never re-read live.
+
+The subtle part is the live re-read. It reads the box's *top* page, because that is where a
+change shows up, so it may only replace that much of a list that has grown past it:
+`contentList.refreshHead` (and `screenerPane.refreshHead`) splices the fresh page in front
+of the rows below it, and `listPaging.headIDs` — what the top page held last time — is how a
+thread that has left the top page leaves the list with it instead of sinking below the fresh
+rows. The pages further down stay as they were read until ctrl+r reads the list again from
+the top. The cursor for what comes next belongs to the deepest page, so a re-read of the top
+only moves it while the top page is the whole list.
+
+A read the user asked for, a page below, and a live re-read are separate lanes
+(`activeRequestID`, `moreRequestID` — `searchMoreID` for the results — and `liveRequestID`)
+with a message each, so growing a list never shows the spinner, never cancels the read the
+reader is waiting on, and never carries the cursor back to the top.
+
 ### Inline images in the TUI
 
 The TUI renders inline images using the Kitty graphics protocol's Unicode Placeholder extension (`internal/tui/kitty.go`). This works because Bubble Tea's cell-based renderer corrupts raw APC escape sequences, but Unicode placeholders are regular text that survives rendering. The approach has three steps:
@@ -155,8 +189,8 @@ the watch being interrupted is an error rather than a quiet exit.
 The TUI's mail list follows the same channel and wants less from it. `internal/cmd/tui_watch.go`
 subscribes and relays the changed box IDs down a channel; `internal/tui/live.go` defines
 that contract as `tui.MailWatcher`, so the TUI never sees cable or auth, and a test hands
-it a plain channel. There is no cursor: the doorbell says which box changed and
-`mailView.refreshBox` reads that box again in full, which is what the list renders anyway.
+it a plain channel. There is no sync cursor: the doorbell says which box changed and
+`mailView.refreshBox` reads that box's top page again, which is where a change shows up.
 A reconnect sends `tui.AnyBoxChanged`, standing for the changes broadcast while the
 connection was down.
 
@@ -164,7 +198,7 @@ connection was down.
 delivery's changes into a single re-read — a thread rings the doorbell once per posting.
 `liveRetryDelay` is how long a re-read waits when a form or a picker is open over the list,
 or a write hasn't landed: the change is held rather than dropped, because a re-read
-replaces what the reader is looking at. `contentList.refreshPostings` is what makes that
+replaces what the reader is looking at. `contentList.refreshHead` is what makes that
 safe — unlike `setPostings` it keeps the cursor on its posting and keeps a selection —
 and the re-read has its own request lane (`liveRequestID`, `postingsRefreshedMsg`) so it
 can never be confused with a read the user asked for, or show the spinner.
@@ -185,7 +219,7 @@ the stream name it used to throw away.
 
 The doorbell always re-reads the count, wherever the user is, because the mail list is
 where The Screener announces itself. When The Screener is what's on screen the queue is
-re-read too, through `screenerPane.refreshRows` — the same keep-your-place trick as the
+re-read too, through `screenerPane.refreshHead` — the same keep-your-place trick as the
 mail list — and held while a decision is in flight or the clear-everything question is up.
 On the history tab nothing is read; the pending pane is just marked unloaded, which is
 what `switchTab` already looks at. Both watches share one websocket

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ and individual email addresses.
 Switching cancels requests from the previous account and reloads the active section;
 Calendar and Journal remain identity-wide.
 
-Navigate between Mail, Contacts, Calendar, and Journal. Mail navigation includes HEY boxes plus separate Labels and Collections tabs. Press Shift+L or Shift+K to choose one, then use `n` and `p` to page through its threads. Use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `g` to manage labels, `k` to add or remove the selected thread from collections, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press `b` to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with `u` while HEY's undo window remains open. Search results retain the matching-message summary; use `n` and `p` to move between result pages.
+Navigate between Mail, Contacts, Calendar, and Journal. Mail navigation includes HEY boxes plus separate Labels and Collections tabs. Press Shift+L or Shift+K to choose one. Every list keeps going: scroll towards the bottom of a box, label, or collection and the next threads are read in behind you, so there are no pages to step through. Use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `g` to manage labels, `k` to add or remove the selected thread from collections, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press `b` to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with `u` while HEY's undo window remains open. Search results retain the matching-message summary and keep going as you scroll, like every other list.
 
 The mail list follows the server. HEY tells the TUI when a box changed over the same
 Action Cable connection `hey watch` uses, and the box on screen is read again a moment
@@ -197,8 +197,9 @@ without moving your place in it.
 
 Press Ctrl+S from the mail list to open The Screener. When senders are waiting, the mail
 list says so above the threads. In The Screener, `y` screens the selected sender in and `n`
-screens them out, Tab moves to Screener History and back, `[` and `]` page through either
-list, `X` clears the whole Screener after a confirmation, and Escape or `q` returns to mail.
+screens them out, Tab moves to Screener History and back, `X` clears the whole Screener
+after a confirmation, and Escape or `q` returns to mail. Both lists keep going as you
+scroll, the same way the mail list does.
 
 Thread attachments always appear with their filename, media type, and size. Use `[` and `]` to select an attachment, `s` to save it without replacing an existing file, and `o` to download and open it in an external application. Attachments never open automatically. Kitty and Ghostty can show inline images. Foot and other terminals use visible text markers.
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/actioncable-go v0.0.0-20260819125529-39dd29b8e4d1
-	github.com/basecamp/hey-sdk/go v0.9.0
+	github.com/basecamp/hey-sdk/go v0.10.0
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/actioncable-go v0.0.0-20260819125529-39dd29b8e4d1 h1:aNCaFvx7FosjImt1A3TM3aWizOgWGHtKUoQ4RTa6Mx8=
 github.com/basecamp/actioncable-go v0.0.0-20260819125529-39dd29b8e4d1/go.mod h1:9+DEydJMniIKraEsd4fDJpFEnqlLUJ6XhAswxRBaITk=
-github.com/basecamp/hey-sdk/go v0.9.0 h1:f1TWkQpc1FnrNknCZfCeViJFfecbhzc/vnOby96JbFE=
-github.com/basecamp/hey-sdk/go v0.9.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
+github.com/basecamp/hey-sdk/go v0.10.0 h1:zYFyzowC/C25HT7h1EAfzxTusW/eeHRVdqIsr/Eqa0U=
+github.com/basecamp/hey-sdk/go v0.10.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/tui/collections_test.go
+++ b/internal/tui/collections_test.go
@@ -91,7 +91,7 @@ func TestMailViewLoadsAndPagesCollections(t *testing.T) {
 		t.Fatal("right from the last box should open Collections")
 	}
 	first := runCmd(v.HandleContentKey(keyPress("enter"))).(postingsLoadedMsg)
-	v.Update(first)
+	more, _ := v.Update(first)
 	if v.currentSourceKind() != mailSourceKindCollection || len(v.postingList.postings) != 1 {
 		t.Fatalf("collection source = %q postings = %+v", v.currentSourceKind(), v.postingList.postings)
 	}
@@ -99,21 +99,23 @@ func TestMailViewLoadsAndPagesCollections(t *testing.T) {
 	if posting.ResolveTopicID() != 501 || len(posting.Collections) != 1 || posting.Collections[0].ID != 12 {
 		t.Errorf("posting = %+v", posting)
 	}
-	if v.notice != "Collection page 1 — 2 threads total" || v.folderNextPage != "next-cursor" {
-		t.Errorf("page state = notice:%q next:%q", v.notice, v.folderNextPage)
+	if v.postingPaging.nextPage != "next-cursor" {
+		t.Errorf("next page = %q, want next-cursor", v.postingPaging.nextPage)
 	}
 
-	second := runCmd(v.HandleContentKey(keyPress("n"))).(postingsLoadedMsg)
-	v.Update(second)
-	if len(v.folderPageHistory) != 1 || v.postingList.postings[0].Summary != "Second page" {
-		t.Errorf("second page = history:%v postings:%+v", v.folderPageHistory, v.postingList.postings)
+	// The first page does not fill the window, so the collection reads on without being
+	// asked and the second page lands under the first.
+	second := runCmd(more).(postingsAppendedMsg)
+	if cmd, _ := v.Update(second); cmd != nil {
+		t.Error("a page with no next cursor should end the collection")
 	}
-	previous := runCmd(v.HandleContentKey(keyPress("p"))).(postingsLoadedMsg)
-	v.Update(previous)
-	if len(v.folderPageHistory) != 0 || v.postingList.postings[0].Summary != "First page" {
-		t.Errorf("previous page = history:%v postings:%+v", v.folderPageHistory, v.postingList.postings)
+	if len(v.postingList.postings) != 2 || v.postingList.postings[1].Summary != "Second page" {
+		t.Errorf("grown list = %+v", v.postingList.postings)
 	}
-	if fmt.Sprint(collectionQueries) != "[ next-cursor ]" {
+	if v.postingPaging.hasMore() {
+		t.Errorf("next page = %q, want none", v.postingPaging.nextPage)
+	}
+	if fmt.Sprint(collectionQueries) != "[ next-cursor]" {
 		t.Errorf("collection page queries = %q", collectionQueries)
 	}
 }
@@ -316,11 +318,14 @@ func TestMailViewCollectionActionUsesTopicNotPostingID(t *testing.T) {
 	}
 }
 
-func TestMailViewCollectionPageHelpUsesPreviousInsteadOfPaperTrail(t *testing.T) {
+// A collection scrolls rather than paging, so p is free to mean what it means everywhere
+// else in the mail list.
+func TestMailViewCollectionHelpOffersPaperTrail(t *testing.T) {
 	v := mailWithPostings()
 	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
 	v.boxIndex = len(v.boxes) - 1
-	v.folderPageHistory = []string{""}
+	v.postingPaging.nextPage = "next-cursor"
+
 	previous, paperTrail := 0, 0
 	for _, binding := range v.HelpBindings() {
 		if binding.key != "p" {
@@ -333,7 +338,7 @@ func TestMailViewCollectionPageHelpUsesPreviousInsteadOfPaperTrail(t *testing.T)
 			paperTrail++
 		}
 	}
-	if previous != 1 || paperTrail != 0 {
+	if previous != 0 || paperTrail != 1 {
 		t.Errorf("bindings = %v", v.HelpBindings())
 	}
 }
@@ -471,14 +476,15 @@ func TestMailViewCollectionPageMessageRejectsWrongSource(t *testing.T) {
 	}
 }
 
-func TestMailViewCollectionEmptySourceStillPages(t *testing.T) {
+func TestMailViewCollectionEmptySourceHasNothingMoreToRead(t *testing.T) {
 	v := mailWithPostings()
 	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindCollection, Name: "Kitchen remodel"})
 	v.boxIndex = len(v.boxes) - 1
 	v.activeRequestID = 1
-	v.Update(postingsLoadedMsg{requestID: 1, boxID: 12, sourceKind: mailSourceKindCollection, totalCount: 0})
-	if v.notice != "Collection page 1" || len(v.postingList.postings) != 0 {
-		t.Errorf("empty collection state = notice:%q postings:%+v", v.notice, v.postingList.postings)
+
+	cmd, _ := v.Update(postingsLoadedMsg{requestID: 1, boxID: 12, sourceKind: mailSourceKindCollection})
+	if cmd != nil || len(v.postingList.postings) != 0 || v.postingPaging.hasMore() {
+		t.Errorf("empty collection state = postings:%+v next:%q", v.postingList.postings, v.postingPaging.nextPage)
 	}
 }
 

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -26,6 +26,62 @@ func formatDisplayDate(ts string) string {
 	return t.Format("Jan 2, 2006")
 }
 
+// listPaging is where a list that grows as the reader scrolls keeps its place in what the
+// server holds: the cursor for the page after the deepest one read, empty once there is
+// nothing left to read; what the top page held when it was last read, which is exactly how
+// much of the list a live re-read replaces; how many pages deep the list has grown; and
+// whether the next page is already on its way, so the bottom is only asked for once.
+type listPaging struct {
+	nextPage string
+	headIDs  map[int64]struct{}
+	pages    int
+	loading  bool
+}
+
+func (p *listPaging) reset() {
+	*p = listPaging{}
+}
+
+// read starts the list over at its top page.
+func (p *listPaging) read(headIDs map[int64]struct{}, nextPage string) {
+	p.headIDs = headIDs
+	p.pages = 1
+	p.nextPage = nextPage
+	p.loading = false
+}
+
+// grew records a page arriving below the list. An empty page is the end of it whatever
+// cursor came with it: paging on from there would ask the same question forever.
+func (p *listPaging) grew(rowsRead int, nextPage string) {
+	p.pages++
+	p.loading = false
+	if rowsRead == 0 {
+		p.nextPage = ""
+	} else {
+		p.nextPage = nextPage
+	}
+}
+
+// refreshed records the top page having been read again. The cursor for what comes next
+// belongs to the deepest page, so a re-read of the top only moves it while the top page is
+// the whole list — below that the reader has already walked past it.
+func (p *listPaging) refreshed(headIDs map[int64]struct{}, nextPage string) {
+	p.headIDs = headIDs
+	if p.pages <= 1 {
+		p.pages = 1
+		p.nextPage = nextPage
+	}
+}
+
+func (p *listPaging) hasMore() bool {
+	return p.nextPage != ""
+}
+
+// loadMoreThreshold is how close to the bottom of a list the cursor comes before the next
+// page is read. A page arrives while there is still something left to scroll through,
+// rather than after the cursor has already stopped against the end.
+const loadMoreThreshold = 5
+
 // contentList renders a scrollable list of postings with a cursor.
 type contentList struct {
 	postings      []models.Posting
@@ -47,11 +103,50 @@ func (c *contentList) setPostings(postings []models.Posting) {
 	c.clearSelected()
 }
 
-// refreshPostings replaces the list with a newly read one while the user is looking at
-// it, so the reader keeps their place: the cursor stays on the posting it was on, the
+// growPostings adds the page after the one at the bottom of the list. A posting the list
+// already shows is dropped rather than added again: a thread that sank in the ordering
+// between two reads would otherwise arrive on two pages.
+func (c *contentList) growPostings(more []models.Posting) {
+	grown := c.postings
+	shown := postingIDs(c.postings)
+	for _, posting := range more {
+		if _, alreadyShown := shown[posting.ID]; !alreadyShown {
+			grown = append(grown, posting)
+		}
+	}
+	c.keepPlaceIn(grown)
+}
+
+// refreshHead replaces the top page of the list with a newly read one and leaves the pages
+// the reader scrolled down to as they were read. headIDs is what the top page held the
+// last time it was read, so a thread that has since left it goes with it rather than
+// sinking into the list below.
+func (c *contentList) refreshHead(head []models.Posting, headIDs map[int64]struct{}) {
+	fresh := postingIDs(head)
+	refreshed := append([]models.Posting(nil), head...)
+	for _, posting := range c.postings {
+		_, wasInHead := headIDs[posting.ID]
+		_, isInHead := fresh[posting.ID]
+		if !wasInHead && !isInHead {
+			refreshed = append(refreshed, posting)
+		}
+	}
+	c.keepPlaceIn(refreshed)
+}
+
+func postingIDs(postings []models.Posting) map[int64]struct{} {
+	ids := make(map[int64]struct{}, len(postings))
+	for _, posting := range postings {
+		ids[posting.ID] = struct{}{}
+	}
+	return ids
+}
+
+// keepPlaceIn puts the list on a newly assembled set of postings while the user is looking
+// at it, so the reader keeps their place: the cursor stays on the posting it was on, the
 // window stays where it was scrolled to, and a multi-selection keeps every row that is
 // still there. A posting that left the box takes the cursor or its selection with it.
-func (c *contentList) refreshPostings(postings []models.Posting) {
+func (c *contentList) keepPlaceIn(postings []models.Posting) {
 	if !c.hideSeenState {
 		postings = partitionSections(postings)
 	}
@@ -211,6 +306,13 @@ func (c *contentList) sectionLabelAt(index int) string {
 		return section.label()
 	}
 	return ""
+}
+
+// hasRowsBelow reports whether the list carries on past the bottom of the window. A list
+// that does not is a list the reader can see the end of, which is a reason to read the page
+// below it without waiting to be asked.
+func (c *contentList) hasRowsBelow() bool {
+	return c.scrollOff+c.visibleItemsFrom(c.scrollOff) < len(c.postings)
 }
 
 func (c *contentList) ensureVisible() {

--- a/internal/tui/live_test.go
+++ b/internal/tui/live_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -231,6 +232,40 @@ func TestMailViewReadsTheBoxWhenTheDelayIsUp(t *testing.T) {
 	}
 }
 
+// A re-read reads the top page of the box, so it may only replace that much: the pages the
+// reader scrolled down to stay as they were read, and a thread that has left the top page
+// leaves the list with it rather than sinking below the fresh rows.
+func TestMailViewReReadReplacesOnlyTheTopPage(t *testing.T) {
+	v := mailWithPostings()
+	v.postingPaging.read(postingIDs(testPostings()), "cursor-2")
+	v.Update(postingsAppendedMsg{
+		requestID:  v.moreRequestID,
+		boxID:      v.currentBoxID(),
+		sourceKind: v.currentSourceKind(),
+		nextPage:   "cursor-3",
+		postings:   []models.Posting{{ID: 102, Summary: "Scrolled to", Seen: true}},
+	})
+
+	v.Update(postingsRefreshedMsg{
+		requestID:  v.liveRequestID,
+		boxID:      v.currentBoxID(),
+		sourceKind: v.currentSourceKind(),
+		nextPage:   "cursor-2",
+		postings:   []models.Posting{{ID: 103, Summary: "Just arrived"}, testPostings()[1]},
+	})
+
+	ids := make([]int64, 0, len(v.postingList.postings))
+	for _, posting := range v.postingList.postings {
+		ids = append(ids, posting.ID)
+	}
+	if fmt.Sprint(ids) != "[103 101 102]" {
+		t.Errorf("list = %v, want the fresh top page above the page below it", ids)
+	}
+	if v.postingPaging.nextPage != "cursor-3" {
+		t.Errorf("next page = %q, want the cursor the deepest page answered with", v.postingPaging.nextPage)
+	}
+}
+
 func TestMailViewIgnoresAReReadOfAnotherBox(t *testing.T) {
 	v := mailWithPostings()
 	v.liveRequestID = 3
@@ -282,7 +317,7 @@ func TestContentListRefreshDropsWhatLeftTheBox(t *testing.T) {
 		t.Fatal("the posting under the cursor should end up selected")
 	}
 
-	list.refreshPostings([]models.Posting{testPostings()[0]})
+	list.refreshHead([]models.Posting{testPostings()[0]}, postingIDs(testPostings()))
 	if list.cursor != 0 {
 		t.Errorf("cursor = %d, want the top once its posting left", list.cursor)
 	}

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -51,15 +51,25 @@ type mailSourcesLoadedMsg struct {
 }
 
 type postingsLoadedMsg struct {
-	requestID   uint64
-	boxID       int64
-	sourceKind  string
-	page        string
-	pageHistory []string
-	nextPage    string
-	totalCount  int
-	postings    []models.Posting
-	err         error
+	requestID  uint64
+	boxID      int64
+	sourceKind string
+	nextPage   string
+	postings   []models.Posting
+	err        error
+}
+
+// postingsAppendedMsg is the page below the one on screen, read because the reader
+// scrolled towards the bottom of the list. It has its own lane so it can never be mistaken
+// for the read the user is waiting on, and so it lands under the cursor rather than
+// carrying it back to the top.
+type postingsAppendedMsg struct {
+	requestID  uint64
+	boxID      int64
+	sourceKind string
+	nextPage   string
+	postings   []models.Posting
+	err        error
 }
 
 // postingsRefreshedMsg is a box re-read after it changed underneath the reader. It has
@@ -69,6 +79,7 @@ type postingsRefreshedMsg struct {
 	requestID  uint64
 	boxID      int64
 	sourceKind string
+	nextPage   string
 	postings   []models.Posting
 	err        error
 }
@@ -88,7 +99,17 @@ type topicLoadedMsg struct {
 type searchResultsLoadedMsg struct {
 	requestID uint64
 	query     string
-	page      int
+	nextPage  int
+	postings  []models.Posting
+	err       error
+}
+
+// searchResultsAppendedMsg is the page of matches below the ones on screen, read because
+// the reader scrolled towards the bottom of the results. Its own lane, like a box's.
+type searchResultsAppendedMsg struct {
+	requestID uint64
+	query     string
+	nextPage  int
 	postings  []models.Posting
 	err       error
 }
@@ -163,13 +184,10 @@ type collectionActionDoneMsg struct {
 type mailView struct {
 	vc *viewContext
 
-	boxes             []models.Box
-	boxIndex          int
-	folderPage        string
-	folderNextPage    string
-	folderPageHistory []string
-	folderTotalCount  int
+	boxes    []models.Box
+	boxIndex int
 
+	postingPaging    listPaging
 	postingList      contentList
 	topicViewport    viewport.Model
 	topicContent     string
@@ -193,7 +211,8 @@ type mailView struct {
 	searchList             contentList
 	searchActive           bool
 	searchQuery            string
-	searchPage             int
+	searchNextPage         int    // the page of matches after the ones on screen, zero at the last
+	searchLoadingMore      bool   // a page of matches is already on its way
 	screenerCount          int    // senders waiting in The Screener
 	lastBulkReplyID        int64  // delayed delivery currently available for undo
 	pendingMutations       int    // writes that must finish before changing the account context
@@ -208,6 +227,8 @@ type mailView struct {
 	liveRequestID   uint64 // identifies the only live re-read allowed to update the list
 	liveRefreshDue  bool   // a re-read is already on its way
 	liveUpdatesOver bool   // the changes stream closed, so the list is a snapshot again
+	moreRequestID   uint64 // identifies the only page-below read allowed to grow the list
+	searchMoreID    uint64 // the same, for the search results
 }
 
 func newMailView(vc *viewContext) *mailView {
@@ -280,16 +301,21 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		// unread threads with the dot; every other source is one flat list.
 		v.postingList.hideSeenState = !v.currentBoxIsImbox()
 		v.postingList.setPostings(msg.postings)
-		if isOrganizedMailSource(v.currentSourceKind()) {
-			v.folderPage = msg.page
-			v.folderPageHistory = msg.pageHistory
-			v.folderNextPage = msg.nextPage
-			v.folderTotalCount = msg.totalCount
-			if v.notice == "" {
-				v.notice = v.folderPageNotice()
-			}
+		v.postingPaging.read(postingIDs(msg.postings), msg.nextPage)
+		return v.loadMorePostings(), true
+
+	case postingsAppendedMsg:
+		if msg.requestID != v.moreRequestID || msg.boxID != v.currentBoxID() || msg.sourceKind != v.currentSourceKind() {
+			return nil, true
 		}
-		return nil, true
+		v.postingPaging.loading = false
+		if msg.err != nil {
+			v.notice = "Could not load more mail: " + msg.err.Error()
+			return nil, true
+		}
+		v.postingList.growPostings(msg.postings)
+		v.postingPaging.grew(len(msg.postings), msg.nextPage)
+		return v.loadMorePostings(), true
 
 	case mailRefreshDueMsg:
 		return v.refreshBox(msg.boxID), true
@@ -302,7 +328,8 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			v.notice = "Could not refresh mail: " + msg.err.Error()
 			return nil, true
 		}
-		v.postingList.refreshPostings(msg.postings)
+		v.postingList.refreshHead(msg.postings, v.postingPaging.headIDs)
+		v.postingPaging.refreshed(postingIDs(msg.postings), msg.nextPage)
 		return nil, true
 
 	case searchResultsLoadedMsg:
@@ -313,15 +340,29 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		if msg.err != nil {
 			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
-		if len(msg.postings) == 0 && v.searchActive && msg.page > v.searchPage {
-			v.notice = "No more search results"
-			return nil, true
-		}
 		v.searchActive = true
 		v.searchQuery = msg.query
-		v.searchPage = msg.page
+		v.searchNextPage = msg.nextPage
+		v.searchLoadingMore = false
 		v.searchList.setPostings(msg.postings)
-		return nil, true
+		return v.loadMoreSearchResults(), true
+
+	case searchResultsAppendedMsg:
+		if msg.requestID != v.searchMoreID || !v.searchActive || msg.query != v.searchQuery {
+			return nil, true
+		}
+		v.searchLoadingMore = false
+		if msg.err != nil {
+			v.notice = "Could not load more results: " + msg.err.Error()
+			return nil, true
+		}
+		v.searchList.growPostings(msg.postings)
+		if len(msg.postings) == 0 {
+			v.searchNextPage = 0
+		} else {
+			v.searchNextPage = msg.nextPage
+		}
+		return v.loadMoreSearchResults(), true
 
 	case topicLoadedMsg:
 		if msg.requestID != v.activeRequestID || msg.boxID != v.currentBoxID() {
@@ -516,7 +557,9 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 				return v.requestPostings(*source), true
 			}
 		}
-		return nil, true
+		// A thread leaving the list can uncover the bottom of it, so what is below comes up
+		// to fill the gap rather than leaving a short list with more waiting behind it.
+		return v.loadMorePostings(), true
 
 	case postingSeenMsg:
 		v.finishMutation()
@@ -734,7 +777,7 @@ func (v *mailView) HelpBindings() []helpBinding {
 		return bindings
 	}
 	if v.searchActive {
-		return []helpBinding{{"enter", "open"}, {"/", "new search"}, {"n", "next page"}, {"p", "previous page"}}
+		return []helpBinding{{"enter", "open"}, {"/", "new search"}}
 	}
 	ignoreBinding := helpBinding{"-", "ignore"}
 	if selected := v.postingList.selectedPosting(); selected != nil && selected.Muted {
@@ -764,23 +807,13 @@ func (v *mailView) HelpBindings() []helpBinding {
 		{"a", "set aside"},
 		{"d", "feed"},
 	}
-	if !isOrganizedMailSource(v.currentSourceKind()) {
-		bindings = append(bindings, helpBinding{"p", "paper trail"})
-	}
 	bindings = append(bindings,
+		helpBinding{"p", "paper trail"},
 		helpBinding{"t", "trash"},
 		helpBinding{"s", "spam"},
 		ignoreBinding,
+		helpBinding{"ctrl+r", "reload"},
 	)
-	if isOrganizedMailSource(v.currentSourceKind()) {
-		if v.folderNextPage != "" {
-			bindings = append(bindings, helpBinding{"n", "next page"})
-		}
-		if len(v.folderPageHistory) > 0 {
-			bindings = append(bindings, helpBinding{"p", "previous page"})
-		}
-	}
-	bindings = append(bindings, helpBinding{"ctrl+r", "reload"})
 	if v.lastBulkReplyID != 0 {
 		bindings = append(bindings, helpBinding{"u", "undo bulk reply"})
 	}
@@ -791,7 +824,10 @@ func (v *mailView) SubnavItems() ([]navItem, int, string, bool) {
 	if v.searchActive || v.searchForm != nil {
 		label := "Search"
 		if v.searchQuery != "" {
-			label = fmt.Sprintf("Search: %s (page %d)", v.searchQuery, max(v.searchPage, 1))
+			label = "Search: " + v.searchQuery
+		}
+		if v.searchLoadingMore {
+			label += " · loading more…"
 		}
 		return nil, 0, label, true
 	}
@@ -800,7 +836,9 @@ func (v *mailView) SubnavItems() ([]navItem, int, string, bool) {
 		label = v.boxes[v.boxIndex].Name
 		if isOrganizedMailSource(v.boxes[v.boxIndex].Kind) {
 			label = terminalSafeFolderText(label)
-			label = fmt.Sprintf("%s (page %d)", label, len(v.folderPageHistory)+1)
+		}
+		if v.postingPaging.loading {
+			label += " · loading more…"
 		}
 	}
 
@@ -964,7 +1002,7 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		cmd, query, submit := v.searchForm.handleKey(msg)
 		if submit {
 			v.searchForm = nil
-			return v.requestSearch(query, 1)
+			return v.requestSearch(query)
 		}
 		return cmd
 	}
@@ -1123,19 +1161,12 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 			v.searchList.moveUp()
 		case tea.KeyDown:
 			v.searchList.moveDown()
+			return v.loadMoreSearchResults()
 		case tea.KeyEnter:
 			return v.openSelected()
 		default:
-			switch msg.String() {
-			case "/":
+			if msg.String() == "/" {
 				return v.startSearch()
-			case "n":
-				return v.requestSearch(v.searchQuery, v.searchPage+1)
-			case "p":
-				if v.searchPage > 1 {
-					return v.requestSearch(v.searchQuery, v.searchPage-1)
-				}
-				v.notice = "Already on the first search page"
 			}
 		}
 		return nil
@@ -1146,17 +1177,10 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		v.postingList.moveUp()
 	case tea.KeyDown:
 		v.postingList.moveDown()
+		return v.loadMorePostings()
 	case tea.KeyEnter:
 		return v.openSelected()
 	default:
-		if isOrganizedMailSource(v.currentSourceKind()) {
-			switch msg.String() {
-			case "n":
-				return v.nextFolderPage()
-			case "p":
-				return v.previousFolderPage()
-			}
-		}
 		switch msg.String() {
 		case "/":
 			return v.startSearch()
@@ -1218,7 +1242,9 @@ func (v *mailView) clearSearch() {
 	v.searchActive = false
 	v.searchQuery = ""
 	v.notice = ""
-	v.searchPage = 0
+	v.searchNextPage = 0
+	v.searchLoadingMore = false
+	v.searchMoreID++
 	v.searchList.setPostings(nil)
 	v.searchForm = nil
 }
@@ -1306,7 +1332,6 @@ func (v *mailView) switchBox(index int) tea.Cmd {
 	v.notice = ""
 	v.postingList.setPostings(nil)
 	v.boxIndex = index
-	v.resetFolderPagination()
 	return v.requestPostings(v.boxes[index])
 }
 
@@ -1365,9 +1390,6 @@ func (v *mailView) applySources(sources []models.Box) tea.Cmd {
 		return nil
 	}
 	v.boxIndex = sourceIndex(v.boxes, currentID, currentKind)
-	if v.boxes[v.boxIndex].ID != currentID || v.boxes[v.boxIndex].Kind != currentKind {
-		v.resetFolderPagination()
-	}
 	return v.requestPostings(v.boxes[v.boxIndex])
 }
 
@@ -1417,13 +1439,32 @@ func (v *mailView) cancelRequest() {
 	v.loading = false
 }
 
+// requestPostings reads a source from its top page. Every list starts there and grows
+// downwards from it, so a read the user asked for is also what puts the list back to the
+// depth it opens at.
 func (v *mailView) requestPostings(source models.Box) tea.Cmd {
-	return v.requestPostingsPage(source, v.folderPage, v.folderPageHistory)
+	v.postingPaging.reset()
+	v.moreRequestID++
+	requestID, ctx := v.beginRequest(mailRequestPostings)
+	return v.fetchPostings(ctx, requestID, source, "")
 }
 
-func (v *mailView) requestPostingsPage(source models.Box, page string, history []string) tea.Cmd {
-	requestID, ctx := v.beginRequest(mailRequestPostings)
-	return v.fetchPostings(ctx, requestID, source, page, append([]string(nil), history...))
+// loadMorePostings reads the page below the one the reader has scrolled to, or the one
+// below a list they can already see the end of. One page is asked for at a time, in its own
+// lane and on the view's own context: the reader is still looking at what is there, so this
+// must not cancel or be cancelled by the read they are waiting on.
+func (v *mailView) loadMorePostings() tea.Cmd {
+	source := v.currentSource()
+	if source == nil || v.postingPaging.loading || !v.postingPaging.hasMore() {
+		return nil
+	}
+	if v.postingList.hasRowsBelow() && len(v.postingList.postings)-v.postingList.cursor > loadMoreThreshold {
+		return nil
+	}
+
+	v.postingPaging.loading = true
+	v.moreRequestID++
+	return v.fetchMorePostings(v.vc.ctx, v.moreRequestID, *source, v.postingPaging.nextPage)
 }
 
 // reloadPostings reads the box on screen again, on the user's say-so. It is how a list
@@ -1505,45 +1546,6 @@ func (v *mailView) noteFailure(what string, err error) {
 	v.notice = truncateToWidth(what+": "+err.Error(), max(v.vc.width-2, 40))
 }
 
-func (v *mailView) nextFolderPage() tea.Cmd {
-	source := v.currentSource()
-	if source == nil || !isOrganizedMailSource(source.Kind) || v.folderNextPage == "" {
-		return nil
-	}
-	history := append(append([]string(nil), v.folderPageHistory...), v.folderPage)
-	return v.requestPostingsPage(*source, v.folderNextPage, history)
-}
-
-func (v *mailView) previousFolderPage() tea.Cmd {
-	source := v.currentSource()
-	if source == nil || !isOrganizedMailSource(source.Kind) || len(v.folderPageHistory) == 0 {
-		return nil
-	}
-	last := len(v.folderPageHistory) - 1
-	page := v.folderPageHistory[last]
-	history := append([]string(nil), v.folderPageHistory[:last]...)
-	return v.requestPostingsPage(*source, page, history)
-}
-
-func (v *mailView) resetFolderPagination() {
-	v.folderPage = ""
-	v.folderNextPage = ""
-	v.folderPageHistory = nil
-	v.folderTotalCount = 0
-}
-
-func (v *mailView) folderPageNotice() string {
-	page := len(v.folderPageHistory) + 1
-	name := "Label"
-	if v.currentSourceKind() == mailSourceKindCollection {
-		name = "Collection"
-	}
-	if v.folderTotalCount > 0 {
-		return fmt.Sprintf("%s page %d — %d threads total", name, page, v.folderTotalCount)
-	}
-	return fmt.Sprintf("%s page %d", name, page)
-}
-
 func (v *mailView) startSearch() tea.Cmd {
 	if v.loading || len(v.boxes) == 0 {
 		return nil
@@ -1553,9 +1555,29 @@ func (v *mailView) startSearch() tea.Cmd {
 	return v.searchForm.init()
 }
 
-func (v *mailView) requestSearch(query string, page int) tea.Cmd {
+// requestSearch runs a search from its first page. Results grow downwards from there, the
+// same way a box does.
+func (v *mailView) requestSearch(query string) tea.Cmd {
+	v.searchNextPage = 0
+	v.searchLoadingMore = false
+	v.searchMoreID++
 	requestID, ctx := v.beginRequest(mailRequestSearch)
-	return v.fetchSearchResults(ctx, requestID, query, max(page, 1))
+	return v.fetchSearchResults(ctx, requestID, query, 1)
+}
+
+// loadMoreSearchResults reads the page of matches below the ones the reader has scrolled
+// to, or below results they can already see the end of.
+func (v *mailView) loadMoreSearchResults() tea.Cmd {
+	if !v.searchActive || v.searchLoadingMore || v.searchNextPage == 0 {
+		return nil
+	}
+	if v.searchList.hasRowsBelow() && len(v.searchList.postings)-v.searchList.cursor > loadMoreThreshold {
+		return nil
+	}
+
+	v.searchLoadingMore = true
+	v.searchMoreID++
+	return v.fetchMoreSearchResults(v.vc.ctx, v.searchMoreID, v.searchQuery, v.searchNextPage)
 }
 
 func (v *mailView) requestTopic(boxID, topicID, postingID int64, title string) tea.Cmd {
@@ -2132,101 +2154,139 @@ func (v *mailView) refreshScreenerCount() tea.Cmd {
 	}
 }
 
-func (v *mailView) fetchPostings(ctx context.Context, requestID uint64, source models.Box, page string, history []string) tea.Cmd {
+func (v *mailView) fetchPostings(ctx context.Context, requestID uint64, source models.Box, page string) tea.Cmd {
 	return func() tea.Msg {
-		var sdkPostings []generated.Posting
-		message := postingsLoadedMsg{requestID: requestID, boxID: source.ID, sourceKind: source.Kind, page: page, pageHistory: history}
-		switch source.Kind {
-		case mailSourceKindFolder:
-			var params *generated.GetFolderParams
-			if page != "" {
-				params = &generated.GetFolderParams{Page: &page}
-			}
-			result, err := v.vc.sdk.Folders().GetPage(ctx, source.ID, params)
-			if err != nil {
-				message.err = err
-				return message
-			}
-			if result != nil {
-				message.nextPage = result.NextPage
-				message.totalCount = result.TotalCount
-				if result.Folder != nil {
-					sdkPostings = result.Folder.Postings
-				}
-			}
-		case mailSourceKindCollection:
-			var params *generated.GetCollectionParams
-			if page != "" {
-				params = &generated.GetCollectionParams{Page: &page}
-			}
-			result, err := v.vc.sdk.Collections().GetPage(ctx, source.ID, params)
-			if err != nil {
-				message.err = err
-				return message
-			}
-			if result != nil {
-				message.nextPage = result.NextPage
-				message.totalCount = result.TotalCount
-				if result.Collection != nil {
-					sdkPostings = result.Collection.Postings
-				}
-			}
-		default:
-			box, err := v.vc.sdk.Boxes().Get(ctx, source.ID, nil)
-			if err != nil {
-				message.err = err
-				return message
-			}
-			if box != nil {
-				sdkPostings = box.Postings
-			}
+		postings, nextPage, err := v.readPostingsPage(ctx, source, page)
+		return postingsLoadedMsg{
+			requestID: requestID, boxID: source.ID, sourceKind: source.Kind,
+			postings: postings, nextPage: nextPage, err: err,
 		}
-		postings := make([]models.Posting, 0, len(sdkPostings))
-		for _, posting := range sdkPostings {
-			postings = append(postings, sdkPostingToModel(posting))
-		}
-		message.postings = postings
-		return message
 	}
 }
 
-// fetchBoxRefresh re-reads a box for the live update. It reads the box and nothing else:
-// a label's page, a search and a thread all stay as they were.
+// fetchMorePostings reads the page below the list, in the growing lane and without the
+// spinner: what the reader is looking at is already on screen.
+func (v *mailView) fetchMorePostings(ctx context.Context, requestID uint64, source models.Box, page string) tea.Cmd {
+	return func() tea.Msg {
+		postings, nextPage, err := v.readPostingsPage(ctx, source, page)
+		return postingsAppendedMsg{
+			requestID: requestID, boxID: source.ID, sourceKind: source.Kind,
+			postings: postings, nextPage: nextPage, err: err,
+		}
+	}
+}
+
+// fetchBoxRefresh re-reads the top page of a box for the live update. It reads that and
+// nothing else: the pages the reader scrolled down to, a search and a thread all stay as
+// they were.
 func (v *mailView) fetchBoxRefresh(ctx context.Context, requestID uint64, source models.Box) tea.Cmd {
 	return func() tea.Msg {
-		message := postingsRefreshedMsg{requestID: requestID, boxID: source.ID, sourceKind: source.Kind}
-		box, err := v.vc.sdk.Boxes().Get(ctx, source.ID, nil)
-		if err != nil {
-			message.err = err
-			return message
+		postings, nextPage, err := v.readPostingsPage(ctx, source, "")
+		return postingsRefreshedMsg{
+			requestID: requestID, boxID: source.ID, sourceKind: source.Kind,
+			postings: postings, nextPage: nextPage, err: err,
 		}
-		if box != nil {
-			postings := make([]models.Posting, 0, len(box.Postings))
-			for _, posting := range box.Postings {
-				postings = append(postings, sdkPostingToModel(posting))
-			}
-			message.postings = postings
-		}
-		return message
 	}
+}
+
+// readPostingsPage reads one page of a source and answers the cursor for the page after
+// it, empty once the source has nothing more to give. An empty page reads the first one.
+func (v *mailView) readPostingsPage(ctx context.Context, source models.Box, page string) ([]models.Posting, string, error) {
+	var sdkPostings []generated.Posting
+	var nextPage string
+
+	switch source.Kind {
+	case mailSourceKindFolder:
+		var params *generated.GetFolderParams
+		if page != "" {
+			params = &generated.GetFolderParams{Page: &page}
+		}
+		result, err := v.vc.sdk.Folders().GetPage(ctx, source.ID, params)
+		if err != nil {
+			return nil, "", err
+		}
+		if result != nil {
+			nextPage = result.NextPage
+			if result.Folder != nil {
+				sdkPostings = result.Folder.Postings
+			}
+		}
+	case mailSourceKindCollection:
+		var params *generated.GetCollectionParams
+		if page != "" {
+			params = &generated.GetCollectionParams{Page: &page}
+		}
+		result, err := v.vc.sdk.Collections().GetPage(ctx, source.ID, params)
+		if err != nil {
+			return nil, "", err
+		}
+		if result != nil {
+			nextPage = result.NextPage
+			if result.Collection != nil {
+				sdkPostings = result.Collection.Postings
+			}
+		}
+	default:
+		var params *generated.GetBoxParams
+		if page != "" {
+			params = &generated.GetBoxParams{Page: &page}
+		}
+		result, err := v.vc.sdk.Boxes().GetPage(ctx, source.ID, params)
+		if err != nil {
+			return nil, "", err
+		}
+		if result != nil {
+			nextPage = result.NextPage
+			if result.Box != nil {
+				sdkPostings = result.Box.Postings
+			}
+		}
+	}
+
+	postings := make([]models.Posting, 0, len(sdkPostings))
+	for _, posting := range sdkPostings {
+		postings = append(postings, sdkPostingToModel(posting))
+	}
+	return postings, nextPage, nil
 }
 
 func (v *mailView) fetchSearchResults(ctx context.Context, requestID uint64, query string, page int) tea.Cmd {
 	return func() tea.Msg {
-		result, err := v.vc.sdk.Search().Search(ctx, hey.SearchParams{Query: query, Page: page})
-		if err != nil {
-			return searchResultsLoadedMsg{requestID: requestID, query: query, page: page, err: err}
-		}
-		var matches []generated.SearchMatch
-		if result != nil {
-			matches = result.Matches
-		}
-		postings := make([]models.Posting, 0, len(matches))
-		for _, match := range matches {
-			postings = append(postings, sdkSearchMatchToModel(match))
-		}
-		return searchResultsLoadedMsg{requestID: requestID, query: query, page: page, postings: postings}
+		postings, nextPage, err := v.readSearchPage(ctx, query, page)
+		return searchResultsLoadedMsg{requestID: requestID, query: query, postings: postings, nextPage: nextPage, err: err}
 	}
+}
+
+// fetchMoreSearchResults reads the page of matches below the ones on screen, in the growing
+// lane and without the spinner.
+func (v *mailView) fetchMoreSearchResults(ctx context.Context, requestID uint64, query string, page int) tea.Cmd {
+	return func() tea.Msg {
+		postings, nextPage, err := v.readSearchPage(ctx, query, page)
+		return searchResultsAppendedMsg{requestID: requestID, query: query, postings: postings, nextPage: nextPage, err: err}
+	}
+}
+
+// readSearchPage reads one page of matches and answers the number of the page after it,
+// zero once the search has nothing more to give. Search numbers its pages where a box
+// cursors them, so this is a page number rather than a token.
+func (v *mailView) readSearchPage(ctx context.Context, query string, page int) ([]models.Posting, int, error) {
+	results, err := v.vc.sdk.Search().SearchPage(ctx, hey.SearchParams{Query: query, Page: max(page, 1)})
+	if err != nil {
+		return nil, 0, err
+	}
+	var matches []generated.SearchMatch
+	if results != nil && results.Result != nil {
+		matches = results.Result.Matches
+	}
+	postings := make([]models.Posting, 0, len(matches))
+	for _, match := range matches {
+		postings = append(postings, sdkSearchMatchToModel(match))
+	}
+	nextPage := 0
+	if results != nil {
+		nextPage = results.NextPage
+	}
+	return postings, nextPage, nil
 }
 
 func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topicID, postingID int64, title string) tea.Cmd {

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -685,12 +685,12 @@ func TestMailViewLoadsFolderSourcesAndPostings(t *testing.T) {
 	if len(v.postingList.postings[0].Folders) != 1 || v.postingList.postings[0].Folders[0].ID != 12 {
 		t.Errorf("posting folders = %+v", v.postingList.postings[0].Folders)
 	}
-	if v.notice != "Label page 1" {
-		t.Errorf("folder pagination notice = %q", v.notice)
+	if v.postingPaging.hasMore() {
+		t.Errorf("a label with one page should have nothing more to read, got %q", v.postingPaging.nextPage)
 	}
 }
 
-func TestMailViewFolderPagination(t *testing.T) {
+func TestMailViewFolderGrowsAsTheReaderScrolls(t *testing.T) {
 	var folderQueries []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -723,34 +723,122 @@ func TestMailViewFolderPagination(t *testing.T) {
 	v.Update(runCmd(v.Init()))
 	v.SubnavRight()
 	first := runCmd(v.HandleContentKey(keyPress("enter"))).(postingsLoadedMsg)
-	v.Update(first)
-	if v.folderNextPage != "next-cursor" || v.notice != "Label page 1 — 2 threads total" {
-		t.Errorf("first page state = next:%q notice:%q", v.folderNextPage, v.notice)
+	more, _ := v.Update(first)
+	if v.postingPaging.nextPage != "next-cursor" {
+		t.Errorf("first page next cursor = %q, want next-cursor", v.postingPaging.nextPage)
 	}
-	if !hasHelpBinding(v.HelpBindings(), "n") {
-		t.Error("first folder page should offer next-page navigation")
-	}
-
-	second := runCmd(v.HandleContentKey(keyPress("n"))).(postingsLoadedMsg)
-	v.Update(second)
-	if len(v.postingList.postings) != 1 || v.postingList.postings[0].Summary != "Second page" || len(v.folderPageHistory) != 1 {
-		t.Errorf("second page state = postings:%+v history:%v", v.postingList.postings, v.folderPageHistory)
-	}
-	_, _, label, _ := v.SubnavItems()
-	if !strings.Contains(label, "page 2") || v.notice != "Label page 2 — 2 threads total" {
-		t.Errorf("second page label=%q notice=%q", label, v.notice)
-	}
-	if !hasHelpBinding(v.HelpBindings(), "p") {
-		t.Error("second folder page should offer previous-page navigation")
+	if more == nil {
+		t.Fatal("a label the reader can see the end of should read on")
 	}
 
-	previous := runCmd(v.HandleContentKey(keyPress("p"))).(postingsLoadedMsg)
-	v.Update(previous)
-	if len(v.folderPageHistory) != 0 || len(v.postingList.postings) != 1 || v.postingList.postings[0].Summary != "First page" {
-		t.Errorf("previous page state = postings:%+v history:%v", v.postingList.postings, v.folderPageHistory)
+	second := runCmd(more).(postingsAppendedMsg)
+	if cmd, _ := v.Update(second); cmd != nil {
+		t.Error("a page with no next cursor should end the label")
 	}
-	if fmt.Sprint(folderQueries) != "[ next-cursor ]" {
+	if len(v.postingList.postings) != 2 || v.postingList.postings[1].Summary != "Second page" {
+		t.Errorf("grown list = %+v", v.postingList.postings)
+	}
+	if v.postingPaging.hasMore() {
+		t.Errorf("next cursor = %q, want none", v.postingPaging.nextPage)
+	}
+	if _, _, label, _ := v.SubnavItems(); label != "Receipts" {
+		t.Errorf("label = %q, want Receipts", label)
+	}
+	if fmt.Sprint(folderQueries) != "[ next-cursor]" {
 		t.Errorf("folder page queries = %q", folderQueries)
+	}
+}
+
+// --- Growing a list as the reader scrolls ---
+
+func TestMailViewBoxGrowsAsTheReaderScrolls(t *testing.T) {
+	var pages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages = append(pages, r.URL.Query().Get("page"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "cursor-2" {
+			_, _ = w.Write([]byte(`{"id":1,"kind":"imbox","name":"Imbox","postings":[
+				{"id":102,"summary":"Third","created_at":"2025-03-01T08:00:00Z","seen":true}]}`))
+			return
+		}
+		w.Header().Set("Link", "<http://"+r.Host+"/boxes/1.json?page=cursor-2>; rel=\"next\"")
+		_, _ = w.Write([]byte(`{"id":1,"kind":"imbox","name":"Imbox","postings":[
+			{"id":100,"summary":"First","created_at":"2025-03-01T10:00:00Z","seen":true},
+			{"id":101,"summary":"Second","created_at":"2025-03-01T09:00:00Z","seen":true}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	vc := testVC()
+	vc.sdk = hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "test-token"}, hey.WithMaxRetries(0))
+	v := newMailView(vc)
+	v.Resize(vc.width, vc.height)
+	v.boxes = orderBoxes(testBoxes())
+
+	first := runCmd(v.requestPostings(v.boxes[0])).(postingsLoadedMsg)
+	more, _ := v.Update(first)
+	if more == nil {
+		t.Fatal("a box the reader can see the end of should read on")
+	}
+
+	appended := runCmd(more).(postingsAppendedMsg)
+	if cmd, _ := v.Update(appended); cmd != nil {
+		t.Error("a page with no next cursor should end the box")
+	}
+	if len(v.postingList.postings) != 3 || v.postingList.postings[2].Summary != "Third" {
+		t.Errorf("grown list = %+v", v.postingList.postings)
+	}
+	if strings.Join(pages, ",") != ",cursor-2" {
+		t.Errorf("page requests = %v", pages)
+	}
+}
+
+func TestMailViewReadsOnOnlyAsTheCursorNearsTheBottom(t *testing.T) {
+	v := mailWithPostings()
+	v.postingList.hideSeenState = true
+	v.postingList.setSize(80, 20)
+	postings := make([]models.Posting, 0, 20)
+	for id := range 20 {
+		postings = append(postings, models.Posting{ID: int64(200 + id), Seen: true})
+	}
+	v.postingList.setPostings(postings)
+	v.postingPaging.nextPage = "cursor-2"
+
+	if cmd := v.loadMorePostings(); cmd != nil {
+		t.Error("a cursor at the top of a full list should not read on")
+	}
+	v.postingList.cursor = len(postings) - 2
+	if cmd := v.loadMorePostings(); cmd == nil {
+		t.Error("a cursor near the bottom should read on")
+	}
+	if !v.postingPaging.loading {
+		t.Error("the page on its way should be marked as such")
+	}
+	if cmd := v.loadMorePostings(); cmd != nil {
+		t.Error("only one page should be asked for at a time")
+	}
+}
+
+// A thread the list already shows is not shown twice when the page below turns it up
+// again, which is what happens when a reply moves it in the ordering between two reads.
+func TestMailViewGrowingSkipsPostingsAlreadyShown(t *testing.T) {
+	v := mailWithPostings()
+	v.postingPaging.nextPage = "cursor-2"
+
+	v.Update(postingsAppendedMsg{
+		requestID:  v.moreRequestID,
+		boxID:      v.currentBoxID(),
+		sourceKind: v.currentSourceKind(),
+		postings: []models.Posting{
+			testPostings()[1],
+			{ID: 102, Summary: "Third", Seen: true},
+		},
+	})
+
+	if len(v.postingList.postings) != 3 {
+		t.Fatalf("grown list = %+v", v.postingList.postings)
+	}
+	if v.postingList.postings[2].ID != 102 {
+		t.Errorf("last posting = %+v, want the one page two added", v.postingList.postings[2])
 	}
 }
 
@@ -2072,8 +2160,8 @@ func TestMailViewSearchFormSubmitsQueryAndRendersResults(t *testing.T) {
 	if recorded.path != "/advanced_search.json" || len(recorded.rawQueries) == 0 || !strings.Contains(recorded.rawQueries[len(recorded.rawQueries)-1], "q=quarterly+planning") {
 		t.Errorf("search request = %s?%v", recorded.path, recorded.rawQueries)
 	}
-	if !v.searchActive || v.searchQuery != "quarterly planning" || v.searchPage != 1 {
-		t.Errorf("search state = active:%v query:%q page:%d", v.searchActive, v.searchQuery, v.searchPage)
+	if !v.searchActive || v.searchQuery != "quarterly planning" || v.searchNextPage != 0 {
+		t.Errorf("search state = active:%v query:%q next:%d", v.searchActive, v.searchQuery, v.searchNextPage)
 	}
 	if len(v.searchList.postings) != 1 || v.searchList.postings[0].ResolveTopicID() != 100 {
 		t.Errorf("search postings = %+v", v.searchList.postings)
@@ -2085,8 +2173,7 @@ func TestMailViewSearchFormSubmitsQueryAndRendersResults(t *testing.T) {
 	if strings.Contains(view, "●") {
 		t.Errorf("search result shows an unread marker without a read state: %q", view)
 	}
-	_, _, label, _ := v.SubnavItems()
-	if !strings.Contains(label, "quarterly planning") || !strings.Contains(label, "page 1") {
+	if _, _, label, _ := v.SubnavItems(); label != "Search: quarterly planning" {
 		t.Errorf("search label = %q", label)
 	}
 }
@@ -2126,7 +2213,6 @@ func TestMailViewIgnoresStaleSearchResults(t *testing.T) {
 	v.Update(searchResultsLoadedMsg{
 		requestID: 1,
 		query:     "stale",
-		page:      1,
 		postings:  []models.Posting{{ID: 99}},
 	})
 	if v.searchActive || len(v.searchList.postings) != 0 {
@@ -2134,48 +2220,64 @@ func TestMailViewIgnoresStaleSearchResults(t *testing.T) {
 	}
 }
 
-func TestMailViewSearchPagination(t *testing.T) {
-	v, recorded := mailWithTestServer(t, http.StatusNoContent)
-	v.searchActive = true
-	v.searchQuery = "quarterly planning"
-	v.searchPage = 1
-	v.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
+func TestMailViewSearchGrowsAsTheReaderScrolls(t *testing.T) {
+	var pages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages = append(pages, r.URL.Query().Get("page"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "2" {
+			_, _ = w.Write([]byte(`{"matches":[{"topic":{"id":101,"name":"Cabinet estimate"},"posting_id":11}]}`))
+			return
+		}
+		w.Header().Set("Link", `<http://`+r.Host+`/advanced_search.json?page=2>; rel="next"`)
+		_, _ = w.Write([]byte(`{"matches":[{"topic":{"id":100,"name":"Hello world"},"posting_id":10}]}`))
+	}))
+	t.Cleanup(server.Close)
 
-	next := v.HandleContentKey(keyPress("n"))
-	if next == nil {
-		t.Fatal("next page should start a request")
+	vc := testVC()
+	vc.ctx = context.Background()
+	vc.sdk = hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "test-token"}, hey.WithMaxRetries(0))
+	v := newMailView(vc)
+	v.Resize(vc.width, vc.height)
+	v.boxes = orderBoxes(testBoxes())
+
+	first := runCmd(v.requestSearch("cabinets")).(searchResultsLoadedMsg)
+	more, _ := v.Update(first)
+	if v.searchNextPage != 2 {
+		t.Fatalf("next page = %d, want 2", v.searchNextPage)
 	}
-	nextMsg := next().(searchResultsLoadedMsg)
-	v.Update(nextMsg)
-	if v.searchPage != 2 || !strings.Contains(recorded.rawQueries[len(recorded.rawQueries)-1], "page=2") {
-		t.Errorf("next page state = %d, queries = %v", v.searchPage, recorded.rawQueries)
+	if more == nil {
+		t.Fatal("results the reader can see the end of should read on")
 	}
 
-	previous := v.HandleContentKey(keyPress("p"))
-	if previous == nil {
-		t.Fatal("previous page should start a request")
+	appended := runCmd(more).(searchResultsAppendedMsg)
+	if cmd, _ := v.Update(appended); cmd != nil {
+		t.Error("a page with no next page should end the results")
 	}
-	previousMsg := previous().(searchResultsLoadedMsg)
-	v.Update(previousMsg)
-	if v.searchPage != 1 {
-		t.Errorf("previous page = %d, want 1", v.searchPage)
+	if len(v.searchList.postings) != 2 || v.searchList.postings[1].ResolveTopicID() != 101 {
+		t.Errorf("grown results = %+v", v.searchList.postings)
+	}
+	if v.searchNextPage != 0 {
+		t.Errorf("next page = %d, want none", v.searchNextPage)
+	}
+	// The first page is the one you get for asking for nothing, so only the second is named.
+	if strings.Join(pages, ",") != ",2" {
+		t.Errorf("page requests = %v", pages)
 	}
 }
 
-func TestMailViewEmptyNextSearchPagePreservesResults(t *testing.T) {
+// An empty page ends the results whatever the server says comes next, or the search would
+// ask the same question forever.
+func TestMailViewEmptySearchPageEndsTheResults(t *testing.T) {
 	v := mailWithPostings()
 	v.searchActive = true
 	v.searchQuery = "quarterly planning"
-	v.searchPage = 1
+	v.searchNextPage = 2
 	v.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100}})
-	v.activeRequestID = 3
 
-	v.Update(searchResultsLoadedMsg{requestID: 3, query: v.searchQuery, page: 2})
-	if v.searchPage != 1 || len(v.searchList.postings) != 1 {
-		t.Errorf("empty next page replaced results: page=%d postings=%v", v.searchPage, v.searchList.postings)
-	}
-	if v.notice != "No more search results" {
-		t.Errorf("notice = %q", v.notice)
+	cmd, _ := v.Update(searchResultsAppendedMsg{requestID: v.searchMoreID, query: v.searchQuery, nextPage: 3})
+	if cmd != nil || v.searchNextPage != 0 || len(v.searchList.postings) != 1 {
+		t.Errorf("empty page = next:%d postings:%v", v.searchNextPage, v.searchList.postings)
 	}
 }
 
@@ -2183,7 +2285,6 @@ func TestMailViewCancelPendingSearchResultPreservesResults(t *testing.T) {
 	v := mailWithPostings()
 	v.searchActive = true
 	v.searchQuery = "quarterly planning"
-	v.searchPage = 1
 	v.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
 
 	if cmd := v.HandleContentKey(keyPress("enter")); cmd == nil {
@@ -2193,7 +2294,7 @@ func TestMailViewCancelPendingSearchResultPreservesResults(t *testing.T) {
 		t.Fatalf("request state = kind:%d loading:%v", v.activeRequestKind, v.loading)
 	}
 	v.ExitThread()
-	if !v.searchActive || v.searchQuery != "quarterly planning" || v.searchPage != 1 || len(v.searchList.postings) != 1 {
+	if !v.searchActive || v.searchQuery != "quarterly planning" || len(v.searchList.postings) != 1 {
 		t.Error("canceling a pending searched thread should preserve search results")
 	}
 	if v.loading || v.activeRequestKind != mailRequestNone {
@@ -2205,7 +2306,6 @@ func TestMailViewSearchResultOpensThreadAndReturnsToResults(t *testing.T) {
 	v, _ := mailWithTestServer(t, http.StatusNoContent)
 	v.searchActive = true
 	v.searchQuery = "quarterly planning"
-	v.searchPage = 1
 	v.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
 
 	open := v.HandleContentKey(keyPress("enter"))
@@ -2267,29 +2367,25 @@ func TestMailViewHelpBindings(t *testing.T) {
 	}
 }
 
-func TestMailViewLabelHelpUsesPOnlyForPreviousPage(t *testing.T) {
+// A label scrolls rather than paging, so it advertises no page keys and p keeps meaning
+// paper trail.
+func TestMailViewLabelHelpOffersNoPageKeys(t *testing.T) {
 	v := mailWithPostings()
 	v.boxes = append(v.boxes, models.Box{ID: 12, Kind: mailSourceKindFolder, Name: "Receipts"})
 	v.boxIndex = len(v.boxes) - 1
+	v.postingPaging.nextPage = "next-cursor"
 
+	var paperTrail int
 	for _, binding := range v.HelpBindings() {
-		if binding.key == "p" {
-			t.Errorf("first label page advertised p binding: %+v", binding)
-		}
-	}
-
-	v.folderPageHistory = []string{""}
-	var previous, paperTrail int
-	for _, binding := range v.HelpBindings() {
-		if binding.key == "p" && binding.desc == "previous page" {
-			previous++
+		if binding.desc == "next page" || binding.desc == "previous page" {
+			t.Errorf("label advertised a page binding: %+v", binding)
 		}
 		if binding.key == "p" && binding.desc == "paper trail" {
 			paperTrail++
 		}
 	}
-	if previous != 1 || paperTrail != 0 {
-		t.Errorf("label p bindings = previous:%d paper-trail:%d; all=%v", previous, paperTrail, v.HelpBindings())
+	if paperTrail != 1 {
+		t.Errorf("label p bindings = paper-trail:%d; all=%v", paperTrail, v.HelpBindings())
 	}
 }
 
@@ -2343,9 +2439,15 @@ func TestMailViewHelpBindingsInSearchResults(t *testing.T) {
 	for _, binding := range bindings {
 		keys[binding.key] = true
 	}
-	for _, expected := range []string{"enter", "/", "n", "p"} {
+	for _, expected := range []string{"enter", "/"} {
 		if !keys[expected] {
 			t.Errorf("search results missing help binding %q: %v", expected, bindings)
+		}
+	}
+	// Results scroll on rather than paging, so there are no page keys to advertise.
+	for _, gone := range []string{"n", "p"} {
+		if keys[gone] {
+			t.Errorf("search results advertised a page binding %q: %v", gone, bindings)
 		}
 	}
 }

--- a/internal/tui/screener.go
+++ b/internal/tui/screener.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -16,27 +15,38 @@ import (
 
 type screenerPendingLoadedMsg struct {
 	requestID uint64
-	page      int
 	rows      []screenerRow
 	count     int
+	nextPage  string
 	err       error
 }
 
-// screenerPendingRefreshedMsg is the queue read again after someone arrived in or left
-// The Screener while it was open. Its own lane, so it can never be taken for a page the
-// user asked for, and the rows land under the cursor rather than replacing it.
+// screenerPendingRefreshedMsg is the top of the queue read again after someone arrived in
+// or left The Screener while it was open. Its own lane, so it can never be taken for a
+// page the user asked for, and the rows land under the cursor rather than replacing it.
 type screenerPendingRefreshedMsg struct {
 	requestID uint64
-	page      int
 	rows      []screenerRow
 	count     int
+	nextPage  string
 	err       error
 }
 
 type screenerScreenedLoadedMsg struct {
 	requestID uint64
-	page      int
 	rows      []screenerRow
+	nextPage  string
+	err       error
+}
+
+// screenerRowsAppendedMsg is the page below the one on screen in either pane, read because
+// the reader scrolled towards the bottom of it. count is only answered for the queue.
+type screenerRowsAppendedMsg struct {
+	requestID uint64
+	tab       screenerTab
+	rows      []screenerRow
+	count     int
+	nextPage  string
 	err       error
 }
 
@@ -80,29 +90,68 @@ type screenerPane struct {
 	rows   []screenerRow
 	cursor int
 	scroll int
-	page   int
+	paging listPaging
 	loaded bool
 }
 
-func (p *screenerPane) setRows(rows []screenerRow, page int) {
+func (p *screenerPane) setRows(rows []screenerRow, nextPage string) {
 	p.rows = rows
 	p.cursor = 0
 	p.scroll = 0
-	p.page = page
 	p.loaded = true
+	p.paging.read(screenerRowIDs(rows), nextPage)
 }
 
-// refreshRows replaces the rows with a newly read page while someone is working through
-// it: the cursor stays on the sender it was on, and the window stays where it was. A
-// sender who has been dealt with elsewhere takes the cursor with them.
-func (p *screenerPane) refreshRows(rows []screenerRow, page int) {
+// growRows adds the page below the one at the bottom of the pane, skipping anyone it
+// already shows: a sender whose place in the ordering changed between two reads would
+// otherwise turn up twice.
+func (p *screenerPane) growRows(more []screenerRow, nextPage string) {
+	grown := p.rows
+	shown := screenerRowIDs(p.rows)
+	for _, row := range more {
+		if _, alreadyShown := shown[row.id]; !alreadyShown {
+			grown = append(grown, row)
+		}
+	}
+	p.keepPlaceIn(grown)
+	p.paging.grew(len(more), nextPage)
+}
+
+// refreshHead replaces the top page of the pane with a newly read one and leaves the pages
+// below it as they were read. A sender who has left the top page goes with it rather than
+// sinking into the rows underneath.
+func (p *screenerPane) refreshHead(head []screenerRow, nextPage string) {
+	fresh := screenerRowIDs(head)
+	refreshed := append([]screenerRow(nil), head...)
+	for _, row := range p.rows {
+		_, wasInHead := p.paging.headIDs[row.id]
+		_, isInHead := fresh[row.id]
+		if !wasInHead && !isInHead {
+			refreshed = append(refreshed, row)
+		}
+	}
+	p.keepPlaceIn(refreshed)
+	p.paging.refreshed(fresh, nextPage)
+}
+
+func screenerRowIDs(rows []screenerRow) map[int64]struct{} {
+	ids := make(map[int64]struct{}, len(rows))
+	for _, row := range rows {
+		ids[row.id] = struct{}{}
+	}
+	return ids
+}
+
+// keepPlaceIn puts the pane on a newly assembled set of rows while someone is working
+// through it: the cursor stays on the sender it was on, and the window stays where it was.
+// A sender who has been dealt with elsewhere takes the cursor with them.
+func (p *screenerPane) keepPlaceIn(rows []screenerRow) {
 	var cursorID int64
 	if row := p.selected(); row != nil {
 		cursorID = row.id
 	}
 
 	p.rows = rows
-	p.page = page
 	p.loaded = true
 	p.cursor = 0
 	for index := range p.rows {
@@ -175,6 +224,7 @@ type screenerView struct {
 	loading         bool
 	requestID       uint64
 	liveRequestID   uint64 // identifies the only live re-read allowed to update the queue
+	moreRequestID   uint64 // identifies the only page-below read allowed to grow a pane
 	mutations       int
 }
 
@@ -186,7 +236,7 @@ func (v *screenerView) Init() tea.Cmd {
 	v.notice = ""
 	v.confirmingClear = false
 	v.tab = screenerPendingTab
-	return v.requestPending(1)
+	return v.requestPending()
 }
 
 // Restyle is a no-op: the screener keeps plain rows and styles them on every View.
@@ -203,13 +253,9 @@ func (v *screenerView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			v.notice = "Could not load The Screener: " + msg.err.Error()
 			return nil, true
 		}
-		if len(msg.rows) == 0 && msg.page > v.pending.page {
-			v.notice = "No more senders waiting"
-			return nil, true
-		}
 		v.pendingCount = msg.count
-		v.pending.setRows(msg.rows, msg.page)
-		return nil, true
+		v.pending.setRows(msg.rows, msg.nextPage)
+		return v.loadMoreRows(), true
 
 	case screenerPendingRefreshedMsg:
 		if msg.requestID != v.liveRequestID || v.tab != screenerPendingTab {
@@ -220,7 +266,7 @@ func (v *screenerView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			return nil, true
 		}
 		v.pendingCount = msg.count
-		v.pending.refreshRows(msg.rows, msg.page)
+		v.pending.refreshHead(msg.rows, msg.nextPage)
 		v.pending.ensureVisible(v.visibleRows())
 		return nil, true
 
@@ -233,12 +279,24 @@ func (v *screenerView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			v.notice = "Could not load Screener History: " + msg.err.Error()
 			return nil, true
 		}
-		if len(msg.rows) == 0 && msg.page > v.history.page {
-			v.notice = "No more decisions"
+		v.history.setRows(msg.rows, msg.nextPage)
+		return v.loadMoreRows(), true
+
+	case screenerRowsAppendedMsg:
+		if msg.requestID != v.moreRequestID || msg.tab != v.tab {
 			return nil, true
 		}
-		v.history.setRows(msg.rows, msg.page)
-		return nil, true
+		pane := v.pane()
+		pane.paging.loading = false
+		if msg.err != nil {
+			v.notice = "Could not load more senders: " + msg.err.Error()
+			return nil, true
+		}
+		if msg.tab == screenerPendingTab {
+			v.pendingCount = msg.count
+		}
+		pane.growRows(msg.rows, msg.nextPage)
+		return v.loadMoreRows(), true
 
 	case screenerDecisionDoneMsg:
 		if v.mutations > 0 {
@@ -252,7 +310,9 @@ func (v *screenerView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.pendingCount = max(v.pendingCount-1, 0)
 		v.history.loaded = false
 		v.notice = msg.name + " " + screenedVerb(msg.status)
-		return nil, true
+		// A sender being dealt with can uncover the bottom of the queue, so the senders
+		// behind them come up rather than leaving an empty pane with a count over it.
+		return v.loadMoreRows(), true
 
 	case screenerClearedMsg:
 		if v.mutations > 0 {
@@ -262,7 +322,7 @@ func (v *screenerView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			v.notice = "Could not clear The Screener: " + msg.err.Error()
 			return nil, true
 		}
-		v.pending.setRows(nil, 1)
+		v.pending.setRows(nil, "")
 		v.pendingCount = 0
 		v.notice = "The Screener is clearing. Everyone waiting will be asked about again on their next email."
 		return nil, true
@@ -287,8 +347,8 @@ func (v *screenerView) View() string {
 		return b.String()
 	}
 	b.WriteString(renderScreenerRows(pane, v.visibleRows(), v.vc.width))
-	if pane.page > 1 {
-		b.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Render(fmt.Sprintf("  Page %d", pane.page)))
+	if pane.paging.loading {
+		b.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Render("  Loading more…"))
 	}
 	return b.String()
 }
@@ -316,13 +376,6 @@ func (v *screenerView) HelpBindings() []helpBinding {
 		bindings = append(bindings, helpBinding{"tab", "the screener"})
 	}
 	bindings = append(bindings, helpBinding{"X", "clear all"})
-	pane := v.pane()
-	if len(pane.rows) > 0 {
-		bindings = append(bindings, helpBinding{"]", "next page"})
-	}
-	if pane.page > 1 {
-		bindings = append(bindings, helpBinding{"[", "previous page"})
-	}
 	return append(bindings, helpBinding{"esc/q", "back to mail"})
 }
 
@@ -355,7 +408,7 @@ func (v *screenerView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		return nil
 	case tea.KeyDown:
 		v.pane().moveDown(v.visibleRows())
-		return nil
+		return v.loadMoreRows()
 	}
 
 	switch key {
@@ -365,6 +418,7 @@ func (v *screenerView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		v.pane().moveUp(v.visibleRows())
 	case "j":
 		v.pane().moveDown(v.visibleRows())
+		return v.loadMoreRows()
 	case "y", "i":
 		return v.screen(hey.ClearanceApproved)
 	case "n":
@@ -372,12 +426,6 @@ func (v *screenerView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "X":
 		v.confirmingClear = true
 		v.notice = ""
-	case "]":
-		return v.requestPage(v.pane().page + 1)
-	case "[":
-		if v.pane().page > 1 {
-			return v.requestPage(v.pane().page - 1)
-		}
 	}
 	return nil
 }
@@ -415,20 +463,36 @@ func (v *screenerView) switchTab(tab screenerTab) tea.Cmd {
 	if v.pane().loaded {
 		return nil
 	}
-	return v.requestPage(1)
-}
-
-func (v *screenerView) requestPage(page int) tea.Cmd {
 	if v.tab == screenerHistoryTab {
-		return v.requestScreened(page)
+		return v.requestScreened()
 	}
-	return v.requestPending(page)
+	return v.requestPending()
 }
 
-func (v *screenerView) requestPending(page int) tea.Cmd {
+func (v *screenerView) requestPending() tea.Cmd {
 	v.requestID++
+	v.moreRequestID++
 	v.loading = true
-	return v.fetchPending(v.requestID, max(page, 1))
+	v.pending.paging.reset()
+	return v.fetchPending(v.requestID)
+}
+
+// loadMoreRows reads the page below the one the reader has scrolled to in the pane they are
+// in, or the one below a pane whose end they can already see. One page is asked for at a
+// time, in its own lane: the rows already on screen are what they are working through.
+func (v *screenerView) loadMoreRows() tea.Cmd {
+	pane := v.pane()
+	if pane.paging.loading || !pane.paging.hasMore() {
+		return nil
+	}
+	rowsBelow := len(pane.rows)-pane.scroll > v.visibleRows()
+	if rowsBelow && len(pane.rows)-pane.cursor > loadMoreThreshold {
+		return nil
+	}
+
+	pane.paging.loading = true
+	v.moreRequestID++
+	return v.fetchMoreRows(v.moreRequestID, v.tab, pane.paging.nextPage)
 }
 
 // refreshPending is what the doorbell asks of The Screener: read the queue again under
@@ -445,13 +509,15 @@ func (v *screenerView) refreshPending() (cmd tea.Cmd, held bool) {
 	}
 
 	v.liveRequestID++
-	return v.fetchPendingRefresh(v.liveRequestID, max(v.pending.page, 1)), false
+	return v.fetchPendingRefresh(v.liveRequestID), false
 }
 
-func (v *screenerView) requestScreened(page int) tea.Cmd {
+func (v *screenerView) requestScreened() tea.Cmd {
 	v.requestID++
+	v.moreRequestID++
 	v.loading = true
-	return v.fetchScreened(v.requestID, max(page, 1))
+	v.history.paging.reset()
+	return v.fetchScreened(v.requestID)
 }
 
 func (v *screenerView) screen(status string) tea.Cmd {
@@ -540,54 +606,65 @@ func (v *screenerView) clearConfirmationView() string {
 
 // --- Fetch commands ---
 
-func (v *screenerView) fetchPending(requestID uint64, page int) tea.Cmd {
+func (v *screenerView) fetchPending(requestID uint64) tea.Cmd {
 	return func() tea.Msg {
-		summary, err := v.vc.sdk.Clearances().Pending(v.vc.ctx, strconv.Itoa(page))
-		if err != nil {
-			return screenerPendingLoadedMsg{requestID: requestID, page: page, err: err}
-		}
-		message := screenerPendingLoadedMsg{requestID: requestID, page: page}
-		if summary != nil {
-			message.count = int(summary.PendingClearancesCount)
-			for _, clearance := range summary.Clearances {
-				message.rows = append(message.rows, pendingScreenerRow(clearance))
-			}
+		rows, count, nextPage, err := v.readPendingPage("")
+		return screenerPendingLoadedMsg{requestID: requestID, rows: rows, count: count, nextPage: nextPage, err: err}
+	}
+}
+
+// fetchPendingRefresh reads the top of the queue in the live lane and without the spinner:
+// nobody is waiting on it.
+func (v *screenerView) fetchPendingRefresh(requestID uint64) tea.Cmd {
+	return func() tea.Msg {
+		rows, count, nextPage, err := v.readPendingPage("")
+		return screenerPendingRefreshedMsg{requestID: requestID, rows: rows, count: count, nextPage: nextPage, err: err}
+	}
+}
+
+func (v *screenerView) fetchScreened(requestID uint64) tea.Cmd {
+	return func() tea.Msg {
+		rows, nextPage, err := v.readScreenedPage("")
+		return screenerScreenedLoadedMsg{requestID: requestID, rows: rows, nextPage: nextPage, err: err}
+	}
+}
+
+// fetchMoreRows reads the page below whichever pane the reader is in, in the growing lane
+// and without the spinner.
+func (v *screenerView) fetchMoreRows(requestID uint64, tab screenerTab, page string) tea.Cmd {
+	return func() tea.Msg {
+		message := screenerRowsAppendedMsg{requestID: requestID, tab: tab}
+		if tab == screenerHistoryTab {
+			message.rows, message.nextPage, message.err = v.readScreenedPage(page)
+		} else {
+			message.rows, message.count, message.nextPage, message.err = v.readPendingPage(page)
 		}
 		return message
 	}
 }
 
-// fetchPendingRefresh reads the same page fetchPending reads, in the live lane and
-// without the spinner: nobody is waiting on it.
-func (v *screenerView) fetchPendingRefresh(requestID uint64, page int) tea.Cmd {
-	return func() tea.Msg {
-		summary, err := v.vc.sdk.Clearances().Pending(v.vc.ctx, strconv.Itoa(page))
-		if err != nil {
-			return screenerPendingRefreshedMsg{requestID: requestID, page: page, err: err}
-		}
-		message := screenerPendingRefreshedMsg{requestID: requestID, page: page}
-		if summary != nil {
-			message.count = int(summary.PendingClearancesCount)
-			for _, clearance := range summary.Clearances {
-				message.rows = append(message.rows, pendingScreenerRow(clearance))
-			}
-		}
-		return message
+func (v *screenerView) readPendingPage(page string) ([]screenerRow, int, string, error) {
+	result, err := v.vc.sdk.Clearances().PendingPage(v.vc.ctx, page)
+	if err != nil || result == nil {
+		return nil, 0, "", err
 	}
+	rows := make([]screenerRow, 0, len(result.Clearances))
+	for _, clearance := range result.Clearances {
+		rows = append(rows, pendingScreenerRow(clearance))
+	}
+	return rows, result.PendingCount, result.NextPage, nil
 }
 
-func (v *screenerView) fetchScreened(requestID uint64, page int) tea.Cmd {
-	return func() tea.Msg {
-		clearances, err := v.vc.sdk.Clearances().Screened(v.vc.ctx, strconv.Itoa(page))
-		if err != nil {
-			return screenerScreenedLoadedMsg{requestID: requestID, page: page, err: err}
-		}
-		message := screenerScreenedLoadedMsg{requestID: requestID, page: page}
-		for _, clearance := range clearances {
-			message.rows = append(message.rows, screenedScreenerRow(clearance))
-		}
-		return message
+func (v *screenerView) readScreenedPage(page string) ([]screenerRow, string, error) {
+	result, err := v.vc.sdk.Clearances().ScreenedPage(v.vc.ctx, page)
+	if err != nil || result == nil {
+		return nil, "", err
 	}
+	rows := make([]screenerRow, 0, len(result.Clearances))
+	for _, clearance := range result.Clearances {
+		rows = append(rows, screenedScreenerRow(clearance))
+	}
+	return rows, result.NextPage, nil
 }
 
 // --- Rendering ---

--- a/internal/tui/screener_test.go
+++ b/internal/tui/screener_test.go
@@ -332,23 +332,70 @@ func TestScreenerOffersClearOnBothPanes(t *testing.T) {
 	}
 }
 
-// --- Pagination ---
+// --- Growing the queue ---
 
-func TestScreenerKeepsQueueWhenNextPageIsEmpty(t *testing.T) {
-	view, state := loadedScreener(t)
-	state.pending = `{"pending_clearances_count":2,"clearances":[]}`
+func TestScreenerGrowsTheQueueAsTheReaderScrolls(t *testing.T) {
+	var pages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages = append(pages, r.URL.Query().Get("page"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "cursor-2" {
+			_, _ = w.Write([]byte(`{"pending_clearances_count":3,"clearances":[
+				{"id":93,"status":"pending","petitioner":{"id":13,"name":"Ann Wu"}}]}`))
+			return
+		}
+		w.Header().Set("Link", `<http://`+r.Host+`/clearances.json?page=cursor-2>; rel="next"`)
+		_, _ = w.Write([]byte(`{"pending_clearances_count":3,"clearances":[
+			{"id":91,"status":"pending","petitioner":{"id":11,"name":"Jane Doe"}},
+			{"id":92,"status":"pending","petitioner":{"id":12,"name":"Bob Smith"}}]}`))
+	}))
+	t.Cleanup(server.Close)
 
-	loaded := runCmd(view.HandleContentKey(keyPress("]"))).(screenerPendingLoadedMsg)
-	if loaded.page != 2 {
-		t.Fatalf("next page = %d, want 2", loaded.page)
+	vc := testVC()
+	vc.ctx = context.Background()
+	vc.sdk = hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "t"}, hey.WithMaxRetries(0))
+	view := newScreenerView(vc)
+
+	loaded := runCmd(view.Init()).(screenerPendingLoadedMsg)
+	more, _ := view.Update(loaded)
+	if more == nil {
+		t.Fatal("a queue the reader can see the end of should read on")
 	}
-	view.Update(loaded)
 
-	if len(view.pending.rows) != 2 || view.notice != "No more senders waiting" {
-		t.Errorf("empty next page = rows:%d notice:%q", len(view.pending.rows), view.notice)
+	appended := runCmd(more).(screenerRowsAppendedMsg)
+	if cmd, _ := view.Update(appended); cmd != nil {
+		t.Error("a page with no next cursor should end the queue")
 	}
-	if requests := state.snapshot(); !strings.Contains(requests[len(requests)-1].query, "page=2") {
-		t.Errorf("page request = %+v", requests[len(requests)-1])
+	if len(view.pending.rows) != 3 || view.pending.rows[2].name != "Ann Wu" {
+		t.Errorf("grown queue = %+v", view.pending.rows)
+	}
+	if view.pending.paging.hasMore() {
+		t.Errorf("next page = %q, want none", view.pending.paging.nextPage)
+	}
+	if strings.Join(pages, ",") != ",cursor-2" {
+		t.Errorf("page requests = %v", pages)
+	}
+}
+
+// A sender the queue shows already is not shown twice when the page below turns them up
+// again, which is what happens when someone else's decision shifts the ordering between
+// two reads.
+func TestScreenerGrowingSkipsSendersAlreadyShown(t *testing.T) {
+	view, _ := loadedScreener(t)
+	view.pending.paging.nextPage = "cursor-2"
+
+	view.Update(screenerRowsAppendedMsg{
+		requestID: view.moreRequestID,
+		tab:       screenerPendingTab,
+		count:     3,
+		rows: []screenerRow{
+			{id: 92, name: "Bob Smith"},
+			{id: 93, name: "Ann Wu"},
+		},
+	})
+
+	if len(view.pending.rows) != 3 || view.pending.rows[2].id != 93 {
+		t.Errorf("grown queue = %+v", view.pending.rows)
 	}
 }
 
@@ -456,7 +503,6 @@ func TestModelRoutesScreenerKeysToTheScreener(t *testing.T) {
 	m = updated.(model)
 	m.screenerView.Update(screenerPendingLoadedMsg{
 		requestID: m.screenerView.requestID,
-		page:      1,
 		count:     1,
 		rows:      []screenerRow{{id: 91, name: "Jane Doe", detail: "Quarterly planning"}},
 	})

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -464,7 +464,6 @@ func TestEscCancelsPendingSearchResultAndPreservesResults(t *testing.T) {
 	m := modelWithBoxes()
 	m.mailView.searchActive = true
 	m.mailView.searchQuery = "quarterly planning"
-	m.mailView.searchPage = 1
 	m.mailView.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
 	m.mailView.requestTopic(m.mailView.currentBoxID(), 100, 10, "Hello world")
 	m.loading = true
@@ -483,7 +482,6 @@ func TestQExitsSearchDuringPendingResult(t *testing.T) {
 	m := modelWithBoxes()
 	m.mailView.searchActive = true
 	m.mailView.searchQuery = "quarterly planning"
-	m.mailView.searchPage = 1
 	m.mailView.searchList.setPostings([]models.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
 	m.mailView.requestTopic(m.mailView.currentBoxID(), 100, 10, "Hello world")
 	m.loading = true

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-2/hjp9RDsDGGHqj6Bxo6n+N6nczCKyZhOI+S3fEIAjw=";
+  vendorHash = "sha256-07s2Vbpxw6RguJ6iiUSBUtCGrqTPx0vdNxzN4F3czCE=";
 
   subPackages = [ "cmd/hey" ];
 


### PR DESCRIPTION
Boxes read one page and stopped there. Labels and collections paged with `n` and `p`. The Screener paged with `[` and `]`. Search paged with `n` and `p` again, and told you "No more search results" once you'd walked off the end. Four lists, three sets of page keys, and a reader who just wanted the next twenty threads had to know which list they were in.

Now every one of them reads one page and grows downwards as you scroll. No page keys, no page numbers, no notices about running out — the list carries on, and stops when the server has nothing left.

| | before | now |
| --- | --- | --- |
| Imbox, Feed, Paper Trail, Set Aside, Reply Later, Bubbled Up | one page, that's all you got | grows |
| Labels, collections | `n` / `p` | grows |
| Search results | `n` / `p` | grows |
| The Screener, Screener History | `[` / `]` | grows |

The cursor coming within `loadMoreThreshold` of the bottom reads the page below, and so does a list whose end is already on screen — so a first page too short to fill the window keeps reading until it does, and a thread leaving the list (trashed, screened, moved) pulls up what was under it.

### The live re-read is the awkward part

It reads the box's **top** page, because that's where a change shows up, so it may only replace that much of a list that has grown past it. `contentList.refreshHead` splices the fresh page in front of the rows below it, and `listPaging.headIDs` — what the top page held last time — is how a thread that has left the top page leaves the list with it, rather than sinking below the fresh rows. Everything deeper stays as it was read until `ctrl+r` reads the list from the top again. The cursor for what comes next belongs to the deepest page, so re-reading the top only moves it while the top page is the whole list.

Three request lanes now instead of two — the read the user asked for, the page below, and the live re-read — each with its own id and message. Growing a list never shows the spinner, never cancels the read the reader is waiting on, and never carries the cursor back to the top.

### Odds and ends

- `listPaging` holds the next cursor, and an empty page ends a list whatever cursor came with it, so a server that keeps answering one can't put us in a loop.
- Search is the exception to the cursor: `Search::Matches::Page` in haystack is a shim over geared's page rather than the real thing and it numbers its pages, so the results carry a `searchNextPage int`. Nothing to keep a `headIDs` for either — results are never re-read live.
- `p` means paper trail everywhere now that it isn't previous-page on a label.
- The subnav says `Imbox · loading more…` while a page is in flight.
- AGENTS.md gets a "Lists grow as the reader scrolls" section; README's key docs are updated.

### Dependencies

Needs **SDK 0.10.0** ([hey-sdk#102](https://github.com/basecamp/hey-sdk/pull/102), released): box, Screener and search reads threw away the `Link` header, so there was no way to know a list had ended. Pinned here, no `replace` directive.

`nix/package.nix`'s `vendorHash` is updated for the new go.sum and verified — `make update-nix-hash` built it green in Docker.

### Checks

`make check` exits 0: fmt, vet, lint, unit tests, tidy, CLI surface snapshot and release lockstep. Smoke tests not run — they need a dev server.
