### PR TITLE
Grow the contact list as the reader scrolls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,11 +208,11 @@ To add a new section: implement the `sectionView` interface in a new file, add a
 
 ### Lists grow as the reader scrolls
 
-Every mail list — a box, a label, a collection, a search — and both of The Screener's panes
-read one page and then grow downwards. There are no page keys: the cursor coming within
-`loadMoreThreshold` of the bottom reads the page below, and so does a list the reader can
-already see the end of, which is why a first page too short to fill the window keeps reading
-until it does.
+Every mail list — a box, a label, a collection, a search — both of The Screener's panes and
+the contact list read one page and then grow downwards. There are no page keys: the cursor
+coming within `loadMoreThreshold` of the bottom reads the page below, and so does a list the
+reader can already see the end of, which is why a first page too short to fill the window
+keeps reading until it does.
 
 The pages come from geared_pagination, which is not offset paging: every JSON read carries
 a `Link` header whose `page` is a cursor into the ordering, and the last page carries none.
@@ -230,6 +230,14 @@ Search is the exception to the cursor: `Search::Matches::Page` is a shim over ge
 rather than the real thing, and it numbers its pages, so the search results carry
 `searchNextPage int` instead of a `listPaging`. There is nothing to keep a `headIDs` for
 either — search results are never re-read live.
+
+Contacts are the same kind of exception, for a different reason. `ContactsController#index`
+pages an Elasticsearch relation with no `ordered_by`, so geared hands out offsets and its
+`Link` header carries a page number; `contactsView` keeps a `nextPage int` and zeroes it on
+the first empty page, the way `hey contacts` already does in `readContactsPage`. The `Link`
+header is not read at all — `Contacts().List` throws it away, and an empty page is a
+cheaper way to learn the same thing than a `ListPage` in the SDK. Contacts are never
+re-read live either, so there is no `headIDs` here.
 
 The subtle part is the live re-read. It reads the box's *top* page, because that is where a
 change shows up, so it may only replace that much of a list that has grown past it:

--- a/internal/tui/contacts.go
+++ b/internal/tui/contacts.go
@@ -34,8 +34,15 @@ const (
 
 type contactsLoadedMsg struct {
 	requestResult
-	page     int
 	contacts []Contact
+	nextPage int
+}
+
+type contactsAppendedMsg struct {
+	requestID uint64
+	contacts  []Contact
+	nextPage  int
+	err       error
 }
 
 type contactDetailLoadedMsg struct {
@@ -72,7 +79,8 @@ type contactsView struct {
 
 	list                contactList
 	loaded              bool
-	page                int
+	nextPage            int  // the page after the contacts on screen, zero at the last one
+	loadingMore         bool // the page below is already on its way
 	detail              Contact
 	note                string
 	inDetail            bool
@@ -85,13 +93,13 @@ type contactsView struct {
 	confirmNoteDelete   bool
 	notice              string
 
-	requests requestLane[contactRequestKind]
+	requests      requestLane[contactRequestKind]
+	moreRequestID uint64 // identifies the only page-below read allowed to grow the list
 }
 
 func newContactsView(vc *viewContext) *contactsView {
 	return &contactsView{
 		vc:         vc,
-		page:       1,
 		detailView: viewport.New(viewport.WithWidth(0), viewport.WithHeight(0)),
 	}
 }
@@ -100,7 +108,7 @@ func (v *contactsView) Init() tea.Cmd {
 	if v.loaded {
 		return nil
 	}
-	return v.requestContacts(1)
+	return v.requestContacts()
 }
 
 func (v *contactsView) Update(msg tea.Msg) (tea.Cmd, bool) {
@@ -109,14 +117,28 @@ func (v *contactsView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		if cmd, ok := v.requests.settle(msg.requestResult); !ok {
 			return cmd, true
 		}
-		if len(msg.contacts) == 0 && v.loaded && msg.page > v.page {
-			v.notice = "No more contacts"
+		v.loaded = true
+		v.loadingMore = false
+		v.nextPage = msg.nextPage
+		v.list.setContacts(msg.contacts)
+		return v.loadMoreContacts(), true
+
+	case contactsAppendedMsg:
+		if msg.requestID != v.moreRequestID {
 			return nil, true
 		}
-		v.loaded = true
-		v.page = msg.page
-		v.list.setContacts(msg.contacts)
-		return nil, true
+		v.loadingMore = false
+		if msg.err != nil {
+			v.notice = errorNotice("Could not load more contacts", msg.err)
+			return nil, true
+		}
+		v.list.growContacts(msg.contacts)
+		if len(msg.contacts) == 0 {
+			v.nextPage = 0
+		} else {
+			v.nextPage = msg.nextPage
+		}
+		return v.loadMoreContacts(), true
 
 	case contactDetailLoadedMsg:
 		if !v.requests.accepts(msg.requestResult) {
@@ -185,7 +207,7 @@ func (v *contactsView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.detail = Contact{}
 		v.note = ""
 		v.notice = "Contact hidden"
-		return nil, true
+		return v.loadMoreContacts(), true
 
 	case contactRevealedMsg:
 		if cmd, ok := v.requests.settle(msg.requestResult); !ok {
@@ -193,7 +215,7 @@ func (v *contactsView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		}
 		v.lastHiddenID = 0
 		v.notice = "Contact shown again"
-		return v.requestContacts(v.page), true
+		return v.requestContacts(), true
 
 	case contactNoteSavedMsg:
 		if !v.requests.accepts(msg.requestResult) {
@@ -271,7 +293,7 @@ func (v *contactsView) HelpBindings() []helpBinding {
 		}
 		return bindings
 	}
-	bindings := []helpBinding{{"a", "add"}, {"r", "refresh"}, {"n/p", "pages"}}
+	bindings := []helpBinding{{"a", "add"}, {"r", "refresh"}}
 	if v.lastHiddenID != 0 {
 		bindings = append(bindings, helpBinding{"u", "show again"})
 	}
@@ -279,7 +301,7 @@ func (v *contactsView) HelpBindings() []helpBinding {
 }
 
 func (v *contactsView) SubnavItems() ([]navItem, int, string, bool) {
-	return nil, 0, fmt.Sprintf("Contacts (page %d)", v.page), true
+	return nil, 0, "Contacts", true
 }
 
 func (v *contactsView) SubnavLeft() tea.Cmd  { return nil }
@@ -344,6 +366,7 @@ func (v *contactsView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		v.list.moveUp()
 	case tea.KeyDown:
 		v.list.moveDown()
+		return v.loadMoreContacts()
 	case tea.KeyEnter:
 		if contact := v.list.selected(); contact != nil {
 			return v.requestContactDetail(contact.ID)
@@ -353,14 +376,7 @@ func (v *contactsView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		case "a":
 			return v.startAddContact()
 		case "r":
-			return v.requestContacts(v.page)
-		case "n":
-			return v.requestContacts(v.page + 1)
-		case "p":
-			if v.page > 1 {
-				return v.requestContacts(v.page - 1)
-			}
-			v.notice = "Already on the first contacts page"
+			return v.requestContacts()
 		case "u":
 			if v.lastHiddenID != 0 {
 				return v.revealContact(v.lastHiddenID)
@@ -439,9 +455,32 @@ func (v *contactsView) Restyle() {
 	}
 }
 
-func (v *contactsView) requestContacts(page int) tea.Cmd {
+// requestContacts reads the contacts from their first page. The list starts there and
+// grows downwards from it, so a read the user asked for is also what puts the list back to
+// the depth it opens at.
+func (v *contactsView) requestContacts() tea.Cmd {
+	v.nextPage = 0
+	v.loadingMore = false
+	v.moreRequestID++
 	requestID, ctx := v.requests.begin(v.vc.ctx, contactRequestList)
-	return v.fetchContacts(ctx, requestID, max(page, 1))
+	return v.fetchContacts(ctx, requestID)
+}
+
+// loadMoreContacts reads the page below the one the reader has scrolled to, or the one
+// below a list they can already see the end of. One page is asked for at a time, in its own
+// lane and on the view's own context: the reader is still looking at what is there, so this
+// must not cancel or be cancelled by the read they are waiting on.
+func (v *contactsView) loadMoreContacts() tea.Cmd {
+	if v.loadingMore || v.nextPage == 0 {
+		return nil
+	}
+	if v.list.hasRowsBelow() && len(v.list.contacts)-v.list.cursor > loadMoreThreshold {
+		return nil
+	}
+
+	v.loadingMore = true
+	v.moreRequestID++
+	return v.fetchMoreContacts(v.vc.ctx, v.moreRequestID, v.nextPage)
 }
 
 func (v *contactsView) requestContactDetail(contactID int64) tea.Cmd {
@@ -578,24 +617,43 @@ func (v *contactsView) renderContactDetail() string {
 	return b.String()
 }
 
-func (v *contactsView) fetchContacts(ctx context.Context, requestID uint64, page int) tea.Cmd {
+func (v *contactsView) fetchContacts(ctx context.Context, requestID uint64) tea.Cmd {
 	return func() tea.Msg {
-		pageValue := fmt.Sprintf("%d", page)
-		params := &generated.ListContactsParams{Page: &pageValue}
-		result, err := v.vc.sdk.Contacts().List(ctx, params)
-		if err != nil {
-			return contactsLoadedMsg{requestResult: newRequestResult(requestID, err), page: page}
-		}
-		var sdkContacts []generated.Contact
-		if result != nil {
-			sdkContacts = *result
-		}
-		contacts := make([]Contact, 0, len(sdkContacts))
-		for _, contact := range sdkContacts {
-			contacts = append(contacts, sdkContactToModel(contact))
-		}
-		return contactsLoadedMsg{requestResult: newRequestResult(requestID, nil), page: page, contacts: contacts}
+		contacts, nextPage, err := v.readContactsPage(ctx, 1)
+		return contactsLoadedMsg{requestResult: newRequestResult(requestID, err), contacts: contacts, nextPage: nextPage}
 	}
+}
+
+// fetchMoreContacts reads the page below the list, in the growing lane and without the
+// spinner: what the reader is looking at is already on screen.
+func (v *contactsView) fetchMoreContacts(ctx context.Context, requestID uint64, page int) tea.Cmd {
+	return func() tea.Msg {
+		contacts, nextPage, err := v.readContactsPage(ctx, page)
+		return contactsAppendedMsg{requestID: requestID, contacts: contacts, nextPage: nextPage, err: err}
+	}
+}
+
+// readContactsPage reads one page of contacts and answers the number of the page after it.
+// HEY numbers the contact index's pages where a box cursors them, and the last page is only
+// known once the page after it comes back empty, which is where the caller zeroes this.
+func (v *contactsView) readContactsPage(ctx context.Context, page int) ([]Contact, int, error) {
+	pageValue := fmt.Sprintf("%d", max(page, 1))
+	result, err := v.vc.sdk.Contacts().List(ctx, &generated.ListContactsParams{Page: &pageValue})
+	if err != nil {
+		return nil, 0, err
+	}
+	var sdkContacts []generated.Contact
+	if result != nil {
+		sdkContacts = *result
+	}
+	contacts := make([]Contact, 0, len(sdkContacts))
+	for _, contact := range sdkContacts {
+		contacts = append(contacts, sdkContactToModel(contact))
+	}
+	if len(contacts) == 0 {
+		return contacts, 0, nil
+	}
+	return contacts, max(page, 1) + 1, nil
 }
 
 func (v *contactsView) fetchContactDetail(ctx context.Context, requestID uint64, contactID int64) tea.Cmd {

--- a/internal/tui/contacts_list.go
+++ b/internal/tui/contacts_list.go
@@ -21,6 +21,12 @@ func (l *contactList) setContacts(contacts []Contact) {
 	l.scrollOff = 0
 }
 
+// growContacts adds the page below the list, leaving the cursor and the scroll where the
+// reader left them.
+func (l *contactList) growContacts(contacts []Contact) {
+	l.contacts = append(l.contacts, contacts...)
+}
+
 func (l *contactList) setSize(width, height int) {
 	l.width = width
 	l.height = height
@@ -40,8 +46,20 @@ func (l *contactList) moveDown() {
 	}
 }
 
+// visibleCount is how many contacts the window holds. Each one takes two lines.
+func (l *contactList) visibleCount() int {
+	return max(l.height/2, 1)
+}
+
+// hasRowsBelow reports whether the list carries on past the bottom of the window. A list
+// that does not is a list the reader can see the end of, which is a reason to read the page
+// below it without waiting to be asked.
+func (l *contactList) hasRowsBelow() bool {
+	return l.scrollOff+l.visibleCount() < len(l.contacts)
+}
+
 func (l *contactList) ensureVisible() {
-	visible := max(l.height/2, 1)
+	visible := l.visibleCount()
 	if l.cursor < l.scrollOff {
 		l.scrollOff = l.cursor
 	}
@@ -78,8 +96,7 @@ func (l *contactList) view() string {
 	if len(l.contacts) == 0 {
 		return styleMuted.Render("  (no contacts)")
 	}
-	visible := max(l.height/2, 1)
-	end := min(l.scrollOff+visible, len(l.contacts))
+	end := min(l.scrollOff+l.visibleCount(), len(l.contacts))
 	cursorMarker, selected := cursorStyles()
 	selectedGap := selectionStyle(lipgloss.NewStyle())
 	normal := lipgloss.NewStyle().Foreground(colorBright)

--- a/internal/tui/contacts_test.go
+++ b/internal/tui/contacts_test.go
@@ -2,11 +2,16 @@ package tui
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
+
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
@@ -42,11 +47,14 @@ func contactsWithTestServer(t *testing.T) (*contactsView, *recordedTUIContacts) 
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/contacts.json":
-			if req.URL.Query().Get("page") == "2" {
+			switch req.URL.Query().Get("page") {
+			case "2":
+				_, _ = w.Write([]byte(`[{"id":21,"name":"Alex Nakamura","email_address":"alex@example.com"},{"id":22,"name":"Priya Raman","email_address":"priya@example.org"}]`))
+			case "3":
 				_, _ = w.Write([]byte(`[]`))
-				return
+			default:
+				_, _ = w.Write([]byte(`[{"id":7,"name":"Jane Doe","email_address":"jane@example.com"}]`))
 			}
-			_, _ = w.Write([]byte(`[{"id":7,"name":"Jane Doe","email_address":"jane@example.com"}]`))
 		case req.Method == http.MethodPost && req.URL.Path == "/contacts.json":
 			if conflict {
 				w.WriteHeader(http.StatusConflict)
@@ -101,7 +109,21 @@ func loadTUIContacts(t *testing.T, view *contactsView) {
 	if _, ok := msg.(contactsLoadedMsg); !ok {
 		t.Fatalf("contacts init returned %T", msg)
 	}
-	view.Update(msg)
+	drainContactPages(t, view, msg)
+}
+
+// drainContactPages applies a contacts response and every page it goes on to read below
+// it, the way the runtime does, so a test sees the list at the depth a reader would.
+func drainContactPages(t *testing.T, view *contactsView, msg tea.Msg) {
+	t.Helper()
+	for range 20 {
+		cmd, _ := view.Update(msg)
+		if cmd == nil {
+			return
+		}
+		msg = cmd()
+	}
+	t.Fatal("contacts never stopped reading pages")
 }
 
 func openTUIContact(t *testing.T, view *contactsView) {
@@ -113,25 +135,123 @@ func openTUIContact(t *testing.T, view *contactsView) {
 	view.Update(cmd())
 }
 
-func TestContactsViewLoadsListsAndPages(t *testing.T) {
+func TestContactsViewGrowsUntilTheListRunsOut(t *testing.T) {
 	view, recorded := contactsWithTestServer(t)
 	loadTUIContacts(t, view)
-	if view.requests.loading || !view.loaded || len(view.list.contacts) != 1 || view.list.contacts[0].ID != 7 {
-		t.Errorf("list state = loading:%v loaded:%v contacts:%+v", view.requests.loading, view.loaded, view.list.contacts)
+	if view.requests.loading || !view.loaded || view.loadingMore || view.nextPage != 0 {
+		t.Errorf("list state = loading:%v loaded:%v growing:%v nextPage:%d", view.requests.loading, view.loaded, view.loadingMore, view.nextPage)
 	}
-
-	next := view.HandleContentKey(keyPress("n"))
-	if next == nil {
-		t.Fatal("next page returned no command")
-	}
-	view.Update(next())
-	if view.page != 1 || len(view.list.contacts) != 1 || view.notice != "No more contacts" {
-		t.Errorf("empty next page changed results: page=%d contacts=%+v notice=%q", view.page, view.list.contacts, view.notice)
+	if ids := contactIDs(view.list.contacts); !slices.Equal(ids, []int64{7, 21, 22}) {
+		t.Errorf("contacts = %v, want the first page and the one below it", ids)
 	}
 	requests, _ := recorded.snapshot()
-	if !strings.Contains(strings.Join(requests, "\n"), "page=2") {
+	if !slices.Equal(requests, []string{
+		"GET /contacts.json?page=1",
+		"GET /contacts.json?page=2",
+		"GET /contacts.json?page=3",
+	}) {
 		t.Errorf("requests = %v", requests)
 	}
+
+	// The reader can see the end of the list, and the empty page said that is all there is.
+	if cmd := view.HandleContentKey(keyPress("down")); cmd != nil {
+		t.Error("scrolling a finished list read another page")
+	}
+}
+
+func TestContactsViewReadsThePageBelowTheCursorOnce(t *testing.T) {
+	view, _ := contactsWithTestServer(t)
+	view.loaded = true
+	view.nextPage = 2
+	view.list.setSize(80, 4)
+	view.list.setContacts(testContactRows(40))
+
+	view.list.cursor = 10
+	if cmd := view.HandleContentKey(keyPress("down")); cmd != nil {
+		t.Error("a list with plenty left below it read the page below")
+	}
+
+	view.list.cursor = len(view.list.contacts) - 2
+	cmd := view.HandleContentKey(keyPress("down"))
+	if cmd == nil || !view.loadingMore {
+		t.Fatal("scrolling to the bottom should read the page below")
+	}
+	if again := view.HandleContentKey(keyPress("down")); again != nil {
+		t.Error("the page below was asked for twice")
+	}
+
+	msg, ok := cmd().(contactsAppendedMsg)
+	if !ok {
+		t.Fatalf("page below answered %T", cmd())
+	}
+	view.Update(msg)
+	if view.nextPage != 3 {
+		t.Errorf("nextPage = %d, want the page after the one that arrived", view.nextPage)
+	}
+	if ids := contactIDs(view.list.contacts[40:]); !slices.Equal(ids, []int64{21, 22}) {
+		t.Errorf("appended contacts = %v", ids)
+	}
+}
+
+func TestContactsViewIgnoresASupersededPageBelow(t *testing.T) {
+	view, _ := contactsWithTestServer(t)
+	view.loaded = true
+	view.nextPage = 2
+	view.loadingMore = true
+	view.moreRequestID = 3
+	view.list.setContacts([]Contact{{ID: 7}})
+
+	view.Update(contactsAppendedMsg{requestID: 2, contacts: []Contact{{ID: 99}}, nextPage: 3})
+	if len(view.list.contacts) != 1 || !view.loadingMore {
+		t.Errorf("stale page grew the list: contacts=%+v growing:%v", view.list.contacts, view.loadingMore)
+	}
+
+	view.Update(contactsAppendedMsg{requestID: 3, err: errors.New("read failed")})
+	if view.loadingMore || !strings.Contains(view.notice, "Could not load more contacts") {
+		t.Errorf("failed page state = growing:%v notice:%q", view.loadingMore, view.notice)
+	}
+}
+
+func TestContactsViewRefreshReadsFromTheTop(t *testing.T) {
+	view, recorded := contactsWithTestServer(t)
+	loadTUIContacts(t, view)
+	view.list.cursor = 2
+
+	cmd := view.HandleContentKey(keyPress("r"))
+	if cmd == nil || view.nextPage != 0 {
+		t.Fatalf("refresh state = cmd:%v nextPage:%d", cmd != nil, view.nextPage)
+	}
+	drainContactPages(t, view, cmd())
+	if ids := contactIDs(view.list.contacts); !slices.Equal(ids, []int64{7, 21, 22}) {
+		t.Errorf("refreshed contacts = %v", ids)
+	}
+	if view.list.cursor != 0 {
+		t.Errorf("refresh left the cursor at %d", view.list.cursor)
+	}
+	requests, _ := recorded.snapshot()
+	if requests[len(requests)-3] != "GET /contacts.json?page=1" {
+		t.Errorf("refresh did not start over: %v", requests)
+	}
+}
+
+func contactIDs(contacts []Contact) []int64 {
+	ids := make([]int64, 0, len(contacts))
+	for _, contact := range contacts {
+		ids = append(ids, contact.ID)
+	}
+	return ids
+}
+
+func testContactRows(count int) []Contact {
+	contacts := make([]Contact, 0, count)
+	for i := range count {
+		contacts = append(contacts, Contact{
+			ID:           int64(100 + i),
+			Name:         fmt.Sprintf("Contact %d", i),
+			EmailAddress: fmt.Sprintf("contact%d@example.com", i),
+		})
+	}
+	return contacts
 }
 
 func TestContactsViewOpensDetailWithAliasesAndNote(t *testing.T) {
@@ -152,7 +272,7 @@ func TestContactsViewOpensDetailWithAliasesAndNote(t *testing.T) {
 func TestContactsViewIgnoresStaleResponses(t *testing.T) {
 	view, _ := contactsWithTestServer(t)
 	view.requests.id = 2
-	view.Update(contactsLoadedMsg{requestResult: requestResult{requestID: 1}, page: 1, contacts: []Contact{{ID: 99}}})
+	view.Update(contactsLoadedMsg{requestResult: requestResult{requestID: 1}, contacts: []Contact{{ID: 99}}})
 	if len(view.list.contacts) != 0 {
 		t.Error("stale contacts changed the list")
 	}
@@ -218,7 +338,7 @@ func TestContactsViewCreateConflictLoadsWrittenContact(t *testing.T) {
 	if !view.inDetail || view.detail.ID != 9 {
 		t.Errorf("written conflict contact was not loaded: %+v", view.detail)
 	}
-	if len(view.list.contacts) != 2 || view.list.contacts[0].ID != 9 {
+	if len(view.list.contacts) != 4 || view.list.contacts[0].ID != 9 {
 		t.Errorf("written conflict contact was not added to the list: %+v", view.list.contacts)
 	}
 }
@@ -290,6 +410,7 @@ func TestContactFormBlankAliasesCreatesExplicitEmptyReplacement(t *testing.T) {
 func TestContactsViewValidatesFormBeforeSaving(t *testing.T) {
 	view, recorded := contactsWithTestServer(t)
 	loadTUIContacts(t, view)
+	loadRequests, _ := recorded.snapshot()
 	view.HandleContentKey(keyPress("a"))
 	if cmd := view.HandleContentKey(keyPress("ctrl+s")); cmd != nil {
 		t.Fatal("invalid form should not save")
@@ -298,8 +419,8 @@ func TestContactsViewValidatesFormBeforeSaving(t *testing.T) {
 		t.Errorf("form status = %q", view.contactForm.status)
 	}
 	requests, _ := recorded.snapshot()
-	if len(requests) != 1 {
-		t.Errorf("validation made requests: %v", requests)
+	if len(requests) != len(loadRequests) {
+		t.Errorf("validation made requests: %v", requests[len(loadRequests):])
 	}
 }
 
@@ -309,7 +430,7 @@ func TestContactsViewHidesAndShowsAgain(t *testing.T) {
 	openTUIContact(t, view)
 	hide := view.HandleContentKey(keyPress("h"))
 	view.Update(hide())
-	if view.inDetail || len(view.list.contacts) != 0 || view.lastHiddenID != 7 || view.notice != "Contact hidden" {
+	if view.inDetail || len(view.list.contacts) != 2 || view.lastHiddenID != 7 || view.notice != "Contact hidden" {
 		t.Errorf("hide state = detail:%v contacts:%+v hidden:%d notice:%q", view.inDetail, view.list.contacts, view.lastHiddenID, view.notice)
 	}
 	reveal := view.HandleContentKey(keyPress("u"))
@@ -317,8 +438,8 @@ func TestContactsViewHidesAndShowsAgain(t *testing.T) {
 	if refresh == nil {
 		t.Fatal("successful reveal should refresh contacts")
 	}
-	view.Update(refresh())
-	if view.lastHiddenID != 0 || len(view.list.contacts) != 1 || view.notice != "Contact shown again" {
+	drainContactPages(t, view, refresh())
+	if view.lastHiddenID != 0 || len(view.list.contacts) != 3 || view.notice != "Contact shown again" {
 		t.Errorf("reveal state = contacts:%+v hidden:%d notice:%q", view.list.contacts, view.lastHiddenID, view.notice)
 	}
 	requests, _ := recorded.snapshot()
@@ -418,7 +539,7 @@ func TestContactsViewHelpBindings(t *testing.T) {
 	for _, binding := range view.HelpBindings() {
 		keys[binding.key] = true
 	}
-	for _, want := range []string{"a", "r", "n/p"} {
+	for _, want := range []string{"a", "r"} {
 		if !keys[want] {
 			t.Errorf("list help missing %q: %v", want, view.HelpBindings())
 		}


### PR DESCRIPTION
The contact list was the last one in the TUI still paged by hand with `n` and `p`. Now it reads its first page and grows downwards like every other list here: the cursor coming within `loadMoreThreshold` of the bottom reads the page below, and so does a list the reader can already see the end of — so a first page too short to fill the window keeps reading until it does.

### Why numbered pages rather than a cursor

The contact index hands out numbered pages rather than a cursor into the ordering, and `Contacts().List` does not surface the `Link` header, so there is nothing to follow from one page to the next but the number. The view keeps a `nextPage int` and zeroes it on the first empty page — which is what `hey contacts` already does in `readContactsPage`, and which costs one cheap request at the end of the list instead of a new `ListPage` operation in the SDK. No SDK change.

### What changed

- `contactsView` grows in its own lane (`moreRequestID`, `contactsAppendedMsg`), so a page below never shows the spinner and never cancels the read the reader is waiting on. `r` still reads from page one; hiding a contact tops the list up, since the removal can expose the end.
- `contactList` gains `growContacts`, which appends without moving the cursor or the scroll, plus `hasRowsBelow`/`visibleCount` in place of the three copies of `max(height/2, 1)`.
- The `n`/`p` bindings, the `page int` and the "No more contacts" notice are gone, and the subnav says "Contacts" rather than "Contacts (page N)".

### Tests

The fixture server serves a real second page now, and `loadTUIContacts` drains growth the way the runtime does. New tests cover growing until the list runs out, reading the page below the cursor exactly once, ignoring a superseded or failed page, and refresh starting over from the top.