### PR TITLE
Cover the Imbox's Previously Seen with art

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ All data-access commands call `requireAuth()` before making API calls. Auth subc
 
 ### State storage
 
-Configuration (base URL only) is stored in `~/.config/hey-cli/config.json`. Credentials are stored in the system keyring (service name: `hey`) with automatic fallback to `~/.config/hey-cli/credentials.json` when the keyring is unavailable. Set `HEY_NO_KEYRING=1` to force file storage.
+Configuration (the base URL, the default linked account, and the Imbox's cover) is stored in `~/.config/hey-cli/config.json`. Credentials are stored in the system keyring (service name: `hey`) with automatic fallback to `~/.config/hey-cli/credentials.json` when the keyring is unavailable. Set `HEY_NO_KEYRING=1` to force file storage.
 
 ### CLI
 
@@ -261,13 +261,22 @@ that is haystack's rule (`Box::Imbox#coverable?`), and it is the same box that g
 seen sections at all.
 
 `ctrl+v` opens `coverPicker`, which draws whichever preset is highlighted — a cover is
-picked by looking at it. The choice lives on `mailView.cover` and lasts the session, and
-that is not laziness: `boxes/_box.jbuilder` does not serve `cover`, so the SDK cannot carry
-it and there is nothing to read a cover back from. Persisting a local choice would only
-compete with the real one once HEY starts serving it. Serving the preset name (and, for
-uploads, a blob URL) is a five-line haystack change; then the picker seeds from the box and
-writes back to it. An uploaded cover has no honest character version — that one wants the
-Kitty path in `kitty.go`.
+picked by looking at it. The choice is stored locally, by `config.Cover` and
+`config.SaveCover`, reached through the `loadCover` and `saveCover` seams on the view
+context so the TUI does not depend on where it lives. A failed write is a notice, not a
+refusal: the cover is on screen either way and all that is lost is remembering it.
+
+**Local storage is the deliberate answer here, not a stopgap.** haystack does keep a cover
+per box, in a `box_covers` table with a real `preset_image` column — but it serves it to
+nobody. There is no `cover` in any jbuilder, and both native apps went their own way rather
+than wait for one: `CoverArtPersistenceManager` on iOS keeps the choice in `Preferences`,
+`CoverArtRepository` on Android keeps it in `CachePrefs`, each with its own numbered presets
+and bundled assets, neither ever asking the server. So a cover set here does not show up on
+the web, and that is true of every HEY client. Before adding a read of `box_covers`, work
+out why two mobile teams decided against it.
+
+An uploaded cover has no honest character version — that one wants the Kitty path in
+`kitty.go`.
 
 The help bar puts chorded keys last, via `modifiersLast`. The single-key bindings are what
 a reader reaches for while working through mail; a `ctrl+` chord in the middle of them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,11 +216,27 @@ line: a circle that does not fit is a pair of brackets. Pin both with a test ove
 of aspect ratios — it is much cheaper than looking.
 
 A painter writes glyphs into a `coverCanvas` and the field is whatever it leaves blank,
-which is why a colorless terminal still gets the art instead of an empty band. This is
-also the one place the TUI paints brand hex instead of the ANSI slots `styles.go` insists
-on — the art *is* HEY's yellow and mint, and a theme-tinted terrazzo would be worse than
-one that ignores the theme. `applyTheme` sets the two things a cover reads: which of the
-two palettes to use, and whether to paint at all.
+which is why a colorless terminal still gets the art instead of an empty band. The colors
+are the ANSI-16 slots, for the reason `styles.go` gives: a desktop theme defines those
+sixteen and retints running terminals over OSC 4, so a cover wears the reader's palette
+and restyles live on a theme switch without anything here being told. HEY's own covers are
+yellow and mint and violet; `coverPalettes` names the slots those stand in for. Do not put
+hex back — a cover in HEY's colors on someone's gruvbox is the one thing that will look
+wrong on every theme but one.
+
+**There is one palette per preset, not a light one and a dark one**, even though the web
+app needs both. Pick each slot for the job it does in a theme rather than for how bright it
+happens to be, and the light-versus-dark question stops being asked. `Black` is the
+background and `White` the foreground in *every* theme, so a field of `Black` is the
+reader's own paper and foreground ink is legible on it either way — that is why HEY's white
+terrazzo chips correctly turn black in light mode without a light palette existing. Hues
+are mid-tones everywhere, so a hue on a hue holds its contrast too.
+
+Choosing a slot for its brightness is the trap, and it fails in the direction that is
+hardest to notice: a light-mode field painted `BrightWhite` comes out *dark*, because on a
+light theme the bright foreground is a dark color. The cover is then inverted on exactly
+the themes the light palette was added to fix. `TestCoversDoNotDependOnTheThemeMode` is
+there to catch it — flipping `Theme.Dark` must not change a single byte of what is drawn.
 
 Everything is deterministic: the scatter and the noise come from a cell's own hash, so a
 cover is the same picture every time, the way the web app's asset is. `coverRenderer`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ section: ctrl+s from the mail list swaps it in as the active view, it captures e
 while it is open, and it asks to be closed again with `screenerClosedMsg`.
 The rest of `internal/tui/` is shared infrastructure: `tui.go` (model and
 router), `section_view.go` (the interface), plus `nav.go`, `content.go`, `help.go`,
-`styles.go`, `loading.go`, `kitty.go`, `html.go`, `live.go` and `calendar_views.go`. Read the directory rather than a
+`styles.go`, `loading.go`, `kitty.go`, `html.go`, `live.go`, `covers.go` and `calendar_views.go`. Read the directory rather than a
 table here.
 
 To add a new section: implement the `sectionView` interface in a new file, add a field and constructor call in `newModel`, and add a case in `switchSection`.
@@ -158,6 +158,97 @@ A read the user asked for, a page below, and a live re-read are separate lanes
 (`activeRequestID`, `moreRequestID` — `searchMoreID` for the results — and `liveRequestID`)
 with a message each, so growing a list never shows the spinner, never cancels the read the
 reader is waiting on, and never carries the cursor back to the top.
+### Imbox cover art
+
+A cover is a lid over Previously Seen, not a decoration next to it. When the Imbox is
+covered the threads the reader has already read are not drawn at all — the box ends at
+what still wants attention — and the art fills the list to the bottom of the screen. That
+is the whole point of the feature in the web app, and it is why `hey`'s version hides
+rather than merely paints.
+
+`internal/tui/covers.go` draws the art. HEY's covers are SVG assets
+(`box-covers/{light,dark}/*.svg` in haystack) and a terminal cannot draw an SVG, so these
+are the same six patterns — blobs, grid, peace, terrazzo, topo, waves — drawn as
+characters. That is not a fallback: a blueprint grid is what box-drawing characters are
+for.
+
+**Curves go in braille.** A `brailleLayer` is a dot grid at 2×4 the resolution of the
+canvas, with `arc` and `ellipse` on it, folded into cells by `drawInto`. `paintTopo` draws
+contours into one; `paintPeace` draws HEY's hand — the two fingers up in a V over a fist,
+which is what the "peace" cover is, not the CND symbol. The dots are square, incidentally:
+a cell is about twice as tall as it is wide and the 2×4 split cancels that exactly, so
+nothing drawn there needs aspect correction. Reach for braille whenever a pattern wants a
+curve, because the cell grid cannot hold one: those same contours in box-drawing characters
+are cell-wide staircases that read as noise, and the hand as five cells of line art read,
+accurately, as a broken television.
+
+Drawing a mark this small is mostly subtraction, and `peaceHand` is worth reading before
+attempting another one. Three things it took several tries to get right:
+
+- **One shape means one outline, and that means a union, not butted arcs.** `silhouette`
+  fills the union of some ellipses and keeps the dots with a neighbor outside it, so the
+  palm, the fingers and the thumb come out as a single continuous stroke around the whole
+  hand. Drawing them as arcs cut to meet each other does not work: the ends never quite
+  land on one another, so the joins show as notches and tails, and every arc that crosses
+  another leaves its own line running through the inside of the shape. The thumb's loop is
+  drawn back over the silhouette afterwards, and is the only interior line the mark has.
+- **A finger pivots about its base, not its center.** Leaning an ellipse about its center
+  swings the base sideways, so each finger's base crosses to the other's side and the loops
+  cross halfway up. The mark then reads, unmistakably, as a rabbit seen from behind.
+- **Four outlines is the ceiling.** The curled fingers belong on the left of a drawn hand
+  and were tried twice, as small ovals and as arcs following the palm; both came out as
+  blobs and took the palm down with them. The V is what carries the mark.
+
+Two traps a new pattern will walk into:
+
+**No emoji codepoints, however apt.** A color font ignores the foreground color it is
+handed, so the glyph arrives in its own colors — U+270C on HEY's yellow came out a muddy
+yellow hand — and it can measure one cell while occupying two. A text presentation
+selector is not reliable protection. Draw the shape instead.
+
+**Scale every dimension with the block, then check the extremes.** A cover is anywhere from
+40×6 to 300×90, so a constant tuned at one size is a constant that only looks right there.
+`blobRibbonShape` is the worked example: the amplitude follows the height, and the
+wavelength takes whichever is larger of a quarter of the width and whatever the amplitude
+needs to stay under `maxBlobSlope`. Scaling by height alone drew chevrons on a tall cover;
+by width alone, a busy repeat on a wide short one. `peaceRadius` is the same lesson in one
+line: a circle that does not fit is a pair of brackets. Pin both with a test over a spread
+of aspect ratios — it is much cheaper than looking.
+
+A painter writes glyphs into a `coverCanvas` and the field is whatever it leaves blank,
+which is why a colorless terminal still gets the art instead of an empty band. This is
+also the one place the TUI paints brand hex instead of the ANSI slots `styles.go` insists
+on — the art *is* HEY's yellow and mint, and a theme-tinted terrazzo would be worse than
+one that ignores the theme. `applyTheme` sets the two things a cover reads: which of the
+two palettes to use, and whether to paint at all.
+
+Everything is deterministic: the scatter and the noise come from a cell's own hash, so a
+cover is the same picture every time, the way the web app's asset is. `coverRenderer`
+memoizes the last one it drew, because the posting list re-renders on every keystroke and
+a cover is a thousand styled cells. Its memo key includes the palette, so a theme switch
+repaints.
+
+What the lid costs the list is in `contentList`. `coveredFrom` is the index the cover
+starts at and `itemCount` is what the reader can still reach, so the cursor cannot land
+under the art and a bulk action cannot aim at threads the reader thinks are put away.
+`settleCover` is what keeps that true as the list changes underneath: opening a thread
+turns it seen, which slides it under the cover, and a live re-read can do the same to a
+selection. `listHeight` holds back the divider and `coverMinRows` at the bottom so the
+cover can never be scrolled past, and `coverView` then gives the art every row the threads
+above it did not use. A list too short for even the floor keeps the divider and skips the
+art — the hint is worth more than a smear.
+
+`v` lifts the cover (`coverPeeked`) and puts it back; the divider carries the hint and the
+hidden count, where the web app puts its buttons. Setting a cover closes it, so a box
+arrives covered rather than however the last one was left. Only the Imbox is coverable —
+that is haystack's rule (`Box::Imbox#coverable?`), and it is the same box that gets the
+seen sections at all.
+
+**The preset is still a stub.** `boxes/_box.jbuilder` does not serve `cover`, so the SDK
+cannot carry it and `imboxCover()` reads `HEY_COVER` instead. Serving the preset name
+(and, for uploads, a blob URL) is a five-line haystack change; then `imboxCover` reads the
+box and the env var goes away. An uploaded cover has no honest character version — that
+one wants the Kitty path in `kitty.go`.
 
 ### Inline images in the TUI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ section: ctrl+s from the mail list swaps it in as the active view, it captures e
 while it is open, and it asks to be closed again with `screenerClosedMsg`.
 The rest of `internal/tui/` is shared infrastructure: `tui.go` (model and
 router), `section_view.go` (the interface), plus `nav.go`, `content.go`, `help.go`,
-`styles.go`, `loading.go`, `kitty.go`, `html.go`, `live.go`, `covers.go` and `calendar_views.go`. Read the directory rather than a
+`styles.go`, `loading.go`, `kitty.go`, `html.go`, `live.go`, `covers.go`, `cover_picker.go` and `calendar_views.go`. Read the directory rather than a
 table here.
 
 To add a new section: implement the `sectionView` interface in a new file, add a field and constructor call in `newModel`, and add a case in `switchSection`.
@@ -260,11 +260,18 @@ arrives covered rather than however the last one was left. Only the Imbox is cov
 that is haystack's rule (`Box::Imbox#coverable?`), and it is the same box that gets the
 seen sections at all.
 
-**The preset is still a stub.** `boxes/_box.jbuilder` does not serve `cover`, so the SDK
-cannot carry it and `imboxCover()` reads `HEY_COVER` instead. Serving the preset name
-(and, for uploads, a blob URL) is a five-line haystack change; then `imboxCover` reads the
-box and the env var goes away. An uploaded cover has no honest character version — that
-one wants the Kitty path in `kitty.go`.
+`ctrl+v` opens `coverPicker`, which draws whichever preset is highlighted — a cover is
+picked by looking at it. The choice lives on `mailView.cover` and lasts the session, and
+that is not laziness: `boxes/_box.jbuilder` does not serve `cover`, so the SDK cannot carry
+it and there is nothing to read a cover back from. Persisting a local choice would only
+compete with the real one once HEY starts serving it. Serving the preset name (and, for
+uploads, a blob URL) is a five-line haystack change; then the picker seeds from the box and
+writes back to it. An uploaded cover has no honest character version — that one wants the
+Kitty path in `kitty.go`.
+
+The help bar puts chorded keys last, via `modifiersLast`. The single-key bindings are what
+a reader reaches for while working through mail; a `ctrl+` chord in the middle of them
+pushes the everyday ones onto a second line and makes the bar read as a lookup table.
 
 ### Inline images in the TUI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,9 +208,9 @@ selector is not reliable protection. Draw the shape instead.
 
 **Scale every dimension with the block, then check the extremes.** A cover is anywhere from
 40×6 to 300×90, so a constant tuned at one size is a constant that only looks right there.
-`blobRibbonShape` is the worked example: the amplitude follows the height, and the
+`waveRibbonShape` is the worked example: the amplitude follows the height, and the
 wavelength takes whichever is larger of a quarter of the width and whatever the amplitude
-needs to stay under `maxBlobSlope`. Scaling by height alone drew chevrons on a tall cover;
+needs to stay under `maxWaveSlope`. Scaling by height alone drew chevrons on a tall cover;
 by width alone, a busy repeat on a wide short one. `peaceRadius` is the same lesson in one
 line: a circle that does not fit is a pair of brackets. Pin both with a test over a spread
 of aspect ratios — it is much cheaper than looking.

--- a/README.md
+++ b/README.md
@@ -210,8 +210,11 @@ Press Ctrl+V to choose one: `blobs`, `grid`, `peace`, `terrazzo`, `topo` or `wav
 same six covers redrawn as characters, so they work in any terminal rather than only the
 ones that can show images. The picker draws whichever you have highlighted. They are
 painted in your terminal's own colors, so a cover matches your theme and follows it when
-you switch. HEY does not serve a box's cover over its API yet, so the choice lasts for the
-session rather than being the one you made on the web.
+you switch.
+
+Your choice is remembered in `~/.config/hey-cli/config.json`, on this machine. It is not
+the cover you picked on the web: HEY keeps that one server-side but serves it to nobody, so
+the iOS and Android apps each keep their own local choice too, and this is the same.
 
 Thread attachments always appear with their filename, media type, and size. Use `[` and `]` to select an attachment, `s` to save it without replacing an existing file, and `o` to download and open it in an external application. Attachments never open automatically. Kitty and Ghostty can show inline images. Foot and other terminals use visible text markers.
 

--- a/README.md
+++ b/README.md
@@ -206,11 +206,12 @@ read goes under it, so the box ends at what still wants your attention instead o
 off into a month of receipts. The divider stays and says how much is under there — press
 `v` to peek, `v` again to close it.
 
-Set `HEY_COVER` to `blobs`, `grid`, `peace`, `terrazzo`, `topo` or `waves` — the same six
-covers, redrawn as characters, so they work in any terminal rather than only the ones that
-can show images. They are painted in your terminal's own colors, so a cover matches your
-theme and follows it when you switch. HEY does not serve a box's cover over its API yet, so
-for now the choice is `HEY_COVER` rather than the one you made on the web.
+Press Ctrl+V to choose one: `blobs`, `grid`, `peace`, `terrazzo`, `topo` or `waves`, the
+same six covers redrawn as characters, so they work in any terminal rather than only the
+ones that can show images. The picker draws whichever you have highlighted. They are
+painted in your terminal's own colors, so a cover matches your theme and follows it when
+you switch. HEY does not serve a box's cover over its API yet, so the choice lasts for the
+session rather than being the one you made on the web.
 
 Thread attachments always appear with their filename, media type, and size. Use `[` and `]` to select an attachment, `s` to save it without replacing an existing file, and `o` to download and open it in an external application. Attachments never open automatically. Kitty and Ghostty can show inline images. Foot and other terminals use visible text markers.
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ screens them out, Tab moves to Screener History and back, `X` clears the whole S
 after a confirmation, and Escape or `q` returns to mail. Both lists keep going as you
 scroll, the same way the mail list does.
 
+The Imbox can wear cover art, the way the HEY web app does: everything you have already
+read goes under it, so the box ends at what still wants your attention instead of trailing
+off into a month of receipts. The divider stays and says how much is under there — press
+`v` to peek, `v` again to close it.
+
+Set `HEY_COVER` to `blobs`, `grid`, `peace`, `terrazzo`, `topo` or `waves` — the same six
+covers, redrawn as characters, so they work in any terminal rather than only the ones that
+can show images. HEY does not serve a box's cover over its API yet, so for now the choice
+is `HEY_COVER` rather than the one you made on the web.
+
 Thread attachments always appear with their filename, media type, and size. Use `[` and `]` to select an attachment, `s` to save it without replacing an existing file, and `o` to download and open it in an external application. Attachments never open automatically. Kitty and Ghostty can show inline images. Foot and other terminals use visible text markers.
 
 Press Shift+O to open Contacts. Use Enter to view a contact, `a` to add, `e` to edit, `n` to edit the private note, `x` twice to delete a note, `h` to hide, and `u` to show the most recently hidden contact again. Escape or `q` goes back.

--- a/README.md
+++ b/README.md
@@ -208,8 +208,9 @@ off into a month of receipts. The divider stays and says how much is under there
 
 Set `HEY_COVER` to `blobs`, `grid`, `peace`, `terrazzo`, `topo` or `waves` — the same six
 covers, redrawn as characters, so they work in any terminal rather than only the ones that
-can show images. HEY does not serve a box's cover over its API yet, so for now the choice
-is `HEY_COVER` rather than the one you made on the web.
+can show images. They are painted in your terminal's own colors, so a cover matches your
+theme and follows it when you switch. HEY does not serve a box's cover over its API yet, so
+for now the choice is `HEY_COVER` rather than the one you made on the web.
 
 Thread attachments always appear with their filename, media type, and size. Use `[` and `]` to select an attachment, `s` to save it without replacing an existing file, and `o` to download and open it in an external application. Attachments never open automatically. Kitty and Ghostty can show inline images. Foot and other terminals use visible text markers.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 type fileConfig struct {
 	BaseURL             string                              `json:"base_url,omitempty"`
 	AccountID           string                              `json:"account_id,omitempty"`
+	Cover               string                              `json:"cover,omitempty"`
 	AccountDefaults     map[string]string                   `json:"account_defaults,omitempty"`
 	TrustedLocalConfigs map[string]trustedLocalConfigRecord `json:"trusted_local_configs,omitempty"`
 }
@@ -360,6 +361,35 @@ func (c *Config) SaveBaseURL(baseURL string) error {
 		return err
 	}
 	file.BaseURL = baseURL
+	return saveGlobalConfig(file)
+}
+
+// Cover is the art over the Imbox's Previously Seen, or "" for none.
+//
+// It is stored here rather than read from HEY on purpose. The web app keeps a
+// cover per box in its own table, but no client reads that: the iOS and Android
+// apps each keep their own choice in device preferences, with their own set of
+// presets, and never ask the server. This is the same decision, and it is the
+// reason a cover set here does not show up on the web.
+func Cover() string {
+	file, err := loadGlobalFileConfig()
+	if err != nil {
+		return ""
+	}
+	return file.Cover
+}
+
+// SaveCover stores the Imbox's cover, leaving every other setting alone. An empty
+// preset drops the key rather than writing a blank one.
+func SaveCover(preset string) error {
+	file, err := loadGlobalFileConfig()
+	if err != nil {
+		return err
+	}
+	if err := migrateLegacyAccountDefault(&file); err != nil {
+		return err
+	}
+	file.Cover = preset
 	return saveGlobalConfig(file)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -480,5 +481,80 @@ func TestSourceTracking(t *testing.T) {
 	}
 	if cfg.SourceOf("base_url") != SourceFlag {
 		t.Errorf("flag source = %q, want %q", cfg.SourceOf("base_url"), SourceFlag)
+	}
+}
+
+func TestCoverRoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("HEY_BASE_URL", "")
+
+	if got := Cover(); got != "" {
+		t.Errorf("Cover before anything was saved = %q, want empty", got)
+	}
+	if err := SaveCover("topo"); err != nil {
+		t.Fatalf("SaveCover: %v", err)
+	}
+	if got := Cover(); got != "topo" {
+		t.Errorf("Cover = %q, want topo", got)
+	}
+
+	// Uncovering writes no key rather than a blank one.
+	if err := SaveCover(""); err != nil {
+		t.Fatalf("SaveCover(\"\"): %v", err)
+	}
+	if got := Cover(); got != "" {
+		t.Errorf("Cover after uncovering = %q, want empty", got)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, "hey-cli", "config.json"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var file map[string]any
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if _, present := file["cover"]; present {
+		t.Errorf("uncovering left a cover key behind: %s", data)
+	}
+}
+
+// A cover is one setting in a shared file; saving it must not take the others out.
+func TestSaveCoverKeepsOtherSettings(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("HEY_BASE_URL", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := cfg.SaveAccountID("12345"); err != nil {
+		t.Fatalf("SaveAccountID: %v", err)
+	}
+	if err := cfg.SaveBaseURL("https://app.hey.localhost:3003"); err != nil {
+		t.Fatalf("SaveBaseURL: %v", err)
+	}
+	before, err := loadGlobalFileConfig()
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	if err := SaveCover("peace"); err != nil {
+		t.Fatalf("SaveCover: %v", err)
+	}
+
+	after, err := loadGlobalFileConfig()
+	if err != nil {
+		t.Fatalf("read config after saving: %v", err)
+	}
+	if after.BaseURL != before.BaseURL {
+		t.Errorf("base_url = %q, want %q", after.BaseURL, before.BaseURL)
+	}
+	if !maps.Equal(after.AccountDefaults, before.AccountDefaults) {
+		t.Errorf("account defaults = %v, want %v", after.AccountDefaults, before.AccountDefaults)
+	}
+	if after.Cover != "peace" {
+		t.Errorf("cover = %q, want peace", after.Cover)
 	}
 }

--- a/internal/tui/bulk_reply_test.go
+++ b/internal/tui/bulk_reply_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -245,8 +246,8 @@ func TestTUIBulkReplyReviewsThenSendsAndOffersUndo(t *testing.T) {
 	if view.lastBulkReplyID != 900 || !strings.Contains(view.notice, "2 bulk replies queued with undo available") || !strings.Contains(view.notice, "press u to undo") {
 		t.Errorf("delivery state = id:%d notice:%q", view.lastBulkReplyID, view.notice)
 	}
-	if help := view.HelpBindings(); help[len(help)-1].key != "u" {
-		t.Errorf("help does not offer undo: %v", help)
+	if !slices.ContainsFunc(view.HelpBindings(), func(b helpBinding) bool { return b.key == "u" }) {
+		t.Errorf("help does not offer undo: %v", view.HelpBindings())
 	}
 
 	requests := state.snapshot()

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -91,6 +91,74 @@ type contentList struct {
 	height        int // visible rows (each posting takes 2 lines)
 	hideSeenState bool
 	selected      map[int64]struct{}
+
+	cover       coverPreset // art that hides Previously Seen, coverNone for none
+	coverPeeked bool        // the reader lifted the cover to get at what is under it
+	coverArt    coverRenderer
+}
+
+// setCover puts art over Previously Seen. Setting it closes the cover, so a box
+// arrives covered rather than however the last one was left.
+func (c *contentList) setCover(preset coverPreset) {
+	c.cover = preset
+	c.coverPeeked = false
+}
+
+// toggleCoverPeek lifts the cover off Previously Seen, or puts it back.
+func (c *contentList) toggleCoverPeek() {
+	c.coverPeeked = !c.coverPeeked
+	c.settleCover()
+}
+
+// settleCover keeps the cursor and the selection out from under the cover. A
+// re-read, or a thread the reader just opened turning seen, otherwise slides
+// them under it, leaving a cursor on a row nobody can see and a bulk action
+// aimed at threads the reader thinks are put away.
+func (c *contentList) settleCover() {
+	c.dropCoveredSelection()
+	c.clampCursor()
+}
+
+// coveredFrom is the index of the first Previously Seen posting while the cover
+// is down, or -1 when nothing is hidden. Everything from there on is under the
+// art: out of reach, and not rendered.
+func (c *contentList) coveredFrom() int {
+	if c.cover == coverNone || c.coverPeeked || c.hideSeenState {
+		return -1
+	}
+	for i := range c.postings {
+		if sectionOf(c.postings[i]) == sectionPreviouslySeen {
+			return i
+		}
+	}
+	return -1
+}
+
+// itemCount is how many postings the reader can move through and act on.
+func (c *contentList) itemCount() int {
+	if from := c.coveredFrom(); from >= 0 {
+		return from
+	}
+	return len(c.postings)
+}
+
+func (c *contentList) dropCoveredSelection() {
+	count := c.itemCount()
+	for id := range c.selected {
+		for i := count; i < len(c.postings); i++ {
+			if c.postings[i].ID == id {
+				delete(c.selected, id)
+				break
+			}
+		}
+	}
+}
+
+func (c *contentList) clampCursor() {
+	last := max(c.itemCount()-1, 0)
+	c.cursor = min(c.cursor, last)
+	c.scrollOff = min(c.scrollOff, last)
+	c.ensureVisible()
 }
 
 func (c *contentList) setPostings(postings []models.Posting) {
@@ -165,7 +233,7 @@ func (c *contentList) keepPlaceIn(postings []models.Posting) {
 	}
 	c.keepSelected()
 	c.scrollOff = min(c.scrollOff, max(len(c.postings)-1, 0))
-	c.ensureVisible()
+	c.settleCover()
 }
 
 // keepSelected drops the postings that are no longer in the list from the selection.
@@ -256,7 +324,7 @@ func (c *contentList) resort() {
 			break
 		}
 	}
-	c.ensureVisible()
+	c.settleCover()
 }
 
 func (c *contentList) setSize(w, h int) {
@@ -272,10 +340,20 @@ func (c *contentList) moveUp() {
 }
 
 func (c *contentList) moveDown() {
-	if c.cursor < len(c.postings)-1 {
+	if c.cursor < c.itemCount()-1 {
 		c.cursor++
 		c.ensureVisible()
 	}
+}
+
+// listHeight is the rows the postings get. A cover holds back its divider and
+// the art's floor at the bottom of the list, so the cover is always on screen
+// rather than something you could scroll past.
+func (c *contentList) listHeight() int {
+	if c.coveredFrom() < 0 {
+		return c.height
+	}
+	return max(c.height-1-coverMinRows, 2)
 }
 
 // visibleItemsFrom reports how many postings fit from start, including only
@@ -283,12 +361,13 @@ func (c *contentList) moveDown() {
 func (c *contentList) visibleItemsFrom(start int) int {
 	rows := 0
 	count := 0
-	for i := start; i < len(c.postings); i++ {
+	height := c.listHeight()
+	for i := start; i < c.itemCount(); i++ {
 		postingRows := 2
 		if c.sectionLabelAt(i) != "" {
 			postingRows++
 		}
-		if rows+postingRows > c.height {
+		if rows+postingRows > height {
 			break
 		}
 		rows += postingRows
@@ -380,7 +459,8 @@ func (c *contentList) view() string {
 	}
 
 	var b strings.Builder
-	end := min(c.scrollOff+c.visibleItemsFrom(c.scrollOff), len(c.postings))
+	rendered := 0
+	end := min(c.scrollOff+c.visibleItemsFrom(c.scrollOff), c.itemCount())
 
 	cursorMarker, _ := cursorStyles()
 	selectedGap := selectionStyle(lipgloss.NewStyle())
@@ -410,7 +490,12 @@ func (c *contentList) view() string {
 		isCursor := i == c.cursor
 
 		if label := c.sectionLabelAt(i); label != "" {
-			fmt.Fprintln(&b, sectionHeader(label, c.width))
+			if c.cover != coverNone && sectionOf(p) == sectionPreviouslySeen {
+				fmt.Fprintln(&b, coverHeader(label, "v to cover", c.width))
+			} else {
+				fmt.Fprintln(&b, sectionHeader(label, c.width))
+			}
+			rendered++
 		}
 
 		// The cursor row renders bold on top of the base styles and, when the
@@ -511,9 +596,28 @@ func (c *contentList) view() string {
 
 		fmt.Fprintln(&b, line1.String())
 		fmt.Fprintln(&b, line2.String())
+		rendered += 2
 	}
 
+	if from := c.coveredFrom(); from >= 0 {
+		b.WriteString(c.coverView(len(c.postings)-from, rendered))
+	}
 	return b.String()
+}
+
+// coverView is the lid over Previously Seen: its divider, saying how much is
+// under there and how to look, and then the art filling the list to the bottom.
+// The threads themselves are not rendered at all — that is the whole point of a
+// cover, and it is why the art can have every row the postings did not use.
+func (c *contentList) coverView(hidden, rowsUsed int) string {
+	hint := fmt.Sprintf("%d hidden · v to peek", hidden)
+	header := coverHeader(sectionPreviouslySeen.label(), hint, c.width)
+
+	rows := c.height - rowsUsed - 1
+	if rows < coverMinRows {
+		return header
+	}
+	return header + "\n" + c.coverArt.view(c.cover, c.width, rows)
 }
 
 // sectionHeader renders a list section label with a rule filling the rest
@@ -524,6 +628,19 @@ func sectionHeader(label string, width int) string {
 		s += " " + lipgloss.NewStyle().Foreground(colorChrome).Render(strings.Repeat("─", fill))
 	}
 	return s
+}
+
+// coverHeader is a section label with a hint on its right, where the HEY web app
+// puts the cover's buttons: "Previously Seen ──── 34 hidden · v to peek".
+func coverHeader(label, hint string, width int) string {
+	rule := lipgloss.NewStyle().Foreground(colorChrome)
+	fill := width - lipgloss.Width(label) - lipgloss.Width(hint) - 4
+	if fill < 1 {
+		return sectionHeader(label, width)
+	}
+	return rule.Bold(true).Render(label) + " " +
+		rule.Render(strings.Repeat("─", fill)) + " " +
+		styleMuted.Render(hint)
 }
 
 // truncateToWidth trims s so its rendered width fits in w cells, appending

--- a/internal/tui/cover_picker.go
+++ b/internal/tui/cover_picker.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// coverPicker chooses the art over the Imbox's Previously Seen. The choice lasts
+// as long as the session: HEY serves a box's cover to the web app but not over
+// JSON, so there is nothing to read it back from and nowhere it belongs on disk.
+type coverPicker struct {
+	choices []coverPreset
+	cursor  int
+	art     coverRenderer
+}
+
+// coverPreviewRows is how much of the highlighted cover the picker shows. Enough
+// to tell the six apart, which is less than they need to look their best.
+const coverPreviewRows = 9
+
+func newCoverPicker(current coverPreset) *coverPicker {
+	picker := &coverPicker{
+		choices: []coverPreset{
+			coverNone, coverBlobs, coverGrid, coverPeace, coverTerrazzo, coverTopo, coverWaves,
+		},
+	}
+	for i, choice := range picker.choices {
+		if choice == current {
+			picker.cursor = i
+			break
+		}
+	}
+	return picker
+}
+
+func (p *coverPicker) selected() coverPreset {
+	if p.cursor < 0 || p.cursor >= len(p.choices) {
+		return coverNone
+	}
+	return p.choices[p.cursor]
+}
+
+func (p *coverPicker) update(msg tea.KeyPressMsg) {
+	switch msg.Key().Code {
+	case tea.KeyUp:
+		if p.cursor > 0 {
+			p.cursor--
+		}
+	case tea.KeyDown:
+		if p.cursor < len(p.choices)-1 {
+			p.cursor++
+		}
+	}
+}
+
+// view lists the presets and draws the highlighted one underneath, because a
+// cover is picked by looking at it rather than by reading six words.
+func (p *coverPicker) view(styles styles, width int) string {
+	contentWidth := max(width-4, 1)
+
+	var b strings.Builder
+	b.WriteString(styles.title.Render("Cover the Imbox"))
+	b.WriteString("\n\n")
+
+	for i, choice := range p.choices {
+		prefix, label := "  ", coverLabel(choice)
+		if i == p.cursor {
+			prefix, label = "› ", styles.title.Render(label)
+		}
+		fmt.Fprintf(&b, "%s%s\n", prefix, label)
+	}
+
+	b.WriteString("\n")
+	if preview := p.art.view(p.selected(), contentWidth, coverPreviewRows); preview != "" {
+		b.WriteString(preview + "\n\n")
+	}
+	b.WriteString(strings.Join(wrapText(
+		"A cover hides the threads you have already read. Press v to look under it.",
+		contentWidth), "\n"))
+	return b.String()
+}
+
+func coverLabel(preset coverPreset) string {
+	if preset == coverNone {
+		return "No cover"
+	}
+	return strings.ToUpper(string(preset)[:1]) + string(preset)[1:]
+}
+
+func (p *coverPicker) helpBindings() []helpBinding {
+	return []helpBinding{
+		{"↑↓", "select"},
+		{"enter", "cover"},
+		{"esc", "cancel"},
+	}
+}

--- a/internal/tui/covers.go
+++ b/internal/tui/covers.go
@@ -143,8 +143,9 @@ func (p coverPalette) current() coverPalette {
 // bright foreground is dark: exactly inverted, and only on the themes the cover
 // was supposed to be fixing.
 var coverPalettes = map[coverPreset]coverPalette{
-	coverBlobs: {field: lipgloss.Cyan, ink: [4]color.Color{lipgloss.BrightYellow}},
-	coverGrid:  {field: lipgloss.Black, ink: [4]color.Color{lipgloss.Blue, lipgloss.BrightBlue}},
+	coverBlobs: {field: lipgloss.Magenta, ink: [4]color.Color{
+		lipgloss.BrightYellow, lipgloss.Red, lipgloss.BrightMagenta, lipgloss.Blue}},
+	coverGrid: {field: lipgloss.Black, ink: [4]color.Color{lipgloss.Blue, lipgloss.BrightBlue}},
 
 	// HEY draws the hand white on a yellow card. Yellow is the lightest hue a theme
 	// has, so a whole cover of it glares in every one of them, and there is no
@@ -161,9 +162,8 @@ var coverPalettes = map[coverPreset]coverPalette{
 	// read as too bright across a whole cover, and there is nothing darker than a
 	// hue except the background. So the field is the background and the contours
 	// keep the violet end of the palette.
-	coverTopo: {field: lipgloss.Black, ink: [4]color.Color{lipgloss.Magenta}},
-	coverWaves: {field: lipgloss.Magenta, ink: [4]color.Color{
-		lipgloss.BrightYellow, lipgloss.Red, lipgloss.BrightMagenta, lipgloss.Blue}},
+	coverTopo:  {field: lipgloss.Black, ink: [4]color.Color{lipgloss.Magenta}},
+	coverWaves: {field: lipgloss.Cyan, ink: [4]color.Color{lipgloss.BrightYellow}},
 }
 
 // --- Canvas ---
@@ -581,33 +581,33 @@ func (l *brailleLayer) peaceHand(x, y, width, height float64) {
 	}
 }
 
-// maxBlobSlope is the steepest a ribbon may climb, in rows per column. A cell is
+// maxWaveSlope is the steepest a ribbon may climb, in rows per column. A cell is
 // about twice as tall as it is wide, so half a row per column is a ribbon at
 // roughly forty-five degrees on screen — a sweep. Past that they read as
 // chevrons.
-const maxBlobSlope = 0.5
+const maxWaveSlope = 0.5
 
-// blobRibbonShape is how tall and how long a ribbon is on a cover this size.
+// waveRibbonShape is how tall and how long a ribbon is on a cover this size.
 // Both scale with the block, so the pattern looks the same at any aspect ratio.
 // The wavelength takes whichever is larger of two floors: a quarter of the width,
 // so a wide cover shows a handful of sweeps instead of one lazy curve, and
-// whatever the amplitude needs to stay under maxBlobSlope, which is what keeps a
+// whatever the amplitude needs to stay under maxWaveSlope, which is what keeps a
 // tall cover from turning into chevrons.
-func blobRibbonShape(width, height int) (amplitude, wavelength float64) {
+func waveRibbonShape(width, height int) (amplitude, wavelength float64) {
 	amplitude = float64(height) / 3
-	return amplitude, max(float64(width)/4, amplitude/maxBlobSlope)
+	return amplitude, max(float64(width)/4, amplitude/maxWaveSlope)
 }
 
-// paintBlobs lays HEY's yellow ribbons over mint. They are solid blocks rather
+// paintWaves lays HEY's yellow ribbons over mint. They are solid blocks rather
 // than the field's background color so the shape survives a colorless terminal.
-func (c *coverCanvas) paintBlobs() {
+func (c *coverCanvas) paintWaves() {
 	// Each ribbon is stretched from the base wavelength and given its own phase.
 	// Sharing a wavelength and offsetting the phase is tempting and wrong: half a
 	// wavelength apart makes the second ribbon an exact reflection of the first,
 	// and the field comes out symmetrical. Stretch factors are all at or above 1
 	// so no ribbon runs steeper than the base one.
 	ribbons := []struct{ stretch, phase float64 }{{1, 0}, {1.3, 1.7}, {1.7, 4.1}}
-	amplitude, wavelength := blobRibbonShape(c.width, c.height)
+	amplitude, wavelength := waveRibbonShape(c.width, c.height)
 	center := float64(c.height-1) / 2
 	thickness := max(float64(c.height)/14, 1)
 
@@ -623,15 +623,15 @@ func (c *coverCanvas) paintBlobs() {
 	}
 }
 
-// paintWaves sweeps a gradient from the top left to the bottom right, warped by
-// a wave so the bands roll instead of stepping straight. Each band gets both a
-// color and a step of the shade ramp: the shades read as a gradient on their own
-// where there is no color, and blend one band into the next where there is.
+// paintBlobs sweeps soft bands of color from the top left to the bottom right,
+// warped so they roll instead of stepping straight. Each band gets both a color
+// and a step of the shade ramp: the shades read as a gradient on their own where
+// there is no color, and blend one band into the next where there is.
 //
 // The web app's version is concentric arcs. A cover is far wider than it is
 // tall, and over that block arcs flatten into vertical stripes, so the curve
 // comes from the warp rather than from a radius.
-func (c *coverCanvas) paintWaves() {
+func (c *coverCanvas) paintBlobs() {
 	shades := []string{"░", "▒", "▓", "█"}
 	const (
 		wavelength = 11

--- a/internal/tui/covers.go
+++ b/internal/tui/covers.go
@@ -1,0 +1,686 @@
+package tui
+
+import (
+	"image/color"
+	"math"
+	"os"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Cover art for the Imbox, drawn where the HEY web app draws it: under the
+// Previously Seen divider, so the seen threads sit behind a piece of art rather
+// than trailing off the bottom of the list.
+//
+// The web app's covers are SVG assets, and a terminal cannot draw an SVG. These
+// are the same six patterns re-drawn as characters, which is not a fallback but
+// the better medium for two of them: a blueprint grid is what box-drawing
+// characters are for, and a contour map is a band boundary in a noise field.
+//
+// A cover is the one place the TUI paints brand colors instead of ANSI slots
+// (see styles.go): the art *is* HEY's yellow and mint, and a grey-on-grey
+// terrazzo would be worse than one that ignores the terminal theme. Colors are
+// laid over glyphs that carry the pattern on their own, so a colorless terminal
+// still gets the art rather than a blank band.
+type coverPreset string
+
+const (
+	coverNone     coverPreset = ""
+	coverBlobs    coverPreset = "blobs"
+	coverGrid     coverPreset = "grid"
+	coverPeace    coverPreset = "peace"
+	coverTerrazzo coverPreset = "terrazzo"
+	coverTopo     coverPreset = "topo"
+	coverWaves    coverPreset = "waves"
+)
+
+// coverMinRows is the point below which a cover is a stripe rather than a
+// picture. A list with less room than this to spare keeps the divider and skips
+// the art, rather than drawing a smear nobody can read.
+const coverMinRows = 5
+
+// The two things about the active theme a cover cares about, set by applyTheme:
+// which of the two palettes to use, and whether to paint at all. NO_COLOR leaves
+// the glyphs, which is the pattern.
+var (
+	coverDarkMode  = true
+	coverColorless = false
+)
+
+// imboxCover is the preset the Imbox is covered with. HEY serves a box's cover to
+// the web app but not over JSON, so HEY_COVER stands in until boxes carry it and
+// this reads the box instead. An unset or unknown value draws nothing.
+func imboxCover() coverPreset {
+	return parseCoverPreset(os.Getenv("HEY_COVER"))
+}
+
+func parseCoverPreset(name string) coverPreset {
+	switch coverPreset(strings.ToLower(strings.TrimSpace(name))) {
+	case coverBlobs:
+		return coverBlobs
+	case coverGrid:
+		return coverGrid
+	case coverPeace:
+		return coverPeace
+	case coverTerrazzo:
+		return coverTerrazzo
+	case coverTopo:
+		return coverTopo
+	case coverWaves:
+		return coverWaves
+	default:
+		return coverNone
+	}
+}
+
+// coverRenderer draws a cover and remembers the last one it drew. The posting
+// list re-renders on every keystroke and a cover is thousands of styled cells,
+// so it is painted when its preset, size or palette changes and not per frame.
+type coverRenderer struct {
+	preset   coverPreset
+	width    int
+	height   int
+	palette  coverPalette
+	rendered string
+}
+
+func (r *coverRenderer) view(preset coverPreset, width, height int) string {
+	palette := coverPalettes[preset].current()
+	if r.rendered != "" && r.preset == preset && r.width == width && r.height == height && r.palette == palette {
+		return r.rendered
+	}
+
+	canvas := newCoverCanvas(width, height, palette)
+	switch preset {
+	case coverBlobs:
+		canvas.paintBlobs()
+	case coverGrid:
+		canvas.paintGrid()
+	case coverPeace:
+		canvas.paintPeace()
+	case coverTerrazzo:
+		canvas.paintTerrazzo()
+	case coverTopo:
+		canvas.paintTopo()
+	case coverWaves:
+		canvas.paintWaves()
+	case coverNone:
+		return ""
+	}
+
+	r.preset, r.width, r.height, r.palette = preset, width, height, palette
+	r.rendered = canvas.view()
+	return r.rendered
+}
+
+// --- Palettes ---
+
+// coverPalette is a cover's field and the inks drawn on it. Each preset names its
+// own inks in the order its painter uses them.
+type coverPalette struct {
+	field color.Color
+	ink   [4]color.Color
+}
+
+// coverModes holds a preset's two palettes. Several presets are the same card in
+// both modes — HEY's yellow peace sign is yellow on a dark background too.
+type coverModes struct {
+	dark  coverPalette
+	light coverPalette
+}
+
+func (m coverModes) current() coverPalette {
+	if coverColorless {
+		return coverPalette{}
+	}
+	if coverDarkMode {
+		return m.dark
+	}
+	return m.light
+}
+
+func coverHex(s string) color.Color { return lipgloss.Color(s) }
+
+var coverPalettes = map[coverPreset]coverModes{
+	coverBlobs: {
+		dark:  coverPalette{field: coverHex("#5eead4"), ink: [4]color.Color{coverHex("#facc15")}},
+		light: coverPalette{field: coverHex("#99f6e4"), ink: [4]color.Color{coverHex("#fbbf24")}},
+	},
+	coverGrid: {
+		dark:  coverPalette{field: coverHex("#0f172a"), ink: [4]color.Color{coverHex("#3b82f6"), coverHex("#60a5fa")}},
+		light: coverPalette{field: coverHex("#f8fafc"), ink: [4]color.Color{coverHex("#93c5fd"), coverHex("#3b82f6")}},
+	},
+	coverPeace: {
+		dark:  coverPalette{field: coverHex("#facc15"), ink: [4]color.Color{coverHex("#ffffff")}},
+		light: coverPalette{field: coverHex("#fde047"), ink: [4]color.Color{coverHex("#ffffff")}},
+	},
+	coverTerrazzo: {
+		dark:  coverPalette{field: coverHex("#1e293b"), ink: [4]color.Color{coverHex("#ffffff"), coverHex("#f87171"), coverHex("#5eead4")}},
+		light: coverPalette{field: coverHex("#f8fafc"), ink: [4]color.Color{coverHex("#334155"), coverHex("#f87171"), coverHex("#2dd4bf")}},
+	},
+	coverTopo: {
+		dark:  coverPalette{field: coverHex("#7c3aed"), ink: [4]color.Color{coverHex("#1e1b3a")}},
+		light: coverPalette{field: coverHex("#a78bfa"), ink: [4]color.Color{coverHex("#3b0764")}},
+	},
+	coverWaves: {
+		dark: coverPalette{field: coverHex("#7c3aed"), ink: [4]color.Color{
+			coverHex("#fcd34d"), coverHex("#f9a8d4"), coverHex("#c084fc"), coverHex("#6d28d9")}},
+		light: coverPalette{field: coverHex("#a78bfa"), ink: [4]color.Color{
+			coverHex("#fde68a"), coverHex("#fbcfe8"), coverHex("#d8b4fe"), coverHex("#8b5cf6")}},
+	},
+}
+
+// --- Canvas ---
+
+// coverCanvas is a grid of cells a painter writes glyphs into. Empty cells are
+// the field: blank, so a colorless terminal shows the pattern rather than a
+// solid block.
+type coverCanvas struct {
+	width   int
+	height  int
+	palette coverPalette
+	glyphs  []string
+	inks    []color.Color
+}
+
+func newCoverCanvas(width, height int, palette coverPalette) *coverCanvas {
+	canvas := &coverCanvas{
+		width:   width,
+		height:  height,
+		palette: palette,
+		glyphs:  make([]string, width*height),
+		inks:    make([]color.Color, width*height),
+	}
+	for i := range canvas.glyphs {
+		canvas.glyphs[i] = " "
+	}
+	return canvas
+}
+
+// set writes a glyph, ignoring anything a painter puts outside the canvas so the
+// painters can compute positions without bounds-checking each one.
+func (c *coverCanvas) set(x, y int, glyph string, ink color.Color) {
+	if x < 0 || y < 0 || x >= c.width || y >= c.height {
+		return
+	}
+	c.glyphs[y*c.width+x] = glyph
+	c.inks[y*c.width+x] = ink
+}
+
+func (c *coverCanvas) view() string {
+	style := lipgloss.NewStyle()
+	if c.palette.field != nil {
+		style = style.Background(c.palette.field)
+	}
+
+	var b strings.Builder
+	for y := range c.height {
+		if y > 0 {
+			b.WriteString("\n")
+		}
+		// Cells with the same ink render as one segment: a cover is a thousand
+		// cells and all but the scatter patterns are long runs of the field.
+		start := 0
+		row := c.glyphs[y*c.width : (y+1)*c.width]
+		inks := c.inks[y*c.width : (y+1)*c.width]
+		for x := 1; x <= c.width; x++ {
+			if x < c.width && inks[x] == inks[start] {
+				continue
+			}
+			segment := style
+			if inks[start] != nil {
+				segment = segment.Foreground(inks[start])
+			}
+			b.WriteString(segment.Render(strings.Join(row[start:x], "")))
+			start = x
+		}
+	}
+	return b.String()
+}
+
+// plain returns the glyph grid without color, which is the pattern itself.
+func (c *coverCanvas) plain() string {
+	rows := make([]string, c.height)
+	for y := range c.height {
+		rows[y] = strings.Join(c.glyphs[y*c.width:(y+1)*c.width], "")
+	}
+	return strings.Join(rows, "\n")
+}
+
+// --- Braille ---
+
+// A braille cell carries a 2×4 grid of dots, which is the finest thing a
+// terminal can draw without leaving text behind. It is what lets a cover hold a
+// curve: eight times the resolution of the cell grid, and thin lines rather than
+// cell-wide staircases.
+//
+// The dots are square. A terminal cell is about twice as tall as it is wide and
+// the 2×4 split cancels that exactly, so anything drawn here needs no aspect
+// correction — a circle of equal radii comes out round.
+const (
+	brailleCols  = 2
+	brailleRows  = 4
+	brailleBlank = '⠀'
+)
+
+// brailleDot maps a dot's position in the cell to its bit. The order is the
+// standard's, which numbers down the left column, then down the right, then the
+// two bottom dots that eight-dot braille added — not row by row.
+var brailleDot = [brailleRows][brailleCols]uint8{
+	{0x01, 0x08},
+	{0x02, 0x10},
+	{0x04, 0x20},
+	{0x40, 0x80},
+}
+
+// brailleLayer is a dot grid the size of a canvas. Painters draw into it in dots
+// and hand the whole thing to drawInto, which folds each 2×4 block into its cell.
+type brailleLayer struct {
+	cols   int // canvas cells across
+	rows   int // canvas cells down
+	width  int // dots across
+	height int // dots down
+	dots   []bool
+}
+
+func newBrailleLayer(cols, rows int) *brailleLayer {
+	width, height := cols*brailleCols, rows*brailleRows
+	return &brailleLayer{
+		cols: cols, rows: rows,
+		width: width, height: height,
+		dots: make([]bool, width*height),
+	}
+}
+
+func (l *brailleLayer) set(x, y int) {
+	if x >= 0 && y >= 0 && x < l.width && y < l.height {
+		l.dots[y*l.width+x] = true
+	}
+}
+
+func (l *brailleLayer) at(x, y int) bool {
+	if x < 0 || y < 0 || x >= l.width || y >= l.height {
+		return false
+	}
+	return l.dots[y*l.width+x]
+}
+
+// arc plots by angle rather than by testing distance per dot: stepping the curve
+// in half-dot lengths leaves no gaps, where a distance test leaves them wherever
+// the curve runs diagonally. tilt turns the ellipse about its center, which is
+// what lets a shape lean.
+func (l *brailleLayer) arc(cx, cy, rx, ry, tilt, from, to float64) {
+	steps := max(int(2*max(rx, ry)*math.Abs(to-from)), 8)
+	sin, cos := math.Sin(tilt), math.Cos(tilt)
+	for i := 0; i <= steps; i++ {
+		angle := from + (to-from)*float64(i)/float64(steps)
+		x, y := rx*math.Cos(angle), ry*math.Sin(angle)
+		l.set(int(math.Round(cx+x*cos-y*sin)), int(math.Round(cy+x*sin+y*cos)))
+	}
+}
+
+func (l *brailleLayer) ellipse(cx, cy, rx, ry, tilt float64) {
+	l.arc(cx, cy, rx, ry, tilt, 0, 2*math.Pi)
+}
+
+// coverEllipse is a filled ellipse, used to build a silhouette out of overlapping
+// shapes rather than to draw one.
+type coverEllipse struct {
+	cx, cy, rx, ry, tilt float64
+}
+
+func (e coverEllipse) contains(px, py float64) bool {
+	dx, dy := px-e.cx, py-e.cy
+	sin, cos := math.Sin(e.tilt), math.Cos(e.tilt)
+	lx, ly := dx*cos+dy*sin, dy*cos-dx*sin
+	return (lx*lx)/(e.rx*e.rx)+(ly*ly)/(e.ry*e.ry) <= 1
+}
+
+// silhouette draws the outline of the union of shapes: one continuous stroke
+// around everything they cover together, with no seam where they meet.
+//
+// Abutting drawn arcs cannot do this. Their ends never quite land on each other,
+// so the joins show as notches and stray tails, and every arc that crosses
+// another leaves its own line running through the inside of the shape. Filling
+// the union and keeping the dots that have a neighbor outside it sidesteps the
+// joins altogether — there is only ever one boundary to find.
+func (l *brailleLayer) silhouette(shapes ...coverEllipse) {
+	inside := func(px, py float64) bool {
+		for _, shape := range shapes {
+			if shape.contains(px, py) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Only the shapes' own extent is scanned. A silhouette is stamped many times
+	// over a cover, and walking the whole dot grid for each one is millions of
+	// point tests to find a shape that covers a corner of it.
+	left, top := math.Inf(1), math.Inf(1)
+	right, bottom := math.Inf(-1), math.Inf(-1)
+	for _, shape := range shapes {
+		reach := max(shape.rx, shape.ry)
+		left, top = min(left, shape.cx-reach), min(top, shape.cy-reach)
+		right, bottom = max(right, shape.cx+reach), max(bottom, shape.cy+reach)
+	}
+
+	for y := max(int(top)-1, 0); y <= min(int(bottom)+1, l.height-1); y++ {
+		for x := max(int(left)-1, 0); x <= min(int(right)+1, l.width-1); x++ {
+			fx, fy := float64(x), float64(y)
+			if !inside(fx, fy) {
+				continue
+			}
+			if !inside(fx-1, fy) || !inside(fx+1, fy) || !inside(fx, fy-1) || !inside(fx, fy+1) {
+				l.set(x, y)
+			}
+		}
+	}
+}
+
+func (l *brailleLayer) drawInto(c *coverCanvas, ink color.Color) {
+	for y := range l.rows {
+		for x := range l.cols {
+			bits := uint8(0)
+			for dy := range brailleRows {
+				for dx := range brailleCols {
+					if l.at(x*brailleCols+dx, y*brailleRows+dy) {
+						bits |= brailleDot[dy][dx]
+					}
+				}
+			}
+			if bits != 0 {
+				c.set(x, y, string(brailleBlank+rune(bits)), ink)
+			}
+		}
+	}
+}
+
+// --- Painters ---
+
+// paintGrid draws blueprint paper: a minor rule every three columns and every
+// other row, a heavier one every fourth minor line.
+func (c *coverCanvas) paintGrid() {
+	const (
+		minorCols, minorRows = 3, 2
+		majorCols, majorRows = 12, 5
+	)
+	minor, major := c.palette.ink[0], c.palette.ink[1]
+
+	for y := range c.height {
+		for x := range c.width {
+			onMajorRow, onMajorCol := y%majorRows == 2, x%majorCols == 6
+			onMinorRow, onMinorCol := y%minorRows == 0, x%minorCols == 0
+			switch {
+			case onMajorRow && onMajorCol:
+				c.set(x, y, "╋", major)
+			case onMajorRow:
+				c.set(x, y, "━", major)
+			case onMajorCol:
+				c.set(x, y, "┃", major)
+			case onMinorRow && onMinorCol:
+				c.set(x, y, "┼", minor)
+			case onMinorRow:
+				c.set(x, y, "─", minor)
+			case onMinorCol:
+				c.set(x, y, "│", minor)
+			}
+		}
+	}
+}
+
+// paintTopo draws a contour map in braille. A dot is on a contour when it sits
+// in a different band of the noise field than the dot left of or above it, which
+// traces the level sets one dot wide.
+//
+// Braille is what makes this read as a map. A contour drawn out of box-drawing
+// characters is a cell wide and a cell tall, so at any size worth looking at the
+// lines come out as thick staircases — closer to noise than to terrain. A
+// braille cell carries a 2×4 grid of dots, so the same contours land eight times
+// finer, and thin. The dots are square, too: a terminal cell is about twice as
+// tall as it is wide, which the 2×4 split cancels exactly, so the field needs no
+// aspect correction and the contours come out round.
+func (c *coverCanvas) paintTopo() {
+	const (
+		bands      = 7
+		featureDiv = 32 // noise lattice, in dots
+	)
+
+	// The sample is shifted a dot in from the origin because a contour compares
+	// against its left and upper neighbors, and the field starts at zero.
+	band := func(x, y int) int {
+		return int(coverNoise(float64(x+1)/featureDiv, float64(y+1)/featureDiv) * bands)
+	}
+
+	dots := newBrailleLayer(c.width, c.height)
+	for y := range dots.height {
+		for x := range dots.width {
+			here := band(x, y)
+			if here != band(x-1, y) || here != band(x, y-1) {
+				dots.set(x, y)
+			}
+		}
+	}
+	dots.drawInto(c, c.palette.ink[0])
+}
+
+// paintTerrazzo scatters chips over the field. The scatter comes from the cell's
+// own hash rather than a random source, so a cover is the same every time it is
+// drawn, the way the web app's is.
+func (c *coverCanvas) paintTerrazzo() {
+	chips := []string{"▪", "◆", "▰", "●", "▮", "◣"}
+	const density = 7 // one chip per this many cells
+
+	for y := range c.height {
+		for x := range c.width {
+			h := coverHash(uint32(x), uint32(y))
+			if h%density != 0 {
+				continue
+			}
+			c.set(x, y, chips[int(h>>16)%len(chips)], c.palette.ink[(h>>8)%3])
+		}
+	}
+}
+
+// paintPeace tiles HEY's hand in braille, offsetting alternate rows.
+//
+// Character cells cannot hold this. Two earlier attempts proved it: U+270C is
+// the right gesture, but a terminal is free to take an emoji codepoint from a
+// color font, which ignores the foreground color it is handed and arrives as its
+// own dull yellow hand, invisible on yellow; box-drawing line art at five cells
+// across has too few strokes to read as anything but a broken television. At 2×4
+// dots to the cell there is room for the fingers, the fist and the thumb.
+func (c *coverCanvas) paintPeace() {
+	dots := newBrailleLayer(c.width, c.height)
+	height := peaceHandHeight(dots.height)
+	width := int(peaceHandAspect * float64(height))
+	spacingX, spacingY := width*5/4, height*5/4
+
+	for y := 0; y < dots.height+spacingY; y += spacingY {
+		offset := 0
+		if (y/spacingY)%2 == 1 {
+			offset = spacingX / 2
+		}
+		for x := offset - spacingX; x < dots.width+spacingX; x += spacingX {
+			dots.peaceHand(float64(x), float64(y), float64(width), float64(height))
+		}
+	}
+	dots.drawInto(c, c.palette.ink[0])
+}
+
+// peaceHandAspect is the hand's width as a fraction of its height. The fingers
+// splay wide enough that the mark comes out nearly square.
+const peaceHandAspect = 0.85
+
+// peaceHandHeight is how tall the hand may be, in dots, on a cover this many dots
+// tall. It never grows past what the cover can hold — clipped, the fingers run off
+// the top and the mark stops being a hand — and it is big enough that the fingers
+// read as loops rather than strokes.
+// The preferred height is generous because the mark has six shapes in it: the
+// curled fingers stop telling themselves apart below about sixty dots, and the
+// whole thing is a smudge below twenty.
+func peaceHandHeight(dotRows int) int {
+	const preferred = 76
+	return max(min(preferred, dotRows-2), 14)
+}
+
+// peaceHand draws HEY's mark: the index and middle fingers up in a V over a
+// closed fist, with the thumb across the front of it. Everything is a fraction of
+// the mark's own box, so the same drawing works at any size the cover allows.
+//
+// The palm, the two fingers and the thumb are one silhouette — a single outline
+// around the whole hand — with the thumb's own loop drawn back over it, which is
+// the only line inside the shape. The thumb is what says the fist is a fist.
+func (l *brailleLayer) peaceHand(x, y, width, height float64) {
+	const lean = 0.42 // radians each finger tips away from vertical
+
+	// A finger is placed by its base, so the two of them rise from one point in
+	// the palm and splay apart. Leaning an ellipse about its own center instead
+	// swings the base sideways, sending each finger's base across to the other's
+	// side: the loops cross halfway up and the mark reads as a rabbit from behind.
+	finger := func(baseX, baseY, halfWidth, length, angle float64) coverEllipse {
+		return coverEllipse{
+			cx:   baseX + length*math.Sin(angle),
+			cy:   baseY - length*math.Cos(angle),
+			rx:   halfWidth,
+			ry:   length,
+			tilt: angle,
+		}
+	}
+
+	const (
+		// The thumb lies across the front of the fist at about twenty degrees off
+		// horizontal, so its angle is measured from vertical like the fingers' but
+		// is nearly a right angle.
+		thumbAngle = math.Pi/2 - 0.35
+		// The curled fingers lie twenty degrees further round than the index, which
+		// is counter-clockwise on screen: a positive angle leans a shape clockwise.
+		curlAngle = -lean - 0.345
+	)
+
+	// The palm is a squashed oval, turned thirty degrees clockwise. Its centre
+	// sits lower than the height alone would suggest so that the fingers still
+	// root well inside it: a shallow palm whose edge only grazes the finger bases
+	// leaves the silhouette pinched where they meet, or breaks it in two.
+	// Shorter on the left than the right, which an ellipse cannot be: the long axis
+	// is trimmed and the centre slid along it by half as much, so the left end
+	// comes in and the right end stays put.
+	palm := coverEllipse{x + width*0.44, y + height*0.752, width * 0.259, height * 0.14, 0.37}
+	index := finger(x+width*0.52, y+height*0.68, width*0.07, height*0.25, -lean)
+	middle := finger(x+width*0.52, y+height*0.68, width*0.07, height*0.28, lean)
+	thumb := finger(x+width*0.545, y+height*0.705, width*0.05, height*0.16, thumbAngle)
+
+	// The last two fingers, curled along the left, overlapping the index just
+	// enough to belong to the same hand.
+	ring := finger(x+width*0.486, y+height*0.715, width*0.045, height*0.14, curlAngle)
+	little := finger(x+width*0.42, y+height*0.745, width*0.04, height*0.12, curlAngle)
+
+	// The palm, the V and the thumb are one silhouette. The curled fingers are not
+	// in it: unioned, their outlines merge into the palm's and trail off along it,
+	// and the two of them read as one lump on the edge of the fist. Laid over a
+	// whole palm they stay two shapes.
+	l.silhouette(palm, index, middle, thumb)
+	for _, over := range []coverEllipse{thumb, ring, little} {
+		l.ellipse(over.cx, over.cy, over.rx, over.ry, over.tilt)
+	}
+}
+
+// maxBlobSlope is the steepest a ribbon may climb, in rows per column. A cell is
+// about twice as tall as it is wide, so half a row per column is a ribbon at
+// roughly forty-five degrees on screen — a sweep. Past that they read as
+// chevrons.
+const maxBlobSlope = 0.5
+
+// blobRibbonShape is how tall and how long a ribbon is on a cover this size.
+// Both scale with the block, so the pattern looks the same at any aspect ratio.
+// The wavelength takes whichever is larger of two floors: a quarter of the width,
+// so a wide cover shows a handful of sweeps instead of one lazy curve, and
+// whatever the amplitude needs to stay under maxBlobSlope, which is what keeps a
+// tall cover from turning into chevrons.
+func blobRibbonShape(width, height int) (amplitude, wavelength float64) {
+	amplitude = float64(height) / 3
+	return amplitude, max(float64(width)/4, amplitude/maxBlobSlope)
+}
+
+// paintBlobs lays HEY's yellow ribbons over mint. They are solid blocks rather
+// than the field's background color so the shape survives a colorless terminal.
+func (c *coverCanvas) paintBlobs() {
+	// Each ribbon is stretched from the base wavelength and given its own phase.
+	// Sharing a wavelength and offsetting the phase is tempting and wrong: half a
+	// wavelength apart makes the second ribbon an exact reflection of the first,
+	// and the field comes out symmetrical. Stretch factors are all at or above 1
+	// so no ribbon runs steeper than the base one.
+	ribbons := []struct{ stretch, phase float64 }{{1, 0}, {1.3, 1.7}, {1.7, 4.1}}
+	amplitude, wavelength := blobRibbonShape(c.width, c.height)
+	center := float64(c.height-1) / 2
+	thickness := max(float64(c.height)/14, 1)
+
+	for x := range c.width {
+		for _, r := range ribbons {
+			ribbon := center + amplitude*math.Sin(float64(x)/(wavelength*r.stretch)+r.phase)
+			for y := range c.height {
+				if math.Abs(float64(y)-ribbon) < thickness {
+					c.set(x, y, "█", c.palette.ink[0])
+				}
+			}
+		}
+	}
+}
+
+// paintWaves sweeps a gradient from the top left to the bottom right, warped by
+// a wave so the bands roll instead of stepping straight. Each band gets both a
+// color and a step of the shade ramp: the shades read as a gradient on their own
+// where there is no color, and blend one band into the next where there is.
+//
+// The web app's version is concentric arcs. A cover is far wider than it is
+// tall, and over that block arcs flatten into vertical stripes, so the curve
+// comes from the warp rather than from a radius.
+func (c *coverCanvas) paintWaves() {
+	shades := []string{"░", "▒", "▓", "█"}
+	const (
+		wavelength = 11
+		amplitude  = 9
+		// Rows count for more than columns because cells are about twice as tall
+		// as they are wide, and the sweep should read as a diagonal.
+		rowWeight = 1.5
+	)
+	span := float64(c.width)/2 + float64(c.height)*rowWeight
+
+	for y := range c.height {
+		for x := range c.width {
+			sweep := float64(x)/2 + float64(y)*rowWeight + amplitude*math.Sin(float64(x)/wavelength)
+			band := min(max(int(sweep/span*float64(len(shades))), 0), len(shades)-1)
+			c.set(x, y, shades[band], c.palette.ink[band])
+		}
+	}
+}
+
+// --- Deterministic value noise ---
+
+func coverHash(x, y uint32) uint32 {
+	const seed = 0x9e3779b9
+	h := x*374761393 + y*668265263 + seed
+	h = (h ^ (h >> 13)) * 1274126177
+	return h ^ (h >> 16)
+}
+
+// coverNoise is value noise in [0,1): the lattice hash, smoothstepped between
+// corners. Enough to grow contours out of, and it needs no assets. It is defined
+// for non-negative coordinates only, which is the whole canvas.
+func coverNoise(x, y float64) float64 {
+	x0, y0 := math.Floor(max(x, 0)), math.Floor(max(y, 0))
+	fx, fy := coverSmoothstep(x-x0), coverSmoothstep(y-y0)
+
+	corner := func(ix, iy float64) float64 {
+		return float64(coverHash(uint32(ix), uint32(iy))%1024) / 1024
+	}
+
+	top := coverLerp(corner(x0, y0), corner(x0+1, y0), fx)
+	bottom := coverLerp(corner(x0, y0+1), corner(x0+1, y0+1), fx)
+	return coverLerp(top, bottom, fy)
+}
+
+func coverSmoothstep(t float64) float64 { return t * t * (3 - 2*t) }
+
+func coverLerp(a, b, t float64) float64 { return a + (b-a)*t }

--- a/internal/tui/covers.go
+++ b/internal/tui/covers.go
@@ -18,11 +18,10 @@ import (
 // the better medium for two of them: a blueprint grid is what box-drawing
 // characters are for, and a contour map is a band boundary in a noise field.
 //
-// A cover is the one place the TUI paints brand colors instead of ANSI slots
-// (see styles.go): the art *is* HEY's yellow and mint, and a grey-on-grey
-// terrazzo would be worse than one that ignores the terminal theme. Colors are
-// laid over glyphs that carry the pattern on their own, so a colorless terminal
-// still gets the art rather than a blank band.
+// The art is painted in the ANSI-16 slots, so a cover wears the terminal's own
+// theme rather than HEY's hex. Colors are laid over glyphs that carry the pattern
+// on their own, so a colorless terminal still gets the art rather than a blank
+// band.
 type coverPreset string
 
 const (
@@ -40,13 +39,11 @@ const (
 // the art, rather than drawing a smear nobody can read.
 const coverMinRows = 5
 
-// The two things about the active theme a cover cares about, set by applyTheme:
-// which of the two palettes to use, and whether to paint at all. NO_COLOR leaves
-// the glyphs, which is the pattern.
-var (
-	coverDarkMode  = true
-	coverColorless = false
-)
+// The only thing about the active theme a cover cares about, set by applyTheme:
+// whether to paint at all. NO_COLOR leaves the glyphs, which is the pattern.
+// Nothing here needs to know whether the theme is light or dark — see
+// coverPalettes for why not.
+var coverColorless = false
 
 // imboxCover is the preset the Imbox is covered with. HEY serves a box's cover to
 // the web app but not over JSON, so HEY_COVER stands in until boxes carry it and
@@ -123,52 +120,45 @@ type coverPalette struct {
 	ink   [4]color.Color
 }
 
-// coverModes holds a preset's two palettes. Several presets are the same card in
-// both modes — HEY's yellow peace sign is yellow on a dark background too.
-type coverModes struct {
-	dark  coverPalette
-	light coverPalette
-}
-
-func (m coverModes) current() coverPalette {
+func (p coverPalette) current() coverPalette {
 	if coverColorless {
 		return coverPalette{}
 	}
-	if coverDarkMode {
-		return m.dark
-	}
-	return m.light
+	return p
 }
 
-func coverHex(s string) color.Color { return lipgloss.Color(s) }
-
-var coverPalettes = map[coverPreset]coverModes{
-	coverBlobs: {
-		dark:  coverPalette{field: coverHex("#5eead4"), ink: [4]color.Color{coverHex("#facc15")}},
-		light: coverPalette{field: coverHex("#99f6e4"), ink: [4]color.Color{coverHex("#fbbf24")}},
-	},
-	coverGrid: {
-		dark:  coverPalette{field: coverHex("#0f172a"), ink: [4]color.Color{coverHex("#3b82f6"), coverHex("#60a5fa")}},
-		light: coverPalette{field: coverHex("#f8fafc"), ink: [4]color.Color{coverHex("#93c5fd"), coverHex("#3b82f6")}},
-	},
-	coverPeace: {
-		dark:  coverPalette{field: coverHex("#facc15"), ink: [4]color.Color{coverHex("#ffffff")}},
-		light: coverPalette{field: coverHex("#fde047"), ink: [4]color.Color{coverHex("#ffffff")}},
-	},
-	coverTerrazzo: {
-		dark:  coverPalette{field: coverHex("#1e293b"), ink: [4]color.Color{coverHex("#ffffff"), coverHex("#f87171"), coverHex("#5eead4")}},
-		light: coverPalette{field: coverHex("#f8fafc"), ink: [4]color.Color{coverHex("#334155"), coverHex("#f87171"), coverHex("#2dd4bf")}},
-	},
-	coverTopo: {
-		dark:  coverPalette{field: coverHex("#7c3aed"), ink: [4]color.Color{coverHex("#1e1b3a")}},
-		light: coverPalette{field: coverHex("#a78bfa"), ink: [4]color.Color{coverHex("#3b0764")}},
-	},
-	coverWaves: {
-		dark: coverPalette{field: coverHex("#7c3aed"), ink: [4]color.Color{
-			coverHex("#fcd34d"), coverHex("#f9a8d4"), coverHex("#c084fc"), coverHex("#6d28d9")}},
-		light: coverPalette{field: coverHex("#a78bfa"), ink: [4]color.Color{
-			coverHex("#fde68a"), coverHex("#fbcfe8"), coverHex("#d8b4fe"), coverHex("#8b5cf6")}},
-	},
+// Covers are painted in the ANSI-16 slots, like the rest of the TUI and for the
+// same reason (see styles.go): a desktop theme defines those sixteen colors and
+// retints running terminals over OSC 4, so the art follows the theme with no work
+// here and restyles live when the theme changes. HEY's own covers are yellow and
+// mint and violet; these name the slots those stand in for, and what arrives is
+// the reader's palette.
+//
+// There is deliberately one palette per preset rather than a light one and a dark
+// one, which is what the web app needs. The slots a cover uses are chosen for the
+// job each one does in a theme, not for how bright it happens to be:
+//
+//   - Black is the background and White the foreground — in every theme, light or
+//     dark. A cover whose field is Black is a cover on the reader's own paper,
+//     and its foreground ink is legible there without anyone deciding which way
+//     round the theme is. That is what makes HEY's white terrazzo chips turn black
+//     in light mode: they are not white, they are the text color.
+//   - A hue — yellow, cyan, magenta, blue — is a mid-tone everywhere, so a hue on
+//     a hue keeps its contrast either way.
+//
+// Reaching for a slot because it looks light or dark is what goes wrong. Painting
+// a light-mode field BrightWhite gets a *dark* field, because on a light theme the
+// bright foreground is dark: exactly inverted, and only on the themes the cover
+// was supposed to be fixing.
+var coverPalettes = map[coverPreset]coverPalette{
+	coverBlobs: {field: lipgloss.Cyan, ink: [4]color.Color{lipgloss.BrightYellow}},
+	coverGrid:  {field: lipgloss.Black, ink: [4]color.Color{lipgloss.Blue, lipgloss.BrightBlue}},
+	coverPeace: {field: lipgloss.Yellow, ink: [4]color.Color{lipgloss.BrightWhite}},
+	coverTerrazzo: {field: lipgloss.Black, ink: [4]color.Color{
+		lipgloss.BrightWhite, lipgloss.Red, lipgloss.Cyan}},
+	coverTopo: {field: lipgloss.Magenta, ink: [4]color.Color{lipgloss.Black}},
+	coverWaves: {field: lipgloss.Magenta, ink: [4]color.Color{
+		lipgloss.BrightYellow, lipgloss.Red, lipgloss.BrightMagenta, lipgloss.Blue}},
 }
 
 // --- Canvas ---
@@ -306,26 +296,10 @@ func (l *brailleLayer) at(x, y int) bool {
 	return l.dots[y*l.width+x]
 }
 
-// arc plots by angle rather than by testing distance per dot: stepping the curve
-// in half-dot lengths leaves no gaps, where a distance test leaves them wherever
-// the curve runs diagonally. tilt turns the ellipse about its center, which is
-// what lets a shape lean.
-func (l *brailleLayer) arc(cx, cy, rx, ry, tilt, from, to float64) {
-	steps := max(int(2*max(rx, ry)*math.Abs(to-from)), 8)
-	sin, cos := math.Sin(tilt), math.Cos(tilt)
-	for i := 0; i <= steps; i++ {
-		angle := from + (to-from)*float64(i)/float64(steps)
-		x, y := rx*math.Cos(angle), ry*math.Sin(angle)
-		l.set(int(math.Round(cx+x*cos-y*sin)), int(math.Round(cy+x*sin+y*cos)))
-	}
-}
-
-func (l *brailleLayer) ellipse(cx, cy, rx, ry, tilt float64) {
-	l.arc(cx, cy, rx, ry, tilt, 0, 2*math.Pi)
-}
-
-// coverEllipse is a filled ellipse, used to build a silhouette out of overlapping
-// shapes rather than to draw one.
+// coverEllipse is a filled ellipse. Everything a cover draws with curves is built
+// out of these and outlined by silhouette; there is no stroke-an-arc primitive,
+// because filling and tracing gives a shape of any thickness and a union of any
+// number of parts for the same effort.
 type coverEllipse struct {
 	cx, cy, rx, ry, tilt float64
 }
@@ -369,14 +343,28 @@ func (l *brailleLayer) silhouette(shapes ...coverEllipse) {
 	for y := max(int(top)-1, 0); y <= min(int(bottom)+1, l.height-1); y++ {
 		for x := max(int(left)-1, 0); x <= min(int(right)+1, l.width-1); x++ {
 			fx, fy := float64(x), float64(y)
-			if !inside(fx, fy) {
-				continue
-			}
-			if !inside(fx-1, fy) || !inside(fx+1, fy) || !inside(fx, fy-1) || !inside(fx, fy+1) {
+			if inside(fx, fy) && !buried(inside, fx, fy) {
 				l.set(x, y)
 			}
 		}
 	}
+}
+
+// coverStroke is how many dots thick a drawn edge is. One dot is a dotted line
+// rather than a line: braille dots do not touch, so a single-dot outline on a
+// bright field reads as a scattering of specks and the shape it describes is lost.
+const coverStroke = 2
+
+// buried reports whether everything within the stroke's reach of this dot is also
+// inside the shape, which is what puts the dot in the interior rather than on the
+// edge. Reaching further than one dot is what thickens the edge.
+func buried(inside func(x, y float64) bool, x, y float64) bool {
+	for step := 1.0; step <= coverStroke; step++ {
+		if !inside(x-step, y) || !inside(x+step, y) || !inside(x, y-step) || !inside(x, y+step) {
+			return false
+		}
+	}
+	return true
 }
 
 func (l *brailleLayer) drawInto(c *coverCanvas, ink color.Color) {
@@ -573,8 +561,10 @@ func (l *brailleLayer) peaceHand(x, y, width, height float64) {
 
 	// The last two fingers, curled along the left, overlapping the index just
 	// enough to belong to the same hand.
-	ring := finger(x+width*0.486, y+height*0.715, width*0.045, height*0.14, curlAngle)
-	little := finger(x+width*0.42, y+height*0.745, width*0.04, height*0.12, curlAngle)
+	// Wide enough that a two-dot stroke still leaves them hollow: any thinner and
+	// the two edges meet in the middle and the finger is a solid smear.
+	ring := finger(x+width*0.486, y+height*0.715, width*0.065, height*0.14, curlAngle)
+	little := finger(x+width*0.42, y+height*0.745, width*0.06, height*0.12, curlAngle)
 
 	// The palm, the V and the thumb are one silhouette. The curled fingers are not
 	// in it: unioned, their outlines merge into the palm's and trail off along it,
@@ -582,7 +572,7 @@ func (l *brailleLayer) peaceHand(x, y, width, height float64) {
 	// whole palm they stay two shapes.
 	l.silhouette(palm, index, middle, thumb)
 	for _, over := range []coverEllipse{thumb, ring, little} {
-		l.ellipse(over.cx, over.cy, over.rx, over.ry, over.tilt)
+		l.silhouette(over)
 	}
 }
 

--- a/internal/tui/covers.go
+++ b/internal/tui/covers.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"image/color"
 	"math"
-	"os"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -44,13 +43,6 @@ const coverMinRows = 5
 // Nothing here needs to know whether the theme is light or dark — see
 // coverPalettes for why not.
 var coverColorless = false
-
-// imboxCover is the preset the Imbox is covered with. HEY serves a box's cover to
-// the web app but not over JSON, so HEY_COVER stands in until boxes carry it and
-// this reads the box instead. An unset or unknown value draws nothing.
-func imboxCover() coverPreset {
-	return parseCoverPreset(os.Getenv("HEY_COVER"))
-}
 
 func parseCoverPreset(name string) coverPreset {
 	switch coverPreset(strings.ToLower(strings.TrimSpace(name))) {

--- a/internal/tui/covers.go
+++ b/internal/tui/covers.go
@@ -153,10 +153,23 @@ func (p coverPalette) current() coverPalette {
 var coverPalettes = map[coverPreset]coverPalette{
 	coverBlobs: {field: lipgloss.Cyan, ink: [4]color.Color{lipgloss.BrightYellow}},
 	coverGrid:  {field: lipgloss.Black, ink: [4]color.Color{lipgloss.Blue, lipgloss.BrightBlue}},
-	coverPeace: {field: lipgloss.Yellow, ink: [4]color.Color{lipgloss.BrightWhite}},
+
+	// HEY draws the hand white on a yellow card. Yellow is the lightest hue a theme
+	// has, so a whole cover of it glares in every one of them, and there is no
+	// darker yellow to reach for — a palette has one. The yellow moves to the hand
+	// instead: the cover still reads yellow, but as line work on the reader's own
+	// paper rather than as a lit panel.
+	coverPeace: {field: lipgloss.Black, ink: [4]color.Color{lipgloss.Yellow}},
+
 	coverTerrazzo: {field: lipgloss.Black, ink: [4]color.Color{
 		lipgloss.BrightWhite, lipgloss.Red, lipgloss.Cyan}},
-	coverTopo: {field: lipgloss.Magenta, ink: [4]color.Color{lipgloss.Black}},
+
+	// A contour map on the reader's own paper. The web's violet is between blue and
+	// magenta and no palette has it; blue is the darkest hue on offer and still
+	// read as too bright across a whole cover, and there is nothing darker than a
+	// hue except the background. So the field is the background and the contours
+	// keep the violet end of the palette.
+	coverTopo: {field: lipgloss.Black, ink: [4]color.Color{lipgloss.Magenta}},
 	coverWaves: {field: lipgloss.Magenta, ink: [4]color.Color{
 		lipgloss.BrightYellow, lipgloss.Red, lipgloss.BrightMagenta, lipgloss.Blue}},
 }

--- a/internal/tui/covers_test.go
+++ b/internal/tui/covers_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"image/color"
 	"slices"
 	"strings"
@@ -360,6 +361,72 @@ func TestCoverPickerRefusesOtherBoxes(t *testing.T) {
 	}
 	if hasHelpBinding(v.HelpBindings(), "ctrl+v") {
 		t.Error("help offers cover art on a box that cannot be covered")
+	}
+}
+
+// The cover outlives the session, so a reader picks one once. It is stored
+// locally rather than read from HEY, the way the iOS and Android apps do it.
+func TestCoverPickerRemembersTheChoice(t *testing.T) {
+	saved := "grid"
+	vc := testVC()
+	vc.loadCover = func() string { return saved }
+	vc.saveCover = func(preset string) error {
+		saved = preset
+		return nil
+	}
+
+	v := newMailView(vc)
+	if v.cover != coverGrid {
+		t.Fatalf("a new mail view opened with %q, want the stored grid", v.cover)
+	}
+
+	v.boxes = orderBoxes(testBoxes())
+	v.Update(currentPostingsLoaded(v, testPostings()))
+	v.HandleContentKey(keyPress("ctrl+v"))
+	for v.coverPicker.selected() != coverPeace {
+		v.HandleContentKey(keyPress("down"))
+	}
+	v.HandleContentKey(keyPress("enter"))
+
+	if saved != "peace" {
+		t.Errorf("stored cover = %q, want peace", saved)
+	}
+	if v.notice != "" {
+		t.Errorf("a cover that stored cleanly left a notice: %q", v.notice)
+	}
+
+	// Uncovering is stored too, or the cover comes back on the next run.
+	v.HandleContentKey(keyPress("ctrl+v"))
+	for v.coverPicker.selected() != coverNone {
+		v.HandleContentKey(keyPress("up"))
+	}
+	v.HandleContentKey(keyPress("enter"))
+	if saved != "" {
+		t.Errorf("stored cover after uncovering = %q, want empty", saved)
+	}
+}
+
+// Failing to store the choice must not stop it taking effect: the cover is on
+// screen either way, and all that is lost is remembering it next time.
+func TestCoverPickerSurvivesAFailedWrite(t *testing.T) {
+	vc := testVC()
+	vc.saveCover = func(string) error { return errors.New("read-only file system") }
+
+	v := newMailView(vc)
+	v.boxes = orderBoxes(testBoxes())
+	v.Update(currentPostingsLoaded(v, testPostings()))
+
+	v.HandleContentKey(keyPress("ctrl+v"))
+	for v.coverPicker.selected() != coverTopo {
+		v.HandleContentKey(keyPress("down"))
+	}
+	v.HandleContentKey(keyPress("enter"))
+
+	if v.cover != coverTopo || v.postingList.cover != coverTopo {
+		t.Errorf("cover = %q, list = %q, want topo despite the failed write", v.cover, v.postingList.cover)
+	}
+	if !strings.Contains(v.notice, "read-only file system") {
+		t.Errorf("notice = %q, want it to say why the cover was not remembered", v.notice)
 	}
 }
 

--- a/internal/tui/covers_test.go
+++ b/internal/tui/covers_test.go
@@ -134,15 +134,15 @@ func TestPeaceHandFitsEveryCover(t *testing.T) {
 // columns drew chevrons on a tall cover, because only the amplitude scaled with
 // the height; a wavelength taken from the height alone then drew a busy repeat on
 // a wide short one. Both properties are pinned here.
-func TestBlobRibbonShapeHoldsAtAnyAspect(t *testing.T) {
+func TestWaveRibbonShapeHoldsAtAnyAspect(t *testing.T) {
 	for _, size := range []struct{ width, height int }{
 		{92, 12}, {190, 55}, {60, 30}, {240, 20}, {40, 6}, {300, 90},
 	} {
-		amplitude, wavelength := blobRibbonShape(size.width, size.height)
+		amplitude, wavelength := waveRibbonShape(size.width, size.height)
 
-		if slope := amplitude / wavelength; slope > maxBlobSlope {
+		if slope := amplitude / wavelength; slope > maxWaveSlope {
 			t.Errorf("%dx%d: ribbons climb %.2f rows per column, want at most %.2f",
-				size.width, size.height, slope, maxBlobSlope)
+				size.width, size.height, slope, maxWaveSlope)
 		}
 		if sweeps := float64(size.width) / wavelength; sweeps > 4.01 {
 			t.Errorf("%dx%d: %.1f sweeps across, want at most 4 so it reads as ribbons",
@@ -154,12 +154,12 @@ func TestBlobRibbonShapeHoldsAtAnyAspect(t *testing.T) {
 	}
 }
 
-// Ribbons cover some of the field, not all of it and not none: HEY's blobs are
+// Ribbons cover some of the field, not all of it and not none: HEY's waves are
 // yellow on mint, and both colors have to be in the picture.
-func TestBlobsLeaveTheFieldShowing(t *testing.T) {
+func TestWavesLeaveTheFieldShowing(t *testing.T) {
 	for _, size := range []struct{ width, height int }{{92, 12}, {190, 55}, {240, 20}} {
 		canvas := newCoverCanvas(size.width, size.height, coverPalette{})
-		canvas.paintBlobs()
+		canvas.paintWaves()
 
 		inked := strings.Count(canvas.plain(), "█")
 		share := float64(inked) / float64(size.width*size.height)

--- a/internal/tui/covers_test.go
+++ b/internal/tui/covers_test.go
@@ -1,0 +1,381 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/basecamp/hey-cli/internal/models"
+)
+
+var allCoverPresets = []coverPreset{coverBlobs, coverGrid, coverPeace, coverTerrazzo, coverTopo, coverWaves}
+
+func TestParseCoverPreset(t *testing.T) {
+	for _, preset := range allCoverPresets {
+		if got := parseCoverPreset(string(preset)); got != preset {
+			t.Errorf("parseCoverPreset(%q) = %q, want %q", preset, got, preset)
+		}
+	}
+
+	if got := parseCoverPreset("  TOPO "); got != coverTopo {
+		t.Errorf("parseCoverPreset with padding and case = %q, want %q", got, coverTopo)
+	}
+	for _, name := range []string{"", "calendar", "sunset"} {
+		if got := parseCoverPreset(name); got != coverNone {
+			t.Errorf("parseCoverPreset(%q) = %q, want no cover", name, got)
+		}
+	}
+}
+
+// A cover has to be exactly the block it was asked for: one row over and the list
+// scrolls, one column over and every row wraps.
+func TestCoverFillsItsBlockExactly(t *testing.T) {
+	const width, height = 60, 9
+
+	for _, preset := range allCoverPresets {
+		renderer := &coverRenderer{}
+		lines := strings.Split(renderer.view(preset, width, height), "\n")
+		if len(lines) != height {
+			t.Errorf("%s: %d rows, want %d", preset, len(lines), height)
+			continue
+		}
+		for i, line := range lines {
+			if w := lipgloss.Width(line); w != width {
+				t.Errorf("%s: row %d is %d cells wide, want %d", preset, i, w, width)
+			}
+		}
+	}
+}
+
+func TestCoverIsDeterministic(t *testing.T) {
+	for _, preset := range allCoverPresets {
+		first := (&coverRenderer{}).view(preset, 40, 8)
+		second := (&coverRenderer{}).view(preset, 40, 8)
+		if first != second {
+			t.Errorf("%s renders differently on a second pass", preset)
+		}
+	}
+}
+
+func TestCoverNoneRendersNothing(t *testing.T) {
+	if got := (&coverRenderer{}).view(coverNone, 40, 8); got != "" {
+		t.Errorf("coverNone rendered %q, want empty", got)
+	}
+}
+
+// The pattern lives in the glyphs, not the colors, so that a colorless terminal
+// still gets art. Assert the grid's shape rather than its escape sequences.
+func TestCoverGridPattern(t *testing.T) {
+	canvas := newCoverCanvas(13, 6, coverPalette{})
+	canvas.paintGrid()
+
+	want := strings.Join([]string{
+		"┼──┼──┃──┼──┼",
+		"│  │  ┃  │  │",
+		"━━━━━━╋━━━━━━",
+		"│  │  ┃  │  │",
+		"┼──┼──┃──┼──┼",
+		"│  │  ┃  │  │",
+	}, "\n")
+
+	if got := canvas.plain(); got != want {
+		t.Errorf("grid pattern:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// Two presets draw curves, which characters cannot hold: contours and a circle
+// both need braille's 2×4 dots. Box-drawing was tried for each and read as noise
+// and as a broken television respectively.
+func TestBraillePaintersDrawOnlyBraille(t *testing.T) {
+	for preset, paint := range map[coverPreset]func(*coverCanvas){
+		coverTopo:  (*coverCanvas).paintTopo,
+		coverPeace: (*coverCanvas).paintPeace,
+	} {
+		canvas := newCoverCanvas(60, 16, coverPalette{})
+		paint(canvas)
+
+		drawn := 0
+		for _, glyph := range canvas.plain() {
+			switch {
+			case glyph == ' ' || glyph == '\n':
+			case glyph > brailleBlank && glyph <= brailleBlank+0xff:
+				drawn++
+			default:
+				t.Fatalf("%s drew %q, which is not a braille cell", preset, glyph)
+			}
+		}
+		if drawn == 0 {
+			t.Errorf("%s drew nothing", preset)
+		}
+	}
+}
+
+// Clipped, the fingers run off the top and the mark stops being a hand, so it
+// shrinks to fit a short cover instead.
+func TestPeaceHandFitsEveryCover(t *testing.T) {
+	for _, rows := range []int{coverMinRows, 8, 12, 24, 55, 90} {
+		dotRows := rows * brailleRows
+		height := peaceHandHeight(dotRows)
+
+		if height > dotRows {
+			t.Errorf("%d rows: a hand %d dots tall does not fit in %d", rows, height, dotRows)
+		}
+		if height < 14 {
+			t.Errorf("%d rows: a hand %d dots tall is too small to read", rows, height)
+		}
+	}
+}
+
+// A ribbon has to stay a ribbon at every shape of cover. Wavelengths fixed in
+// columns drew chevrons on a tall cover, because only the amplitude scaled with
+// the height; a wavelength taken from the height alone then drew a busy repeat on
+// a wide short one. Both properties are pinned here.
+func TestBlobRibbonShapeHoldsAtAnyAspect(t *testing.T) {
+	for _, size := range []struct{ width, height int }{
+		{92, 12}, {190, 55}, {60, 30}, {240, 20}, {40, 6}, {300, 90},
+	} {
+		amplitude, wavelength := blobRibbonShape(size.width, size.height)
+
+		if slope := amplitude / wavelength; slope > maxBlobSlope {
+			t.Errorf("%dx%d: ribbons climb %.2f rows per column, want at most %.2f",
+				size.width, size.height, slope, maxBlobSlope)
+		}
+		if sweeps := float64(size.width) / wavelength; sweeps > 4.01 {
+			t.Errorf("%dx%d: %.1f sweeps across, want at most 4 so it reads as ribbons",
+				size.width, size.height, sweeps)
+		}
+		if amplitude < 1 {
+			t.Errorf("%dx%d: amplitude %.2f leaves the ribbons flat", size.width, size.height, amplitude)
+		}
+	}
+}
+
+// Ribbons cover some of the field, not all of it and not none: HEY's blobs are
+// yellow on mint, and both colors have to be in the picture.
+func TestBlobsLeaveTheFieldShowing(t *testing.T) {
+	for _, size := range []struct{ width, height int }{{92, 12}, {190, 55}, {240, 20}} {
+		canvas := newCoverCanvas(size.width, size.height, coverPalette{})
+		canvas.paintBlobs()
+
+		inked := strings.Count(canvas.plain(), "█")
+		share := float64(inked) / float64(size.width*size.height)
+		if share < 0.15 || share > 0.6 {
+			t.Errorf("%dx%d: ribbons cover %.0f%% of the cover, want between 15%% and 60%%",
+				size.width, size.height, share*100)
+		}
+	}
+}
+
+func TestCoverColorlessKeepsTheGlyphs(t *testing.T) {
+	t.Cleanup(func() { applyTheme(defaultTheme()) })
+	applyTheme(noColorTheme())
+
+	for _, preset := range allCoverPresets {
+		rendered := (&coverRenderer{}).view(preset, 40, 8)
+		if strings.Contains(rendered, "\x1b") {
+			t.Errorf("%s emitted an escape sequence with color disabled", preset)
+		}
+		if strings.TrimSpace(rendered) == "" {
+			t.Errorf("%s rendered nothing but blanks with color disabled", preset)
+		}
+	}
+}
+
+// The renderer keeps the last cover it drew, so its memo has to notice a theme
+// switch — otherwise a light terminal keeps the dark palette until it resizes.
+func TestCoverRepaintsOnThemeChange(t *testing.T) {
+	t.Cleanup(func() { applyTheme(defaultTheme()) })
+
+	renderer := &coverRenderer{}
+	dark := renderer.view(coverTerrazzo, 40, 8)
+
+	light := defaultTheme()
+	light.Dark = false
+	applyTheme(light)
+
+	if renderer.view(coverTerrazzo, 40, 8) == dark {
+		t.Error("cover kept the dark palette after switching to a light theme")
+	}
+}
+
+// --- The cover as a lid ---
+
+func coveredList(cover coverPreset, height int, seen ...bool) *contentList {
+	postings := make([]models.Posting, len(seen))
+	for i, isSeen := range seen {
+		postings[i] = models.Posting{
+			ID:      int64(i + 1),
+			Name:    coveredThreadName(isSeen, i),
+			Seen:    isSeen,
+			Creator: models.Contact{Name: "Jason Fried"},
+		}
+	}
+	list := &contentList{width: 60, height: height, cover: cover}
+	list.setPostings(postings)
+	return list
+}
+
+func coveredThreadName(seen bool, index int) string {
+	if seen {
+		return "Read thread " + string(rune('A'+index))
+	}
+	return "Unread thread " + string(rune('A'+index))
+}
+
+// The point of a cover is that what is under it is not on screen. The divider
+// stays, so the reader knows there is something there and how to get at it.
+func TestCoverHidesPreviouslySeen(t *testing.T) {
+	list := coveredList(coverTopo, 24, false, true, true, true)
+
+	view := list.view()
+	if !strings.Contains(view, sectionPreviouslySeen.label()) {
+		t.Error("covered list dropped the Previously Seen divider")
+	}
+	if !strings.Contains(view, "3 hidden · v to peek") {
+		t.Error("covered list gave no hint about what is under the cover")
+	}
+	for _, posting := range list.postings[1:] {
+		if strings.Contains(view, posting.Name) {
+			t.Errorf("%q is visible through the cover", posting.Name)
+		}
+	}
+	if !strings.Contains(view, list.postings[0].Name) {
+		t.Error("the cover hid an unseen thread")
+	}
+}
+
+// Hidden threads are out of reach too — a cursor under the cover would be a
+// cursor nobody can see, and a bulk action nobody meant.
+func TestCoveredThreadsAreOutOfReach(t *testing.T) {
+	list := coveredList(coverTopo, 24, false, false, true, true)
+
+	if got := list.itemCount(); got != 2 {
+		t.Errorf("itemCount = %d, want 2", got)
+	}
+	for range 5 {
+		list.moveDown()
+	}
+	if list.cursor != 1 {
+		t.Errorf("cursor reached %d, want to stop at 1", list.cursor)
+	}
+	if posting := list.selectedPosting(); posting == nil || posting.Seen {
+		t.Error("the cursor got under the cover")
+	}
+}
+
+func TestPeekingLiftsTheCover(t *testing.T) {
+	list := coveredList(coverTopo, 24, false, true, true)
+	list.toggleCoverPeek()
+
+	view := list.view()
+	if got := list.itemCount(); got != 3 {
+		t.Errorf("itemCount after peeking = %d, want 3", got)
+	}
+	if !strings.Contains(view, list.postings[2].Name) {
+		t.Error("peeking did not reveal the seen threads")
+	}
+	if !strings.Contains(view, "v to cover") {
+		t.Error("a peeked list does not say how to put the cover back")
+	}
+
+	list.toggleCoverPeek()
+	if got := list.itemCount(); got != 1 {
+		t.Errorf("itemCount after covering again = %d, want 1", got)
+	}
+}
+
+// The art gets every row the threads above it did not use, so the cover reaches
+// the bottom of the screen instead of floating as a band.
+func TestCoverFillsToTheBottom(t *testing.T) {
+	for _, height := range []int{18, 24, 40} {
+		list := coveredList(coverWaves, height, false, false, true, true, true)
+		rows := strings.Count(list.view(), "\n") + 1
+		if rows != height {
+			t.Errorf("height %d: covered list rendered %d rows", height, rows)
+		}
+	}
+}
+
+// A list with no room for art keeps the divider: the hint matters more than the
+// picture, and half a picture is worse than none.
+func TestCoverDropsTheArtBeforeTheDivider(t *testing.T) {
+	list := coveredList(coverTopo, coverMinRows+2, false, false, true)
+
+	view := list.view()
+	if !strings.Contains(view, "1 hidden · v to peek") {
+		t.Error("a short covered list lost its divider")
+	}
+	if rows := strings.Count(view, "\n") + 1; rows > coverMinRows+2 {
+		t.Errorf("short covered list rendered %d rows, over its height", rows)
+	}
+}
+
+// With everything read, the Imbox is the cover and nothing else.
+func TestCoverWithNothingUnread(t *testing.T) {
+	list := coveredList(coverPeace, 20, true, true)
+
+	if got := list.itemCount(); got != 0 {
+		t.Errorf("itemCount = %d, want 0", got)
+	}
+	view := list.view()
+	if !strings.Contains(view, "2 hidden · v to peek") {
+		t.Error("an all-read Imbox does not say what is under the cover")
+	}
+	if rows := strings.Count(view, "\n") + 1; rows != 20 {
+		t.Errorf("all-read covered list rendered %d rows, want 20", rows)
+	}
+}
+
+func TestUncoveredAndFlatListsShowEverything(t *testing.T) {
+	uncovered := coveredList(coverNone, 24, false, true, true)
+	if got := uncovered.itemCount(); got != 3 {
+		t.Errorf("uncovered list reaches %d postings, want 3", got)
+	}
+
+	flat := coveredList(coverTopo, 24, false, true, true)
+	flat.hideSeenState = true
+	if got := flat.itemCount(); got != 3 {
+		t.Errorf("list without seen sections reaches %d postings, want 3", got)
+	}
+}
+
+// Reading a thread puts it under the cover, which must not leave the cursor or a
+// selection stranded there.
+func TestMarkingSeenSlidesAThreadUnderTheCover(t *testing.T) {
+	list := coveredList(coverTopo, 24, false, false, true)
+	list.cursor = 1
+	list.toggleSelected()
+
+	list.markSeen(1)
+
+	if got := list.itemCount(); got != 1 {
+		t.Errorf("itemCount = %d, want 1", got)
+	}
+	if list.cursor >= list.itemCount() {
+		t.Errorf("cursor %d is under the cover", list.cursor)
+	}
+	if ids := list.selectedIDs(); len(ids) != 0 {
+		t.Errorf("selection %v survived under the cover", ids)
+	}
+}
+
+// The Imbox stacks three sections and only the last one is covered.
+func TestBubbledUpAndNewStayVisible(t *testing.T) {
+	list := &contentList{width: 60, height: 24, cover: coverTopo}
+	list.setPostings([]models.Posting{
+		{ID: 1, Name: "Bubbled thread", BubbledUp: true},
+		{ID: 2, Name: "Unread thread"},
+		{ID: 3, Name: "Read thread", Seen: true},
+	})
+
+	view := list.view()
+	for _, name := range []string{"Bubbled thread", "Unread thread"} {
+		if !strings.Contains(view, name) {
+			t.Errorf("%q was covered", name)
+		}
+	}
+	if strings.Contains(view, "Read thread") {
+		t.Error("the seen thread is visible through the cover")
+	}
+}

--- a/internal/tui/covers_test.go
+++ b/internal/tui/covers_test.go
@@ -2,9 +2,11 @@ package tui
 
 import (
 	"image/color"
+	"slices"
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/basecamp/hey-cli/internal/models"
@@ -243,6 +245,144 @@ func TestCoverRepaintsWhenColorGoesAway(t *testing.T) {
 	applyTheme(noColorTheme())
 	if renderer.view(coverTerrazzo, 40, 8) == colored {
 		t.Error("cover kept its colors after color was turned off")
+	}
+}
+
+// --- Picking a cover ---
+
+func TestCoverPickerOffersEveryPresetAndNone(t *testing.T) {
+	picker := newCoverPicker(coverNone)
+
+	if len(picker.choices) != len(allCoverPresets)+1 {
+		t.Fatalf("picker offers %d choices, want every preset plus none", len(picker.choices))
+	}
+	if picker.choices[0] != coverNone {
+		t.Errorf("first choice is %q, want no cover", picker.choices[0])
+	}
+	for _, preset := range allCoverPresets {
+		if !slices.Contains(picker.choices, preset) {
+			t.Errorf("picker does not offer %s", preset)
+		}
+	}
+}
+
+// The picker opens on what is already covering the Imbox, so enter is a no-op
+// rather than a surprise.
+func TestCoverPickerStartsOnTheCurrentCover(t *testing.T) {
+	for _, preset := range append([]coverPreset{coverNone}, allCoverPresets...) {
+		if got := newCoverPicker(preset).selected(); got != preset {
+			t.Errorf("picker opened on %q, want %q", got, preset)
+		}
+	}
+}
+
+func TestCoverPickerMovesAndStops(t *testing.T) {
+	picker := newCoverPicker(coverNone)
+	last := len(picker.choices) - 1
+
+	for range len(picker.choices) + 3 {
+		picker.update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	if picker.cursor != last {
+		t.Errorf("cursor ran to %d, want to stop at %d", picker.cursor, last)
+	}
+
+	for range len(picker.choices) + 3 {
+		picker.update(tea.KeyPressMsg{Code: tea.KeyUp})
+	}
+	if picker.cursor != 0 {
+		t.Errorf("cursor ran to %d, want to stop at 0", picker.cursor)
+	}
+}
+
+// A cover is chosen by looking at it, so the picker draws the highlighted one.
+func TestCoverPickerPreviewsTheHighlightedCover(t *testing.T) {
+	picker := newCoverPicker(coverTopo)
+	view := picker.view(newStyles(), 60)
+
+	if !strings.Contains(view, "Topo") {
+		t.Error("picker does not name the highlighted cover")
+	}
+	preview := (&coverRenderer{}).view(coverTopo, 56, coverPreviewRows)
+	if !strings.Contains(view, preview) {
+		t.Error("picker does not draw the highlighted cover")
+	}
+
+	if strings.Contains(newCoverPicker(coverNone).view(newStyles(), 60), preview) {
+		t.Error("picker drew art for no cover")
+	}
+}
+
+// ctrl+v picks the cover, and the choice outlives the box it was made in: there
+// is nowhere to read a cover back from, so the session is what remembers it.
+func TestCoverPickerAppliesToTheImbox(t *testing.T) {
+	v := mailWithPostings()
+
+	if cmd := v.HandleContentKey(keyPress("ctrl+v")); cmd != nil {
+		t.Fatal("opening the cover picker should not start a request")
+	}
+	if v.coverPicker == nil || !v.CapturingInput() {
+		t.Fatal("ctrl+v did not open a picker that captures input")
+	}
+
+	for v.coverPicker.selected() != coverTopo {
+		v.HandleContentKey(keyPress("down"))
+	}
+	v.HandleContentKey(keyPress("enter"))
+
+	if v.coverPicker != nil {
+		t.Error("enter left the picker open")
+	}
+	if v.cover != coverTopo || v.postingList.cover != coverTopo {
+		t.Errorf("cover = %q, list = %q, want topo", v.cover, v.postingList.cover)
+	}
+
+	// A re-read of the box keeps it, and so does coming back from another box.
+	v.Update(currentPostingsLoaded(v, testPostings()))
+	if v.postingList.cover != coverTopo {
+		t.Errorf("reading the Imbox again dropped the cover: %q", v.postingList.cover)
+	}
+}
+
+// Only the Imbox is coverable, which is haystack's rule. Elsewhere the key says so
+// rather than doing nothing.
+func TestCoverPickerRefusesOtherBoxes(t *testing.T) {
+	v := mailWithPostings()
+	v.boxIndex = 1
+	v.Update(currentPostingsLoaded(v, testPostings()))
+
+	v.HandleContentKey(keyPress("ctrl+v"))
+	if v.coverPicker != nil {
+		t.Error("picker opened on a box that cannot be covered")
+	}
+	if v.notice == "" {
+		t.Error("picker refused silently")
+	}
+	if hasHelpBinding(v.HelpBindings(), "ctrl+v") {
+		t.Error("help offers cover art on a box that cannot be covered")
+	}
+}
+
+// The chorded keys sit at the end of the help bar, together, keeping their order.
+// Scattered among the single keys they push the everyday ones onto a second line.
+func TestModifiersLast(t *testing.T) {
+	got := modifiersLast([]helpBinding{
+		{"/", "search"},
+		{"ctrl+s", "screener"},
+		{"c", "compose"},
+		{"ctrl+r", "reload"},
+		{"u", "undo"},
+	})
+
+	want := []helpBinding{
+		{"/", "search"},
+		{"c", "compose"},
+		{"u", "undo"},
+		{"ctrl+s", "screener"},
+		{"ctrl+r", "reload"},
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("bindings = %v, want %v", got, want)
 	}
 }
 

--- a/internal/tui/covers_test.go
+++ b/internal/tui/covers_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"image/color"
 	"strings"
 	"testing"
 
@@ -167,6 +168,53 @@ func TestBlobsLeaveTheFieldShowing(t *testing.T) {
 	}
 }
 
+// Covers are painted in the ANSI-16 slots so they follow the terminal's theme.
+// A hex value here would look right on the one theme it was picked against and
+// wrong on every other, and would not follow a theme switch.
+func TestCoverPalettesUseThemeColors(t *testing.T) {
+	ansiSlots := map[color.Color]bool{}
+	for slot := lipgloss.Black; slot <= lipgloss.BrightWhite; slot++ {
+		ansiSlots[slot] = true
+	}
+	if len(ansiSlots) != 16 {
+		t.Fatalf("collected %d ANSI slots, want 16 — the check below passes on anything", len(ansiSlots))
+	}
+	if ansiSlots[lipgloss.Color("#facc15")] {
+		t.Fatal("a hex color counts as a theme color, so the check below is no check at all")
+	}
+
+	for _, preset := range allCoverPresets {
+		palette := coverPalettes[preset]
+		for _, c := range append(palette.ink[:], palette.field) {
+			if c != nil && !ansiSlots[c] {
+				t.Errorf("%s uses %v, which is not one of the sixteen theme colors", preset, c)
+			}
+		}
+	}
+}
+
+// A cover has one palette, not a light one and a dark one, because every slot it
+// uses does the same job in either kind of theme. Switching the mode must not
+// change what is drawn — if it does, some slot is being picked for its brightness,
+// which is the mistake that paints a light theme's field with its text color.
+func TestCoversDoNotDependOnTheThemeMode(t *testing.T) {
+	t.Cleanup(func() { applyTheme(defaultTheme()) })
+
+	for _, preset := range allCoverPresets {
+		dark := defaultTheme()
+		dark.Dark = true
+		applyTheme(dark)
+		inDark := (&coverRenderer{}).view(preset, 40, 8)
+
+		light := defaultTheme()
+		light.Dark = false
+		applyTheme(light)
+		if inLight := (&coverRenderer{}).view(preset, 40, 8); inLight != inDark {
+			t.Errorf("%s renders differently on a light theme", preset)
+		}
+	}
+}
+
 func TestCoverColorlessKeepsTheGlyphs(t *testing.T) {
 	t.Cleanup(func() { applyTheme(defaultTheme()) })
 	applyTheme(noColorTheme())
@@ -182,20 +230,19 @@ func TestCoverColorlessKeepsTheGlyphs(t *testing.T) {
 	}
 }
 
-// The renderer keeps the last cover it drew, so its memo has to notice a theme
-// switch — otherwise a light terminal keeps the dark palette until it resizes.
-func TestCoverRepaintsOnThemeChange(t *testing.T) {
+// The renderer keeps the last cover it drew, so its memo has to notice color being
+// turned off — otherwise a NO_COLOR terminal keeps painting until it resizes. A
+// retint needs no repaint: the ANSI slots do not change, the terminal's idea of
+// them does.
+func TestCoverRepaintsWhenColorGoesAway(t *testing.T) {
 	t.Cleanup(func() { applyTheme(defaultTheme()) })
 
 	renderer := &coverRenderer{}
-	dark := renderer.view(coverTerrazzo, 40, 8)
+	colored := renderer.view(coverTerrazzo, 40, 8)
 
-	light := defaultTheme()
-	light.Dark = false
-	applyTheme(light)
-
-	if renderer.view(coverTerrazzo, 40, 8) == dark {
-		t.Error("cover kept the dark palette after switching to a light theme")
+	applyTheme(noColorTheme())
+	if renderer.view(coverTerrazzo, 40, 8) == colored {
+		t.Error("cover kept its colors after color was turned off")
 	}
 }
 

--- a/internal/tui/covers_test.go
+++ b/internal/tui/covers_test.go
@@ -430,6 +430,40 @@ func TestCoverPickerSurvivesAFailedWrite(t *testing.T) {
 	}
 }
 
+// A list grows when the reader can see the end of it, and a covered list ends at the
+// divider with most of its rows still under the art. That must not read on: there
+// is nothing to scroll into, and every page arriving would go under the cover too
+// and ask for the next one.
+func TestACoveredListDoesNotReadOnForever(t *testing.T) {
+	v := mailWithPostings()
+	v.cover = coverTopo
+	v.postingList.setCover(coverTopo)
+	v.postingList.setSize(80, 20)
+
+	postings := make([]models.Posting, 0, 31)
+	postings = append(postings, models.Posting{ID: 1, Name: "Unread thread"})
+	for id := range 30 {
+		postings = append(postings, models.Posting{ID: int64(200 + id), Name: "Read thread", Seen: true})
+	}
+	v.postingList.setPostings(postings)
+	v.postingPaging.nextPage = "cursor-2"
+
+	if v.postingList.itemCount() != 1 {
+		t.Fatalf("the cover left %d threads reachable, want 1", v.postingList.itemCount())
+	}
+	if cmd := v.loadMorePostings(); cmd != nil {
+		t.Error("a covered list read on although the rows below it are under the art")
+	}
+
+	// Lifting the cover puts them back within reach, and then the rule applies as
+	// it does to any other list.
+	v.postingList.toggleCoverPeek()
+	v.postingList.cursor = len(postings) - 2
+	if cmd := v.loadMorePostings(); cmd == nil {
+		t.Error("a peeked list did not read on with the cursor near the bottom")
+	}
+}
+
 // The chorded keys sit at the end of the help bar, together, keeping their order.
 // Scattered among the single keys they push the everyday ones onto a second line.
 func TestModifiersLast(t *testing.T) {

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -12,6 +12,24 @@ type helpBinding struct {
 	desc string
 }
 
+// modifiersLast moves the chorded keys to the end of the bar, keeping the order
+// within each group. The single-key bindings are the ones a reader reaches for
+// while working through mail, and scattering ctrl+ chords among them pushes those
+// onto a second line and makes the whole bar read as a lookup table. Held
+// together at the end they are a group you can skip past.
+func modifiersLast(bindings []helpBinding) []helpBinding {
+	plain := make([]helpBinding, 0, len(bindings))
+	chorded := make([]helpBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		if strings.Contains(binding.key, "+") {
+			chorded = append(chorded, binding)
+		} else {
+			plain = append(plain, binding)
+		}
+	}
+	return append(plain, chorded...)
+}
+
 // helpBar renders a row of key bindings at the bottom of the screen.
 type helpBar struct {
 	width    int

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -298,8 +298,15 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
 		// Only the Imbox separates New for You from Previously Seen and marks
-		// unread threads with the dot; every other source is one flat list.
-		v.postingList.hideSeenState = !v.currentBoxIsImbox()
+		// unread threads with the dot; every other source is one flat list. The
+		// Imbox is also the only box HEY lets you cover.
+		isImbox := v.currentBoxIsImbox()
+		v.postingList.hideSeenState = !isImbox
+		if isImbox {
+			v.postingList.setCover(imboxCover())
+		} else {
+			v.postingList.setCover(coverNone)
+		}
 		v.postingList.setPostings(msg.postings)
 		v.postingPaging.read(postingIDs(msg.postings), msg.nextPage)
 		return v.loadMorePostings(), true
@@ -814,6 +821,13 @@ func (v *mailView) HelpBindings() []helpBinding {
 		ignoreBinding,
 		helpBinding{"ctrl+r", "reload"},
 	)
+	if v.postingList.cover != coverNone {
+		peek := helpBinding{"v", "peek under cover"}
+		if v.postingList.coverPeeked {
+			peek = helpBinding{"v", "cover"}
+		}
+		bindings = append(bindings, peek)
+	}
 	if v.lastBulkReplyID != 0 {
 		bindings = append(bindings, helpBinding{"u", "undo bulk reply"})
 	}
@@ -1200,6 +1214,9 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 			return v.startFolderPicker()
 		case "k":
 			return v.startCollectionPicker()
+		case "v":
+			v.postingList.toggleCoverPeek()
+			return nil
 		case "ctrl+r":
 			return v.reloadPostings()
 		default:

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -203,6 +203,8 @@ type mailView struct {
 	compose                *composeForm                // non-nil while a message, reply or forward is being written
 	bulkReply              *bulkReplyForm              // non-nil while a bulk reply is being previewed or written
 	movePicker             *movePicker                 // non-nil while a destination box is being selected
+	coverPicker            *coverPicker                // non-nil while the Imbox's cover is being chosen
+	cover                  coverPreset                 // the session's cover; HEY does not serve one to read
 	folderPicker           *folderPicker               // non-nil while folder labels are being managed
 	collectionPicker       *collectionMembershipPicker // non-nil while collection membership is being managed
 	labels                 *labelPicker                // non-nil while a label is being chosen
@@ -303,7 +305,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		isImbox := v.currentBoxIsImbox()
 		v.postingList.hideSeenState = !isImbox
 		if isImbox {
-			v.postingList.setCover(imboxCover())
+			v.postingList.setCover(v.cover)
 		} else {
 			v.postingList.setCover(coverNone)
 		}
@@ -662,6 +664,9 @@ func (v *mailView) View() string {
 	if v.movePicker != nil {
 		return v.movePicker.view(v.vc.styles, v.vc.width)
 	}
+	if v.coverPicker != nil {
+		return v.coverPicker.view(v.vc.styles, v.vc.width)
+	}
 	if v.folderPicker != nil {
 		return v.folderPicker.view(v.vc.styles, v.vc.width)
 	}
@@ -739,7 +744,9 @@ func (v *mailView) updateSourceDiscoveryNotice() {
 
 // CapturingInput reports whether a form or picker is open and wants every key.
 func (v *mailView) CapturingInput() bool {
-	return v.compose != nil || v.bulkReply != nil || v.movePicker != nil || v.folderPicker != nil || v.collectionPicker != nil || v.labels != nil || v.collections != nil || v.searchForm != nil
+	return v.compose != nil || v.bulkReply != nil || v.movePicker != nil || v.coverPicker != nil ||
+		v.folderPicker != nil || v.collectionPicker != nil || v.labels != nil || v.collections != nil ||
+		v.searchForm != nil
 }
 
 func (v *mailView) AccountSwitchBlocked() bool {
@@ -758,6 +765,9 @@ func (v *mailView) HelpBindings() []helpBinding {
 	}
 	if v.movePicker != nil {
 		return v.movePicker.helpBindings()
+	}
+	if v.coverPicker != nil {
+		return v.coverPicker.helpBindings()
 	}
 	if v.folderPicker != nil {
 		return v.folderPicker.helpBindings()
@@ -828,10 +838,13 @@ func (v *mailView) HelpBindings() []helpBinding {
 		}
 		bindings = append(bindings, peek)
 	}
+	if v.currentBoxIsImbox() {
+		bindings = append(bindings, helpBinding{"ctrl+v", "cover art"})
+	}
 	if v.lastBulkReplyID != 0 {
 		bindings = append(bindings, helpBinding{"u", "undo bulk reply"})
 	}
-	return bindings
+	return modifiersLast(bindings)
 }
 
 func (v *mailView) SubnavItems() ([]navItem, int, string, bool) {
@@ -1039,6 +1052,21 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		return nil
 	}
 
+	if v.coverPicker != nil {
+		switch msg.Key().Code {
+		case tea.KeyEscape:
+			v.coverPicker = nil
+			return nil
+		case tea.KeyEnter:
+			v.cover = v.coverPicker.selected()
+			v.coverPicker = nil
+			v.postingList.setCover(v.cover)
+			return nil
+		}
+		v.coverPicker.update(msg)
+		return nil
+	}
+
 	if v.labels != nil {
 		switch msg.Key().Code {
 		case tea.KeyEscape:
@@ -1217,6 +1245,8 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		case "v":
 			v.postingList.toggleCoverPeek()
 			return nil
+		case "ctrl+v":
+			return v.startCoverPicker()
 		case "ctrl+r":
 			return v.reloadPostings()
 		default:
@@ -1246,6 +1276,7 @@ func (v *mailView) ExitThread() {
 		v.inThread = false
 		v.compose = nil
 		v.movePicker = nil
+		v.coverPicker = nil
 		v.folderPicker = nil
 		v.collectionPicker = nil
 		v.cancelRequest()
@@ -1764,6 +1795,17 @@ func (v *mailView) startMove() {
 		return
 	}
 	v.movePicker = picker
+}
+
+// startCoverPicker opens the cover picker. Only the Imbox can be covered, which
+// is haystack's rule, so anywhere else the key says why rather than doing nothing.
+func (v *mailView) startCoverPicker() tea.Cmd {
+	if !v.currentBoxIsImbox() {
+		v.notice = "Only the Imbox can be covered"
+		return nil
+	}
+	v.coverPicker = newCoverPicker(v.cover)
+	return nil
 }
 
 func (v *mailView) startFolderPicker() tea.Cmd {

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -234,11 +234,15 @@ type mailView struct {
 }
 
 func newMailView(vc *viewContext) *mailView {
-	return &mailView{
+	view := &mailView{
 		vc:            vc,
 		topicViewport: viewport.New(viewport.WithWidth(0), viewport.WithHeight(0)),
 		searchList:    contentList{hideSeenState: true},
 	}
+	if vc.loadCover != nil {
+		view.cover = parseCoverPreset(vc.loadCover())
+	}
+	return view
 }
 
 func (v *mailView) Init() tea.Cmd {
@@ -1061,6 +1065,14 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 			v.cover = v.coverPicker.selected()
 			v.coverPicker = nil
 			v.postingList.setCover(v.cover)
+			// The cover is on screen either way; failing to write it only costs
+			// the choice on the next run, which is worth a notice and not a
+			// refusal to change the cover.
+			if v.vc.saveCover != nil {
+				if err := v.vc.saveCover(string(v.cover)); err != nil {
+					v.notice = "Could not remember the cover: " + err.Error()
+				}
+			}
 			return nil
 		}
 		v.coverPicker.update(msg)

--- a/internal/tui/section_view.go
+++ b/internal/tui/section_view.go
@@ -12,6 +12,11 @@ import (
 type attachmentSaveFunc func(context.Context, string, string, bool) (int64, error)
 type attachmentOpenFunc func(string) error
 
+// The Imbox's cover crosses the seam as a preset name rather than a coverPreset,
+// so that what stores it does not have to know how covers are drawn.
+type coverLoadFunc func() string
+type coverSaveFunc func(preset string) error
+
 type viewContext struct {
 	rootSDK              *hey.Client
 	sdk                  *hey.Client
@@ -22,6 +27,8 @@ type viewContext struct {
 	saveAttachment       attachmentSaveFunc
 	openAttachment       attachmentOpenFunc
 	newAttachmentTempDir func() (string, error)
+	loadCover            coverLoadFunc
+	saveCover            coverSaveFunc
 	width                int
 	height               int // content area height
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -58,6 +58,8 @@ func applyTheme(theme Theme) {
 	if theme.Selection != nil && (theme.Trusted || contrastRatio(theme.Accent, theme.Selection) >= minSelectionContrast) {
 		colorSelection = theme.Selection
 	}
+	coverDarkMode = theme.Dark
+	_, coverColorless = theme.Accent.(lipgloss.NoColor)
 	// The pill keeps its classic black text on the ANSI accent, but a themed
 	// accent can be dark enough that black is unreadable on it — lupine's blue
 	// carries black at only 3.7:1 — so pick whichever of black or white reads

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -58,7 +58,6 @@ func applyTheme(theme Theme) {
 	if theme.Selection != nil && (theme.Trusted || contrastRatio(theme.Accent, theme.Selection) >= minSelectionContrast) {
 		colorSelection = theme.Selection
 	}
-	coverDarkMode = theme.Dark
 	_, coverColorless = theme.Accent.(lipgloss.NoColor)
 	// The pill keeps its classic black text on the ANSI accent, but a themed
 	// accent can be dark enough that black is unreadable on it — lupine's blue

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -15,6 +15,7 @@ import (
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	attachmentfiles "github.com/basecamp/hey-cli/internal/attachments"
+	"github.com/basecamp/hey-cli/internal/config"
 )
 
 // --- Shared messages ---
@@ -148,6 +149,8 @@ func newViewContext(ctx context.Context, rootSDK, sdk *hey.Client, styles styles
 		newAttachmentTempDir: func() (string, error) {
 			return os.MkdirTemp("", "hey-cli-attachment-*")
 		},
+		loadCover: config.Cover,
+		saveCover: config.SaveCover,
 	}
 }
 


### PR DESCRIPTION
HEY lets you put a cover over the Imbox, and what it covers is everything you have already read: the box ends at what still wants your attention instead of trailing off into a month of receipts. This does the same.

`ctrl+v` picks one of the six, `v` lifts it to look underneath, and the divider says how much is under there.

```
New for You ────────────────────────────────────────────────
  ● Your order has shipped #R288764931            Aug 21, 2026
    Framework — Good news! We've generated a tracking number
  ● Fwd: Obavijest o primitku računa              Aug 11, 2026
    Dražen Marjanović — Forwarded message
Previously Seen ───────────────── 22 hidden · v to peek
                (art, to the bottom of the screen)
```

## Hidden means out of reach

Read threads are not drawn at all, and `itemCount` stops the cursor at the divider, so `j` cannot walk onto a row nobody can see and `space` cannot select something you think you have put away. `settleCover` keeps that true as the list moves underneath: opening a thread marks it seen, which slides it under the lid, and a live re-read can do the same to a selection.

## Six patterns, drawn as characters

HEY's covers are SVG assets and a terminal cannot draw an SVG, so these are the same six patterns drawn as characters. Not a fallback for two of them: a blueprint grid is what box-drawing characters are for, and braille's 2×4 dots hold a contour map and HEY's hand where the cell grid holds neither. The pattern lives in the glyphs rather than the colors, so `NO_COLOR` gets the art too.

Everything is painted in the ANSI-16 slots, so a cover wears your theme and follows it when you switch — one palette per preset, with each slot picked for the job it does in a theme rather than how bright it happens to be. There is a test asserting that flipping light/dark changes not a byte of what is drawn.

## The choice is stored locally, on purpose

haystack keeps a cover per box in `box_covers`, but serves it to nobody — no jbuilder exposes it. Both native apps went their own way rather than wait for one: `CoverArtPersistenceManager` on iOS keeps the choice in `Preferences`, `CoverArtRepository` on Android in `CachePrefs`, each with their own presets, neither asking the server. This does the same, in `config.json`. So a cover set here does not show up on the web, which is true of every HEY client.

## Also here

The help bar puts chorded keys last. The single-key bindings are what you reach for while working through mail, and a `ctrl+` chord among them pushes the everyday ones onto a second line.

## Notes for review

- `v` and `ctrl+v` were free in the mail list, though Calendar uses `v` for its view mode.
- Rebased onto the list-paging work. The one place they meet is `loadMorePostings`: a covered list must not read on, since the rows below the divider are under the art and every page arriving would go under it too. The existing guard reads the whole list rather than the reachable part, so it already holds — the last commit is the test that says so on purpose.
- An uploaded cover has no honest character version; that one wants the Kitty path in `kitty.go`.