### PR TITLE
Render contact notes, sharpen format help, gate smoke on strict

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -629,7 +629,7 @@ The dev server must be running at `http://app.hey.localhost:3003` (override with
 1. `TestMain` in `helpers_test.go` orchestrates setup: finds the binary, checks server reachability, launches headless Chrome via chromedp to log in and extract the `session_token` cookie, then authenticates the CLI with `hey auth login --cookie`.
 2. All CLI invocations run in an isolated environment: temp `XDG_CONFIG_HOME`, `HEY_NO_KEYRING=1`, `HEY_BASE_URL` pointing to the dev server.
 3. Helper functions (`hey()`, `heyOK()`, `heyJSON()`, `heyFail()`) run the binary and parse output. `dataAs[T]()` generically unmarshals response data.
-4. Tests that depend on write operations (compose, todo add, journal write, reply, timetrack start) skip gracefully when the server returns errors, since the SDK's parameter format may not match the server's expectations.
+4. Tests that depend on write operations (compose, todo add, journal write, reply, timetrack start) skip gracefully when the server returns errors, since the SDK's parameter format may not match the server's expectations. Set `HEY_SMOKE_STRICT=1` to turn every such skip into a failure — that is the release gate, where a skipped check is not a passed one.
 5. Test data uses `uniqueID()` (nanosecond timestamps) to avoid collisions. Cleanup happens via `t.Cleanup()`.
 6. `hey upgrade` is covered only as far as a dev build's `upgrade_required` refusal (and `hey version --json`). The live self-update against a real release runs in `.github/workflows/upgrade-smoke.yml`, never against the dev server.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -638,7 +638,7 @@ The dev server must be running at `http://app.hey.localhost:3003` (override with
 1. Create or edit a `*_test.go` file in `tests/smoke/` (package `smoke_test`).
 2. Use `heyJSON(t, "command", "args...")` for commands that should succeed and return JSON.
 3. Use `heyFail(t, "command", "args...")` for commands that should fail.
-4. For write operations that may fail server-side, use `hey(t, ...)` directly and skip on non-zero exit: `if code != 0 { t.Skipf("... (exit %d): %s", code, stderr) }`.
+4. For write operations that may fail server-side, use `hey(t, ...)` directly and skip on non-zero exit through the strict-aware helper: `if code != 0 { skipf(t, "... (exit %d): %s", code, stderr) }`. Never call `t.Skip` directly — `skipf` is what turns a skip into a failure under `HEY_SMOKE_STRICT=1`.
 5. Use `dataAs[T](t, resp)` to unmarshal response data into typed structs.
 6. For browser cross-verification, use `browserPageText(t, url)` to get page content.
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ hey screener deny 91 --spam        # turn them away and mark what they sent as s
 hey screener history               # who has already been screened
 hey screener clear                 # empty the queue without deciding
 hey threads 123                    # read a full email thread
+hey threads 123 --markdown         # the thread as one Markdown document
+hey threads 123 --html > 123.html  # HEY's original HTML, to a file
 hey share 123                      # get a sharing link for a thread
 hey unshare 123                    # turn off the sharing link
 hey attachments 123                # list files attached to the thread

--- a/internal/cmd/contact_note_show.go
+++ b/internal/cmd/contact_note_show.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/output"
-	"github.com/basecamp/hey-cli/internal/terminal"
 )
 
 type contactNoteShowCommand struct {
@@ -46,11 +45,7 @@ func (c *contactNoteShowCommand) run(cmd *cobra.Command, args []string) error {
 		return writeNoteHTML(cmd.OutOrStdout(), note.NoteHtml)
 	}
 	if writer.IsStyled() {
-		if note.Note == "" {
-			fmt.Fprintln(cmd.OutOrStdout(), "(empty)")
-		} else {
-			fmt.Fprintln(cmd.OutOrStdout(), terminal.Sanitize(note.Note))
-		}
+		fmt.Fprintln(cmd.OutOrStdout(), renderedNote(note.Note, note.NoteHtml))
 		return nil
 	}
 	return writeOK(note,

--- a/internal/cmd/contacts_show.go
+++ b/internal/cmd/contacts_show.go
@@ -11,6 +11,8 @@ import (
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/markdown"
 	"github.com/basecamp/hey-cli/internal/output"
 	"github.com/basecamp/hey-cli/internal/terminal"
 )
@@ -123,9 +125,18 @@ func printContactDetails(cmd *cobra.Command, result contactShowResult) {
 		fmt.Fprintf(w, "Screening: %s\n", terminal.SanitizeLine(result.Clearance.Status))
 	}
 	fmt.Fprintln(w, "\nPrivate note:")
-	if result.Note == "" {
-		fmt.Fprintln(w, "(empty)")
-	} else {
-		fmt.Fprintln(w, terminal.Sanitize(result.Note))
+	fmt.Fprintln(w, renderedNote(result.Note, result.NoteHTML))
+}
+
+// renderedNote is a contact note for a terminal: the rich note rendered from its HTML
+// when HEY served one, the plain note otherwise, and never the HTML itself.
+func renderedNote(note, noteHTML string) string {
+	switch {
+	case noteHTML != "":
+		return markdown.Render(htmlutil.ToMarkdown(noteHTML), stdoutWidth())
+	case note != "":
+		return terminal.Sanitize(note)
+	default:
+		return "(empty)"
 	}
 }

--- a/internal/cmd/contacts_test.go
+++ b/internal/cmd/contacts_test.go
@@ -175,22 +175,32 @@ func TestContactsShowIncludesAliasesAndPrivateNote(t *testing.T) {
 	}
 }
 
-// The styled detail never prints HTML; --html is a format of its own and writes the
-// note's markup alone. Either way the text HEY served is inert on a terminal.
-func TestContactsShowStyledDetailIsPlainAndSanitized(t *testing.T) {
+// The styled detail renders the rich note and never prints its HTML; --html is a format
+// of its own and writes the markup alone. Either way the text HEY served is inert.
+func TestContactsShowStyledDetailRendersTheNoteAndSanitizes(t *testing.T) {
 	var output bytes.Buffer
 	command := &cobra.Command{}
 	command.SetOut(&output)
 	printContactDetails(command, contactShowResult{
 		ContactDetail: generated.ContactDetail{Id: 7, Name: "Jane \x1b[31mDoe", EmailAddress: "jane@example.com"},
-		Note:          "Plain \x1b]0;note\x07note",
-		NoteHTML:      "<p>Rich note</p>",
+		Note:          "Call back about the *invoice*",
+		NoteHTML:      "<p>Call back about the <strong>invoice</strong> &amp;#27;[31m</p>",
 	})
-	if strings.Contains(output.String(), "<p>") || strings.Contains(output.String(), "\x1b") {
-		t.Errorf("styled contact detail = %q", output.String())
+	shown := output.String()
+	if strings.Contains(shown, "<p>") || strings.Contains(shown, "<strong>") || strings.Contains(shown, "\x1b[31m") {
+		t.Errorf("styled contact detail = %q", shown)
 	}
-	if !strings.Contains(output.String(), "Jane Doe") || !strings.Contains(output.String(), "Plain note") {
-		t.Errorf("styled contact detail = %q, want the text kept", output.String())
+	if !strings.Contains(shown, "Jane Doe") || !strings.Contains(shown, "invoice") || !strings.Contains(shown, "&#27;[31m") {
+		t.Errorf("styled contact detail = %q, want the text kept", shown)
+	}
+}
+
+func TestRenderedNoteFallsBackToThePlainNote(t *testing.T) {
+	if got := renderedNote("Plain \x1b]0;note\x07note", ""); got != "Plain note" {
+		t.Errorf("renderedNote = %q", got)
+	}
+	if got := renderedNote("", ""); got != "(empty)" {
+		t.Errorf("renderedNote = %q", got)
 	}
 }
 

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -145,11 +145,11 @@ FLAGS
       --account    Select a linked mail account ID or all
       --json       Output JSON with metadata
       --jq         Filter JSON with a built-in jq expression
-      --markdown   Output as Markdown
+      --markdown   Output Markdown: a table for a listing, a document for a thread
       --quiet      Output result data only
       --ids-only   Output only IDs, one per line
       --count      Output only the count of results
-      --styled     Force styled output even when piped
+      --styled     Human rendering, bodies as rendered Markdown — the default on a terminal; forces it when piped
       --html       Write the original HTML to a pipe or file (threads, journal read, contacts show, contacts note show)
       --stats      Include request stats in response meta
       --base-url   Override server URL

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -163,8 +163,8 @@ func newRootCmd() *cobra.Command {
 	root.PersistentFlags().BoolVar(&quietFlag, "quiet", false, "Output result data only")
 	root.PersistentFlags().BoolVar(&idsOnly, "ids-only", false, "Output only IDs, one per line")
 	root.PersistentFlags().BoolVar(&countFlag, "count", false, "Output only the count of results")
-	root.PersistentFlags().BoolVar(&markdownF, "markdown", false, "Output as Markdown")
-	root.PersistentFlags().BoolVar(&styledFlag, "styled", false, "Force styled output even when piped")
+	root.PersistentFlags().BoolVar(&markdownF, "markdown", false, "Output Markdown: a table for a listing, a document for a thread")
+	root.PersistentFlags().BoolVar(&styledFlag, "styled", false, "Human rendering, bodies as rendered Markdown — the default on a terminal; forces it when piped")
 	root.PersistentFlags().BoolVar(&agentFlag, "agent", false, "Agent mode (JSON envelope, no TTY formatting)")
 	_ = root.PersistentFlags().MarkHidden("agent") // flag is registered immediately above
 	root.PersistentFlags().StringVar(&baseURL, "base-url", "", "Override server URL")

--- a/internal/cmd/testdata/sink_manifest.txt
+++ b/internal/cmd/testdata/sink_manifest.txt
@@ -37,6 +37,7 @@ sanitizer markdownSafeText
 sanitizer htmlutil.ToMarkdown
 sanitizer htmlToMarkdown
 sanitizer addRow
+sanitizer renderedNote
 
 sink fmt.Fprint
 sink fmt.Fprintf

--- a/tests/smoke/attachments_test.go
+++ b/tests/smoke/attachments_test.go
@@ -27,7 +27,7 @@ func TestAttachmentSendListAndSave(t *testing.T) {
 		"--json",
 	)
 	if code != 0 {
-		t.Skipf("attachment sending is unavailable (exit %d): %s", code, stderr)
+		skipf(t, "attachment sending is unavailable (exit %d): %s", code, stderr)
 	}
 	var composeResponse Response
 	if err := json.Unmarshal([]byte(stdout), &composeResponse); err != nil || !composeResponse.OK {

--- a/tests/smoke/boxes_test.go
+++ b/tests/smoke/boxes_test.go
@@ -189,12 +189,12 @@ func TestMovePosting(t *testing.T) {
 		}
 	}
 	if postingID == 0 {
-		t.Skip("no seen postings in Imbox to move without changing unread state")
+		skipf(t, "no seen postings in Imbox to move without changing unread state")
 	}
 
 	stdout, stderr, code := hey(t, "move", intStr(postingID), "--to", "feedbox", "--json")
 	if code != 0 {
-		t.Skipf("moving postings is unavailable on this server (exit %d): %s", code, stderr)
+		skipf(t, "moving postings is unavailable on this server (exit %d): %s", code, stderr)
 	}
 	t.Cleanup(func() {
 		_, cleanupStderr, cleanupCode := hey(t, "move", intStr(postingID), "--to", "imbox", "--json")

--- a/tests/smoke/bulk_reply_test.go
+++ b/tests/smoke/bulk_reply_test.go
@@ -14,7 +14,7 @@ func TestBulkReplyPreview(t *testing.T) {
 		} `json:"postings"`
 	}](t, heyJSON(t, "box", "imbox", "--limit", "10"))
 	if len(box.Postings) == 0 {
-		t.Skip("no Imbox postings available for a read-only bulk reply preview")
+		skipf(t, "no Imbox postings available for a read-only bulk reply preview")
 	}
 
 	args := []string{"bulk-reply", "preview"}

--- a/tests/smoke/collections_test.go
+++ b/tests/smoke/collections_test.go
@@ -27,7 +27,7 @@ func TestCollectionsAndCollection(t *testing.T) {
 		t.Error("collections response omitted summary")
 	}
 	if len(collections) == 0 {
-		t.Skip("no collections available for collection detail validation")
+		skipf(t, "no collections available for collection detail validation")
 	}
 
 	collection := collections[0]
@@ -51,7 +51,7 @@ func TestCollectionsAndCollection(t *testing.T) {
 func TestCollectionOutputFormats(t *testing.T) {
 	collections := dataAs[[]smokeCollection](t, heyJSON(t, "collections"))
 	if len(collections) == 0 {
-		t.Skip("no collections available for output validation")
+		skipf(t, "no collections available for output validation")
 	}
 	id := strconv.FormatInt(collections[0].ID, 10)
 	for _, args := range [][]string{
@@ -83,7 +83,7 @@ func TestCollectionMutations(t *testing.T) {
 		"--json",
 	)
 	if code != 0 {
-		t.Skipf("could not create a disposable thread (exit %d): %s", code, stderr)
+		skipf(t, "could not create a disposable thread (exit %d): %s", code, stderr)
 	}
 	t.Cleanup(func() { cleanupThreadBySubject(t, subject) })
 
@@ -92,13 +92,13 @@ func TestCollectionMutations(t *testing.T) {
 		t.Fatalf("could not find disposable thread: %v", err)
 	}
 	if postingID == 0 || topicID == 0 || accountID == 0 {
-		t.Skip("disposable thread did not expose posting, topic, and account IDs")
+		skipf(t, "disposable thread did not expose posting, topic, and account IDs")
 	}
 
 	collectionName := "Smoke collection " + uid
 	_, stderr, code = hey(t, "collection", "create", collectionName, "--summary", "Disposable collection smoke coverage", "--account", strconv.FormatInt(accountID, 10), "--json")
 	if code != 0 {
-		t.Skipf("collection creation unavailable (exit %d): %s", code, stderr)
+		skipf(t, "collection creation unavailable (exit %d): %s", code, stderr)
 	}
 
 	collectionID, err := findCollectionIDByName(t, collectionName)
@@ -127,7 +127,7 @@ func collectionWriteJSON(t *testing.T, args ...string) Response {
 	args = append(args, "--json")
 	stdout, stderr, code := hey(t, args...)
 	if code != 0 {
-		t.Skipf("collection write unavailable (exit %d): %s", code, stderr)
+		skipf(t, "collection write unavailable (exit %d): %s", code, stderr)
 	}
 	var response Response
 	if err := json.Unmarshal([]byte(stdout), &response); err != nil {

--- a/tests/smoke/compose_test.go
+++ b/tests/smoke/compose_test.go
@@ -158,7 +158,7 @@ func TestForward(t *testing.T) {
 	}
 	data := dataAs[BoxResp](t, resp)
 	if len(data.Postings) == 0 {
-		t.Skip("no postings in imbox to forward")
+		skipf(t, "no postings in imbox to forward")
 	}
 	topicID := extractTopicID(data.Postings[0].AppURL)
 	if topicID == "" {
@@ -171,7 +171,7 @@ func TestForward(t *testing.T) {
 		"--json",
 	)
 	if code != 0 {
-		t.Skipf("forward is unavailable on this server (exit %d): %s", code, stderr)
+		skipf(t, "forward is unavailable on this server (exit %d): %s", code, stderr)
 	}
 	var forwardResp Response
 	if err := json.Unmarshal([]byte(stdout), &forwardResp); err != nil {

--- a/tests/smoke/contacts_test.go
+++ b/tests/smoke/contacts_test.go
@@ -18,7 +18,7 @@ type smokeContact struct {
 func TestContactsListAndShow(t *testing.T) {
 	contacts := dataAs[[]smokeContact](t, heyJSON(t, "contacts", "list"))
 	if len(contacts) == 0 {
-		t.Skip("no contacts available for read-only detail validation")
+		skipf(t, "no contacts available for read-only detail validation")
 	}
 	contact := dataAs[smokeContact](t, heyJSON(t, "contacts", "show", intStr(contacts[0].ID)))
 	if contact.ID != contacts[0].ID || contact.EmailAddress == "" {
@@ -99,7 +99,7 @@ func contactWriteJSON(t *testing.T, args ...string) Response {
 	args = append(args, "--json")
 	stdout, stderr, code := hey(t, args...)
 	if code != 0 {
-		t.Skipf("contact write unavailable (exit %d): %s", code, stderr)
+		skipf(t, "contact write unavailable (exit %d): %s", code, stderr)
 	}
 	var response Response
 	if err := json.Unmarshal([]byte(stdout), &response); err != nil {

--- a/tests/smoke/helpers_test.go
+++ b/tests/smoke/helpers_test.go
@@ -194,7 +194,7 @@ func skipf(t *testing.T, format string, args ...any) {
 	if os.Getenv("HEY_SMOKE_STRICT") != "" {
 		t.Fatalf("strict: "+format, args...)
 	}
-	skipf(t, format, args...)
+	t.Skipf(format, args...)
 }
 
 func envOr(key, fallback string) string {

--- a/tests/smoke/helpers_test.go
+++ b/tests/smoke/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -191,7 +192,7 @@ func cliEnv() []string {
 // where a check that did not run is not a check that passed.
 func skipf(t *testing.T, format string, args ...any) {
 	t.Helper()
-	if os.Getenv("HEY_SMOKE_STRICT") != "" {
+	if strict, _ := strconv.ParseBool(os.Getenv("HEY_SMOKE_STRICT")); strict {
 		t.Fatalf("strict: "+format, args...)
 	}
 	t.Skipf(format, args...)

--- a/tests/smoke/helpers_test.go
+++ b/tests/smoke/helpers_test.go
@@ -187,6 +187,16 @@ func cliEnv() []string {
 // Setup helpers
 // ---------------------------------------------------------------------------
 
+// skipf skips a test the server cannot support — or fails it, under HEY_SMOKE_STRICT=1,
+// where a check that did not run is not a check that passed.
+func skipf(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if os.Getenv("HEY_SMOKE_STRICT") != "" {
+		t.Fatalf("strict: "+format, args...)
+	}
+	skipf(t, format, args...)
+}
+
 func envOr(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v

--- a/tests/smoke/ignore_test.go
+++ b/tests/smoke/ignore_test.go
@@ -17,7 +17,7 @@ func TestIgnoreAndStopIgnoring(t *testing.T) {
 
 	box := dataAs[BoxResp](t, heyJSON(t, "box", "imbox"))
 	if len(box.Postings) == 0 {
-		t.Skip("no threads in Imbox to ignore")
+		skipf(t, "no threads in Imbox to ignore")
 	}
 	posting := box.Postings[0]
 	postingID := intStr(posting.ID)

--- a/tests/smoke/labels_test.go
+++ b/tests/smoke/labels_test.go
@@ -27,7 +27,7 @@ func TestLabelsAndLabel(t *testing.T) {
 		t.Error("labels response omitted summary")
 	}
 	if len(folders) == 0 {
-		t.Skip("no labels available for label detail validation")
+		skipf(t, "no labels available for label detail validation")
 	}
 
 	folder := folders[0]
@@ -56,7 +56,7 @@ func TestLabelMutations(t *testing.T) {
 		"--json",
 	)
 	if code != 0 {
-		t.Skipf("could not create a disposable thread (exit %d): %s", code, stderr)
+		skipf(t, "could not create a disposable thread (exit %d): %s", code, stderr)
 	}
 	t.Cleanup(func() { cleanupThreadBySubject(t, subject) })
 
@@ -65,13 +65,13 @@ func TestLabelMutations(t *testing.T) {
 		t.Fatalf("could not find disposable thread: %v", err)
 	}
 	if postingID == 0 {
-		t.Skip("disposable thread did not appear in Imbox")
+		skipf(t, "disposable thread did not appear in Imbox")
 	}
 
 	labelName := "Smoke label " + uid
 	_, stderr, code = hey(t, "label", "create", labelName, strconv.FormatInt(postingID, 10), "--json")
 	if code != 0 {
-		t.Skipf("label creation unavailable (exit %d): %s", code, stderr)
+		skipf(t, "label creation unavailable (exit %d): %s", code, stderr)
 	}
 	t.Cleanup(func() { cleanupLabelByName(t, labelName, postingID) })
 
@@ -95,7 +95,7 @@ func labelWriteJSON(t *testing.T, args ...string) Response {
 	args = append(args, "--json")
 	stdout, stderr, code := hey(t, args...)
 	if code != 0 {
-		t.Skipf("label write unavailable (exit %d): %s", code, stderr)
+		skipf(t, "label write unavailable (exit %d): %s", code, stderr)
 	}
 	var response Response
 	if err := json.Unmarshal([]byte(stdout), &response); err != nil {

--- a/tests/smoke/search_test.go
+++ b/tests/smoke/search_test.go
@@ -49,7 +49,7 @@ func TestSearchFreeTextAndRefinements(t *testing.T) {
 		}
 	}
 	if subject == "" {
-		t.Skip("no Imbox thread available for read-only search validation")
+		skipf(t, "no Imbox thread available for read-only search validation")
 	}
 
 	var freeText []smokeSearchResult

--- a/tests/smoke/share_test.go
+++ b/tests/smoke/share_test.go
@@ -17,7 +17,7 @@ func TestShareAndUnshare(t *testing.T) {
 		"--json",
 	)
 	if code != 0 {
-		t.Skipf("could not create a controlled thread (exit %d): %s", code, stderr)
+		skipf(t, "could not create a controlled thread (exit %d): %s", code, stderr)
 	}
 
 	var composeResp Response
@@ -46,7 +46,7 @@ func TestShareAndUnshare(t *testing.T) {
 	needsCleanup = true
 	stdout, stderr, code = hey(t, "share", threadID, "--json")
 	if code != 0 {
-		t.Skipf("sharing links are unavailable on this server (exit %d): %s", code, stderr)
+		skipf(t, "sharing links are unavailable on this server (exit %d): %s", code, stderr)
 	}
 	cleanupMustSucceed = true
 	var shareResp Response

--- a/tests/smoke/threads_test.go
+++ b/tests/smoke/threads_test.go
@@ -45,13 +45,13 @@ func longThread(t *testing.T, replies int) (topicID string, subject string) {
 	if code != 0 {
 		skipf(t, "could not compose the thread's first message (exit %d): %s", code, stderr)
 	}
-	t.Cleanup(func() { cleanupThreadBySubject(t, subject) })
-
 	// Delivery to the Imbox is asynchronous; wait for the posting the way the other
-	// mutation tests do.
+	// mutation tests do. The cleanup is registered once the posting is known to exist,
+	// so a thread that never arrived does not turn a skip into a cleanup failure.
 	if _, err := waitForPostingIDBySubject(t, subject); err != nil {
 		skipf(t, "the composed thread %q did not appear in the Imbox: %v", subject, err)
 	}
+	t.Cleanup(func() { cleanupThreadBySubject(t, subject) })
 	resp := heyJSON(t, "box", "imbox", "--all")
 	type posting struct {
 		AppURL  string `json:"app_url"`

--- a/tests/smoke/threads_test.go
+++ b/tests/smoke/threads_test.go
@@ -139,15 +139,18 @@ func TestThreadsReadsALongThreadAsMarkdown(t *testing.T) {
 	}
 }
 
-// Every output format answers a thread the way the contract says.
+// Every output format answers the same thread — one longer than a geared page — the
+// way the contract says.
 func TestThreadsFormats(t *testing.T) {
-	topicID, _ := longThread(t, 2)
+	const replies = 11
+	const entries = replies + 1
+	topicID, _ := longThread(t, replies)
 
 	t.Run("json", func(t *testing.T) {
 		resp := heyJSON(t, "threads", topicID)
-		entries := dataAs[[]threadEntry](t, resp)
-		if len(entries) != 3 || resp.Summary != fmt.Sprintf("3 entries in thread %s", topicID) {
-			t.Errorf("entries = %d, summary = %q", len(entries), resp.Summary)
+		got := dataAs[[]threadEntry](t, resp)
+		if len(got) != entries || resp.Summary != fmt.Sprintf("%d entries in thread %s", entries, topicID) {
+			t.Errorf("entries = %d, summary = %q", len(got), resp.Summary)
 		}
 	})
 
@@ -156,7 +159,7 @@ func TestThreadsFormats(t *testing.T) {
 		if !strings.HasPrefix(out, "# Thread "+topicID+"\n") {
 			t.Errorf("markdown = %q, want a document heading", out)
 		}
-		if strings.Count(out, "\n## From: ") != 3 || strings.Count(out, "\n---\n") != 3 {
+		if strings.Count(out, "\n## From: ") != entries || strings.Count(out, "\n---\n") != entries {
 			t.Errorf("markdown = %q, want a heading and a rule per entry", out)
 		}
 		if strings.Contains(out, "<p") || strings.Contains(out, "<div") {
@@ -167,8 +170,8 @@ func TestThreadsFormats(t *testing.T) {
 	t.Run("ids", func(t *testing.T) {
 		out := heyOK(t, "threads", topicID, "--ids-only")
 		ids := strings.Fields(out)
-		if len(ids) != 3 {
-			t.Errorf("--ids-only = %q, want three IDs", out)
+		if len(ids) != entries {
+			t.Errorf("--ids-only = %q, want %d IDs", out, entries)
 		}
 		for _, id := range ids {
 			if _, err := strconv.ParseInt(id, 10, 64); err != nil {
@@ -178,29 +181,29 @@ func TestThreadsFormats(t *testing.T) {
 	})
 
 	t.Run("count", func(t *testing.T) {
-		if out := strings.TrimSpace(heyOK(t, "threads", topicID, "--count")); out != "3" {
-			t.Errorf("--count = %q, want 3", out)
+		if out := strings.TrimSpace(heyOK(t, "threads", topicID, "--count")); out != strconv.Itoa(entries) {
+			t.Errorf("--count = %q, want %d", out, entries)
 		}
 	})
 
 	t.Run("quiet", func(t *testing.T) {
 		out := heyOK(t, "threads", topicID, "--quiet")
-		var entries []threadEntry
-		if err := json.Unmarshal([]byte(out), &entries); err != nil || len(entries) != 3 {
+		var got []threadEntry
+		if err := json.Unmarshal([]byte(out), &got); err != nil || len(got) != entries {
 			t.Errorf("--quiet = %q, err = %v, want the bare entries", out, err)
 		}
 	})
 
 	t.Run("jq", func(t *testing.T) {
 		out := heyOK(t, "threads", topicID, "--jq", ".data | length")
-		if strings.TrimSpace(out) != "3" {
-			t.Errorf("--jq = %q, want 3", out)
+		if strings.TrimSpace(out) != strconv.Itoa(entries) {
+			t.Errorf("--jq = %q, want %d", out, entries)
 		}
 	})
 
 	t.Run("styled", func(t *testing.T) {
 		out := heyOK(t, "threads", topicID, "--styled")
-		if strings.Count(out, "From: ") != 3 {
+		if strings.Count(out, "From: ") != entries {
 			t.Errorf("styled = %q, want a From line per entry", out)
 		}
 		// The composed text had literal asterisks, which render as the asterisks they
@@ -213,7 +216,7 @@ func TestThreadsFormats(t *testing.T) {
 
 	t.Run("html to a pipe", func(t *testing.T) {
 		out := heyOK(t, "threads", topicID, "--html")
-		if strings.Count(out, "<!-- hey entry ") != 3 {
+		if strings.Count(out, "<!-- hey entry ") != entries {
 			t.Errorf("--html = %q, want a comment per entry", out)
 		}
 		if !strings.Contains(out, "<div") && !strings.Contains(out, "<p") {

--- a/tests/smoke/threads_test.go
+++ b/tests/smoke/threads_test.go
@@ -203,8 +203,11 @@ func TestThreadsFormats(t *testing.T) {
 		if strings.Count(out, "From: ") != 3 {
 			t.Errorf("styled = %q, want a From line per entry", out)
 		}
-		if strings.Contains(out, "<p") || strings.Contains(out, "**") {
-			t.Errorf("styled = %q, want rendered Markdown, not tags or markers", out)
+		// The composed text had literal asterisks, which render as the asterisks they
+		// are; what must not appear is markup — a tag, or a backslash escape left
+		// unrendered.
+		if strings.Contains(out, "<p") || strings.Contains(out, `\*`) {
+			t.Errorf("styled = %q, want rendered Markdown, not tags or unrendered escapes", out)
 		}
 	})
 

--- a/tests/smoke/threads_test.go
+++ b/tests/smoke/threads_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 type threadEntry struct {
@@ -22,10 +23,15 @@ type threadEntry struct {
 	} `json:"creator"`
 }
 
+// firstMessage is the plain text the long thread starts with. compose sends it as
+// text, so in the thread it is prose: the asterisks and the list dashes come back
+// escaped, and the URL comes back as the literal it is.
+const firstMessage = "First: the **quarterly** numbers are at https://example.com/reports/q3 — see the bullets\n\n- Revenue up\n- Churn down"
+
 // longThread composes a message and replies to it until the thread is longer than one
 // geared page, so every format is exercised against a thread the entries index serves
 // in more than one page. It skips — or fails, under HEY_SMOKE_STRICT — when the server
-// will not let the CLI write.
+// will not let the CLI write, and trashes the thread when the test is done.
 func longThread(t *testing.T, replies int) (topicID string, subject string) {
 	t.Helper()
 	uid := uniqueID()
@@ -33,13 +39,19 @@ func longThread(t *testing.T, replies int) (topicID string, subject string) {
 	_, stderr, code := hey(t, "compose",
 		"--to", smokeEmail,
 		"--subject", subject,
-		"-m", "First: the **quarterly** numbers are at https://example.com/reports/q3 — see the bullets\n\n- Revenue up\n- Churn down",
+		"-m", firstMessage,
 		"--json",
 	)
 	if code != 0 {
 		skipf(t, "could not compose the thread's first message (exit %d): %s", code, stderr)
 	}
+	t.Cleanup(func() { cleanupThreadBySubject(t, subject) })
 
+	// Delivery to the Imbox is asynchronous; wait for the posting the way the other
+	// mutation tests do.
+	if _, err := waitForPostingIDBySubject(t, subject); err != nil {
+		skipf(t, "the composed thread %q did not appear in the Imbox: %v", subject, err)
+	}
 	resp := heyJSON(t, "box", "imbox", "--all")
 	type posting struct {
 		AppURL  string `json:"app_url"`
@@ -56,7 +68,7 @@ func longThread(t *testing.T, replies int) (topicID string, subject string) {
 		}
 	}
 	if topicID == "" {
-		skipf(t, "the composed thread %q did not appear in the Imbox", subject)
+		skipf(t, "the composed thread %q has no topic in the Imbox", subject)
 	}
 
 	for i := range replies {
@@ -69,7 +81,7 @@ func longThread(t *testing.T, replies int) (topicID string, subject string) {
 }
 
 // A thread longer than a page reads whole, oldest first, with every entry's body as
-// Markdown: the composed links and emphasis survive, and no HTML tag does.
+// Markdown: the composed text survives as prose, its URL intact, and no HTML tag does.
 func TestThreadsReadsALongThreadAsMarkdown(t *testing.T) {
 	const replies = 11
 	topicID, _ := longThread(t, replies)
@@ -100,28 +112,24 @@ func TestThreadsReadsALongThreadAsMarkdown(t *testing.T) {
 		}
 	}
 
+	// The text was sent as text, so it is prose in the Markdown: the asterisks are
+	// escaped rather than emphasis, the URL is the literal it was, and the em dash —
+	// a multibyte character — survives intact.
 	first := entries[0].Body
-	if !strings.Contains(first, "**quarterly**") || !strings.Contains(first, "https://example.com/reports/q3") {
-		t.Errorf("first body = %q, want the emphasis and the link as Markdown", first)
+	for _, want := range []string{`\*\*quarterly\*\*`, "https://example.com/reports/q3", "— see the bullets", "Revenue up", "Churn down"} {
+		if !strings.Contains(first, want) {
+			t.Errorf("first body = %q, want %q in it", first, want)
+		}
 	}
-	if !strings.Contains(first, "- Revenue up") {
-		t.Errorf("first body = %q, want the list as Markdown", first)
+	if strings.Contains(first, "**quarterly**") {
+		t.Errorf("first body = %q, want the asterisks escaped, not emphasis", first)
 	}
 	if last := entries[len(entries)-1].Body; !strings.Contains(last, fmt.Sprintf("Reply %d of %d", replies, replies)) {
 		t.Errorf("last body = %q, want the last reply", last)
 	}
-
-	// Every entry's summary is a prefix of its body, compared rune by rune: HEY's
-	// preview ends in an ellipsis and a byte-wise prefix check would slice a multibyte
-	// character in half.
 	for _, entry := range entries {
-		summary := []rune(strings.TrimSuffix(strings.TrimSpace(entry.Summary), "…"))
-		body := []rune(strings.Join(strings.Fields(entry.Body), " "))
-		if len(summary) == 0 || len(body) < len(summary) {
-			continue
-		}
-		if !strings.HasPrefix(string(body), strings.TrimSpace(string(summary[:min(len(summary), 20)]))) {
-			t.Logf("entry %d summary %q is not a prefix of its body %q (HEY previews may differ from rendered Markdown)", entry.ID, entry.Summary, entry.Body)
+		if !utf8.ValidString(entry.Summary) || !utf8.ValidString(entry.Body) {
+			t.Errorf("entry %d carries invalid UTF-8: summary %q body %q", entry.ID, entry.Summary, entry.Body)
 		}
 	}
 

--- a/tests/smoke/threads_test.go
+++ b/tests/smoke/threads_test.go
@@ -1,0 +1,230 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type threadEntry struct {
+	ID        int64  `json:"id"`
+	CreatedAt string `json:"created_at"`
+	Summary   string `json:"summary"`
+	Body      string `json:"body"`
+	BodyState string `json:"body_state"`
+	Creator   struct {
+		Name         string `json:"name"`
+		EmailAddress string `json:"email_address"`
+	} `json:"creator"`
+}
+
+// longThread composes a message and replies to it until the thread is longer than one
+// geared page, so every format is exercised against a thread the entries index serves
+// in more than one page. It skips — or fails, under HEY_SMOKE_STRICT — when the server
+// will not let the CLI write.
+func longThread(t *testing.T, replies int) (topicID string, subject string) {
+	t.Helper()
+	uid := uniqueID()
+	subject = fmt.Sprintf("Long thread %s", uid)
+	_, stderr, code := hey(t, "compose",
+		"--to", smokeEmail,
+		"--subject", subject,
+		"-m", "First: the **quarterly** numbers are at https://example.com/reports/q3 — see the bullets\n\n- Revenue up\n- Churn down",
+		"--json",
+	)
+	if code != 0 {
+		skipf(t, "could not compose the thread's first message (exit %d): %s", code, stderr)
+	}
+
+	resp := heyJSON(t, "box", "imbox", "--all")
+	type posting struct {
+		AppURL  string `json:"app_url"`
+		Summary string `json:"summary"`
+		Name    string `json:"name"`
+	}
+	type boxResp struct {
+		Postings []posting `json:"postings"`
+	}
+	for _, p := range dataAs[boxResp](t, resp).Postings {
+		if strings.Contains(p.Name, uid) || strings.Contains(p.Summary, uid) {
+			topicID = extractTopicID(p.AppURL)
+			break
+		}
+	}
+	if topicID == "" {
+		skipf(t, "the composed thread %q did not appear in the Imbox", subject)
+	}
+
+	for i := range replies {
+		_, stderr, code := hey(t, "reply", topicID, "-m", fmt.Sprintf("Reply %d of %d in %s", i+1, replies, uid), "--json")
+		if code != 0 {
+			skipf(t, "reply %d failed (exit %d): %s", i+1, code, stderr)
+		}
+	}
+	return topicID, subject
+}
+
+// A thread longer than a page reads whole, oldest first, with every entry's body as
+// Markdown: the composed links and emphasis survive, and no HTML tag does.
+func TestThreadsReadsALongThreadAsMarkdown(t *testing.T) {
+	const replies = 11
+	topicID, _ := longThread(t, replies)
+
+	resp := heyJSON(t, "threads", topicID)
+	entries := dataAs[[]threadEntry](t, resp)
+	if len(entries) != replies+1 {
+		t.Fatalf("thread has %d entries, want %d", len(entries), replies+1)
+	}
+	if resp.Notice != "" {
+		t.Errorf("notice = %q, want none for a thread read whole", resp.Notice)
+	}
+
+	seen := map[int64]bool{}
+	for i, entry := range entries {
+		if seen[entry.ID] {
+			t.Errorf("entry %d appears twice", entry.ID)
+		}
+		seen[entry.ID] = true
+		if i > 0 && entries[i-1].CreatedAt > entry.CreatedAt {
+			t.Errorf("entry %d (%s) comes after %d (%s): not oldest first", entry.ID, entry.CreatedAt, entries[i-1].ID, entries[i-1].CreatedAt)
+		}
+		if entry.BodyState != "hydrated" {
+			t.Errorf("entry %d body_state = %q, want hydrated", entry.ID, entry.BodyState)
+		}
+		if strings.Contains(entry.Body, "<div") || strings.Contains(entry.Body, "<p") || strings.Contains(entry.Body, "<br") {
+			t.Errorf("entry %d body carries HTML: %q", entry.ID, entry.Body)
+		}
+	}
+
+	first := entries[0].Body
+	if !strings.Contains(first, "**quarterly**") || !strings.Contains(first, "https://example.com/reports/q3") {
+		t.Errorf("first body = %q, want the emphasis and the link as Markdown", first)
+	}
+	if !strings.Contains(first, "- Revenue up") {
+		t.Errorf("first body = %q, want the list as Markdown", first)
+	}
+	if last := entries[len(entries)-1].Body; !strings.Contains(last, fmt.Sprintf("Reply %d of %d", replies, replies)) {
+		t.Errorf("last body = %q, want the last reply", last)
+	}
+
+	// Every entry's summary is a prefix of its body, compared rune by rune: HEY's
+	// preview ends in an ellipsis and a byte-wise prefix check would slice a multibyte
+	// character in half.
+	for _, entry := range entries {
+		summary := []rune(strings.TrimSuffix(strings.TrimSpace(entry.Summary), "…"))
+		body := []rune(strings.Join(strings.Fields(entry.Body), " "))
+		if len(summary) == 0 || len(body) < len(summary) {
+			continue
+		}
+		if !strings.HasPrefix(string(body), strings.TrimSpace(string(summary[:min(len(summary), 20)]))) {
+			t.Logf("entry %d summary %q is not a prefix of its body %q (HEY previews may differ from rendered Markdown)", entry.ID, entry.Summary, entry.Body)
+		}
+	}
+
+	count := strings.TrimSpace(heyOK(t, "threads", topicID, "--count"))
+	if count != strconv.Itoa(replies+1) {
+		t.Errorf("--count = %q, want %d", count, replies+1)
+	}
+}
+
+// Every output format answers a thread the way the contract says.
+func TestThreadsFormats(t *testing.T) {
+	topicID, _ := longThread(t, 2)
+
+	t.Run("json", func(t *testing.T) {
+		resp := heyJSON(t, "threads", topicID)
+		entries := dataAs[[]threadEntry](t, resp)
+		if len(entries) != 3 || resp.Summary != fmt.Sprintf("3 entries in thread %s", topicID) {
+			t.Errorf("entries = %d, summary = %q", len(entries), resp.Summary)
+		}
+	})
+
+	t.Run("markdown", func(t *testing.T) {
+		out := heyOK(t, "threads", topicID, "--markdown")
+		if !strings.HasPrefix(out, "# Thread "+topicID+"\n") {
+			t.Errorf("markdown = %q, want a document heading", out)
+		}
+		if strings.Count(out, "\n## From: ") != 3 || strings.Count(out, "\n---\n") != 3 {
+			t.Errorf("markdown = %q, want a heading and a rule per entry", out)
+		}
+		if strings.Contains(out, "<p") || strings.Contains(out, "<div") {
+			t.Errorf("markdown = %q carries HTML", out)
+		}
+	})
+
+	t.Run("ids", func(t *testing.T) {
+		out := heyOK(t, "threads", topicID, "--ids-only")
+		ids := strings.Fields(out)
+		if len(ids) != 3 {
+			t.Errorf("--ids-only = %q, want three IDs", out)
+		}
+		for _, id := range ids {
+			if _, err := strconv.ParseInt(id, 10, 64); err != nil {
+				t.Errorf("--ids-only line %q is not an ID", id)
+			}
+		}
+	})
+
+	t.Run("count", func(t *testing.T) {
+		if out := strings.TrimSpace(heyOK(t, "threads", topicID, "--count")); out != "3" {
+			t.Errorf("--count = %q, want 3", out)
+		}
+	})
+
+	t.Run("quiet", func(t *testing.T) {
+		out := heyOK(t, "threads", topicID, "--quiet")
+		var entries []threadEntry
+		if err := json.Unmarshal([]byte(out), &entries); err != nil || len(entries) != 3 {
+			t.Errorf("--quiet = %q, err = %v, want the bare entries", out, err)
+		}
+	})
+
+	t.Run("jq", func(t *testing.T) {
+		out := heyOK(t, "threads", topicID, "--jq", ".data | length")
+		if strings.TrimSpace(out) != "3" {
+			t.Errorf("--jq = %q, want 3", out)
+		}
+	})
+
+	t.Run("styled", func(t *testing.T) {
+		out := heyOK(t, "threads", topicID, "--styled")
+		if strings.Count(out, "From: ") != 3 {
+			t.Errorf("styled = %q, want a From line per entry", out)
+		}
+		if strings.Contains(out, "<p") || strings.Contains(out, "**") {
+			t.Errorf("styled = %q, want rendered Markdown, not tags or markers", out)
+		}
+	})
+
+	t.Run("html to a pipe", func(t *testing.T) {
+		out := heyOK(t, "threads", topicID, "--html")
+		if strings.Count(out, "<!-- hey entry ") != 3 {
+			t.Errorf("--html = %q, want a comment per entry", out)
+		}
+		if !strings.Contains(out, "<div") && !strings.Contains(out, "<p") {
+			t.Errorf("--html = %q, want HEY's HTML", out)
+		}
+		file := filepath.Join(t.TempDir(), "thread.html")
+		if err := os.WriteFile(file, []byte(out), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("html refuses other selectors", func(t *testing.T) {
+		_, stderr := heyFail(t, "threads", topicID, "--html", "--json")
+		if !strings.Contains(stderr, "cannot use --html with --json") {
+			t.Errorf("stderr = %q", stderr)
+		}
+	})
+
+	t.Run("html refused elsewhere", func(t *testing.T) {
+		_, stderr := heyFail(t, "boxes", "--html")
+		if !strings.Contains(stderr, "--html is not supported by hey boxes") {
+			t.Errorf("stderr = %q", stderr)
+		}
+	})
+}

--- a/tests/smoke/timetrack_test.go
+++ b/tests/smoke/timetrack_test.go
@@ -138,7 +138,7 @@ func TestTimetrackCategories(t *testing.T) {
 	title := "Client work " + uniqueID()
 	_, stderr, code := hey(t, "timetrack", "category", "create", title)
 	if code != 0 {
-		t.Skipf("timetrack category create unavailable (exit %d): %s", code, stderr)
+		skipf(t, "timetrack category create unavailable (exit %d): %s", code, stderr)
 	}
 
 	categoryID := findTimeTrackCategory(t, title)

--- a/tests/smoke/trash_test.go
+++ b/tests/smoke/trash_test.go
@@ -16,7 +16,7 @@ func TestTrash(t *testing.T) {
 		"--json",
 	)
 	if code != 0 {
-		t.Skipf("could not create a disposable thread (exit %d): %s", code, stderr)
+		skipf(t, "could not create a disposable thread (exit %d): %s", code, stderr)
 	}
 
 	boxResp := heyJSON(t, "box", "imbox")
@@ -37,7 +37,7 @@ func TestTrash(t *testing.T) {
 		}
 	}
 	if postingID == 0 {
-		t.Skip("disposable thread did not appear in Imbox")
+		skipf(t, "disposable thread did not appear in Imbox")
 	}
 
 	stdout := heyOK(t, "trash", intStr(postingID), "--json")


### PR DESCRIPTION
Stacked on #252 → #251 → #250.

- **Contact notes**: `hey contacts show` and `hey contacts note show` render the rich note's HTML as Markdown in styled output, the same way a thread body renders; the plain note stands in only when there is no HTML. Neither prints markup; `--html` (from #250) writes it.
- **Help**: the curated flag list says what `--styled`, `--markdown` and `--html` do — styled is the human rendering with bodies as rendered Markdown and the default on a terminal; markdown is a table for a listing and a document for a thread; html names its four commands.
- **Smoke**: `HEY_SMOKE_STRICT=1` turns every `skipf` into a failure, which is the release gate the plan asks for (a skipped check is not a passed one). New `tests/smoke/threads_test.go` composes a thread and replies until it is longer than one geared page (12 entries), then asserts oldest-first order, unique IDs, `body_state: hydrated` throughout, Markdown bodies with the composed link/emphasis/list and no HTML tags, a rune-safe summary-prefix comparison, `--count`, and walks every output format through the contract (`--html` to a pipe included, plus the two refusals).
- README gains the `--markdown` / `--html > file` examples; AGENTS.md documents `HEY_SMOKE_STRICT`.

The stack also carries a fix into #250 found while writing the contact-note test: `ToMarkdown` writes prose `&` as `&amp;` and `Render` re-encoded it, so "Fried & Hansson" showed as "Fried &amp; Hansson". `Render` now leaves an `&amp;` in prose alone (glamour's one decode makes it `&`), still encodes any other `&`, and gives image alt text — which glamour shows verbatim — exactly the one decode `&amp;` needs. `internal/markdown/pipeline_test.go` runs `ToMarkdown` into `Render` for the cases that matter.

Smoke has **not** been run against a dev server from this environment (none is reachable here) — release readiness per the plan is withheld until `HEY_SMOKE_STRICT=1 make test-smoke` passes on the tip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render contact notes as Markdown in styled output, sharpen format flag help, and gate smoke skips under strict mode. Previously contacts showed plain text or inert HTML; now rich note HTML renders to Markdown, plain note is a fallback, and only --html writes markup.

- Contacts: hey contacts show and hey contacts note show render note HTML via htmlutil → markdown.Render using renderedNote(); fall back to sanitized plain text or “(empty)”; never print HTML. Tests cover rendering, fallback, and sanitization.
- Help: --styled = human rendering with bodies as rendered Markdown (default on a terminal; forces it when piped); --markdown = table for a listing, document for a thread; --html = threads, journal read, contacts show, contacts note show. README adds hey threads --markdown and --html > file examples.
- Smoke: skipf turns skips into failures under HEY_SMOKE_STRICT=1 (boolean; 0/false disable). New long-thread test composes plain text, replies past one page, waits for the posting before registering cleanup, and verifies oldest-first order, unique IDs, body_state: hydrated, Markdown bodies without HTML, valid UTF‑8, styled rendering without tags or unrendered backslashes, and the contract for --json, --jq, --markdown, --styled, --ids-only, --count, and --html (pipe output and refusal combinations).
- Rollout: run HEY_SMOKE_STRICT=1 make test-smoke before release.

<sup>Written for commit b38c8cf24326aee33939f0ae5b57b63d6f5ee69b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

