### PR TITLE
Frame a thread's --html output as an HTML document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,22 @@ links keep their URLs and headings, lists, quotes, tables and code survive.
 `Entry.BodyHTML` keeps the original HTML for `--html` and for
 `ExtractImageURLs`/`ExtractAttachments`, which need the attributes the Markdown drops.
 
+`--html` is the one format that writes that HTML out, and it has two shapes. A thread
+(`writeThreadHTML` in `internal/cmd/topic.go`) is an HTML5 document: `<!doctype html>`,
+`<meta charset="utf-8">`, `<title>Thread N</title>`, then one
+`<article id="entry-ID" data-entry-id data-created-at data-body-state>` per entry, oldest
+first, with a `<header>` naming the sender and date (sanitized, then HTML-escaped) and the
+entry's HTML verbatim — or nothing, with `data-body-state` saying why (`bodyless`,
+`over_limit`, `failed`, or `hydrated` and empty). A partial thread needs `--allow-partial`
+as everywhere else and then ends with `<!-- notice: … -->` before `</body>`
+(`htmlCommentSafe` keeps a value from closing the comment), with the notice on stderr too.
+A single body — `journal read`, `contacts show`, `contacts note show` (`writeNoteHTML`) —
+is a fragment: the body as HEY served it, nothing for an empty one. The difference is
+deliberate: a thread has entries to frame; one body gets pasted into something else.
+`--stats` is refused with `--html` like every other selector, since there is no envelope to
+carry stats. `writeThreadHTML` is exempt in the sink manifest because writing the body raw
+*is* the format, and `validateHTMLFlag` keeps it off a terminal.
+
 `internal/markdown` renders that Markdown for a terminal: `Render(md, width)` wraps
 glamour, and `LinkifyURLs` wraps bare URLs in OSC 8 so they stay clickable. The style in
 `style.go` uses ANSI color slots rather than glamour's fixed palettes, for the same reason

--- a/README.md
+++ b/README.md
@@ -270,10 +270,26 @@ pipeable.
 
 `--html` writes the original HTML, for the commands that hold some: `hey threads`,
 `hey journal read`, `hey contacts show` and `hey contacts note show`. It is a format of
-its own — it cannot be combined with the other output flags, every other command refuses
-it, and it is meant for a file or a pipe: on a terminal it is refused with the redirect
-spelled out, since markup on a terminal is neither readable nor safe. A thread writes each
-entry's HTML, oldest first, behind a comment naming the entry, its sender and its date.
+its own — it cannot be combined with the other output flags (`--stats` included: there is
+no envelope to carry stats), every other command refuses it, and it is meant for a file or
+a pipe: on a terminal it is refused with the redirect spelled out, since markup on a
+terminal is neither readable nor safe.
+
+A thread is written as one HTML5 document, so a downstream tool can parse it rather than
+split it: `<!doctype html>`, `<html lang="en">`, a `<head>` with `<meta charset="utf-8">`
+and `<title>Thread N</title>`, then in `<body>` one
+`<article id="entry-ID" data-entry-id="ID" data-created-at="…" data-body-state="…">` per
+entry, oldest first. Each article opens with a `<header>` naming the sender and the date
+(HTML-escaped) and then holds the entry's HTML exactly as HEY served it. An entry without
+a body holds only its header, and `data-body-state` says why — `bodyless` when HEY served
+none, `over_limit` or `failed` when the load left it unread, `hydrated` when it was read
+and was empty. A thread that could only be read in part is refused as for every other
+format; with `--allow-partial` the document ends with the notice in an HTML comment
+(`<!-- notice: … -->`) just before `</body>`, and the notice goes to stderr as well.
+
+A single body — a journal entry, a contact's note — is written as a fragment instead: the
+HTML as HEY served it, nothing for an empty one. A thread has entries to frame; one body
+is what gets pasted into something else.
 
 ### Email
 

--- a/internal/cmd/html_linux_test.go
+++ b/internal/cmd/html_linux_test.go
@@ -94,7 +94,7 @@ func TestHTMLWritesToARealPipe(t *testing.T) {
 	if runErr != nil {
 		t.Fatalf("unexpected error: %v", runErr)
 	}
-	if !strings.Contains(out.String(), "<p>piped</p>") {
-		t.Errorf("pipe carried %q, want the HTML", out.String())
+	if !strings.HasPrefix(out.String(), "<!doctype html>\n") || !strings.Contains(out.String(), "<p>piped</p>") {
+		t.Errorf("pipe carried %q, want the HTML document", out.String())
 	}
 }

--- a/internal/cmd/html_test.go
+++ b/internal/cmd/html_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/threadload"
 )
 
 // runCLIRaw drives the root command against a test server with exactly the arguments
@@ -47,8 +48,10 @@ func usageMessage(t *testing.T, err error) string {
 	return apiErr.Message
 }
 
-// --html writes the original HTML of a thread to a pipe: each entry's markup, oldest
-// first, introduced by a comment naming the entry.
+// --html writes a thread to a pipe as one HTML document: a head declaring the charset and
+// naming the thread, then an <article> per entry, oldest first, holding the entry's
+// original markup after a header naming the sender and the date. An entry without a
+// body holds only its header, and says why in data-body-state.
 func TestThreadsHTMLWritesEachEntryToAPipe(t *testing.T) {
 	server, _ := threadEntriesServer(t,
 		[][]int64{{12, 11}},
@@ -62,13 +65,90 @@ func TestThreadsHTMLWritesEachEntryToAPipe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v (stderr %q)", err, stderr)
 	}
-	want := "<!-- hey entry 11 from Rick Sanchez at 2026-04-12T09:30 -->\n<div>the first <b>word</b></div>\n" +
-		"\n<!-- hey entry 12 from Rick Sanchez at 2026-04-13T09:30 -->\n<!-- no body: bodyless -->\n"
+	want := "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Thread 7</title>\n</head>\n<body>\n" +
+		"<article id=\"entry-11\" data-entry-id=\"11\" data-created-at=\"2026-04-12T09:30\" data-body-state=\"hydrated\">\n" +
+		"<header>From: Rick Sanchez — 2026-04-12T09:30</header>\n" +
+		"<div>the first <b>word</b></div>\n" +
+		"</article>\n" +
+		"<article id=\"entry-12\" data-entry-id=\"12\" data-created-at=\"2026-04-13T09:30\" data-body-state=\"bodyless\">\n" +
+		"<header>From: Rick Sanchez — 2026-04-13T09:30</header>\n" +
+		"</article>\n" +
+		"</body>\n</html>\n"
 	if stdout != want {
 		t.Errorf("stdout =\n%q\nwant\n%q", stdout, want)
 	}
 	if stderr != "" {
 		t.Errorf("stderr = %q, want nothing", stderr)
+	}
+}
+
+// The sender is whatever the entry says it is, so it is escaped wherever it lands —
+// text and attribute alike — and stripped of controls first; the body is HEY's HTML and
+// is written as it came, markup and all, since that is what --html is for.
+func TestThreadsHTMLEscapesTheSenderAndKeepsTheBodyVerbatim(t *testing.T) {
+	var out bytes.Buffer
+	entries := []threadEntry{{
+		ID:                    11,
+		CreatedAt:             "2026-04-12T09:30",
+		BodyState:             "hydrated",
+		AlternativeSenderName: "Rick <b>\"Pickle\"</b> \x1b[31m& Co",
+		BodyHTML:              `<div onclick="x()">the <b>word</b> &amp; more</div>`,
+	}}
+	if err := writeThreadHTML(&out, 7, entries, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantHeader := "<header>From: Rick &lt;b&gt;&#34;Pickle&#34;&lt;/b&gt; &amp; Co — 2026-04-12T09:30</header>\n"
+	if !strings.Contains(out.String(), wantHeader) {
+		t.Errorf("document =\n%s\nwant the header %q", out.String(), wantHeader)
+	}
+	if !strings.Contains(out.String(), "\n"+`<div onclick="x()">the <b>word</b> &amp; more</div>`+"\n</article>\n") {
+		t.Errorf("document =\n%s\nwant the body verbatim", out.String())
+	}
+}
+
+// A thread read in part ends its document with the notice in a comment, and says it on
+// stderr too; without --allow-partial the refusal is the same as for every other format.
+func TestThreadsHTMLCarriesThePartialNoticeInAComment(t *testing.T) {
+	limits := threadload.DefaultLimits
+	limits.MaxPages = 1
+	withThreadLimits(t, limits)
+	stdoutTerminal(t, false)
+
+	server, _ := partialThreadServer(t, [][]int64{{13, 12}, {11}})
+	stdout, stderr, err := runCLIRaw(t, server, "threads", "7", "--html", "--allow-partial")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantEnd := "</article>\n<!-- notice: only the newest 2 entries were read; older ones exist, beyond the 1-page limit -->\n</body>\n</html>\n"
+	if !strings.HasSuffix(stdout, wantEnd) {
+		t.Errorf("stdout =\n%q\nwant it to end with the notice comment before </body>:\n%q", stdout, wantEnd)
+	}
+	if strings.Count(stdout, "<article ") != 2 {
+		t.Errorf("stdout = %q, want the two entries that were read", stdout)
+	}
+	if !strings.Contains(stderr, "notice: only the newest 2 entries were read") {
+		t.Errorf("stderr = %q, want the notice", stderr)
+	}
+
+	server, _ = partialThreadServer(t, [][]int64{{13, 12}, {11}})
+	stdout, _, err = runCLIRaw(t, server, "threads", "7", "--html")
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) || !strings.Contains(apiErr.Message, "read only in part") || !strings.Contains(apiErr.Hint, "--allow-partial") {
+		t.Errorf("error = %v, want the partial-thread refusal naming --allow-partial", err)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want nothing for a refused thread", stdout)
+	}
+}
+
+// A notice cannot end the comment it is written in.
+func TestThreadsHTMLNoticeCannotEndItsComment(t *testing.T) {
+	var out bytes.Buffer
+	if err := writeThreadHTML(&out, 7, nil, "limit --> reached"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "<!-- notice: limit - -> reached -->\n</body>") {
+		t.Errorf("document = %q", out.String())
 	}
 }
 
@@ -127,12 +207,14 @@ func TestHTMLIsRefusedByOtherCommandsBeforeAnythingElse(t *testing.T) {
 	}
 }
 
-func TestHTMLCommentsCannotBeEndedByASender(t *testing.T) {
+func TestHTMLCommentsCannotBeEndedByWhatTheyHold(t *testing.T) {
 	if got := htmlCommentSafe("Rick --> <script>\x1b[31m"); got != "Rick - -> <script>" {
 		t.Errorf("htmlCommentSafe = %q", got)
 	}
 }
 
+// A single body — a contact's note, a journal entry — is a fragment, not a document:
+// the HTML as HEY served it, and nothing at all when there is none.
 func TestNoteHTMLWritesNothingForAnEmptyNote(t *testing.T) {
 	var out bytes.Buffer
 	if err := writeNoteHTML(&out, ""); err != nil || out.Len() != 0 {
@@ -148,7 +230,7 @@ type failingWriter struct{}
 func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("disk full") }
 
 func TestThreadHTMLReportsAWriteError(t *testing.T) {
-	err := writeThreadHTML(failingWriter{}, []threadEntry{{ID: 1, BodyHTML: "<p>x</p>"}})
+	err := writeThreadHTML(failingWriter{}, 7, []threadEntry{{ID: 1, BodyHTML: "<p>x</p>"}}, "")
 	if err == nil || !strings.Contains(err.Error(), "disk full") {
 		t.Errorf("error = %v, want the write failure", err)
 	}

--- a/internal/cmd/testdata/sink_manifest.txt
+++ b/internal/cmd/testdata/sink_manifest.txt
@@ -62,3 +62,4 @@ exempt internal/cmd/setup.go:showWizardSuccess check names and statuses are this
 exempt internal/cmd/upgrade_selfupdate.go:extractTarGzMember archive member names come from a release whose signature was verified first
 exempt internal/cmd/upgrade_selfupdate.go:extractZipMember archive member names come from a release whose signature was verified first
 exempt internal/cmd/topic.go:writeThreadMarkdown the body it writes is the Markdown ToMarkdown produced, which carries no control characters, and the document is Markdown for a reader rather than a terminal
+exempt internal/cmd/topic.go:writeThreadHTML the body is HEY's HTML written as HEY served it — that is the --html format — to a file or a pipe and never a terminal (validateHTMLFlag refuses one); the sender is SanitizeLine'd and HTML-escaped before it is written

--- a/internal/cmd/topic.go
+++ b/internal/cmd/topic.go
@@ -55,7 +55,7 @@ func newThreadsCommand() *topicCommand {
 		Use:   "threads <id>",
 		Short: "Read a thread",
 		Annotations: map[string]string{
-			"agent_notes": "Returns a thread with all entries, oldest first. Entry bodies are Markdown; --html returns HEY's original HTML instead. A thread that could only be read in part is refused unless --allow-partial is passed, in which case each entry's body_state says what was read. Use the topic ID with hey reply or hey forward.",
+			"agent_notes": "Returns a thread with all entries, oldest first. Entry bodies are Markdown; --html writes an HTML document instead, one <article> per entry (data-entry-id, data-created-at, data-body-state) holding HEY's original HTML. A thread that could only be read in part is refused unless --allow-partial is passed, in which case each entry's body_state says what was read. Use the topic ID with hey reply or hey forward.",
 		},
 		Example: `  hey threads 12345
   hey threads 12345 --json
@@ -95,16 +95,17 @@ func (c *topicCommand) run(cmd *cobra.Command, args []string) error {
 	}
 	entries := threadEntries(thread, format == output.FormatHTML)
 
-	// The envelope carries the notice, the styled view and the Markdown document
-	// print it; every other format — a count, IDs, --quiet, --html — gets it on stderr,
-	// so what is missing is said wherever the output cannot say it.
+	// The envelope carries the notice, the styled view, the Markdown document and the
+	// HTML document print it; every other format — a count, IDs, --quiet — gets it on
+	// stderr, so what is missing is said wherever the output cannot say it. --html gets
+	// it on stderr as well: a comment in a file nobody opens is not a warning.
 	if stderrNotice := paginationNoticeForStderr(format, notice); stderrNotice != "" && format != output.FormatMarkdown {
 		fmt.Fprintln(cmd.ErrOrStderr(), stderrNotice)
 	}
 
 	switch format {
 	case output.FormatHTML:
-		return writeThreadHTML(cmd.OutOrStdout(), entries)
+		return writeThreadHTML(cmd.OutOrStdout(), threadID, entries, notice)
 	case output.FormatStyled:
 		printThreadStyled(cmd.OutOrStdout(), entries, notice)
 		return nil
@@ -215,28 +216,63 @@ func writeThreadMarkdown(w io.Writer, threadID int64, entries []threadEntry, not
 	return nil
 }
 
-// writeThreadHTML is what --html writes for a thread: each entry's original HTML, oldest
-// first, each introduced by a comment naming the entry, its sender and its date, with a
-// blank line between entries. An entry without a body says why in its comment. A write
-// that fails is the command's error.
-func writeThreadHTML(w io.Writer, entries []threadEntry) error {
-	for i, e := range entries {
-		if i > 0 {
-			if _, err := io.WriteString(w, "\n"); err != nil {
+// writeThreadHTML is what --html writes for a thread: one HTML5 document, parseable by
+// anything that reads HTML, titled after the thread and declaring its charset, with one
+// <article> per entry, oldest first. The article carries the entry's ID, date and body
+// state as data attributes, opens with a <header> naming the sender and the date, and
+// then holds the entry's original HTML exactly as HEY served it — the whole point of the
+// format. An entry without a body holds nothing after its header; data-body-state says
+// whether HEY served none (bodyless), the load left it unread (over_limit, failed) or it
+// was read and was empty (hydrated). A thread read in part, which --allow-partial lets
+// through as it does for every other format, ends with the notice in a comment before
+// </body>, alongside the copy on stderr.
+//
+// A thread is a document because it has entries to frame; the single-body reads —
+// journal read, contacts show, contacts note show — write a fragment instead (see
+// writeNoteHTML), one body as HEY served it and nothing for an empty one, because one
+// body is what gets pasted into something else. --stats is refused with --html like every
+// other selector: there is no envelope here to carry stats.
+//
+// The sender is whatever the entry says it is, so it is sanitized and HTML-escaped before
+// it is written as text or as an attribute; the date and state are this program's own
+// and are escaped all the same. A write that fails is the command's error: a document
+// cut short by a full disk must not exit 0.
+func writeThreadHTML(w io.Writer, threadID int64, entries []threadEntry, notice string) error {
+	write := func(s string) error {
+		if _, err := io.WriteString(w, s); err != nil {
+			return fmt.Errorf("write thread HTML: %w", err)
+		}
+		return nil
+	}
+	if err := write(fmt.Sprintf("<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Thread %d</title>\n</head>\n<body>\n", threadID)); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		sender := html.EscapeString(terminal.SanitizeLine(threadEntrySender(e)))
+		createdAt := html.EscapeString(e.CreatedAt)
+		opening := fmt.Sprintf("<article id=\"entry-%d\" data-entry-id=\"%d\" data-created-at=\"%s\" data-body-state=\"%s\">\n<header>From: %s — %s</header>\n",
+			e.ID, e.ID, createdAt, html.EscapeString(e.BodyState), sender, createdAt)
+		if err := write(opening); err != nil {
+			return err
+		}
+		// The body is written straight from the entry, not through the closure, so the
+		// sink check sees the one raw write this format is made of and its exemption in
+		// the manifest says why.
+		if e.BodyHTML != "" {
+			if _, err := io.WriteString(w, e.BodyHTML+"\n"); err != nil {
 				return fmt.Errorf("write thread HTML: %w", err)
 			}
 		}
-		body := e.BodyHTML
-		if body == "" {
-			body = "<!-- no body: " + htmlCommentSafe(e.BodyState) + " -->"
-		}
-		_, err := fmt.Fprintf(w, "<!-- hey entry %d from %s at %s -->\n%s\n",
-			e.ID, html.EscapeString(htmlCommentSafe(threadEntrySender(e))), e.CreatedAt, body)
-		if err != nil {
-			return fmt.Errorf("write thread HTML: %w", err)
+		if err := write("</article>\n"); err != nil {
+			return err
 		}
 	}
-	return nil
+	if notice != "" {
+		if err := write("<!-- notice: " + htmlCommentSafe(notice) + " -->\n"); err != nil {
+			return err
+		}
+	}
+	return write("</body>\n</html>\n")
 }
 
 // htmlCommentSafe keeps a value from ending the comment it is written into.

--- a/internal/cmd/topic.go
+++ b/internal/cmd/topic.go
@@ -237,6 +237,14 @@ func writeThreadMarkdown(w io.Writer, threadID int64, entries []threadEntry, not
 // it is written as text or as an attribute; the date and state are this program's own
 // and are escaped all the same. A write that fails is the command's error: a document
 // cut short by a full disk must not exit 0.
+//
+// The body itself is written as HEY served it, which is the point of --html, so nothing
+// here keeps a body from carrying an </article> of its own. It cannot: a body is Trix
+// output, and article is not among the tags Trix keeps; an inbound email's markup
+// arrives attribute-escaped inside the figure's JSON (see htmlutil). Re-serializing
+// the body through a parser would hold the framing against HTML HEY does not serve, at
+// the price of the verbatim contract. A reader that needs each entry as its own value
+// has --json.
 func writeThreadHTML(w io.Writer, threadID int64, entries []threadEntry, notice string) error {
 	write := func(s string) error {
 		if _, err := io.WriteString(w, s); err != nil {

--- a/internal/output/writer.go
+++ b/internal/output/writer.go
@@ -29,8 +29,12 @@ const (
 	FormatCount
 	FormatMarkdown
 	// FormatHTML is the raw writer behind --html: the original HTML of the one thing a
-	// command reads, written to a pipe or a file. It carries no envelope, so OK refuses
-	// it; the commands that support it write the HTML themselves.
+	// command reads, written to a pipe or a file. A thread is written as an HTML document
+	// with an <article> per entry, since it has entries to frame; a single body — a
+	// journal entry, a contact's note — is written as a fragment, as HEY served it, since
+	// one body is what gets pasted elsewhere. It carries no envelope, so OK refuses it
+	// and --stats has nowhere to go; the commands that support it write the HTML
+	// themselves.
 	FormatHTML
 )
 

--- a/tests/smoke/threads_test.go
+++ b/tests/smoke/threads_test.go
@@ -216,8 +216,11 @@ func TestThreadsFormats(t *testing.T) {
 
 	t.Run("html to a pipe", func(t *testing.T) {
 		out := heyOK(t, "threads", topicID, "--html")
-		if strings.Count(out, "<!-- hey entry ") != entries {
-			t.Errorf("--html = %q, want a comment per entry", out)
+		if !strings.HasPrefix(out, "<!doctype html>\n") || !strings.Contains(out, `<meta charset="utf-8">`) || !strings.HasSuffix(out, "</body>\n</html>\n") {
+			t.Errorf("--html = %q, want an HTML document declaring its charset", out)
+		}
+		if strings.Count(out, "<article ") != entries {
+			t.Errorf("--html = %q, want an <article> per entry", out)
 		}
 		if !strings.Contains(out, "<div") && !strings.Contains(out, "<p") {
 			t.Errorf("--html = %q, want HEY's HTML", out)


### PR DESCRIPTION
Closes #247

`--html` wrote a thread as a run of bodies behind `<!-- hey entry … -->` comments — a minimum, not a format. This completes the matrix that issue collects.

## A thread is an HTML5 document

```html
<!doctype html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Thread 12345</title>
</head>
<body>
<article id="entry-11" data-entry-id="11" data-created-at="2026-04-12T09:30" data-body-state="hydrated">
<header>From: Rick Sanchez — 2026-04-12T09:30</header>
<div>the first <b>word</b></div>
</article>
<article id="entry-12" data-entry-id="12" data-created-at="2026-04-13T09:30" data-body-state="bodyless">
<header>From: Rick Sanchez — 2026-04-13T09:30</header>
</article>
<!-- notice: only the newest 2 entries were read; older ones exist, beyond the 1-page limit -->
</body>
</html>
```

- One `<article>` per entry, oldest first; `data-body-state` is `hydrated`, `bodyless`, `over_limit` or `failed`.
- The `<header>` carries the sender (`terminal.SanitizeLine`, then `html.EscapeString`) and the date; the body is HEY's HTML verbatim, or nothing when there is none.
- A partial thread is refused without `--allow-partial` exactly as for every other format; with it the notice lands in a comment before `</body>` (`htmlCommentSafe` keeps it from closing the comment) and on stderr as before.
- Write errors are still the command's error.

## What stays as it was, now documented

- `journal read --html`, `contacts show --html`, `contacts note show --html` write a **fragment**: one body as HEY served it, nothing for an empty one. A thread has entries to frame; a note is one body you paste elsewhere.
- `--stats` with `--html` stays rejected: there is no envelope to carry stats.

## Sink check

`writeThreadHTML` writes `e.BodyHTML` straight from the entry so `TestSinksAreSanitized` sees the one raw write this format is made of; the exemption in `testdata/sink_manifest.txt` says why it is safe (a file or a pipe, never a terminal — `validateHTMLFlag` refuses one). Verified the check fails without the line.

## Touched

`internal/cmd/topic.go`, `internal/output/writer.go` (FormatHTML comment), `internal/cmd/html_test.go`, `html_linux_test.go`, `testdata/sink_manifest.txt`, `tests/smoke/threads_test.go` (counts `<article`, asserts doctype/charset), README, AGENTS.md, the `agent_notes` on `hey threads`.

`go build`, `go test ./internal/cmd ./internal/output`, smoke `go vet`, `golangci-lint` (0 issues), `gofmt -l`, `make check-surface` all green; no surface change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Frames a thread’s `--html` output as a single HTML5 document so downstream tools can parse it. Previously it streamed entry bodies behind HTML comments; now it emits one document with an `<article>` per entry, preserving HEY HTML verbatim and escaping/sanitizing sender text.

- Document shape: `<!doctype html>`, `<html lang="en">`, `<meta charset="utf-8">`, `<title>Thread N</title>`, then `<article id="entry-ID" data-entry-id data-created-at data-body-state>` per entry (oldest first) with a `<header>` naming the sender and date. Entry bodies are written exactly as served; sender text and all attributes are escaped. `data-body-state` is `hydrated`, `bodyless`, `over_limit`, or `failed`.
- Partial threads: refused without `--allow-partial`. With it, append `<!-- notice: … -->` before `</body>` and also write the notice to stderr.
- Other commands: `journal read`, `contacts show`, and `contacts note show` still write a fragment (single body only). `--stats` with `--html` stays rejected.
- Safety/IO: `--html` is refused on a terminal; write errors propagate. `writeThreadHTML` performs one raw body write by design (sink manifest exemption). Framing trusts HEY’s HTML to stay inside `<article>`: Trix doesn’t keep an `<article>` tag, and inbound email markup is attribute‑escaped; re-serializing would break the verbatim contract.

**Migration**
- If you parsed the old comment-delimited output, switch to parsing the HTML document. Select entries via `<article>` and its `data-entry-id`, `data-created-at`, and `data-body-state` attributes. No change for single-body `--html` outputs.

<sup>Written for commit 4367973bcfba1716cbff3f46906ae525e3eaec69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

