### PR TITLE
Do not warn when the callback server's listener is already closed

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -340,7 +340,11 @@ func (m *Manager) waitForCallback(ctx context.Context, expectedState, authURL, c
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:gosec // G118: cancel deferred in goroutine; async shutdown required to avoid handler self-deadlock
 			go func() {
 				defer cancel()
-				if shutdownErr := server.Shutdown(shutdownCtx); shutdownErr != nil && !errors.Is(shutdownErr, http.ErrServerClosed) {
+				// The listener is closed on the way out of waitForCallback, and
+				// Shutdown closes it too; whichever gets there second sees
+				// net.ErrClosed, which is the server being down, not a failure.
+				if shutdownErr := server.Shutdown(shutdownCtx); shutdownErr != nil &&
+					!errors.Is(shutdownErr, http.ErrServerClosed) && !errors.Is(shutdownErr, net.ErrClosed) {
 					fmt.Fprintf(os.Stderr, "warning: callback server shutdown failed: %v\n", shutdownErr)
 				}
 			}()


### PR DESCRIPTION
`TestLoginOptionsLoggerReceivesProgress` flakes on CI (it failed `main`'s own latest run, 317f34f, and twice on #251's race job): `waitForCallback` defers `listener.Close()` and the async `server.Shutdown` closes the listener too, so whichever gets there second sees `net.ErrClosed` and the warning lands on stderr. Reproduces locally with `go test -count=10 ./internal/auth -run TestLoginOptionsLoggerReceivesProgress`.

A closed listener is the server being down, not a failure; it is no longer warned about. 30 race-detector runs of the test pass with the change.

Separate from the #250–#253 stack on purpose: it is `main`'s bug in a package the stack does not touch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop warning when the callback server shutdown sees an already closed listener. Previously `waitForCallback` printed "callback server shutdown failed" to stderr on `net.ErrClosed`; now we treat it like `http.ErrServerClosed`, preventing flaky output that breaks `TestLoginOptionsLoggerReceivesProgress`.

Only logging changed; shutdown behavior and listener lifecycle remain the same.

<sup>Written for commit 066247f8f96d587a891524490fb848131b7e57df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

