### PR TITLE
Seal Markdown behind a type only ToMarkdown can make

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,8 +162,10 @@ handed. The model has three layers, and it is worth knowing which one a change t
   it does not follow a value through a local variable — so it is an inventory of the
   direct pattern, not a taint analysis; treat a new exemption as something to justify in
   the manifest.
-- **Bodies** are Markdown from `htmlutil.ToMarkdown`, which serializes each context on
-  its own terms: prose escapes metacharacters and writes every `&` as `&amp;` (the live
+- **Bodies** are `htmlutil.Markdown`, a sealed type only `htmlutil.ToMarkdown` can make
+  (unexported field, no constructor, marshals as the string it holds) and the only thing
+  `markdown.Render` accepts — so a string from anywhere else cannot reach glamour by
+  looking like Markdown. `ToMarkdown` serializes each context on its own terms: prose escapes metacharacters and writes every `&` as `&amp;` (the live
   bug this closed was `&amp;#27;[31m` decoding twice, once in the HTML parser and once in
   the Markdown renderer, into a red terminal); inline code and fences are verbatim inside
   delimiters longer than any run they hold; destinations percent-encode what would end

--- a/internal/cmd/thread_markdown_test.go
+++ b/internal/cmd/thread_markdown_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/threadload"
 )
 
@@ -13,7 +14,7 @@ import (
 func TestPrintThreadMarkdownShapesOneDocument(t *testing.T) {
 	var out bytes.Buffer
 	err := writeThreadMarkdown(&out, 7, []threadEntry{
-		{ID: 11, CreatedAt: "2026-04-12T09:30", Creator: threadContact{Name: "Rick *Sanchez*"}, Body: "See the [plan](https://example.com/plan).", BodyState: "hydrated"},
+		{ID: 11, CreatedAt: "2026-04-12T09:30", Creator: threadContact{Name: "Rick *Sanchez*"}, Body: htmlutil.ToMarkdown(`<p>See the <a href="https://example.com/plan">plan</a>.</p>`), BodyState: "hydrated"},
 		{ID: 12, CreatedAt: "2026-04-13T09:30", Creator: threadContact{Name: "Morty Smith"}, Summary: "A _preview_", BodyState: "bodyless"},
 		{ID: 13, CreatedAt: "2026-04-14T09:30", Creator: threadContact{Name: "Summer Smith"}, Summary: "Never shown", BodyState: string(threadload.StateFailed)},
 		{ID: 14, CreatedAt: "2026-04-15T09:30", Creator: threadContact{Name: "Beth Smith"}, Summary: "Never shown", BodyState: string(threadload.StateHydrated)},
@@ -34,7 +35,7 @@ func TestPrintThreadMarkdownShapesOneDocument(t *testing.T) {
 }
 
 func TestThreadMarkdownReportsAWriteError(t *testing.T) {
-	err := writeThreadMarkdown(failingWriter{}, 7, []threadEntry{{ID: 1, Body: "x", BodyState: "hydrated"}}, "")
+	err := writeThreadMarkdown(failingWriter{}, 7, []threadEntry{{ID: 1, Body: htmlutil.ToMarkdown("<p>x</p>"), BodyState: "hydrated"}}, "")
 	if err == nil || !strings.Contains(err.Error(), "disk full") {
 		t.Errorf("error = %v, want the write failure", err)
 	}

--- a/internal/cmd/thread_partial_test.go
+++ b/internal/cmd/thread_partial_test.go
@@ -71,10 +71,18 @@ func withThreadLimits(t *testing.T, limits threadload.Limits) {
 	t.Cleanup(func() { threadLimits = previous })
 }
 
+// decodedEntry is a thread entry as --json carries it, read back with a plain string
+// body: only ToMarkdown can make an htmlutil.Markdown, so the decoded form is not one.
+type decodedEntry struct {
+	ID        int64  `json:"id"`
+	Body      string `json:"body"`
+	BodyState string `json:"body_state"`
+}
+
 type threadResponse struct {
-	OK     bool          `json:"ok"`
-	Data   []threadEntry `json:"data"`
-	Notice string        `json:"notice"`
+	OK     bool           `json:"ok"`
+	Data   []decodedEntry `json:"data"`
+	Notice string         `json:"notice"`
 }
 
 func decodeThread(t *testing.T, stdout string) threadResponse {

--- a/internal/cmd/thread_partial_test.go
+++ b/internal/cmd/thread_partial_test.go
@@ -94,6 +94,42 @@ func decodeThread(t *testing.T, stdout string) threadResponse {
 	return response
 }
 
+// --json carries a body only for an entry that has one: a body that was not read is
+// omitted rather than written as "", which is the contract a decoder reading the key's
+// presence depends on. decodedEntry cannot tell the two apart, so this reads the raw
+// objects.
+func TestThreadsJSONOmitsABodyItDidNotRead(t *testing.T) {
+	server, _ := partialThreadServer(t, [][]int64{{13, 12, 11}}, 12)
+	stdoutTerminal(t, false)
+
+	stdout, _, err := runCLIRaw(t, server, "--json", "threads", "7", "--allow-partial")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var response struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("decode %q: %v", stdout, err)
+	}
+	if len(response.Data) != 3 {
+		t.Fatalf("got %d entries, want 3", len(response.Data))
+	}
+	for _, entry := range response.Data {
+		body, present := entry["body"]
+		switch entry["id"] {
+		case float64(12):
+			if present {
+				t.Errorf("entry 12 carries body %#v, want the key omitted for a body that was not read", body)
+			}
+		default:
+			if text, ok := body.(string); !ok || text == "" {
+				t.Errorf("entry %v carries body %#v, want a Markdown string", entry["id"], body)
+			}
+		}
+	}
+}
+
 func partialError(t *testing.T, err error) {
 	t.Helper()
 	var apiErr *apierr.Error

--- a/internal/cmd/topic.go
+++ b/internal/cmd/topic.go
@@ -31,17 +31,17 @@ type threadContact struct {
 // the body: hydrated, bodyless (HEY served none), over_limit or failed (it was not
 // read), or not_requested (the format did not need it).
 type threadEntry struct {
-	ID                    int64         `json:"id"`
-	CreatedAt             string        `json:"created_at"`
-	UpdatedAt             string        `json:"updated_at"`
-	Creator               threadContact `json:"creator"`
-	AlternativeSenderName string        `json:"alternative_sender_name"`
-	Summary               string        `json:"summary"`
-	Kind                  string        `json:"kind"`
-	AppURL                string        `json:"app_url"`
-	Body                  string        `json:"body,omitempty"`
-	BodyState             string        `json:"body_state,omitempty"`
-	BodyHTML              string        `json:"-"`
+	ID                    int64             `json:"id"`
+	CreatedAt             string            `json:"created_at"`
+	UpdatedAt             string            `json:"updated_at"`
+	Creator               threadContact     `json:"creator"`
+	AlternativeSenderName string            `json:"alternative_sender_name"`
+	Summary               string            `json:"summary"`
+	Kind                  string            `json:"kind"`
+	AppURL                string            `json:"app_url"`
+	Body                  htmlutil.Markdown `json:"body,omitzero"`
+	BodyState             string            `json:"body_state,omitempty"`
+	BodyHTML              string            `json:"-"`
 }
 
 type topicCommand struct {
@@ -145,7 +145,7 @@ func printThreadStyled(w io.Writer, entries []threadEntry, notice string) {
 		fmt.Fprintf(w, "From: %s  [%s]  #%d\n", terminal.SanitizeLine(threadEntrySender(e)), e.CreatedAt, e.ID)
 		fmt.Fprintln(w)
 		switch {
-		case e.Body != "":
+		case !e.Body.IsEmpty():
 			fmt.Fprintln(w, markdown.Render(e.Body, stdoutWidth()))
 		case e.BodyState == string(threadload.StateHydrated):
 			fmt.Fprintln(w, "(empty body)")
@@ -191,8 +191,8 @@ func writeThreadMarkdown(w io.Writer, threadID int64, entries []threadEntry, not
 		}
 		var body string
 		switch {
-		case e.Body != "":
-			body = e.Body + "\n"
+		case !e.Body.IsEmpty():
+			body = e.Body.String() + "\n"
 		case e.BodyState == string(threadload.StateHydrated):
 			body = "*(empty body)*\n"
 		case e.BodyState == string(threadload.StateBodyless) && e.Summary != "":
@@ -274,7 +274,8 @@ func newThreadEntry(loaded *threadload.Entry, html bool) threadEntry {
 	updatedAt := entry.UpdatedAt
 	summary := entry.Summary
 	appURL := entry.AppUrl
-	body, bodyHTML := "", ""
+	var body htmlutil.Markdown
+	bodyHTML := ""
 
 	if message := loaded.Message; message != nil {
 		if creator.Id == 0 {

--- a/internal/cmd/topic_test.go
+++ b/internal/cmd/topic_test.go
@@ -127,7 +127,7 @@ func TestEntriesInThreadReadsEveryPageOldestFirst(t *testing.T) {
 			t.Errorf("entry %d = %d, want %d", index, entries[index].ID, want)
 		}
 	}
-	if entries[0].Body != "the first word" {
+	if entries[0].Body.String() != "the first word" {
 		t.Errorf("body = %q, want the oldest entry's", entries[0].Body)
 	}
 	if entries[0].CreatedAt != "2026-04-12T09:30" {
@@ -222,10 +222,10 @@ func TestEntriesInThreadConvertsBodiesToMarkdown(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !strings.Contains(entries[0].Body, "# Quarterly planning") {
+	if !strings.Contains(entries[0].Body.String(), "# Quarterly planning") {
 		t.Errorf("body = %q, want Markdown", entries[0].Body)
 	}
-	if !strings.Contains(entries[0].Body, "https://example.com/plan") {
+	if !strings.Contains(entries[0].Body.String(), "https://example.com/plan") {
 		t.Errorf("body = %q, want the link to keep its URL", entries[0].Body)
 	}
 	// A body is held in one form: Markdown here, and the HTML only under --html.
@@ -236,7 +236,7 @@ func TestEntriesInThreadConvertsBodiesToMarkdown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if html := threadEntries(thread, true); html[0].BodyHTML != trix || html[0].Body != "" {
+	if html := threadEntries(thread, true); html[0].BodyHTML != trix || !html[0].Body.IsEmpty() {
 		t.Errorf("--html entry = %+v, want HEY's original HTML and no Markdown", html[0])
 	}
 }
@@ -254,7 +254,7 @@ func TestEntriesInThreadReadsAnInboundEmailsEmbeddedBody(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !strings.Contains(entries[0].Body, "Your invoice is ready.") {
+	if !strings.Contains(entries[0].Body.String(), "Your invoice is ready.") {
 		t.Errorf("body = %q, want the embedded email", entries[0].Body)
 	}
 }

--- a/internal/htmlutil/markdown.go
+++ b/internal/htmlutil/markdown.go
@@ -11,8 +11,13 @@ import (
 
 // ToMarkdown converts HTML content to Markdown. Unlike ToText it keeps what a
 // flattened email throws away: link URLs, emphasis, headings, list nesting,
-// quotes, code blocks and tables.
-func ToMarkdown(s string) string {
+// quotes, code blocks and tables. What it returns is the only Markdown
+// markdown.Render accepts; see the Markdown type.
+func ToMarkdown(s string) Markdown {
+	return Markdown{text: toMarkdown(s)}
+}
+
+func toMarkdown(s string) string {
 	m := &markdownizer{}
 	doc, err := html.Parse(strings.NewReader(s))
 	if err != nil {

--- a/internal/htmlutil/markdown_safety_test.go
+++ b/internal/htmlutil/markdown_safety_test.go
@@ -10,7 +10,9 @@ import (
 	"unicode/utf8"
 
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/text"
 	"golang.org/x/net/html"
 )
 
@@ -461,6 +463,52 @@ func TestToMarkdownDeepNestingIsText(t *testing.T) {
 	}
 }
 
+// assertSafeTree holds the serializer property on goldmark's own tree: Markdown from
+// ToMarkdown parses to no raw HTML, links and images only to allowed destinations, and
+// text with no control character in it. It is the AST-level statement of what the four
+// serializers promise, and the one a future serializer has to keep.
+func assertSafeTree(t *testing.T, md string) {
+	t.Helper()
+	source := []byte(md)
+	doc := conformant.Parser().Parse(text.NewReader(source))
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		switch n := n.(type) {
+		case *ast.RawHTML, *ast.HTMLBlock:
+			t.Errorf("ToMarkdown produced raw HTML in %q", md)
+		case *ast.Link:
+			if !allowedScheme(string(n.Destination)) || hasControl(string(n.Destination)) {
+				t.Errorf("ToMarkdown linked to %q in %q", n.Destination, md)
+			}
+		case *ast.Image:
+			if !allowedScheme(string(n.Destination)) || hasControl(string(n.Destination)) {
+				t.Errorf("ToMarkdown imaged %q in %q", n.Destination, md)
+			}
+		case *ast.AutoLink:
+			if url := string(n.URL(source)); !allowedScheme(url) || hasControl(url) {
+				t.Errorf("ToMarkdown autolinked %q in %q", url, md)
+			}
+		case *ast.Text:
+			if hasControl(string(n.Segment.Value(source))) {
+				t.Errorf("ToMarkdown left a control in %q", md)
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+}
+
+func TestToMarkdownTreeIsSafe(t *testing.T) {
+	for _, in := range []string{
+		`<p>hello &amp;#27;[31mRED <a href="javascript:alert(1)">x</a> <img src="data:x" alt="a"> <b>&lt;script&gt;</b></p>`,
+		`<p><a href=")&#27;[31m">x</a> <a href="https://example.com/a?b=1&amp;c=2">q</a></p>`,
+		"<pre>```\n&amp;#27;</pre><table><tr><td>&amp;#27;|</td></tr></table>",
+	} {
+		assertSafeTree(t, toMarkdown(in))
+	}
+}
+
 // Whatever the HTML, the Markdown carries no control character, and neither does
 // what a conformant renderer makes of it: an entity that survives to the renderer
 // is decoded there, so this is the property that closes the double decode.
@@ -494,5 +542,6 @@ func FuzzToMarkdownTerminalSafety(f *testing.F) {
 		if text := domText(t, out.String()); hasControl(text) {
 			t.Fatalf("toMarkdown(%q) = %q renders with a control character: %q", in, md, text)
 		}
+		assertSafeTree(t, md)
 	})
 }

--- a/internal/htmlutil/markdown_safety_test.go
+++ b/internal/htmlutil/markdown_safety_test.go
@@ -89,7 +89,7 @@ func hasControl(s string) bool {
 // in the email, and a Markdown renderer that decodes entities would turn them into
 // a live escape byte.
 func TestToMarkdownTextEntityCannotDecodeTwice(t *testing.T) {
-	got := ToMarkdown(`<p>hello &amp;#27;[31mRED</p>`)
+	got := toMarkdown(`<p>hello &amp;#27;[31mRED</p>`)
 	if got != `hello &amp;#27;\[31mRED` {
 		t.Errorf("ToMarkdown = %q", got)
 	}
@@ -118,7 +118,7 @@ func TestToMarkdownTextIsNeverSyntax(t *testing.T) {
 		"a | b",
 		"back\\slash",
 	} {
-		md := ToMarkdown("<p>" + html.EscapeString(literal) + "</p>")
+		md := toMarkdown("<p>" + html.EscapeString(literal) + "</p>")
 		if got := renderedText(t, md); got != literal {
 			t.Errorf("%q: ToMarkdown = %q renders as %q", literal, md, got)
 		}
@@ -138,7 +138,7 @@ func TestToMarkdownTextIsNeverSyntaxAcrossNodes(t *testing.T) {
 		{`<p><span>&amp;</span>amp;</p>`, "&amp;"},
 		{`<p><span>*</span>x<span>*</span></p>`, "*x*"},
 	} {
-		md := ToMarkdown(test.in)
+		md := toMarkdown(test.in)
 		if got := renderedText(t, md); got != test.literal {
 			t.Errorf("%s: ToMarkdown = %q renders as %q, want %q", test.in, md, got, test.literal)
 		}
@@ -149,7 +149,7 @@ func TestToMarkdownTextIsNeverSyntaxAcrossNodes(t *testing.T) {
 }
 
 func TestToMarkdownKeepsTheReplacementCharacter(t *testing.T) {
-	got := ToMarkdown("<p>caf\uFFFDe <code>\uFFFD</code></p>")
+	got := toMarkdown("<p>caf\uFFFDe <code>\uFFFD</code></p>")
 	if got != "caf\uFFFDe `\uFFFD`" {
 		t.Errorf("ToMarkdown = %q", got)
 	}
@@ -164,14 +164,14 @@ func TestToMarkdownTextStripsControls(t *testing.T) {
 		"del":             "<p>note\x7f</p>",
 		"carriage return": "<p>Invoice\rPAID</p>",
 	} {
-		if got := ToMarkdown(in); hasControl(got) {
+		if got := toMarkdown(in); hasControl(got) {
 			t.Errorf("%s: ToMarkdown = %q carries a control character", name, got)
 		}
 	}
 }
 
 func TestToMarkdownInlineCodeEntityCannotDecode(t *testing.T) {
-	got := ToMarkdown(`<p><code>&amp;#27;[31mRED</code></p>`)
+	got := toMarkdown(`<p><code>&amp;#27;[31mRED</code></p>`)
 	if got != "`&#27;[31mRED`" {
 		t.Errorf("ToMarkdown = %q", got)
 	}
@@ -192,7 +192,7 @@ func TestToMarkdownInlineCodeSizesItsDelimiters(t *testing.T) {
 		{"<code>a\nb</code>", "`a b`", "a b"},
 		{"<code></code>", "", ""},
 	} {
-		got := ToMarkdown("<p>" + test.in + "</p>")
+		got := toMarkdown("<p>" + test.in + "</p>")
 		if got != test.want {
 			t.Errorf("%s: ToMarkdown = %q, want %q", test.in, got, test.want)
 		}
@@ -210,7 +210,7 @@ func TestToMarkdownInlineCodeSizesItsDelimiters(t *testing.T) {
 }
 
 func TestToMarkdownFencedCodeCannotBeClosedFromInside(t *testing.T) {
-	got := ToMarkdown("<pre>first\n```\nnot outside\n</pre><p>after</p>")
+	got := toMarkdown("<pre>first\n```\nnot outside\n</pre><p>after</p>")
 	want := "````\nfirst\n```\nnot outside\n````\n\nafter"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -222,7 +222,7 @@ func TestToMarkdownFencedCodeCannotBeClosedFromInside(t *testing.T) {
 }
 
 func TestToMarkdownFencedCodeKeepsBlankLinesAndStripsControls(t *testing.T) {
-	got := ToMarkdown("<pre>one\n\n\x1b[31mtwo\t3</pre>")
+	got := toMarkdown("<pre>one\n\n\x1b[31mtwo\t3</pre>")
 	want := "```\none\n\n[31mtwo\t3\n```"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -239,7 +239,7 @@ func TestToMarkdownFencedCodeInfoStringIsALanguageOrNothing(t *testing.T) {
 		{"language-" + strings.Repeat("x", 40), "```"},
 		{"language-\x1b[31m", "```"},
 	} {
-		got := ToMarkdown(`<pre><code class="` + test.class + `">x</code></pre>`)
+		got := toMarkdown(`<pre><code class="` + test.class + `">x</code></pre>`)
 		if first := strings.SplitN(got, "\n", 2)[0]; first != test.want {
 			t.Errorf("%s: fence = %q, want %q", test.class, first, test.want)
 		}
@@ -249,7 +249,7 @@ func TestToMarkdownFencedCodeInfoStringIsALanguageOrNothing(t *testing.T) {
 // A closing parenthesis in an href would end the Markdown destination, leaving the
 // rest of the attribute in the paragraph as text a renderer parses.
 func TestToMarkdownDestinationCannotExitTheLink(t *testing.T) {
-	got := ToMarkdown(`<p><a href=")&#27;[31mRED">x</a></p>`)
+	got := toMarkdown(`<p><a href=")&#27;[31mRED">x</a></p>`)
 	if got != "[x](%29[31mRED)" {
 		t.Errorf("ToMarkdown = %q", got)
 	}
@@ -265,7 +265,7 @@ func TestToMarkdownDestinationCannotExitTheLink(t *testing.T) {
 }
 
 func TestToMarkdownDestinationKeepsQueryStrings(t *testing.T) {
-	got := ToMarkdown(`<p><a href="https://example.com/a?b=1&amp;c=2&amp;#27;&amp;copy=1">q</a></p>`)
+	got := toMarkdown(`<p><a href="https://example.com/a?b=1&amp;c=2&amp;#27;&amp;copy=1">q</a></p>`)
 	if got != "[q](https://example.com/a?b=1&c=2&amp;#27;&copy=1)" {
 		t.Errorf("ToMarkdown = %q", got)
 	}
@@ -275,7 +275,7 @@ func TestToMarkdownDestinationKeepsQueryStrings(t *testing.T) {
 }
 
 func TestToMarkdownDestinationEncodesWhatWouldEndIt(t *testing.T) {
-	got := ToMarkdown(`<p><a href="https://example.com/a b(c)<d>\e|f">x</a></p>`)
+	got := toMarkdown(`<p><a href="https://example.com/a b(c)<d>\e|f">x</a></p>`)
 	want := `[x](https://example.com/a%20b%28c%29%3Cd%3E%5Ce%7Cf)`
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -302,7 +302,7 @@ func TestToMarkdownDestinationSchemes(t *testing.T) {
 		{"  javascript:alert(1)", "x", false},
 		{"", "x", false},
 	} {
-		got := ToMarkdown(`<p><a href="` + html.EscapeString(test.href) + `">x</a></p>`)
+		got := toMarkdown(`<p><a href="` + html.EscapeString(test.href) + `">x</a></p>`)
 		if got != test.want {
 			t.Errorf("%q: ToMarkdown = %q, want %q", test.href, got, test.want)
 		}
@@ -320,7 +320,7 @@ func TestToMarkdownAutolinkOnlyForAbsoluteURLs(t *testing.T) {
 		{`<a href="/rails/blobs/q3.pdf"></a>`, "[/rails/blobs/q3.pdf](/rails/blobs/q3.pdf)"},
 		{`<a href="https://example.org/a b">https://example.org/a b</a>`, "<https://example.org/a%20b>"},
 	} {
-		if got := ToMarkdown("<p>" + test.in + "</p>"); got != test.want {
+		if got := toMarkdown("<p>" + test.in + "</p>"); got != test.want {
 			t.Errorf("%s: ToMarkdown = %q, want %q", test.in, got, test.want)
 		}
 	}
@@ -329,7 +329,7 @@ func TestToMarkdownAutolinkOnlyForAbsoluteURLs(t *testing.T) {
 // A label that reads as one URL while pointing at another never collapses into an
 // autolink: the destination is written beside the label, where it can be compared.
 func TestToMarkdownDeceptiveLabelShowsTheDestination(t *testing.T) {
-	got := ToMarkdown(`<p><a href="https://evil.example/login">https://bank.example/login</a></p>`)
+	got := toMarkdown(`<p><a href="https://evil.example/login">https://bank.example/login</a></p>`)
 	want := "[https://bank.example/login](https://evil.example/login)"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -337,7 +337,7 @@ func TestToMarkdownDeceptiveLabelShowsTheDestination(t *testing.T) {
 }
 
 func TestToMarkdownImageAltAndSourceAreSerialized(t *testing.T) {
-	got := ToMarkdown(`<p><img alt="a]b &amp;#27;" src="https://example.com/i.png?x=1&amp;y=2"> <img alt="gone" src="javascript:x"> <img src="data:image/png;base64,AAAA"></p>`)
+	got := toMarkdown(`<p><img alt="a]b &amp;#27;" src="https://example.com/i.png?x=1&amp;y=2"> <img alt="gone" src="javascript:x"> <img src="data:image/png;base64,AAAA"></p>`)
 	want := `![a\]b &amp;#27;](https://example.com/i.png?x=1&y=2) gone`
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -350,7 +350,7 @@ func TestToMarkdownImageAltAndSourceAreSerialized(t *testing.T) {
 // An image whose source may not be linked leaves its alt text as prose, escaped as
 // prose: at the start of a line "# title" is a heading unless it is escaped there.
 func TestToMarkdownUnlinkableImageAltIsProse(t *testing.T) {
-	got := ToMarkdown(`<p><img alt="# title" src="javascript:x"></p>`)
+	got := toMarkdown(`<p><img alt="# title" src="javascript:x"></p>`)
 	if got != `\# title` {
 		t.Errorf("ToMarkdown = %q", got)
 	}
@@ -360,7 +360,7 @@ func TestToMarkdownUnlinkableImageAltIsProse(t *testing.T) {
 }
 
 func TestToMarkdownAttachmentNamesAreSerialized(t *testing.T) {
-	got := ToMarkdown(`<figure data-trix-attachment='{"url":"javascript:x","filename":"*report*.png","contentType":"image/png"}'></figure>` +
+	got := toMarkdown(`<figure data-trix-attachment='{"url":"javascript:x","filename":"*report*.png","contentType":"image/png"}'></figure>` +
 		`<figure data-trix-attachment='{"url":"/rails/blobs/q3.pdf","filename":"[q3].pdf","contentType":"application/pdf"}'></figure>`)
 	want := "📎 \\*report\\*.png\n\n📎 \\[q3\\].pdf"
 	if got != want {
@@ -369,7 +369,7 @@ func TestToMarkdownAttachmentNamesAreSerialized(t *testing.T) {
 }
 
 func TestToMarkdownTableCellsEscapePipes(t *testing.T) {
-	got := ToMarkdown("<table><tr><th>a|b</th></tr><tr><td>c | d</td></tr></table>")
+	got := toMarkdown("<table><tr><th>a|b</th></tr><tr><td>c | d</td></tr></table>")
 	want := "| a\\|b |\n| --- |\n| c \\| d |"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -384,7 +384,7 @@ func TestToMarkdownTableCellsEscapePipes(t *testing.T) {
 func TestToMarkdownEscapesALongLineInLinearTime(t *testing.T) {
 	long := strings.Repeat("a.b)c. ", 100_000)
 	start := time.Now()
-	got := ToMarkdown("<p>" + long + "</p>")
+	got := toMarkdown("<p>" + long + "</p>")
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Fatalf("ToMarkdown took %s on a %d-byte line", elapsed, len(long))
 	}
@@ -399,11 +399,11 @@ func TestToMarkdownEscapesALongLineInLinearTime(t *testing.T) {
 func TestToMarkdownAllocatesLinearly(t *testing.T) {
 	allocated := func(size int) uint64 {
 		body := "<p>" + strings.Repeat("Fried &amp; Hansson <b>shipped</b> it. ", size/40) + "</p>"
-		ToMarkdown(body)
+		toMarkdown(body)
 		var before, after runtime.MemStats
 		runtime.GC()
 		runtime.ReadMemStats(&before)
-		ToMarkdown(body)
+		toMarkdown(body)
 		runtime.ReadMemStats(&after)
 		return after.TotalAlloc - before.TotalAlloc
 	}
@@ -414,7 +414,7 @@ func TestToMarkdownAllocatesLinearly(t *testing.T) {
 }
 
 func TestToMarkdownBoundsQuoteAndListDepth(t *testing.T) {
-	quotes := ToMarkdown(strings.Repeat("<blockquote>", 40) + "deep" + strings.Repeat("</blockquote>", 40))
+	quotes := toMarkdown(strings.Repeat("<blockquote>", 40) + "deep" + strings.Repeat("</blockquote>", 40))
 	if got := strings.Count(quotes, ">"); got != maxNestingDepth {
 		t.Errorf("quote depth = %d, want %d: %q", got, maxNestingDepth, quotes)
 	}
@@ -423,7 +423,7 @@ func TestToMarkdownBoundsQuoteAndListDepth(t *testing.T) {
 	for range 40 {
 		b.WriteString("<ul><li>item")
 	}
-	lists := ToMarkdown(b.String())
+	lists := toMarkdown(b.String())
 	for _, line := range strings.Split(lists, "\n") {
 		if indent := len(line) - len(strings.TrimLeft(line, " ")); indent > 2*(maxNestingDepth-1) {
 			t.Errorf("list indented %d columns, want at most %d: %q", indent, 2*(maxNestingDepth-1), line)
@@ -442,7 +442,7 @@ func TestToMarkdownCappedListItemsStayApart(t *testing.T) {
 		b.WriteString("<ul><li>outer")
 	}
 	b.WriteString("<ul><li>b</li><li>c</li></ul>")
-	got := ToMarkdown(b.String())
+	got := toMarkdown(b.String())
 	if strings.Contains(got, "bc") || !strings.Contains(got, "- b\n") || !strings.Contains(got, "- c") {
 		t.Errorf("ToMarkdown = %q, want b and c as separate items", got)
 	}
@@ -452,7 +452,7 @@ func TestToMarkdownCappedListItemsStayApart(t *testing.T) {
 }
 
 func TestToMarkdownDeepNestingIsText(t *testing.T) {
-	got := ToMarkdown(strings.Repeat("<div>", 5000) + "x" + strings.Repeat("</div>", 5000))
+	got := toMarkdown(strings.Repeat("<div>", 5000) + "x" + strings.Repeat("</div>", 5000))
 	if hasControl(got) {
 		t.Errorf("ToMarkdown carries a control character")
 	}
@@ -483,16 +483,16 @@ func FuzzToMarkdownTerminalSafety(f *testing.F) {
 		if !utf8.ValidString(in) {
 			t.Skip()
 		}
-		md := ToMarkdown(in)
+		md := toMarkdown(in)
 		if hasControl(md) {
-			t.Fatalf("ToMarkdown(%q) = %q carries a control character", in, md)
+			t.Fatalf("toMarkdown(%q) = %q carries a control character", in, md)
 		}
 		var out bytes.Buffer
 		if err := conformant.Convert([]byte(md), &out); err != nil {
 			t.Fatalf("goldmark: %v", err)
 		}
 		if text := domText(t, out.String()); hasControl(text) {
-			t.Fatalf("ToMarkdown(%q) = %q renders with a control character: %q", in, md, text)
+			t.Fatalf("toMarkdown(%q) = %q renders with a control character: %q", in, md, text)
 		}
 	})
 }

--- a/internal/htmlutil/markdown_test.go
+++ b/internal/htmlutil/markdown_test.go
@@ -6,13 +6,13 @@ import (
 )
 
 func TestToMarkdownEmpty(t *testing.T) {
-	if got := ToMarkdown(""); got != "" {
+	if got := toMarkdown(""); got != "" {
 		t.Errorf("ToMarkdown empty = %q, want empty", got)
 	}
 }
 
 func TestToMarkdownParagraphs(t *testing.T) {
-	got := ToMarkdown("<p>The numbers are in.</p><p>Details to follow.</p>")
+	got := toMarkdown("<p>The numbers are in.</p><p>Details to follow.</p>")
 	want := "The numbers are in.\n\nDetails to follow."
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -20,7 +20,7 @@ func TestToMarkdownParagraphs(t *testing.T) {
 }
 
 func TestToMarkdownHeadings(t *testing.T) {
-	got := ToMarkdown("<h1>Quarterly update</h1><h3>Revenue</h3>")
+	got := toMarkdown("<h1>Quarterly update</h1><h3>Revenue</h3>")
 	want := "# Quarterly update\n\n### Revenue"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -28,7 +28,7 @@ func TestToMarkdownHeadings(t *testing.T) {
 }
 
 func TestToMarkdownEmphasis(t *testing.T) {
-	got := ToMarkdown("<p><strong>Ryan</strong> shipped <em>fast</em>, <s>eventually</s> <code>gild</code></p>")
+	got := toMarkdown("<p><strong>Ryan</strong> shipped <em>fast</em>, <s>eventually</s> <code>gild</code></p>")
 	want := "**Ryan** shipped *fast*, ~~eventually~~ `gild`"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -36,7 +36,7 @@ func TestToMarkdownEmphasis(t *testing.T) {
 }
 
 func TestToMarkdownKeepsLinkURLs(t *testing.T) {
-	got := ToMarkdown(`<p>See the <a href="https://example.com/reports/q3">Q3 report</a>.</p>`)
+	got := toMarkdown(`<p>See the <a href="https://example.com/reports/q3">Q3 report</a>.</p>`)
 	want := "See the [Q3 report](https://example.com/reports/q3)."
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -44,7 +44,7 @@ func TestToMarkdownKeepsLinkURLs(t *testing.T) {
 }
 
 func TestToMarkdownCollapsesSelfLinkingURL(t *testing.T) {
-	got := ToMarkdown(`<p><a href="https://example.org">https://example.org</a></p>`)
+	got := toMarkdown(`<p><a href="https://example.org">https://example.org</a></p>`)
 	want := "<https://example.org>"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -52,7 +52,7 @@ func TestToMarkdownCollapsesSelfLinkingURL(t *testing.T) {
 }
 
 func TestToMarkdownNestedLists(t *testing.T) {
-	got := ToMarkdown("<ul><li>Revenue up</li><li>Churn down<ul><li>enterprise flat</li></ul></li></ul>")
+	got := toMarkdown("<ul><li>Revenue up</li><li>Churn down<ul><li>enterprise flat</li></ul></li></ul>")
 	want := "- Revenue up\n- Churn down\n  - enterprise flat"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -60,7 +60,7 @@ func TestToMarkdownNestedLists(t *testing.T) {
 }
 
 func TestToMarkdownOrderedList(t *testing.T) {
-	got := ToMarkdown("<ol><li>Draft the pricing change</li><li>Ship it</li></ol>")
+	got := toMarkdown("<ol><li>Draft the pricing change</li><li>Ship it</li></ol>")
 	want := "1. Draft the pricing change\n2. Ship it"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -68,7 +68,7 @@ func TestToMarkdownOrderedList(t *testing.T) {
 }
 
 func TestToMarkdownBlockquote(t *testing.T) {
-	got := ToMarkdown("<blockquote><p>Ship before the holidays.</p></blockquote>")
+	got := toMarkdown("<blockquote><p>Ship before the holidays.</p></blockquote>")
 	want := "> Ship before the holidays."
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -76,7 +76,7 @@ func TestToMarkdownBlockquote(t *testing.T) {
 }
 
 func TestToMarkdownCodeBlockWithLanguage(t *testing.T) {
-	got := ToMarkdown(`<pre><code class="language-ruby">Card.gilded.count
+	got := toMarkdown(`<pre><code class="language-ruby">Card.gilded.count
 </code></pre>`)
 	want := "```ruby\nCard.gilded.count\n```"
 	if got != want {
@@ -85,7 +85,7 @@ func TestToMarkdownCodeBlockWithLanguage(t *testing.T) {
 }
 
 func TestToMarkdownTable(t *testing.T) {
-	got := ToMarkdown("<table><tr><th>Plan</th><th>Price</th></tr><tr><td>Personal</td><td>$99/yr</td></tr></table>")
+	got := toMarkdown("<table><tr><th>Plan</th><th>Price</th></tr><tr><td>Personal</td><td>$99/yr</td></tr></table>")
 	want := "| Plan | Price |\n| --- | --- |\n| Personal | $99/yr |"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -93,7 +93,7 @@ func TestToMarkdownTable(t *testing.T) {
 }
 
 func TestToMarkdownHardBreak(t *testing.T) {
-	got := ToMarkdown("<p>Thanks,<br>Jason</p>")
+	got := toMarkdown("<p>Thanks,<br>Jason</p>")
 	want := "Thanks,  \nJason"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -101,7 +101,7 @@ func TestToMarkdownHardBreak(t *testing.T) {
 }
 
 func TestToMarkdownHorizontalRule(t *testing.T) {
-	got := ToMarkdown("<p>Above</p><hr><p>Below</p>")
+	got := toMarkdown("<p>Above</p><hr><p>Below</p>")
 	want := "Above\n\n---\n\nBelow"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -109,7 +109,7 @@ func TestToMarkdownHorizontalRule(t *testing.T) {
 }
 
 func TestToMarkdownImage(t *testing.T) {
-	got := ToMarkdown(`<p><img src="/rails/blobs/chart.png" alt="Revenue chart"></p>`)
+	got := toMarkdown(`<p><img src="/rails/blobs/chart.png" alt="Revenue chart"></p>`)
 	want := "![Revenue chart](/rails/blobs/chart.png)"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -117,7 +117,7 @@ func TestToMarkdownImage(t *testing.T) {
 }
 
 func TestToMarkdownTrixImageAttachment(t *testing.T) {
-	got := ToMarkdown(`<figure data-trix-attachment='{"url":"/rails/blobs/chart.png","filename":"chart.png","contentType":"image/png"}'></figure>`)
+	got := toMarkdown(`<figure data-trix-attachment='{"url":"/rails/blobs/chart.png","filename":"chart.png","contentType":"image/png"}'></figure>`)
 	want := "![chart.png](/rails/blobs/chart.png)"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -125,7 +125,7 @@ func TestToMarkdownTrixImageAttachment(t *testing.T) {
 }
 
 func TestToMarkdownTrixFileAttachment(t *testing.T) {
-	got := ToMarkdown(`<figure data-trix-attachment='{"url":"/rails/blobs/q3.pdf","filename":"q3-report.pdf","contentType":"application/pdf"}'></figure>`)
+	got := toMarkdown(`<figure data-trix-attachment='{"url":"/rails/blobs/q3.pdf","filename":"q3-report.pdf","contentType":"application/pdf"}'></figure>`)
 	want := "📎 q3-report.pdf"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -133,7 +133,7 @@ func TestToMarkdownTrixFileAttachment(t *testing.T) {
 }
 
 func TestToMarkdownActionTextAttachment(t *testing.T) {
-	got := ToMarkdown(`<p>Attached:</p><action-text-attachment url="/rails/blobs/q3.pdf" filename="q3-report.pdf" content-type="application/pdf"></action-text-attachment>`)
+	got := toMarkdown(`<p>Attached:</p><action-text-attachment url="/rails/blobs/q3.pdf" filename="q3-report.pdf" content-type="application/pdf"></action-text-attachment>`)
 	want := "Attached:\n\n📎 q3-report.pdf"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -144,7 +144,7 @@ func TestToMarkdownActionTextAttachment(t *testing.T) {
 // text/html attachment: the entire body lives in the attachment's content
 // attribute, and skipping it leaves nothing but HEY's truncated summary.
 func TestToMarkdownEmbeddedHTMLAttachment(t *testing.T) {
-	got := ToMarkdown(`<div><figure data-trix-attachment='{"contentType":"text/html","content":"<shadow-content><template><style>p{color:red}</style><p>Dear customer,</p><p>Please <a href=\"https://example.com/sign\">sign the document</a>.</p></template></shadow-content>","data":{}}'></figure></div>`)
+	got := toMarkdown(`<div><figure data-trix-attachment='{"contentType":"text/html","content":"<shadow-content><template><style>p{color:red}</style><p>Dear customer,</p><p>Please <a href=\"https://example.com/sign\">sign the document</a>.</p></template></shadow-content>","data":{}}'></figure></div>`)
 
 	want := "Dear customer,\n\nPlease [sign the document](https://example.com/sign)."
 	if got != want {
@@ -159,7 +159,7 @@ func TestToMarkdownEmbeddedContentStopsRecursing(t *testing.T) {
 			strings.ReplaceAll(nested, `"`, `\"`) + `"}'></figure>`
 	}
 
-	if got := ToMarkdown(nested); strings.Contains(got, "innermost") {
+	if got := toMarkdown(nested); strings.Contains(got, "innermost") {
 		t.Errorf("ToMarkdown = %q, should stop before the innermost level", got)
 	}
 }
@@ -200,14 +200,14 @@ func TestToMarkdownKeepsSpaceAroundInlineElements(t *testing.T) {
 			want: "the invoice came to 10 000 kroner",
 		},
 	} {
-		if got := ToMarkdown(test.in); got != test.want {
+		if got := toMarkdown(test.in); got != test.want {
 			t.Errorf("%s: ToMarkdown = %q, want %q", test.name, got, test.want)
 		}
 	}
 }
 
 func TestToMarkdownStripsScriptAndStyle(t *testing.T) {
-	got := ToMarkdown("<style>p{color:red}</style><p>Hello</p><script>alert('xss')</script>")
+	got := toMarkdown("<style>p{color:red}</style><p>Hello</p><script>alert('xss')</script>")
 	if got != "Hello" {
 		t.Errorf("ToMarkdown = %q, want %q", got, "Hello")
 	}
@@ -216,7 +216,7 @@ func TestToMarkdownStripsScriptAndStyle(t *testing.T) {
 // An entity is decoded once, by the HTML parser, and what it stood for is then
 // escaped so that no Markdown renderer decodes it a second time.
 func TestToMarkdownDecodesEntitiesOnce(t *testing.T) {
-	got := ToMarkdown("<p>Fried &amp; Hansson &lt;hey&gt; &amp;amp;</p>")
+	got := toMarkdown("<p>Fried &amp; Hansson &lt;hey&gt; &amp;amp;</p>")
 	want := `Fried &amp; Hansson \<hey\> &amp;amp;`
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -227,7 +227,7 @@ func TestToMarkdownDecodesEntitiesOnce(t *testing.T) {
 }
 
 func TestToMarkdownCollapsesSourceWhitespace(t *testing.T) {
-	got := ToMarkdown("<div>\n  <p>\n    The numbers   are\n    in.\n  </p>\n</div>")
+	got := toMarkdown("<div>\n  <p>\n    The numbers   are\n    in.\n  </p>\n</div>")
 	want := "The numbers are in."
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
@@ -235,7 +235,7 @@ func TestToMarkdownCollapsesSourceWhitespace(t *testing.T) {
 }
 
 func TestToMarkdownWholeEmail(t *testing.T) {
-	got := ToMarkdown(`<div class="trix-content"><h2>Quarterly update</h2>` +
+	got := toMarkdown(`<div class="trix-content"><h2>Quarterly update</h2>` +
 		`<p>Hi <strong>Ryan</strong>,</p>` +
 		`<p>See the <a href="https://example.com/reports/q3">Q3 report</a>.</p>` +
 		`<ul><li>Revenue up <em>12%</em></li></ul>` +

--- a/internal/htmlutil/markdown_type.go
+++ b/internal/htmlutil/markdown_type.go
@@ -1,11 +1,13 @@
 package htmlutil
 
 // Markdown is Markdown that ToMarkdown produced: every context serialized on its own
-// terms, no control character left in it. It is the only kind of Markdown
-// markdown.Render accepts, and nothing but ToMarkdown can make one — the field is
-// unexported and there is no constructor — so a body from anywhere else cannot reach a
-// terminal renderer by being a string that happens to look like Markdown. It marshals to
-// JSON as the string it holds, which is what --json carries.
+// terms, and no control character left in it other than the newlines and tabs that
+// Markdown itself is written with — a fence keeps its tabs, and a sink that shows it
+// sanitizes with the same two allowed. It is the only kind of Markdown markdown.Render
+// accepts, and nothing but ToMarkdown can make one — the field is unexported and there
+// is no constructor — so a body from anywhere else cannot reach a terminal renderer by
+// being a string that happens to look like Markdown. It marshals to JSON as the string
+// it holds, which is what --json carries.
 type Markdown struct {
 	text string
 }

--- a/internal/htmlutil/markdown_type.go
+++ b/internal/htmlutil/markdown_type.go
@@ -1,0 +1,22 @@
+package htmlutil
+
+// Markdown is Markdown that ToMarkdown produced: every context serialized on its own
+// terms, no control character left in it. It is the only kind of Markdown
+// markdown.Render accepts, and nothing but ToMarkdown can make one — the field is
+// unexported and there is no constructor — so a body from anywhere else cannot reach a
+// terminal renderer by being a string that happens to look like Markdown. It marshals to
+// JSON as the string it holds, which is what --json carries.
+type Markdown struct {
+	text string
+}
+
+// String is the Markdown text, for a sink that writes Markdown rather than rendering it.
+func (m Markdown) String() string { return m.text }
+
+// IsEmpty reports Markdown with nothing in it; IsZero is the same, for `omitzero`.
+func (m Markdown) IsEmpty() bool { return m.text == "" }
+
+func (m Markdown) IsZero() bool { return m.text == "" }
+
+// MarshalText writes the Markdown as a JSON string.
+func (m Markdown) MarshalText() ([]byte, error) { return []byte(m.text), nil }

--- a/internal/mail/entry.go
+++ b/internal/mail/entry.go
@@ -21,7 +21,7 @@ type Entry struct {
 	Creator               Contact
 	AlternativeSenderName string
 	Summary               string
-	Body                  string
+	Body                  htmlutil.Markdown
 	BodyHTML              string
 }
 

--- a/internal/mail/entry_test.go
+++ b/internal/mail/entry_test.go
@@ -27,7 +27,7 @@ func TestNewEntry(t *testing.T) {
 	if entry.Creator.ID != 42 || entry.Creator.EmailAddress != "jane@example.com" {
 		t.Errorf("creator = %+v", entry.Creator)
 	}
-	if entry.Body != "Message body with a [plan](https://example.com/plan)" {
+	if entry.Body.String() != "Message body with a [plan](https://example.com/plan)" {
 		t.Errorf("body = %q, want Markdown", entry.Body)
 	}
 	if entry.BodyHTML != `<p>Message body with a <a href="https://example.com/plan">plan</a></p>` {

--- a/internal/markdown/render.go
+++ b/internal/markdown/render.go
@@ -8,6 +8,8 @@ import (
 
 	"charm.land/glamour/v2"
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/basecamp/hey-cli/internal/htmlutil"
 )
 
 // DefaultWidth is the word wrap used when the caller has no width of its own.
@@ -26,12 +28,20 @@ var (
 // back to the Markdown source when glamour cannot be set up, so a rendering
 // problem costs formatting rather than the message itself.
 //
-// The Markdown is treated as untrusted on the way in and the output is checked on
-// the way out: see prepareSource and contain. One consequence worth knowing is that
+// Only htmlutil.ToMarkdown can produce the Markdown this accepts: the type is the
+// provenance, so a string from anywhere else cannot reach glamour. The Markdown is
+// still treated as untrusted on the way in and the output is checked on the way out:
+// see prepareSource and contain. One consequence worth knowing is that
 // `&` is always literal here — an entity reference in the source is shown as the
 // characters it was written with, because the HTML it came from already decoded
 // the entities that were meant to be decoded.
-func Render(md string, width int) string {
+func Render(md htmlutil.Markdown, width int) string {
+	return render(md.String(), width)
+}
+
+// render is Render for the package's own tests and fallbacks, which hand it Markdown
+// text directly; everything outside the package goes through the sealed type.
+func render(md string, width int) string {
 	safe, forGlamour, deep := prepareSource(md)
 	if strings.TrimSpace(safe) == "" {
 		return ""

--- a/internal/markdown/render_test.go
+++ b/internal/markdown/render_test.go
@@ -6,13 +6,13 @@ import (
 )
 
 func TestRenderEmpty(t *testing.T) {
-	if got := Render("   \n ", 80); got != "" {
+	if got := render("   \n ", 80); got != "" {
 		t.Errorf("Render blank = %q, want empty", got)
 	}
 }
 
 func TestRenderStylesEmphasis(t *testing.T) {
-	got := Render("Hi **Ryan**", 80)
+	got := render("Hi **Ryan**", 80)
 	if !strings.Contains(got, "Ryan") {
 		t.Errorf("Render = %q, should keep the text", got)
 	}
@@ -22,7 +22,7 @@ func TestRenderStylesEmphasis(t *testing.T) {
 }
 
 func TestRenderDropsHeadingMarkers(t *testing.T) {
-	got := Render("## Quarterly update", 80)
+	got := render("## Quarterly update", 80)
 	if strings.Contains(got, "#") {
 		t.Errorf("Render = %q, should not leave heading markers", got)
 	}
@@ -32,7 +32,7 @@ func TestRenderDropsHeadingMarkers(t *testing.T) {
 }
 
 func TestRenderLeavesNoTrailingWhitespace(t *testing.T) {
-	for _, line := range strings.Split(Render("Hi **Ryan**", 80), "\n") {
+	for _, line := range strings.Split(render("Hi **Ryan**", 80), "\n") {
 		if strings.HasSuffix(line, " ") {
 			t.Errorf("line %q has trailing whitespace", line)
 		}
@@ -40,7 +40,7 @@ func TestRenderLeavesNoTrailingWhitespace(t *testing.T) {
 }
 
 func TestRenderWrapsToWidth(t *testing.T) {
-	got := Render(strings.Repeat("word ", 40), 30)
+	got := render(strings.Repeat("word ", 40), 30)
 	for _, line := range strings.Split(got, "\n") {
 		if len(line) > 30 {
 			t.Errorf("line %q is wider than 30 columns", line)
@@ -49,7 +49,7 @@ func TestRenderWrapsToWidth(t *testing.T) {
 }
 
 func TestRenderLinksAreClickable(t *testing.T) {
-	got := Render("See the [Q3 report](https://example.com/reports/q3).", 80)
+	got := render("See the [Q3 report](https://example.com/reports/q3).", 80)
 	if !strings.Contains(got, "\x1b]8;") {
 		t.Errorf("Render = %q, should emit an OSC 8 hyperlink", got)
 	}
@@ -59,7 +59,7 @@ func TestRenderLinksAreClickable(t *testing.T) {
 }
 
 func TestRenderFallsBackToDefaultWidth(t *testing.T) {
-	if Render("Hello", 0) == "" {
+	if render("Hello", 0) == "" {
 		t.Error("Render with no width returned nothing")
 	}
 }

--- a/internal/markdown/safety_test.go
+++ b/internal/markdown/safety_test.go
@@ -49,12 +49,12 @@ func TestRenderNeverDecodesEntities(t *testing.T) {
 		"hex entity":    {"&#x1b;[31mRED", "&#x1b;[31mRED"},
 		"named entity":  {"&lpar;&#27;[31mRED", "&lpar;&#27;[31mRED"},
 	} {
-		out := Render(test.md, 80)
+		out := render(test.md, 80)
 		if strings.Contains(out, "\x1b[31m") {
-			t.Errorf("%s: Render(%q) = %q turned red", name, test.md, out)
+			t.Errorf("%s: render(%q) = %q turned red", name, test.md, out)
 		}
 		if !strings.Contains(visible(out), test.literal) {
-			t.Errorf("%s: Render(%q) = %q lost the literal text", name, test.md, out)
+			t.Errorf("%s: render(%q) = %q lost the literal text", name, test.md, out)
 		}
 	}
 }
@@ -67,14 +67,14 @@ func TestRenderShowsAmpersandsAsWritten(t *testing.T) {
 		"&copy; 2026":                 "&copy; 2026",
 		"[q](https://e.com/?a=1&b=2)": "https://e.com/?a=1&b=2",
 	} {
-		if out := visible(Render(md, 200)); !strings.Contains(out, want) {
-			t.Errorf("Render(%q) shows %q, want %q in it", md, out, want)
+		if out := visible(render(md, 200)); !strings.Contains(out, want) {
+			t.Errorf("render(%q) shows %q, want %q in it", md, out, want)
 		}
 	}
 }
 
 func TestRenderKeepsQueryStringsInHyperlinks(t *testing.T) {
-	out := Render("[q](https://example.com/?a=1&b=2)", 80)
+	out := render("[q](https://example.com/?a=1&b=2)", 80)
 	if !strings.Contains(out, "\x1b]8;id=") || !strings.Contains(out, ";https://example.com/?a=1&b=2\x07") {
 		t.Errorf("Render = %q, want an OSC 8 link to the URL with its query string", out)
 	}
@@ -91,12 +91,12 @@ func TestRenderStripsRawControls(t *testing.T) {
 		"in a fence": "```\n\x1b[31m\n```",
 		"in a link":  "[x](https://example.com/\x1b[31m)",
 	} {
-		out := Render(md, 80)
+		out := render(md, 80)
 		if strings.Contains(out, "\x1b[31m") || strings.Contains(out, "\x1b]0;") {
-			t.Errorf("%s: Render(%q) = %q carries the injected sequence", name, md, out)
+			t.Errorf("%s: render(%q) = %q carries the injected sequence", name, md, out)
 		}
 		if hasControl(visible(out)) {
-			t.Errorf("%s: Render(%q) = %q carries a control character", name, md, out)
+			t.Errorf("%s: render(%q) = %q carries a control character", name, md, out)
 		}
 	}
 }
@@ -105,7 +105,7 @@ func TestRenderOutputIsOnlySGRAndHyperlinks(t *testing.T) {
 	md := "# Title\n\nHi **Ryan**, see the [Q3 report](https://example.com/q3) and <https://example.org>.\n\n" +
 		"- one *two* ~~three~~ `four`\n- https://example.com/bare\n\n> quote\n\n```ruby\nputs 1\n```\n\n" +
 		"| a | b |\n| --- | --- |\n| 1 | 2 |\n\n---\n\n![chart](/rails/blobs/chart.png) and [relative](/rails/blobs/q3.pdf) and [mail](mailto:jane@example.com)"
-	out := Render(md, 60)
+	out := render(md, 60)
 	if !sgrOnly(out) {
 		t.Fatalf("Render = %q carries a sequence outside the allow-list", out)
 	}
@@ -118,7 +118,7 @@ func TestRenderOutputIsOnlySGRAndHyperlinks(t *testing.T) {
 }
 
 func TestRenderHyperlinksOnlyAllowedSchemes(t *testing.T) {
-	out := Render("[relative](/rails/blobs/q3.pdf) [mail](mailto:jane@example.com) [web](https://example.com) [ftp](ftp://example.com/x)", 200)
+	out := render("[relative](/rails/blobs/q3.pdf) [mail](mailto:jane@example.com) [web](https://example.com) [ftp](ftp://example.com/x)", 200)
 	for _, uri := range []string{"https://example.com", "mailto:jane@example.com"} {
 		if !strings.Contains(out, ";"+uri+"\x07") {
 			t.Errorf("Render = %q, want a hyperlink to %s", out, uri)
@@ -201,7 +201,7 @@ func TestRenderShowsADeeplyNestedDocumentUnrendered(t *testing.T) {
 		"indented quotes": "  " + strings.Repeat("> ", 100) + "deep",
 	} {
 		done := make(chan string, 1)
-		go func() { done <- Render(md, 40) }()
+		go func() { done <- render(md, 40) }()
 		select {
 		case out := <-done:
 			if !strings.Contains(visible(out), "deep") {
@@ -219,7 +219,7 @@ func TestRenderShowsADeeplyNestedDocumentUnrendered(t *testing.T) {
 // Under the cap, nesting renders as usual — and a fenced line of markers is code,
 // which counts for nothing.
 func TestRenderNestsUnderTheCap(t *testing.T) {
-	out := Render(strings.Repeat("> ", maxNestingDepth)+"quoted\n\n```\n"+strings.Repeat("> ", 100)+"code\n```", 80)
+	out := render(strings.Repeat("> ", maxNestingDepth)+"quoted\n\n```\n"+strings.Repeat("> ", 100)+"code\n```", 80)
 	if !strings.Contains(out, "│ quoted") || !strings.Contains(visible(out), "code") {
 		t.Errorf("Render = %q, want the quote rendered and the code kept", out)
 	}
@@ -228,7 +228,7 @@ func TestRenderNestsUnderTheCap(t *testing.T) {
 // A bidirectional override in a body is stripped on the way to the terminal: what the
 // reader sees is what was written, in the order it was written.
 func TestRenderStripsBidiControlsFromBodies(t *testing.T) {
-	out := Render("invoice\u202efdp.exe", 80)
+	out := render("invoice\u202efdp.exe", 80)
 	if strings.ContainsRune(out, 0x202e) || !strings.Contains(visible(out), "invoicefdp.exe") {
 		t.Errorf("Render = %q", out)
 	}
@@ -255,7 +255,7 @@ func TestRendererCacheIsBounded(t *testing.T) {
 	renderersMutex.Unlock()
 
 	for width := 20; width < 20+maxCachedRenderers*3; width++ {
-		if Render("hello", width) == "" {
+		if render("hello", width) == "" {
 			t.Fatalf("Render at width %d returned nothing", width)
 		}
 	}
@@ -289,9 +289,9 @@ func FuzzContainment(f *testing.F) {
 		if !utf8.ValidString(md) {
 			t.Skip()
 		}
-		out := Render(md, 40)
+		out := render(md, 40)
 		if !sgrOnly(out) {
-			t.Fatalf("Render(%q) = %q carries a sequence outside the allow-list", md, out)
+			t.Fatalf("render(%q) = %q carries a sequence outside the allow-list", md, out)
 		}
 		for _, open := range strings.Split(out, "\x1b]8;")[1:] {
 			params, rest, _ := strings.Cut(open, ";")
@@ -300,7 +300,7 @@ func FuzzContainment(f *testing.F) {
 				uri = uri[:i]
 			}
 			if uri != "" && !allowedHyperlink(uri) {
-				t.Fatalf("Render(%q) = %q links to %q (params %q)", md, out, uri, params)
+				t.Fatalf("render(%q) = %q links to %q (params %q)", md, out, uri, params)
 			}
 		}
 	})

--- a/internal/tui/html.go
+++ b/internal/tui/html.go
@@ -6,7 +6,7 @@ func htmlToText(s string) string {
 	return htmlutil.ToText(s)
 }
 
-func htmlToMarkdown(s string) string {
+func htmlToMarkdown(s string) htmlutil.Markdown {
 	return htmlutil.ToMarkdown(s)
 }
 

--- a/internal/tui/journal.go
+++ b/internal/tui/journal.go
@@ -7,6 +7,7 @@ import (
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/markdown"
 )
 
@@ -21,7 +22,7 @@ const (
 
 type journalDetailMsg struct {
 	requestResult
-	body   string
+	body   htmlutil.Markdown
 	images [][]byte
 }
 
@@ -61,6 +62,9 @@ func (v *journalView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		}
 		v.inThread = true
 		v.topicContent = markdown.Render(msg.body, max(v.vc.width-4, 40))
+		if msg.body.IsEmpty() {
+			v.topicContent = "(empty)"
+		}
 		v.topicViewport.SetContent(v.topicContent)
 		v.topicViewport.GotoTop()
 		var uploadCmds []tea.Cmd
@@ -151,7 +155,7 @@ func (v *journalView) fetchJournalEntry(ctx context.Context, requestID uint64, d
 	return func() tea.Msg {
 		content, err := v.vc.sdk.Journal().GetContent(ctx, date)
 		if err != nil || content == "" {
-			return journalDetailMsg{requestResult: newRequestResult(requestID, nil), body: "(empty)"}
+			return journalDetailMsg{requestResult: newRequestResult(requestID, nil)}
 		}
 
 		var images [][]byte

--- a/internal/tui/journal_test.go
+++ b/internal/tui/journal_test.go
@@ -11,12 +11,14 @@ import (
 	"time"
 
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/htmlutil"
 )
 
 func journalWithEntry() *journalView {
 	v := newJournalView(testVC())
 	v.Init()
-	v.Update(journalDetailMsg{requestResult: currentJournalRequest(v), body: "Today was great"})
+	v.Update(journalDetailMsg{requestResult: currentJournalRequest(v), body: htmlutil.ToMarkdown("<p>Today was great</p>")})
 	return v
 }
 
@@ -98,7 +100,7 @@ func TestJournalViewHandlesDetailLoaded(t *testing.T) {
 	v := newJournalView(testVC())
 	v.Init() // sets dateIndex to today
 
-	_, consumed := v.Update(journalDetailMsg{requestResult: currentJournalRequest(v), body: "Entry body"})
+	_, consumed := v.Update(journalDetailMsg{requestResult: currentJournalRequest(v), body: htmlutil.ToMarkdown("<p>Entry body</p>")})
 	if !consumed {
 		t.Error("journalDetailMsg should be consumed")
 	}
@@ -115,7 +117,7 @@ func TestJournalViewIgnoresStaleResponse(t *testing.T) {
 	v.Init()
 
 	// A response to the read the reader has since moved off
-	_, consumed := v.Update(journalDetailMsg{requestResult: requestResult{requestID: v.requests.id - 1}, body: "old content"})
+	_, consumed := v.Update(journalDetailMsg{requestResult: requestResult{requestID: v.requests.id - 1}, body: htmlutil.ToMarkdown("<p>old content</p>")})
 	if !consumed {
 		t.Error("stale journalDetailMsg should still be consumed")
 	}

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -2061,7 +2061,7 @@ func (v *mailView) renderEntries(entries []mail.Entry) string {
 		if e.Summary != "" {
 			fmt.Fprintf(&b, "%s\n", terminal.SanitizeLine(e.Summary))
 		}
-		if e.Body != "" {
+		if !e.Body.IsEmpty() {
 			fmt.Fprintf(&b, "\n%s\n", v.vc.styles.entryBody.Render(markdown.Render(e.Body, sepWidth)))
 		}
 		entryAttachments := attachmentsForMessage(v.attachments, e.ID)

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -263,7 +263,7 @@ func TestMailViewHandlesTopicLoaded(t *testing.T) {
 		boxID:   1,
 		topicID: 100,
 		title:   "Test topic",
-		entries: []mail.Entry{{Creator: mail.Contact{Name: "Alice"}, Body: "hello"}},
+		entries: []mail.Entry{{Creator: mail.Contact{Name: "Alice"}, Body: htmlutil.ToMarkdown("<p>hello</p>")}},
 	})
 	if !consumed {
 		t.Error("topicLoadedMsg should be consumed")


### PR DESCRIPTION
Closes #245.

`htmlutil.Markdown` is a sealed provenance type — unexported field, no constructor, made only by `htmlutil.ToMarkdown`, marshals to JSON as the string it holds — and `markdown.Render` accepts nothing else. Every body that reaches glamour (CLI thread entries, TUI thread and journal views, contact notes) now provably came through the context serializers; a raw string can no longer reach the renderer by looking like Markdown. `mail.Entry.Body`, the CLI's `threadEntry.Body` (`json:"body,omitzero"`) and the TUI's journal message carry the type.

The serializer property is also stated at the AST: `assertSafeTree` parses `ToMarkdown`'s output with goldmark and checks no raw HTML nodes, only allowed link/image/autolink destinations, and no control in any text segment — in a table test and in `FuzzToMarkdownTerminalSafety`.

The `markdown` package keeps an unexported `render(string, int)` for its own tests (entities, depth, bidi, containment fuzz), which probe Markdown text directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seal Markdown behind a provenance type and restrict rendering to that type. Previously `markdown.Render` accepted any string; now it accepts only `htmlutil.Markdown` from `htmlutil.ToMarkdown`, blocking raw strings from reaching the renderer and preserving terminal-safety guarantees. The Markdown contract now explicitly allows only newlines and tabs as remaining control characters.

- Introduces `htmlutil.Markdown` (unexported field, no constructor). Only `htmlutil.ToMarkdown` can produce it; it marshals to JSON as the string it holds and permits only newline and tab as controls.
- Changes `markdown.Render` to accept `htmlutil.Markdown`; keeps an unexported `render(string, int)` for package tests, and adds unexported `htmlutil.toMarkdown` for serializer tests.
- Updates `mail.Entry.Body`, CLI `threadEntry.Body` (`json:"body,omitzero"`), and TUI journal/message bodies to `htmlutil.Markdown`; use `.IsEmpty()` for checks and `.String()` when emitting raw Markdown.
- `--json` carries bodies as strings and omits the `body` key when a body was not read (pinned by tests). Decoders that re-read CLI JSON should use a plain string field; they cannot reconstruct the sealed type.
- States and tests the serializer property on the `goldmark` AST (`assertSafeTree`): no raw HTML nodes, only allowed link/image/autolink destinations, and no disallowed control characters; the fuzz target invokes this check.

<sup>Written for commit 484751d6e15802f46910581f48a1768cada77d39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

