### PR TITLE
Read whole threads in the TUI through the loader, within an image budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,9 +106,10 @@ because both were mis-stated here before:
   in the HTML. A thread that could be read only in part is refused without
   `--allow-partial`; with it the notice says what is missing (`threadNotice` in
   `internal/cmd/thread_source.go`). The package takes a `Source` interface rather than the
-  SDK, so `cmd` hands it `sdkThreadSource`; `tui` could do the same without an import
-  cycle, but `mailView.fetchTopic` still reads one page, deliberately, until its image
-  loading has budgets of its own (#246). HEY serves the entry index newest first; the
+  SDK; `threadload.NewSDKSource` is the adapter both the CLI and the TUI hand it, and the TUI's `mailView.fetchTopic` reads through it
+  too — every page, oldest first, unread bodies marked and a notice for a partial read —
+  and then fetches inline images within `imageBudget` (`internal/tui/image_budget.go`:
+  count, bytes, deadline, de-dup, HEY blob paths only). HEY serves the entry index newest first; the
   loader admits newest first and reverses once, so a thread reads oldest first.
 
   The entry index is geared_pagination like every other list here, so its page is a cursor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,11 @@ because both were mis-stated here before:
   SDK; `threadload.NewSDKSource` is the adapter both the CLI and the TUI hand it, and the TUI's `mailView.fetchTopic` reads through it
   too — every page, oldest first, unread bodies marked and a notice for a partial read —
   and then fetches inline images within `imageBudget` (`internal/tui/image_budget.go`:
-  count, bytes, deadline, de-dup, HEY blob paths only). HEY serves the entry index newest first; the
+  requests, bytes, deadline, de-dup, clean HEY blob paths only — every request is charged
+  to the count whatever it answers, and each fetch is told what is left of the bytes so an
+  oversized image stops on the wire). A thread read only in part keeps its notice on
+  screen for as long as it is open (`mailView.threadNotice`) and is not marked seen by
+  being opened; the seen key still is. HEY serves the entry index newest first; the
   loader admits newest first and reverses once, so a thread reads oldest first.
 
   The entry index is geared_pagination like every other list here, so its page is a cursor

--- a/internal/cmd/sdk_transport.go
+++ b/internal/cmd/sdk_transport.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"mime"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/basecamp/hey-cli/internal/threadload"
 )
 
 // The SDK's generated parsers read every response body with io.ReadAll before
@@ -36,8 +37,10 @@ import (
 // is a message with a very large HTML body several times over.
 const maxTextResponseBytes int64 = 16 << 20
 
-// ErrResponseTooLarge is the error a capped body ends with once it passes the cap.
-var ErrResponseTooLarge = errors.New("response body exceeded the size limit")
+// ErrResponseTooLarge is the error a capped body ends with once it passes the cap. It
+// wraps threadload.ErrOverLimit, so a loader that meets it through the SDK knows the
+// one message was too large rather than the service failing.
+var ErrResponseTooLarge = fmt.Errorf("%w: response body exceeded the size limit", threadload.ErrOverLimit)
 
 // cappedTransport wraps an http.RoundTripper so that text-bearing responses cannot
 // deliver more than limit decompressed bytes.

--- a/internal/cmd/thread_source.go
+++ b/internal/cmd/thread_source.go
@@ -2,77 +2,18 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
-
-	"github.com/basecamp/hey-sdk/go/pkg/generated"
-	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/threadload"
 )
-
-// sdkThreadSource reads a thread through the SDK for threadload: the paginated entries
-// index, which carries the cursor `Topics().GetEntries` throws away, and each entry's
-// message, which is where HEY keeps the body.
-type sdkThreadSource struct {
-	client *hey.Client
-}
-
-func (s sdkThreadSource) EntriesPage(ctx context.Context, topicID int64, cursor string) (threadload.Page, error) {
-	page, err := s.client.Topics().GetEntriesPage(ctx, topicID, cursor)
-	if err != nil {
-		// A request the context ended mid-flight surfaces as a network error; that
-		// is the context ending, which the loader handles, not the index failing.
-		if ctx.Err() != nil {
-			return threadload.Page{}, ctx.Err()
-		}
-		return threadload.Page{}, apierr.FromSDK(err)
-	}
-	if page == nil {
-		return threadload.Page{}, fmt.Errorf("thread %d answered no entry page at cursor %q", topicID, cursor)
-	}
-	return threadload.Page{Entries: page.Entries, Next: page.NextPage}, nil
-}
-
-// Message reads one entry's message. A rate limit, an expired credential, a server
-// error or a lost connection is about the service, not the message, and is marked
-// systemic so the loader stops the fan-out rather than asking two thousand more times.
-func (s sdkThreadSource) Message(ctx context.Context, entryID int64) (*generated.Message, error) {
-	message, err := s.client.Messages().Get(ctx, entryID)
-	if err != nil {
-		// A request the context ended mid-flight surfaces as a network error; that
-		// is the context ending, which the loader handles, not the service failing.
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		if errors.Is(err, ErrResponseTooLarge) || strings.Contains(err.Error(), ErrResponseTooLarge.Error()) {
-			return nil, fmt.Errorf("%w: %w", threadload.ErrOverLimit, err)
-		}
-		return nil, systemic(apierr.FromSDK(err))
-	}
-	return message, nil
-}
-
-func systemic(err error) error {
-	var apiErr *apierr.Error
-	if errors.As(err, &apiErr) {
-		switch {
-		case apiErr.Code == apierr.CodeRateLimit, apiErr.Code == apierr.CodeAuth, apiErr.Code == apierr.CodeForbidden,
-			apiErr.Code == apierr.CodeNetwork, apiErr.HTTPStatus >= 500:
-			return fmt.Errorf("%w: %w", threadload.ErrSystemic, err)
-		}
-	}
-	return err
-}
 
 // threadLimits is what the CLI reads a thread within. A variable so tests can lower it.
 var threadLimits = threadload.DefaultLimits
 
 // loadThread reads a thread within threadLimits, with or without bodies.
 func loadThread(ctx context.Context, threadID int64, hydrate bool) (*threadload.Thread, error) {
-	thread, err := threadload.Load(ctx, sdkThreadSource{client: sdk}, threadload.Request{
+	thread, err := threadload.Load(ctx, threadload.NewSDKSource(sdk), threadload.Request{
 		TopicID: threadID,
 		Hydrate: hydrate,
 		Limits:  threadLimits,
@@ -86,54 +27,9 @@ func loadThread(ctx context.Context, threadID int64, hydrate bool) (*threadload.
 	return thread, nil
 }
 
-// threadNotice says what a load did not get, or nothing when it got everything. It is
-// the notice a partial result carries and the message a refused one is refused with.
+// threadNotice is the thread's notice in terms of the CLI's limits.
 func threadNotice(thread *threadload.Thread) string {
-	var parts []string
-	if thread.IndexTruncated {
-		reason := ""
-		switch thread.IndexTruncatedBy {
-		case threadload.TruncatedByPages:
-			reason = fmt.Sprintf("beyond the %d-page limit", threadLimits.MaxPages)
-		case threadload.TruncatedByEntries:
-			reason = fmt.Sprintf("beyond the %d-entry limit", threadLimits.MaxEntries)
-		case threadload.TruncatedByBytes:
-			reason = fmt.Sprintf("beyond the %d-byte limit on what a read keeps", threadLimits.MaxRetainedBytes)
-		case threadload.TruncatedByDeadline:
-			reason = fmt.Sprintf("the %s read limit passed before the index was read to its end", threadLimits.Deadline)
-		}
-		parts = append(parts, fmt.Sprintf("only the newest %d entries were read; older ones exist, %s", len(thread.Entries), reason))
-	}
-	if thread.Omitted > 0 {
-		failed, overLimit := 0, 0
-		for _, entry := range thread.Entries {
-			switch entry.State {
-			case threadload.StateFailed:
-				failed++
-			case threadload.StateOverLimit:
-				overLimit++
-			case threadload.StateHydrated, threadload.StateBodyless, threadload.StateNotRequested:
-			}
-		}
-		detail := ""
-		switch {
-		case failed > 0 && overLimit > 0:
-			detail = fmt.Sprintf(" (%d failed, %d over the read limits)", failed, overLimit)
-		case failed > 0:
-			detail = " (failed)"
-		case overLimit > 0:
-			detail = " (over the read limits)"
-		}
-		parts = append(parts, fmt.Sprintf("%d of %d bodies could not be read%s", thread.Omitted, len(thread.Entries), detail))
-	}
-	switch len(parts) {
-	case 0:
-		return ""
-	case 1:
-		return parts[0]
-	default:
-		return parts[0] + "; " + parts[1]
-	}
+	return thread.Notice(threadLimits)
 }
 
 // errPartialThread is how a partial read is refused without --allow-partial: an API

--- a/internal/mail/entry.go
+++ b/internal/mail/entry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/terminal"
+	"github.com/basecamp/hey-cli/internal/threadload"
 )
 
 // Entry is one message in a thread. CreatedAt is the time HEY served, not a string of it,
@@ -23,6 +24,22 @@ type Entry struct {
 	Summary               string
 	Body                  htmlutil.Markdown
 	BodyHTML              string
+	// BodyState is what became of the body when the entry came through threadload:
+	// hydrated, bodyless, over_limit or failed. Empty for an entry read another way.
+	BodyState string
+}
+
+// LoadedEntry describes an entry threadload read: the message when there is one, and
+// what became of the body either way.
+func LoadedEntry(loaded threadload.Entry) Entry {
+	if loaded.Message == nil {
+		entry := NewEntry(loaded.Entry, generated.Message{})
+		entry.BodyState = string(loaded.State)
+		return entry
+	}
+	entry := NewEntry(loaded.Entry, *loaded.Message)
+	entry.BodyState = string(loaded.State)
+	return entry
 }
 
 // NewEntry describes a thread's entry against the message HEY served for it. A topic

--- a/internal/threadload/sdk.go
+++ b/internal/threadload/sdk.go
@@ -1,0 +1,115 @@
+package threadload
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+)
+
+// NewSDKSource reads a thread through the SDK: the paginated entries index, which
+// carries the cursor `Topics().GetEntries` throws away, and each entry's message, which
+// is where HEY keeps the body. It is the Source both the CLI and the TUI hand Load.
+func NewSDKSource(client *hey.Client) Source {
+	return sdkSource{client: client}
+}
+
+type sdkSource struct {
+	client *hey.Client
+}
+
+func (s sdkSource) EntriesPage(ctx context.Context, topicID int64, cursor string) (Page, error) {
+	page, err := s.client.Topics().GetEntriesPage(ctx, topicID, cursor)
+	if err != nil {
+		// A request the context ended mid-flight surfaces as a network error; that
+		// is the context ending, which the loader handles, not the index failing.
+		if ctx.Err() != nil {
+			return Page{}, ctx.Err()
+		}
+		return Page{}, apierr.FromSDK(err)
+	}
+	if page == nil {
+		return Page{}, fmt.Errorf("thread %d answered no entry page at cursor %q", topicID, cursor)
+	}
+	return Page{Entries: page.Entries, Next: page.NextPage}, nil
+}
+
+// Message reads one entry's message. A rate limit, an expired credential, a server
+// error or a lost connection is about the service, not the message, and is marked
+// systemic so the loader stops the fan-out rather than asking two thousand more times.
+// A response the transport refused as too large is ErrOverLimit for that entry alone.
+func (s sdkSource) Message(ctx context.Context, entryID int64) (*generated.Message, error) {
+	message, err := s.client.Messages().Get(ctx, entryID)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		// The transport wraps ErrOverLimit; the SDK may or may not keep the chain.
+		if errors.Is(err, ErrOverLimit) || strings.Contains(err.Error(), ErrOverLimit.Error()) {
+			return nil, fmt.Errorf("%w: %w", ErrOverLimit, err)
+		}
+		return nil, systemic(apierr.FromSDK(err))
+	}
+	return message, nil
+}
+
+func systemic(err error) error {
+	var apiErr *apierr.Error
+	if errors.As(err, &apiErr) {
+		switch {
+		case apiErr.Code == apierr.CodeRateLimit, apiErr.Code == apierr.CodeAuth, apiErr.Code == apierr.CodeForbidden,
+			apiErr.Code == apierr.CodeNetwork, apiErr.HTTPStatus >= 500:
+			return fmt.Errorf("%w: %w", ErrSystemic, err)
+		}
+	}
+	return err
+}
+
+// Notice says what a load did not get, or nothing when it got everything, in terms of
+// the limits it was read within. It is the notice a partial result carries and the
+// message a refused one is refused with.
+func (t *Thread) Notice(limits Limits) string {
+	var parts []string
+	if t.IndexTruncated {
+		reason := ""
+		switch t.IndexTruncatedBy {
+		case TruncatedByPages:
+			reason = fmt.Sprintf("beyond the %d-page limit", limits.MaxPages)
+		case TruncatedByEntries:
+			reason = fmt.Sprintf("beyond the %d-entry limit", limits.MaxEntries)
+		case TruncatedByBytes:
+			reason = fmt.Sprintf("beyond the %d-byte limit on what a read keeps", limits.MaxRetainedBytes)
+		case TruncatedByDeadline:
+			reason = fmt.Sprintf("the %s read limit passed before the index was read to its end", limits.Deadline)
+		}
+		parts = append(parts, fmt.Sprintf("only the newest %d entries were read; older ones exist, %s", len(t.Entries), reason))
+	}
+	if t.Omitted > 0 {
+		failed, overLimit := 0, 0
+		for _, entry := range t.Entries {
+			switch entry.State {
+			case StateFailed:
+				failed++
+			case StateOverLimit:
+				overLimit++
+			case StateHydrated, StateBodyless, StateNotRequested:
+			}
+		}
+		detail := ""
+		switch {
+		case failed > 0 && overLimit > 0:
+			detail = fmt.Sprintf(" (%d failed, %d over the read limits)", failed, overLimit)
+		case failed > 0:
+			detail = " (failed)"
+		case overLimit > 0:
+			detail = " (over the read limits)"
+		}
+		parts = append(parts, fmt.Sprintf("%d of %d bodies could not be read%s", t.Omitted, len(t.Entries), detail))
+	}
+	return strings.Join(parts, "; ")
+}

--- a/internal/tui/image_budget.go
+++ b/internal/tui/image_budget.go
@@ -1,0 +1,89 @@
+package tui
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Inline images are fetched for a thread or a journal page after its text is read, one
+// request per image, from a server that chose the images. The fetcher already bounds
+// each image — origin, bytes, pixels, content type — and imageBudget bounds the set:
+// how many are fetched for one view, how many bytes they may add up to, how long the
+// whole fetch may take, and that the same URL is fetched once. A relative URL is fetched
+// only from HEY's blob paths, the one place an email's images live.
+//
+// Lazy loading — fetching an image as the viewport reaches it — is not done here; every
+// image within the budget is fetched before the view renders, and the budget is what
+// keeps that bounded. The limits are literal numbers for the same reason threadload's
+// are: a reader should be able to say what the TUI will and will not do.
+const (
+	// maxImagesPerView is how many inline images one thread or journal page fetches.
+	maxImagesPerView = 24
+	// maxImageBytesPerView is how many bytes of image data one view keeps in all.
+	maxImageBytesPerView int64 = 48 << 20
+	// imageFetchDeadline is how long all of one view's image fetches may take.
+	imageFetchDeadline = 20 * time.Second
+	// heyBlobPathPrefix is where a relative image URL must point.
+	heyBlobPathPrefix = "/rails/"
+)
+
+type imageBudget struct {
+	remaining      int
+	remainingBytes int64
+	seen           map[string]struct{}
+}
+
+func newImageBudget() *imageBudget {
+	return &imageBudget{remaining: maxImagesPerView, remainingBytes: maxImageBytesPerView, seen: map[string]struct{}{}}
+}
+
+// fetchImages fetches the images a view may show, in the order their URLs were found,
+// within the budget and the deadline. A URL that fails, repeats, points outside HEY's
+// blob paths or would exceed the budget is skipped; the rest are returned in order.
+func (b *imageBudget) fetchImages(ctx context.Context, fetcher imageFetcher, urls []string) [][]byte {
+	if fetcher == nil || len(urls) == 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, imageFetchDeadline)
+	defer cancel()
+
+	var images [][]byte
+	for _, source := range urls {
+		if b.remaining <= 0 || ctx.Err() != nil {
+			break
+		}
+		if !b.admit(source) {
+			continue
+		}
+		data, err := fetcher.Fetch(ctx, source)
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		if int64(len(data)) > b.remainingBytes {
+			continue
+		}
+		b.remainingBytes -= int64(len(data))
+		b.remaining--
+		images = append(images, data)
+	}
+	return images
+}
+
+// admit reports whether a URL is one the budget will fetch: not seen before, and if
+// relative, under HEY's blob paths.
+func (b *imageBudget) admit(source string) bool {
+	if _, seen := b.seen[source]; seen {
+		return false
+	}
+	b.seen[source] = struct{}{}
+	parsed, err := url.Parse(source)
+	if err != nil {
+		return false
+	}
+	if !parsed.IsAbs() && !strings.HasPrefix(parsed.Path, heyBlobPathPrefix) {
+		return false
+	}
+	return true
+}

--- a/internal/tui/image_budget.go
+++ b/internal/tui/image_budget.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"path"
 	"strings"
@@ -49,10 +50,12 @@ func newImageBudget() *imageBudget {
 }
 
 // fetchImages fetches the images a view may show, in the order their URLs were found,
-// within the budget and the deadline. A URL that repeats or points outside HEY's blob
-// paths is not requested; one that fails or would not fit in what is left of the byte
-// budget is skipped. Every request made is charged to the count, whatever it answers:
-// the content chose the URLs, and a URL that fails is still a request it caused.
+// within the budget and the deadline. A URL that repeats, points outside HEY's blob
+// paths or the fetcher refuses on sight is not requested; one that fails or would not
+// fit in what is left of the byte budget is skipped. Every request made is charged to
+// the count, whatever it answers: the content chose the URLs, and a URL that fails is
+// still a request it caused. A refusal is not a request, so it costs nothing — two
+// dozen third-party images ahead of HEY's own cannot use up the count.
 func (b *imageBudget) fetchImages(ctx context.Context, fetcher imageFetcher, urls []string) [][]byte {
 	if fetcher == nil || len(urls) == 0 {
 		return nil
@@ -72,6 +75,10 @@ func (b *imageBudget) fetchImages(ctx context.Context, fetcher imageFetcher, url
 		// The fetcher is told what is left, so an image that would not fit is stopped
 		// on the wire rather than downloaded whole and then discarded.
 		data, err := fetcher.Fetch(ctx, source, b.remainingBytes)
+		if errors.Is(err, errImageRefused) {
+			b.remaining++
+			continue
+		}
 		if err != nil || len(data) == 0 || int64(len(data)) > b.remainingBytes {
 			continue
 		}

--- a/internal/tui/image_budget.go
+++ b/internal/tui/image_budget.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -10,16 +11,18 @@ import (
 // Inline images are fetched for a thread or a journal page after its text is read, one
 // request per image, from a server that chose the images. The fetcher already bounds
 // each image — origin, bytes, pixels, content type — and imageBudget bounds the set:
-// how many are fetched for one view, how many bytes they may add up to, how long the
-// whole fetch may take, and that the same URL is fetched once. A relative URL is fetched
-// only from HEY's blob paths, the one place an email's images live.
+// how many requests one view may make, how many bytes the images it keeps may add up
+// to, how long the whole fetch may take, and that the same URL is fetched once. A
+// relative URL is fetched only from HEY's blob paths, the one place an email's images
+// live.
 //
 // Lazy loading — fetching an image as the viewport reaches it — is not done here; every
 // image within the budget is fetched before the view renders, and the budget is what
-// keeps that bounded. The limits are literal numbers for the same reason threadload's
-// are: a reader should be able to say what the TUI will and will not do.
+// keeps that bounded (#262 is the follow-up). The limits are literal numbers for the
+// same reason threadload's are: a reader should be able to say what the TUI will and
+// will not do.
 const (
-	// maxImagesPerView is how many inline images one thread or journal page fetches.
+	// maxImagesPerView is how many image requests one thread or journal page makes.
 	maxImagesPerView = 24
 	// maxImageBytesPerView is how many bytes of image data one view keeps in all.
 	maxImageBytesPerView int64 = 48 << 20
@@ -32,47 +35,57 @@ const (
 type imageBudget struct {
 	remaining      int
 	remainingBytes int64
+	deadline       time.Duration
 	seen           map[string]struct{}
 }
 
 func newImageBudget() *imageBudget {
-	return &imageBudget{remaining: maxImagesPerView, remainingBytes: maxImageBytesPerView, seen: map[string]struct{}{}}
+	return &imageBudget{
+		remaining:      maxImagesPerView,
+		remainingBytes: maxImageBytesPerView,
+		deadline:       imageFetchDeadline,
+		seen:           map[string]struct{}{},
+	}
 }
 
 // fetchImages fetches the images a view may show, in the order their URLs were found,
-// within the budget and the deadline. A URL that fails, repeats, points outside HEY's
-// blob paths or would exceed the budget is skipped; the rest are returned in order.
+// within the budget and the deadline. A URL that repeats or points outside HEY's blob
+// paths is not requested; one that fails or would not fit in what is left of the byte
+// budget is skipped. Every request made is charged to the count, whatever it answers:
+// the content chose the URLs, and a URL that fails is still a request it caused.
 func (b *imageBudget) fetchImages(ctx context.Context, fetcher imageFetcher, urls []string) [][]byte {
 	if fetcher == nil || len(urls) == 0 {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(ctx, imageFetchDeadline)
+	ctx, cancel := context.WithTimeout(ctx, b.deadline)
 	defer cancel()
 
 	var images [][]byte
 	for _, source := range urls {
-		if b.remaining <= 0 || ctx.Err() != nil {
+		if b.remaining <= 0 || b.remainingBytes <= 0 || ctx.Err() != nil {
 			break
 		}
 		if !b.admit(source) {
 			continue
 		}
-		data, err := fetcher.Fetch(ctx, source)
-		if err != nil || len(data) == 0 {
-			continue
-		}
-		if int64(len(data)) > b.remainingBytes {
+		b.remaining--
+		// The fetcher is told what is left, so an image that would not fit is stopped
+		// on the wire rather than downloaded whole and then discarded.
+		data, err := fetcher.Fetch(ctx, source, b.remainingBytes)
+		if err != nil || len(data) == 0 || int64(len(data)) > b.remainingBytes {
 			continue
 		}
 		b.remainingBytes -= int64(len(data))
-		b.remaining--
 		images = append(images, data)
 	}
 	return images
 }
 
-// admit reports whether a URL is one the budget will fetch: not seen before, and if
-// relative, under HEY's blob paths.
+// admit reports whether a URL is one the budget will request: not seen before, and if
+// relative, a clean path under HEY's blob paths. The path is judged as it resolves, so
+// "/rails/../admin/export.png" is the request outside the blob paths that it is, and a
+// path that is not already clean is refused rather than rewritten — HEY never serves
+// one, so there is nothing to fetch behind it.
 func (b *imageBudget) admit(source string) bool {
 	if _, seen := b.seen[source]; seen {
 		return false
@@ -82,8 +95,8 @@ func (b *imageBudget) admit(source string) bool {
 	if err != nil {
 		return false
 	}
-	if !parsed.IsAbs() && !strings.HasPrefix(parsed.Path, heyBlobPathPrefix) {
-		return false
+	if parsed.IsAbs() {
+		return true
 	}
-	return true
+	return parsed.Host == "" && path.Clean(parsed.Path) == parsed.Path && strings.HasPrefix(parsed.Path, heyBlobPathPrefix)
 }

--- a/internal/tui/image_budget.go
+++ b/internal/tui/image_budget.go
@@ -94,10 +94,13 @@ func (b *imageBudget) fetchImages(ctx context.Context, fetcher imageFetcher, url
 // path that is not already clean is refused rather than rewritten — HEY never serves
 // one, so there is nothing to fetch behind it.
 func (b *imageBudget) admit(source string) bool {
-	if _, seen := b.seen[source]; seen {
+	// A fragment never goes on the wire, so two URLs that differ only there are one
+	// request, and one image.
+	request, _, _ := strings.Cut(source, "#")
+	if _, seen := b.seen[request]; seen {
 		return false
 	}
-	b.seen[source] = struct{}{}
+	b.seen[request] = struct{}{}
 	parsed, err := url.Parse(source)
 	if err != nil {
 		return false

--- a/internal/tui/image_budget_test.go
+++ b/internal/tui/image_budget_test.go
@@ -1,0 +1,95 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingFetcher answers every URL with a body of the size it names, or an error.
+type countingFetcher struct {
+	calls atomic.Int64
+	size  int
+	fail  map[string]bool
+	slow  time.Duration
+}
+
+func (f *countingFetcher) Fetch(ctx context.Context, source string) ([]byte, error) {
+	f.calls.Add(1)
+	if f.slow > 0 {
+		select {
+		case <-time.After(f.slow):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.fail[source] {
+		return nil, errors.New("no such image")
+	}
+	return []byte(strings.Repeat("x", f.size)), nil
+}
+
+func TestImageBudgetFetchesAtMostTheCount(t *testing.T) {
+	urls := make([]string, 0, maxImagesPerView+5)
+	for i := range cap(urls) {
+		urls = append(urls, fmt.Sprintf("/rails/blobs/%d.png", i))
+	}
+	fetcher := &countingFetcher{size: 10}
+	images := newImageBudget().fetchImages(context.Background(), fetcher, urls)
+	if len(images) != maxImagesPerView || fetcher.calls.Load() != maxImagesPerView {
+		t.Errorf("fetched %d images with %d requests, want %d and no request past the count", len(images), fetcher.calls.Load(), maxImagesPerView)
+	}
+}
+
+func TestImageBudgetFetchesEachURLOnce(t *testing.T) {
+	fetcher := &countingFetcher{size: 10}
+	images := newImageBudget().fetchImages(context.Background(), fetcher, []string{"/rails/blobs/a.png", "/rails/blobs/a.png", "/rails/blobs/b.png"})
+	if len(images) != 2 || fetcher.calls.Load() != 2 {
+		t.Errorf("fetched %d images with %d requests, want 2 and 2", len(images), fetcher.calls.Load())
+	}
+}
+
+// A relative URL is fetched only from HEY's blob paths; an absolute one is left to the
+// fetcher's own origin rules.
+func TestImageBudgetFetchesRelativeURLsOnlyFromBlobPaths(t *testing.T) {
+	fetcher := &countingFetcher{size: 10}
+	images := newImageBudget().fetchImages(context.Background(), fetcher, []string{
+		"/rails/active_storage/blobs/redirect/abc/chart.png",
+		"/rails/blobs/chart.png",
+		"/admin/export.png",
+		"../rails/blobs/up.png",
+		"https://gopher.hey.com/avatar.png",
+	})
+	if len(images) != 3 || fetcher.calls.Load() != 3 {
+		t.Errorf("fetched %d images with %d requests, want the two blob paths and the absolute URL only", len(images), fetcher.calls.Load())
+	}
+}
+
+func TestImageBudgetKeepsWithinTheByteBudget(t *testing.T) {
+	fetcher := &countingFetcher{size: int(maxImageBytesPerView/2) + 1}
+	images := newImageBudget().fetchImages(context.Background(), fetcher, []string{"/rails/blobs/a.png", "/rails/blobs/b.png", "/rails/blobs/c.png"})
+	if len(images) != 1 {
+		t.Errorf("kept %d images, want one: the second would pass the byte budget", len(images))
+	}
+}
+
+func TestImageBudgetSkipsFailuresAndKeepsOrder(t *testing.T) {
+	fetcher := &countingFetcher{size: 10, fail: map[string]bool{"/rails/blobs/b.png": true}}
+	images := newImageBudget().fetchImages(context.Background(), fetcher, []string{"/rails/blobs/a.png", "/rails/blobs/b.png", "/rails/blobs/c.png"})
+	if len(images) != 2 {
+		t.Errorf("kept %d images, want the two that loaded", len(images))
+	}
+}
+
+func TestImageBudgetStopsAtTheCallersCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fetcher := &countingFetcher{size: 10}
+	if images := newImageBudget().fetchImages(ctx, fetcher, []string{"/rails/blobs/a.png"}); len(images) != 0 || fetcher.calls.Load() != 0 {
+		t.Errorf("fetched %d with %d requests after cancellation", len(images), fetcher.calls.Load())
+	}
+}

--- a/internal/tui/image_budget_test.go
+++ b/internal/tui/image_budget_test.go
@@ -97,9 +97,9 @@ func TestImageBudgetDoesNotChargeARefusedURL(t *testing.T) {
 
 func TestImageBudgetFetchesEachURLOnce(t *testing.T) {
 	fetcher := &countingFetcher{size: 10}
-	images := newImageBudget().fetchImages(context.Background(), fetcher, []string{"/rails/blobs/a.png", "/rails/blobs/a.png", "/rails/blobs/b.png"})
+	images := newImageBudget().fetchImages(context.Background(), fetcher, []string{"/rails/blobs/a.png", "/rails/blobs/a.png", "/rails/blobs/a.png#1", "/rails/blobs/a.png#2", "/rails/blobs/b.png"})
 	if len(images) != 2 || fetcher.calls.Load() != 2 {
-		t.Errorf("fetched %d images with %d requests, want 2 and 2", len(images), fetcher.calls.Load())
+		t.Errorf("fetched %d images with %d requests, want 2 and 2: a fragment does not make a new request", len(images), fetcher.calls.Load())
 	}
 }
 

--- a/internal/tui/image_budget_test.go
+++ b/internal/tui/image_budget_test.go
@@ -18,11 +18,15 @@ type countingFetcher struct {
 	calls      atomic.Int64
 	size       int
 	fail       map[string]bool
+	refuse     map[string]bool // answered errImageRefused without a request
 	slow       time.Duration
 	allowances []int64
 }
 
 func (f *countingFetcher) Fetch(ctx context.Context, source string, maxBytes int64) ([]byte, error) {
+	if f.refuse[source] {
+		return nil, errImageRefused
+	}
 	f.calls.Add(1)
 	f.allowances = append(f.allowances, maxBytes)
 	if f.slow > 0 {
@@ -70,6 +74,24 @@ func TestImageBudgetChargesEveryRequestToTheCount(t *testing.T) {
 	images := newImageBudget().fetchImages(context.Background(), fetcher, urls)
 	if len(images) != 0 || fetcher.calls.Load() != maxImagesPerView {
 		t.Errorf("fetched %d images with %d requests, want none and no request past the count", len(images), fetcher.calls.Load())
+	}
+}
+
+// A URL the fetcher refuses on sight — a third-party origin — was never requested, so
+// it is not charged: a page of them ahead of HEY's own images leaves the count intact.
+func TestImageBudgetDoesNotChargeARefusedURL(t *testing.T) {
+	urls := make([]string, 0, maxImagesPerView+1)
+	refuse := map[string]bool{}
+	for i := range maxImagesPerView {
+		source := fmt.Sprintf("https://tracker.example/%d.png", i)
+		urls = append(urls, source)
+		refuse[source] = true
+	}
+	urls = append(urls, "/rails/blobs/chart.png")
+	fetcher := &countingFetcher{size: 10, refuse: refuse}
+	images := newImageBudget().fetchImages(context.Background(), fetcher, urls)
+	if len(images) != 1 || fetcher.calls.Load() != 1 {
+		t.Errorf("fetched %d images with %d requests, want HEY's own image fetched after the refusals", len(images), fetcher.calls.Load())
 	}
 }
 

--- a/internal/tui/image_budget_test.go
+++ b/internal/tui/image_budget_test.go
@@ -4,22 +4,27 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
-// countingFetcher answers every URL with a body of the size it names, or an error.
+// countingFetcher answers every URL with a body of the size it names, or an error, and
+// refuses a body past the allowance it is handed the way the real fetcher stops one on
+// the wire. It remembers the allowances it was given, in order.
 type countingFetcher struct {
-	calls atomic.Int64
-	size  int
-	fail  map[string]bool
-	slow  time.Duration
+	calls      atomic.Int64
+	size       int
+	fail       map[string]bool
+	slow       time.Duration
+	allowances []int64
 }
 
-func (f *countingFetcher) Fetch(ctx context.Context, source string) ([]byte, error) {
+func (f *countingFetcher) Fetch(ctx context.Context, source string, maxBytes int64) ([]byte, error) {
 	f.calls.Add(1)
+	f.allowances = append(f.allowances, maxBytes)
 	if f.slow > 0 {
 		select {
 		case <-time.After(f.slow):
@@ -30,18 +35,41 @@ func (f *countingFetcher) Fetch(ctx context.Context, source string) ([]byte, err
 	if f.fail[source] {
 		return nil, errors.New("no such image")
 	}
+	if maxBytes > 0 && int64(f.size) > maxBytes {
+		return nil, errors.New("image exceeds the allowance")
+	}
 	return []byte(strings.Repeat("x", f.size)), nil
 }
 
-func TestImageBudgetFetchesAtMostTheCount(t *testing.T) {
-	urls := make([]string, 0, maxImagesPerView+5)
-	for i := range cap(urls) {
+func blobURLs(n int) []string {
+	urls := make([]string, 0, n)
+	for i := range n {
 		urls = append(urls, fmt.Sprintf("/rails/blobs/%d.png", i))
 	}
+	return urls
+}
+
+func TestImageBudgetFetchesAtMostTheCount(t *testing.T) {
 	fetcher := &countingFetcher{size: 10}
-	images := newImageBudget().fetchImages(context.Background(), fetcher, urls)
+	images := newImageBudget().fetchImages(context.Background(), fetcher, blobURLs(maxImagesPerView+5))
 	if len(images) != maxImagesPerView || fetcher.calls.Load() != maxImagesPerView {
 		t.Errorf("fetched %d images with %d requests, want %d and no request past the count", len(images), fetcher.calls.Load(), maxImagesPerView)
+	}
+}
+
+// The count is a bound on requests, not on images kept: a URL that fails is charged
+// like one that loads, so content full of broken images cannot keep the TUI requesting
+// until the deadline.
+func TestImageBudgetChargesEveryRequestToTheCount(t *testing.T) {
+	urls := blobURLs(maxImagesPerView + 5)
+	fail := map[string]bool{}
+	for _, source := range urls {
+		fail[source] = true
+	}
+	fetcher := &countingFetcher{size: 10, fail: fail}
+	images := newImageBudget().fetchImages(context.Background(), fetcher, urls)
+	if len(images) != 0 || fetcher.calls.Load() != maxImagesPerView {
+		t.Errorf("fetched %d images with %d requests, want none and no request past the count", len(images), fetcher.calls.Load())
 	}
 }
 
@@ -62,6 +90,10 @@ func TestImageBudgetFetchesRelativeURLsOnlyFromBlobPaths(t *testing.T) {
 		"/rails/blobs/chart.png",
 		"/admin/export.png",
 		"../rails/blobs/up.png",
+		"/rails/../admin/export.png",
+		"/rails/blobs/../../admin/export.png",
+		"/rails/./blobs/chart.png",
+		"//gopher.hey.com/rails/blobs/chart.png",
 		"https://gopher.hey.com/avatar.png",
 	})
 	if len(images) != 3 || fetcher.calls.Load() != 3 {
@@ -69,11 +101,18 @@ func TestImageBudgetFetchesRelativeURLsOnlyFromBlobPaths(t *testing.T) {
 	}
 }
 
+// The fetcher is handed what is left of the byte budget, so an image that would pass
+// it is stopped on the wire at that allowance rather than downloaded whole.
 func TestImageBudgetKeepsWithinTheByteBudget(t *testing.T) {
-	fetcher := &countingFetcher{size: int(maxImageBytesPerView/2) + 1}
+	size := int(maxImageBytesPerView/2) + 1
+	fetcher := &countingFetcher{size: size}
 	images := newImageBudget().fetchImages(context.Background(), fetcher, []string{"/rails/blobs/a.png", "/rails/blobs/b.png", "/rails/blobs/c.png"})
 	if len(images) != 1 {
 		t.Errorf("kept %d images, want one: the second would pass the byte budget", len(images))
+	}
+	remaining := maxImageBytesPerView - int64(size)
+	if want := []int64{maxImageBytesPerView, remaining, remaining}; !slices.Equal(fetcher.allowances, want) {
+		t.Errorf("allowances = %v, want %v: each fetch is told what is left", fetcher.allowances, want)
 	}
 }
 
@@ -82,6 +121,22 @@ func TestImageBudgetSkipsFailuresAndKeepsOrder(t *testing.T) {
 	images := newImageBudget().fetchImages(context.Background(), fetcher, []string{"/rails/blobs/a.png", "/rails/blobs/b.png", "/rails/blobs/c.png"})
 	if len(images) != 2 {
 		t.Errorf("kept %d images, want the two that loaded", len(images))
+	}
+}
+
+// The deadline is the budget's own: a fetch still in flight when it passes is cancelled,
+// and nothing after it is requested.
+func TestImageBudgetStopsAtItsDeadline(t *testing.T) {
+	fetcher := &countingFetcher{size: 10, slow: time.Second}
+	budget := newImageBudget()
+	budget.deadline = 20 * time.Millisecond
+	started := time.Now()
+	images := budget.fetchImages(context.Background(), fetcher, []string{"/rails/blobs/a.png", "/rails/blobs/b.png"})
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Errorf("fetching took %s, want the in-flight fetch cancelled at the deadline", elapsed)
+	}
+	if len(images) != 0 || fetcher.calls.Load() != 1 {
+		t.Errorf("fetched %d images with %d requests, want none and no request after the deadline", len(images), fetcher.calls.Load())
 	}
 }
 

--- a/internal/tui/image_fetcher.go
+++ b/internal/tui/image_fetcher.go
@@ -24,8 +24,12 @@ type imageBlobDownloader interface {
 	DownloadBlob(context.Context, string, io.Writer) (int64, http.Header, error)
 }
 
+// An imageFetcher reads one image, within its own bounds and within maxBytes, which is
+// what the caller has left to spend on it: a body past that is stopped on the wire, not
+// downloaded whole and then refused. A maxBytes of zero or less leaves the fetcher's own
+// bound as the only one.
 type imageFetcher interface {
-	Fetch(context.Context, string) ([]byte, error)
+	Fetch(ctx context.Context, source string, maxBytes int64) ([]byte, error)
 }
 
 const (
@@ -97,10 +101,14 @@ func newTrustedImageFetcherWithOrigins(client imageBlobDownloader, heyOrigin str
 	}
 }
 
-func (f *trustedImageFetcher) Fetch(ctx context.Context, source string) ([]byte, error) {
+func (f *trustedImageFetcher) Fetch(ctx context.Context, source string, maxBytes int64) ([]byte, error) {
 	parsed, err := url.Parse(source)
 	if err != nil {
 		return nil, fmt.Errorf("invalid image URL: %w", err)
+	}
+	limit := f.maxBytes
+	if maxBytes > 0 && maxBytes < limit {
+		limit = maxBytes
 	}
 
 	if parsed.User != nil {
@@ -111,11 +119,11 @@ func (f *trustedImageFetcher) Fetch(ctx context.Context, source string) ([]byte,
 	}
 
 	if !parsed.IsAbs() || sameURLOrigin(parsed, f.heyOrigin) {
-		destination := &limitedImageBuffer{limit: f.maxBytes}
+		destination := &limitedImageBuffer{limit: limit}
 		_, headers, downloadErr := f.hey.DownloadBlob(ctx, source, destination)
 		if downloadErr != nil {
 			if errors.Is(downloadErr, errImageTooLarge) {
-				return nil, fmt.Errorf("HEY image exceeds the %d byte limit", f.maxBytes)
+				return nil, fmt.Errorf("HEY image exceeds the %d byte limit", limit)
 			}
 			return nil, downloadErr
 		}
@@ -142,15 +150,15 @@ func (f *trustedImageFetcher) Fetch(ctx context.Context, source string) ([]byte,
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("gopher returned HTTP %d", response.StatusCode)
 	}
-	if response.ContentLength > f.maxBytes {
-		return nil, fmt.Errorf("gopher image exceeds the %d byte limit", f.maxBytes)
+	if response.ContentLength > limit {
+		return nil, fmt.Errorf("gopher image exceeds the %d byte limit", limit)
 	}
-	data, err := io.ReadAll(io.LimitReader(response.Body, f.maxBytes+1))
+	data, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
 	if err != nil {
 		return nil, err
 	}
-	if int64(len(data)) > f.maxBytes {
-		return nil, fmt.Errorf("gopher image exceeds the %d byte limit", f.maxBytes)
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("gopher image exceeds the %d byte limit", limit)
 	}
 	if err := validateImageData(data, response.Header); err != nil {
 		return nil, err

--- a/internal/tui/image_fetcher.go
+++ b/internal/tui/image_fetcher.go
@@ -37,6 +37,11 @@ const (
 	maxInlineImagePixels int64 = 100 * 1000 * 1000
 )
 
+// errImageRefused is the error a fetcher answers for a URL it will not request at all —
+// malformed, carrying credentials, or from an origin it does not trust. No request was
+// made, which is what a budget counting requests needs to know.
+var errImageRefused = errors.New("image URL refused")
+
 type trustedImageFetcher struct {
 	heyOrigin     *url.URL
 	hey           imageBlobDownloader
@@ -104,7 +109,7 @@ func newTrustedImageFetcherWithOrigins(client imageBlobDownloader, heyOrigin str
 func (f *trustedImageFetcher) Fetch(ctx context.Context, source string, maxBytes int64) ([]byte, error) {
 	parsed, err := url.Parse(source)
 	if err != nil {
-		return nil, fmt.Errorf("invalid image URL: %w", err)
+		return nil, fmt.Errorf("%w: invalid image URL: %w", errImageRefused, err)
 	}
 	limit := f.maxBytes
 	if maxBytes > 0 && maxBytes < limit {
@@ -112,10 +117,10 @@ func (f *trustedImageFetcher) Fetch(ctx context.Context, source string, maxBytes
 	}
 
 	if parsed.User != nil {
-		return nil, fmt.Errorf("image URL must not contain credentials")
+		return nil, fmt.Errorf("%w: image URL must not contain credentials", errImageRefused)
 	}
 	if !parsed.IsAbs() && parsed.Host != "" {
-		return nil, fmt.Errorf("image URL must be relative or use an explicit trusted origin")
+		return nil, fmt.Errorf("%w: image URL must be relative or use an explicit trusted origin", errImageRefused)
 	}
 
 	if !parsed.IsAbs() || sameURLOrigin(parsed, f.heyOrigin) {
@@ -135,7 +140,7 @@ func (f *trustedImageFetcher) Fetch(ctx context.Context, source string, maxBytes
 	}
 
 	if _, trusted := f.gopherOrigins[urlOrigin(parsed)]; !trusted {
-		return nil, fmt.Errorf("image URL is not from HEY or Gopher")
+		return nil, fmt.Errorf("%w: image URL is not from HEY or Gopher", errImageRefused)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)

--- a/internal/tui/image_fetcher_test.go
+++ b/internal/tui/image_fetcher_test.go
@@ -75,8 +75,12 @@ func TestTrustedImageFetcherRejectsLookalikeAndUnsafeOrigins(t *testing.T) {
 		"file:///etc/passwd",
 	} {
 		t.Run(source, func(t *testing.T) {
-			if _, err := fetcher.Fetch(context.Background(), source, 0); err == nil {
+			_, err := fetcher.Fetch(context.Background(), source, 0)
+			if err == nil {
 				t.Fatalf("unsafe image URL succeeded: %s", source)
+			}
+			if !errors.Is(err, errImageRefused) {
+				t.Errorf("error = %v, want a refusal without a request", err)
 			}
 		})
 	}

--- a/internal/tui/image_fetcher_test.go
+++ b/internal/tui/image_fetcher_test.go
@@ -75,7 +75,7 @@ func TestTrustedImageFetcherRejectsLookalikeAndUnsafeOrigins(t *testing.T) {
 		"file:///etc/passwd",
 	} {
 		t.Run(source, func(t *testing.T) {
-			if _, err := fetcher.Fetch(context.Background(), source); err == nil {
+			if _, err := fetcher.Fetch(context.Background(), source, 0); err == nil {
 				t.Fatalf("unsafe image URL succeeded: %s", source)
 			}
 		})
@@ -99,7 +99,7 @@ func TestTrustedImageFetcherRejectsURLCredentialsBeforeRequest(t *testing.T) {
 	parsed.User = url.UserPassword("user", "password")
 	fetcher := newTrustedImageFetcherWithOrigins(rejectingImageBlobDownloader(t), "https://app.hey.com", gopher.URL)
 
-	if _, err := fetcher.Fetch(context.Background(), parsed.String()); err == nil {
+	if _, err := fetcher.Fetch(context.Background(), parsed.String(), 0); err == nil {
 		t.Fatal("image URL containing credentials succeeded")
 	}
 	if got := requests.Load(); got != 0 {
@@ -114,7 +114,7 @@ func TestTrustedImageFetcherRejectsNetworkPathURL(t *testing.T) {
 		"https://gopher.hey.com",
 	)
 
-	if _, err := fetcher.Fetch(context.Background(), "//127.0.0.1/internal.png"); err == nil {
+	if _, err := fetcher.Fetch(context.Background(), "//127.0.0.1/internal.png", 0); err == nil {
 		t.Fatal("network-path image URL succeeded")
 	}
 }
@@ -134,7 +134,7 @@ func TestTrustedImageFetcherLoadsRelativeAndSameOriginHEYImages(t *testing.T) {
 			})
 			fetcher := newTrustedImageFetcherWithOrigins(downloader, "https://app.hey.com", "https://gopher.hey.com")
 
-			got, err := fetcher.Fetch(context.Background(), source)
+			got, err := fetcher.Fetch(context.Background(), source, 0)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -153,7 +153,7 @@ func TestTrustedImageFetcherRejectsOversizedHEYImage(t *testing.T) {
 	fetcher := newTrustedImageFetcherWithOrigins(downloader, "https://app.hey.com", "https://gopher.hey.com")
 	fetcher.maxBytes = 8
 
-	if _, err := fetcher.Fetch(context.Background(), "/image.png"); err == nil {
+	if _, err := fetcher.Fetch(context.Background(), "/image.png", 0); err == nil {
 		t.Fatal("oversized HEY image succeeded")
 	}
 }
@@ -174,7 +174,7 @@ func TestTrustedImageFetcherLoadsImageFromGopherWithoutHEYCredentials(t *testing
 		gopher.URL,
 	)
 
-	got, err := fetcher.Fetch(context.Background(), gopher.URL+"/signed/image.png")
+	got, err := fetcher.Fetch(context.Background(), gopher.URL+"/signed/image.png", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestTrustedImageFetcherAcceptsAnImageWithNoContentType(t *testing.T) {
 		gopher.URL,
 	)
 
-	got, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png")
+	got, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png", 0)
 	if err != nil {
 		t.Fatalf("image without a Content-Type was rejected: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestTrustedImageFetcherRejectsNonImageContent(t *testing.T) {
 		gopher.URL,
 	)
 
-	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png"); err == nil {
+	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png", 0); err == nil {
 		t.Fatal("non-image Gopher response succeeded")
 	}
 }
@@ -247,7 +247,7 @@ func TestTrustedImageFetcherRejectsExcessivePixelDimensions(t *testing.T) {
 		gopher.URL,
 	)
 
-	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png"); err == nil {
+	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png", 0); err == nil {
 		t.Fatal("image with excessive pixel dimensions succeeded")
 	}
 }
@@ -265,7 +265,7 @@ func TestTrustedImageFetcherRejectsMalformedImage(t *testing.T) {
 		gopher.URL,
 	)
 
-	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png"); err == nil {
+	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png", 0); err == nil {
 		t.Fatal("malformed image succeeded")
 	}
 }
@@ -284,7 +284,7 @@ func TestTrustedImageFetcherRejectsOversizedGopherImage(t *testing.T) {
 	)
 	fetcher.maxBytes = 8
 
-	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png"); err == nil {
+	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/image.png", 0); err == nil {
 		t.Fatal("oversized Gopher image succeeded")
 	}
 }
@@ -309,7 +309,7 @@ func TestTrustedImageFetcherRejectsGopherRedirectOutsideTrustedOrigin(t *testing
 		gopher.URL,
 	)
 
-	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/signed/image.png"); err == nil {
+	if _, err := fetcher.Fetch(context.Background(), gopher.URL+"/signed/image.png", 0); err == nil {
 		t.Fatal("Gopher redirect to an untrusted origin succeeded")
 	}
 	if got := untrustedRequests.Load(); got != 0 {

--- a/internal/tui/journal.go
+++ b/internal/tui/journal.go
@@ -160,12 +160,7 @@ func (v *journalView) fetchJournalEntry(ctx context.Context, requestID uint64, d
 
 		var images [][]byte
 		if v.vc.imageRenderer.protocol() == imageProtocolKitty && v.vc.imageFetcher != nil {
-			for _, imageURL := range extractImageURLs(content) {
-				data, fetchErr := v.vc.imageFetcher.Fetch(ctx, imageURL)
-				if fetchErr == nil && len(data) > 0 {
-					images = append(images, data)
-				}
-			}
+			images = newImageBudget().fetchImages(ctx, v.vc.imageFetcher, extractImageURLs(content))
 		}
 
 		return journalDetailMsg{requestResult: newRequestResult(requestID, nil), body: htmlToMarkdown(content), images: images}

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -1129,13 +1129,18 @@ func (v *mailView) Resize(width, height int) {
 
 // threadNotices is what is shown above an open thread's viewport: the partial-read
 // notice for as long as the thread is open, and the one-shot notice while it is up. Each
-// is one row, truncated to the width, so the rows they take can be counted.
+// is one row, truncated to the width, so the rows they take can be counted, and the
+// thread itself keeps at least one: in a section too short for both, a notice gives
+// way rather than pushing the viewport out.
 func (v *mailView) threadNotices() []string {
 	var notices []string
 	for _, notice := range []string{v.threadNotice, v.notice} {
 		if notice != "" {
 			notices = append(notices, truncateToWidth(notice, max(v.vc.width, 4)))
 		}
+	}
+	if room := max(v.contentHeight-1, 0); len(notices) > room {
+		notices = notices[:room]
 	}
 	return notices
 }
@@ -2031,6 +2036,8 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 		entries := make([]mail.Entry, len(thread.Entries))
 		var attachments []messageAttachment
 		var imageURLs []string
+		// Only a terminal that can draw the images pays for finding them.
+		wantImages := v.vc.imageRenderer.protocol() == imageProtocolKitty && v.vc.imageFetcher != nil
 		for i, loaded := range thread.Entries {
 			entries[i] = mail.LoadedEntry(loaded)
 			if loaded.Message == nil {
@@ -2046,13 +2053,15 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 					URL:         attachment.URL,
 				})
 			}
-			imageURLs = append(imageURLs, extractImageURLs(loaded.Message.Content)...)
+			if wantImages {
+				imageURLs = append(imageURLs, extractImageURLs(loaded.Message.Content)...)
+			}
 			// The loader's copy is released once the entry has what it shows.
 			thread.Entries[i].Message = nil
 		}
 
 		var images [][]byte
-		if v.vc.imageRenderer.protocol() == imageProtocolKitty && v.vc.imageFetcher != nil {
+		if wantImages {
 			images = newImageBudget().fetchImages(ctx, v.vc.imageFetcher, imageURLs)
 		}
 

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -94,9 +94,11 @@ type topicLoadedMsg struct {
 	entries     []mail.Entry
 	attachments []messageAttachment
 	images      [][]byte
-	// notice says what the read did not get, or is empty.
-	notice string
-	err    error
+	// notice says what the read did not get, or is empty; complete is whether it got
+	// everything — every entry in the index, every body within the limits.
+	notice   string
+	complete bool
+	err      error
 }
 
 type searchResultsLoadedMsg struct {
@@ -206,6 +208,7 @@ type mailView struct {
 	attachmentCursor int
 	imageContent     string
 	inThread         bool
+	threadNotice     string // what the open thread's read did not get; stays until the thread is left
 
 	modal                  modal       // the form or picker over the list, and the only one there can be
 	cover                  coverPreset // the session's cover; HEY does not serve one to read
@@ -383,7 +386,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.entries = msg.entries
 		v.attachments = msg.attachments
 		v.attachmentCursor = 0
-		v.notice = msg.notice
+		v.threadNotice = msg.notice
 		var imageContent strings.Builder
 		var uploadCmds []tea.Cmd
 		for _, imgData := range msg.images {
@@ -399,7 +402,13 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.imageContent = imageContent.String()
 		v.rebuildTopicContent()
 		v.topicViewport.GotoTop()
-		return tea.Batch(append(uploadCmds, v.markPostingSeen(msg.boxID, msg.postingID))...), true
+		// A thread read only in part is not marked seen by being opened: the reader has
+		// not had all of it, and seen would slide it under the Imbox's cover. The seen
+		// key is there for a thread they are done with anyway.
+		if msg.complete {
+			uploadCmds = append(uploadCmds, v.markPostingSeen(msg.boxID, msg.postingID))
+		}
+		return tea.Batch(uploadCmds...), true
 
 	case replyContextLoadedMsg:
 		if msg.boxID != v.currentBoxID() {
@@ -640,10 +649,13 @@ func (v *mailView) View() string {
 		return v.modal.draw(v)
 	}
 	if v.inThread {
-		if v.notice != "" {
-			return v.vc.styles.title.Render(v.notice) + "\n" + v.topicViewport.View()
+		var lines []string
+		for _, notice := range []string{v.threadNotice, v.notice} {
+			if notice != "" {
+				lines = append(lines, v.vc.styles.title.Render(notice))
+			}
 		}
-		return v.topicViewport.View()
+		return strings.Join(append(lines, v.topicViewport.View()), "\n")
 	}
 	if v.searchActive {
 		if v.notice != "" {
@@ -1059,6 +1071,7 @@ func (v *mailView) ExitThread() {
 	}
 	if v.inThread {
 		v.inThread = false
+		v.threadNotice = ""
 		v.modal = nil
 		v.requests.cancel()
 		return
@@ -1137,6 +1150,7 @@ func (v *mailView) switchBox(index int) tea.Cmd {
 		return nil
 	}
 	v.inThread = false
+	v.threadNotice = ""
 	v.clearSearch()
 	v.requests.cancel()
 	v.notice = ""
@@ -2027,6 +2041,7 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 			attachments: attachments,
 			images:      images,
 			notice:      thread.Notice(tuiThreadLimits),
+			complete:    thread.Complete(),
 		}
 	}
 }

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -209,6 +209,7 @@ type mailView struct {
 	imageContent     string
 	inThread         bool
 	threadNotice     string // what the open thread's read did not get; stays until the thread is left
+	contentHeight    int    // the rows the section has, which the thread's notices and viewport share
 
 	modal                  modal       // the form or picker over the list, and the only one there can be
 	cover                  coverPreset // the session's cover; HEY does not serve one to read
@@ -387,6 +388,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.attachments = msg.attachments
 		v.attachmentCursor = 0
 		v.threadNotice = msg.notice
+		v.fitThreadViewport()
 		var imageContent strings.Builder
 		var uploadCmds []tea.Cmd
 		for _, imgData := range msg.images {
@@ -649,11 +651,10 @@ func (v *mailView) View() string {
 		return v.modal.draw(v)
 	}
 	if v.inThread {
+		v.fitThreadViewport()
 		var lines []string
-		for _, notice := range []string{v.threadNotice, v.notice} {
-			if notice != "" {
-				lines = append(lines, v.vc.styles.title.Render(notice))
-			}
+		for _, notice := range v.threadNotices() {
+			lines = append(lines, v.vc.styles.title.Render(notice))
 		}
 		return strings.Join(append(lines, v.topicViewport.View()), "\n")
 	}
@@ -1122,7 +1123,31 @@ func (v *mailView) Resize(width, height int) {
 	v.postingList.setSize(width, height)
 	v.searchList.setSize(width, height)
 	v.topicViewport.SetWidth(width)
-	v.topicViewport.SetHeight(height)
+	v.contentHeight = height
+	v.fitThreadViewport()
+}
+
+// threadNotices is what is shown above an open thread's viewport: the partial-read
+// notice for as long as the thread is open, and the one-shot notice while it is up. Each
+// is one row, truncated to the width, so the rows they take can be counted.
+func (v *mailView) threadNotices() []string {
+	var notices []string
+	for _, notice := range []string{v.threadNotice, v.notice} {
+		if notice != "" {
+			notices = append(notices, truncateToWidth(notice, max(v.vc.width, 4)))
+		}
+	}
+	return notices
+}
+
+// fitThreadViewport gives the thread's viewport the rows its notices leave, so the
+// section never draws more rows than it has. The one-shot notice comes and goes from
+// dozens of sites, so the fit is also checked where the thread is drawn.
+func (v *mailView) fitThreadViewport() {
+	height := max(v.contentHeight-len(v.threadNotices()), 1)
+	if v.topicViewport.Height() != height {
+		v.topicViewport.SetHeight(height)
+	}
 }
 
 // handleBoxShortcut handles number-key shortcuts for switching boxes.

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -8,7 +8,6 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
@@ -20,6 +19,7 @@ import (
 	"github.com/basecamp/hey-cli/internal/mail"
 	"github.com/basecamp/hey-cli/internal/markdown"
 	"github.com/basecamp/hey-cli/internal/terminal"
+	"github.com/basecamp/hey-cli/internal/threadload"
 )
 
 // --- Mail messages ---
@@ -94,7 +94,9 @@ type topicLoadedMsg struct {
 	entries     []mail.Entry
 	attachments []messageAttachment
 	images      [][]byte
-	err         error
+	// notice says what the read did not get, or is empty.
+	notice string
+	err    error
 }
 
 type searchResultsLoadedMsg struct {
@@ -381,6 +383,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.entries = msg.entries
 		v.attachments = msg.attachments
 		v.attachmentCursor = 0
+		v.notice = msg.notice
 		var imageContent strings.Builder
 		var uploadCmds []tea.Cmd
 		for _, imgData := range msg.images {
@@ -1960,68 +1963,58 @@ func (v *mailView) readSearchPage(ctx context.Context, query string, page int) (
 	return postings, nextPage, nil
 }
 
+// tuiThreadLimits is what the TUI reads a thread within: threadload's defaults, at the
+// TUI's own concurrency.
+var tuiThreadLimits = func() threadload.Limits {
+	limits := threadload.DefaultLimits
+	limits.Concurrency = maxConcurrentMessageFetches
+	return limits
+}()
+
+// fetchTopic reads a whole thread through threadload — every page of the index, every
+// body within the limits — and then its inline images within the image budget. A
+// thread read only in part is shown with a notice rather than refused: the reader is
+// looking at it, and can see what is missing.
 func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topicID, postingID int64, title string) tea.Cmd {
 	return func() tea.Msg {
-		topic, err := v.vc.sdk.Topics().Get(ctx, topicID)
+		thread, err := threadload.Load(ctx, threadload.NewSDKSource(v.vc.sdk), threadload.Request{
+			TopicID: topicID,
+			Hydrate: true,
+			Limits:  tuiThreadLimits,
+		})
 		if err != nil {
 			return topicLoadedMsg{requestID: requestID, boxID: boxID, topicID: topicID, title: title, err: err}
 		}
-		if topic == nil {
+		if len(thread.Entries) == 0 {
 			return topicLoadedMsg{requestID: requestID, boxID: boxID, topicID: topicID, title: title, err: fmt.Errorf("topic %d returned no data", topicID)}
 		}
 
-		messages := make([]generated.Message, len(topic.Entries))
-		group, groupCtx := errgroup.WithContext(ctx)
-		group.SetLimit(maxConcurrentMessageFetches)
-		for i, entry := range topic.Entries {
-			group.Go(func() error {
-				message, getErr := v.vc.sdk.Messages().Get(groupCtx, entry.Id)
-				if getErr != nil {
-					return fmt.Errorf("get message %d: %w", entry.Id, getErr)
-				}
-				if message == nil {
-					return fmt.Errorf("message %d returned no data", entry.Id)
-				}
-				messages[i] = *message
-				return nil
-			})
-		}
-		if getErr := group.Wait(); getErr != nil {
-			return topicLoadedMsg{
-				requestID: requestID,
-				boxID:     boxID,
-				topicID:   topicID,
-				title:     title,
-				err:       getErr,
-			}
-		}
-
-		entries := make([]mail.Entry, len(topic.Entries))
+		entries := make([]mail.Entry, len(thread.Entries))
 		var attachments []messageAttachment
-		for i, entry := range topic.Entries {
-			entries[i] = mail.NewEntry(entry, messages[i])
-			for position, attachment := range htmlutil.ExtractAttachments(messages[i].Content) {
+		var imageURLs []string
+		for i, loaded := range thread.Entries {
+			entries[i] = mail.LoadedEntry(loaded)
+			if loaded.Message == nil {
+				continue
+			}
+			for position, attachment := range htmlutil.ExtractAttachments(loaded.Message.Content) {
 				attachments = append(attachments, messageAttachment{
-					ID:          fmt.Sprintf("%d:%d", entry.Id, position+1),
-					MessageID:   entry.Id,
+					ID:          fmt.Sprintf("%d:%d", loaded.Entry.Id, position+1),
+					MessageID:   loaded.Entry.Id,
 					Filename:    attachment.Filename,
 					ContentType: attachment.ContentType,
 					ByteSize:    attachment.ByteSize,
 					URL:         attachment.URL,
 				})
 			}
+			imageURLs = append(imageURLs, extractImageURLs(loaded.Message.Content)...)
+			// The loader's copy is released once the entry has what it shows.
+			thread.Entries[i].Message = nil
 		}
 
 		var images [][]byte
 		if v.vc.imageRenderer.protocol() == imageProtocolKitty && v.vc.imageFetcher != nil {
-			for _, entry := range entries {
-				for _, imageURL := range extractImageURLs(entry.BodyHTML) {
-					data, fetchErr := v.vc.imageFetcher.Fetch(ctx, imageURL)
-					if fetchErr == nil && len(data) > 0 {
-						images = append(images, data)
-					}
-				}
-			}
+			images = newImageBudget().fetchImages(ctx, v.vc.imageFetcher, imageURLs)
 		}
 
 		return topicLoadedMsg{
@@ -2033,6 +2026,7 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 			entries:     entries,
 			attachments: attachments,
 			images:      images,
+			notice:      thread.Notice(tuiThreadLimits),
 		}
 	}
 }
@@ -2061,8 +2055,11 @@ func (v *mailView) renderEntries(entries []mail.Entry) string {
 		if e.Summary != "" {
 			fmt.Fprintf(&b, "%s\n", terminal.SanitizeLine(e.Summary))
 		}
-		if !e.Body.IsEmpty() {
+		switch {
+		case !e.Body.IsEmpty():
 			fmt.Fprintf(&b, "\n%s\n", v.vc.styles.entryBody.Render(markdown.Render(e.Body, sepWidth)))
+		case e.BodyState == string(threadload.StateOverLimit), e.BodyState == string(threadload.StateFailed):
+			fmt.Fprintf(&b, "\n%s\n", v.vc.styles.entryDate.Render("(body not read: "+e.BodyState+")"))
 		}
 		entryAttachments := attachmentsForMessage(v.attachments, e.ID)
 		if panel := renderAttachmentPanel(entryAttachments, selectedAttachmentForMessage(v.attachments, v.attachmentCursor, e.ID)); panel != "" {

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -113,8 +113,8 @@ func mailWithTestServer(t *testing.T, status int) (*mailView, *recordedMailReque
 		switch r.URL.Path {
 		case "/advanced_search.json":
 			_, _ = w.Write([]byte(`{"matches":[{"topic":{"id":100,"name":"Hello world","app_url":"https://app.hey.com/topics/100","updated_at":"2026-08-19T09:00:00Z"},"posting_id":10,"entries":[{"id":501,"kind":"message","summary":"Matching message summary","created_at":"2026-08-19T09:00:00Z","creator":{"id":10,"name":"Alice"}}]}]}`))
-		case "/topics/100.json":
-			_, _ = w.Write([]byte(`{"id":100,"name":"Hello world","entries":[{"id":501,"kind":"message","summary":"Hello world","created_at":"2026-08-19T09:00:00Z","creator":{"id":10,"name":"Alice"}}]}`))
+		case "/topics/100/entries.json":
+			_, _ = w.Write([]byte(`[{"id":501,"kind":"message","summary":"Hello world","created_at":"2026-08-19T09:00:00Z","creator":{"id":10,"name":"Alice"}}]`))
 		case "/messages/501.json":
 			_, _ = w.Write([]byte(`{"id":501,"subject":"Hello world","content":"<p>Message body</p>","created_at":"2026-08-19T09:00:00Z","creator":{"id":10,"name":"Alice"}}`))
 		default:
@@ -1397,7 +1397,7 @@ func TestMailViewEnterOpensSelectedThread(t *testing.T) {
 	}
 	v.Update(loaded)
 
-	wantRequests := "GET /topics/100.json,GET /messages/501.json"
+	wantRequests := "GET /topics/100/entries.json,GET /messages/501.json"
 	if got := strings.Join(recorded.requests, ","); got != wantRequests {
 		t.Errorf("requests = %q, want %q", got, wantRequests)
 	}
@@ -1414,9 +1414,9 @@ func TestMailViewDownloadsImageDataOnlyForKittyRenderer(t *testing.T) {
 	imageData := testPNG(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/topics/100.json":
+		case "/topics/100/entries.json":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"id":100,"name":"Latest image","entries":[{"id":501,"kind":"message"}]}`))
+			_, _ = w.Write([]byte(`[{"id":501,"kind":"message"}]`))
 		case "/messages/501.json":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":501,"content":"<action-text-attachment url=\"/rails/blobs/chart.png\" filename=\"chart.png\" content-type=\"image/png\"></action-text-attachment>"}`))
@@ -1468,8 +1468,8 @@ func TestMailViewDoesNotFetchImagesOutsideHEYOrGopher(t *testing.T) {
 	heyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/topics/100.json":
-			_, _ = w.Write([]byte(`{"id":100,"name":"Untrusted image","entries":[{"id":501,"kind":"message"}]}`))
+		case "/topics/100/entries.json":
+			_, _ = w.Write([]byte(`[{"id":501,"kind":"message"}]`))
 		case "/messages/501.json":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":      501,
@@ -1515,12 +1515,13 @@ func TestMailViewFetchesThreadMessagesConcurrentlyInOrder(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path == "/topics/100.json" {
+		if r.URL.Path == "/topics/100/entries.json" {
+			// The index is served newest first, as HEY serves it.
 			entries := make([]map[string]any, entryCount)
 			for i := range entries {
-				entries[i] = map[string]any{"id": 501 + i, "kind": "message"}
+				entries[i] = map[string]any{"id": 501 + entryCount - 1 - i, "kind": "message"}
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": 100, "name": "Thread", "entries": entries})
+			_ = json.NewEncoder(w).Encode(entries)
 			return
 		}
 
@@ -1622,8 +1623,8 @@ func TestMailViewCancelPendingDetailStopsMessageRequests(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/topics/100.json":
-			_, _ = w.Write([]byte(`{"id":100,"name":"Hello world","entries":[{"id":501,"kind":"message"}]}`))
+		case "/topics/100/entries.json":
+			_, _ = w.Write([]byte(`[{"id":501,"kind":"message"}]`))
 		case "/messages/501.json":
 			close(messageStarted)
 			<-r.Context().Done()
@@ -2684,5 +2685,54 @@ func TestThreadEntriesCarryTheTimeOfDay(t *testing.T) {
 	}
 	if formatDisplayDateTime(entries[0].CreatedAt) == formatDisplayDateTime(entries[1].CreatedAt) {
 		t.Error("two entries on the same day rendered identically, so the reader cannot order them")
+	}
+}
+
+// A thread longer than one geared page is read whole in the TUI, oldest first, through
+// the same loader the CLI uses; a body that could not be read is marked, not faked.
+func TestMailViewReadsEveryPageOfAThreadAndMarksUnreadBodies(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/topics/100/entries.json" && r.URL.Query().Get("page") == "":
+			w.Header().Set("Link", fmt.Sprintf(`<http://%s/topics/100/entries.json?page=eyJwYWdlIjoy>; rel="next"`, r.Host))
+			_, _ = w.Write([]byte(`[{"id":503,"kind":"message","summary":"third"},{"id":502,"kind":"message","summary":"second"}]`))
+		case r.URL.Path == "/topics/100/entries.json":
+			_, _ = w.Write([]byte(`[{"id":501,"kind":"message","summary":"first"}]`))
+		case r.URL.Path == "/messages/502.json":
+			http.Error(w, `{"error":"gone"}`, http.StatusNotFound)
+		case strings.HasPrefix(r.URL.Path, "/messages/"):
+			id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/messages/"), ".json")
+			fmt.Fprintf(w, `{"id":%s,"content":"<p>body %s</p>"}`, id, id)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "test-token"}, hey.WithMaxRetries(0))
+	vc := testVC()
+	vc.sdk = client
+	v := newMailView(vc)
+	loaded := v.fetchTopic(context.Background(), 1, 1, 100, 500, "Long thread")().(topicLoadedMsg)
+	if loaded.err != nil {
+		t.Fatalf("fetch topic: %v", loaded.err)
+	}
+	if len(loaded.entries) != 3 || loaded.entries[0].ID != 501 || loaded.entries[2].ID != 503 {
+		t.Fatalf("entries = %+v, want three, oldest first", loaded.entries)
+	}
+	if loaded.entries[1].BodyState != "failed" || !loaded.entries[1].Body.IsEmpty() {
+		t.Errorf("entry 502 = %+v, want failed with no body", loaded.entries[1])
+	}
+	if !strings.Contains(loaded.notice, "1 of 3 bodies could not be read") {
+		t.Errorf("notice = %q", loaded.notice)
+	}
+
+	view := v.renderEntries(loaded.entries)
+	if !strings.Contains(view, "body 501") || !strings.Contains(view, "body 503") {
+		t.Errorf("view lacks the read bodies: %q", view)
+	}
+	if !strings.Contains(view, "(body not read: failed)") {
+		t.Errorf("view does not mark the unread body: %q", view)
 	}
 }

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -319,6 +319,48 @@ func TestMailViewMarksOpenedThreadSeen(t *testing.T) {
 	}
 }
 
+// A thread read only in part keeps saying so for as long as it is open — the notice is
+// thread state, not the one-shot kind a key press clears — and opening it does not mark
+// it seen: the reader has not had all of it, and seen would put it under the cover.
+func TestMailViewKeepsAPartialThreadsNoticeAndLeavesItUnseen(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.requests.loading = true
+	v.requests.kind = mailRequestTopic
+
+	cmd, _ := v.Update(topicLoadedMsg{
+		requestID: v.requests.id,
+		boxID:     1,
+		topicID:   100,
+		postingID: 100,
+		title:     "Hello world",
+		entries:   []mail.Entry{{ID: 501, Creator: mail.Contact{Name: "Alice"}, BodyState: "failed"}},
+		notice:    "1 of 1 bodies could not be read (failed)",
+		complete:  false,
+	})
+	if msg := runCmd(cmd); msg != nil {
+		t.Fatalf("opening a partial thread sent %#v, want no mark seen", msg)
+	}
+	if recorded.method != "" {
+		t.Errorf("request = %s %s, want none", recorded.method, recorded.path)
+	}
+	if v.postingList.postings[v.postingIndex(100)].Seen {
+		t.Error("a partial thread should stay unseen")
+	}
+	if !strings.Contains(v.View(), "1 of 1 bodies could not be read") {
+		t.Errorf("view lacks the notice: %q", v.View())
+	}
+
+	v.HandleContentKey(keyPress("j"))
+	if !strings.Contains(v.View(), "1 of 1 bodies could not be read") {
+		t.Errorf("a key press dismissed the partial-thread notice: %q", v.View())
+	}
+
+	v.ExitThread()
+	if v.inThread || v.threadNotice != "" {
+		t.Errorf("leaving the thread left inThread=%v notice=%q", v.inThread, v.threadNotice)
+	}
+}
+
 func TestMailViewLeavesBubbledUpThreadAloneWhenOpened(t *testing.T) {
 	v, recorded := mailWithTestServer(t, http.StatusNoContent)
 	v.postingList.postings[0].BubbledUp = true

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -371,6 +371,14 @@ func TestMailViewKeepsAPartialThreadsNoticeAndLeavesItUnseen(t *testing.T) {
 		t.Errorf("thread view draws %d rows in 20 with no notice", rows)
 	}
 	v.threadNotice = "1 of 1 bodies could not be read (failed)"
+	v.notice = "Saved attachment to agenda.pdf"
+	for _, height := range []int{1, 2, 3} {
+		v.Resize(80, height)
+		if rows := strings.Count(v.View(), "\n") + 1; rows != height {
+			t.Errorf("thread view draws %d rows in %d with two notices: a notice gives way, the thread keeps a row", rows, height)
+		}
+	}
+	v.notice = ""
 
 	v.ExitThread()
 	if v.inThread || v.threadNotice != "" {

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -355,6 +355,23 @@ func TestMailViewKeepsAPartialThreadsNoticeAndLeavesItUnseen(t *testing.T) {
 		t.Errorf("a key press dismissed the partial-thread notice: %q", v.View())
 	}
 
+	// The notice takes a row the viewport gives up, so the section draws the rows it
+	// has and no more, whatever the notices do.
+	v.Resize(80, 20)
+	if rows := strings.Count(v.View(), "\n") + 1; rows != 20 {
+		t.Errorf("thread view draws %d rows in 20, notice included", rows)
+	}
+	v.notice = "Saved attachment to agenda.pdf"
+	if rows := strings.Count(v.View(), "\n") + 1; rows != 20 {
+		t.Errorf("thread view draws %d rows in 20 with two notices", rows)
+	}
+	v.notice = ""
+	v.threadNotice = ""
+	if rows := strings.Count(v.View(), "\n") + 1; rows != 20 {
+		t.Errorf("thread view draws %d rows in 20 with no notice", rows)
+	}
+	v.threadNotice = "1 of 1 bodies could not be read (failed)"
+
 	v.ExitThread()
 	if v.inThread || v.threadNotice != "" {
 		t.Errorf("leaving the thread left inThread=%v notice=%q", v.inThread, v.threadNotice)


### PR DESCRIPTION
Closes #246. Stacked on #258 (`safe-markdown`).

- `mailView.fetchTopic` reads through `internal/threadload` — every page, oldest first, at the TUI's concurrency (6) — via `threadload.NewSDKSource`, which moved into `threadload` together with `Thread.Notice(limits)` so the CLI and the TUI share the adapter and the wording. Unread bodies render as `(body not read: over_limit|failed)`; a partial read sets the view's notice rather than refusing (the reader is looking at it). `mail.Entry` gains `BodyState`; `mail.LoadedEntry` builds an entry from a loaded one.
- `imageBudget` (`internal/tui/image_budget.go`) bounds the inline-image fetch for a thread or a journal page: ≤ 24 requests (charged when made, whatever they answer; a URL the fetcher refuses on sight is not a request), ≤ 48 MiB kept in all (each fetch is told what is left and stops the transfer there), a 20 s deadline owned by the budget, each URL once, relative URLs only on a clean path under `/rails/` (HEY's blob paths — `/rails/../admin/x.png` is refused as the path it resolves to); the fetcher's per-image origin/bytes/pixel/content-type bounds still apply. Tests cover count, charged failures, bytes and allowances, de-dup, path allowlist, deadline, cancellation.
- A partial read's notice is thread state (`mailView.threadNotice`), shown for as long as the thread is open rather than cleared by the next key; and a partial thread is not marked seen by being opened — the seen key still works on it. The notices take rows the viewport gives up, so the section never draws more rows than it has.
- Not done here: lazy loading as the viewport reaches an image, split out as #262. The fetch is already a separate step that can become its own message.
- The CLI's `ErrResponseTooLarge` now wraps `threadload.ErrOverLimit`, so the SDK adapter recognises a too-large message wherever the error chain survives.

