### PR TITLE
Align TUI mail shortcuts with the HEY web app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,7 +489,7 @@ cover can never be scrolled past, and `coverView` then gives the art every row t
 above it did not use. A list too short for even the floor keeps the divider and skips the
 art — the hint is worth more than a smear.
 
-`v` lifts the cover (`coverPeeked`) and puts it back; the divider carries the hint and the
+`x` lifts the cover (`coverPeeked`) and puts it back; the divider carries the hint and the
 hidden count, where the web app puts its buttons. Setting a cover closes it, so a box
 arrives covered rather than however the last one was left. Only the Imbox is coverable —
 that is haystack's rule (`Box::Imbox#coverable?`), and it is the same box that gets the

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -30,16 +30,16 @@ since `Topics().Get` already carries the entry list.
 | `/bubblebox.json` | GET | SDK `Boxes().GetBubblebox` | `hey box bubblebox` | covered |
 | `/my/navigation.json` | GET | SDK `Identity().GetNavigation` | `hey labels`, Mail TUI navigation | covered |
 | `/folders/{id}.json` | GET | SDK `Folders().GetPage` | `hey label <id>`, Mail TUI labels | covered |
-| `/postings/filings.json` | POST | SDK `Postings().File` | `hey label add`, TUI `g` | covered |
-| `/postings/filings.json` | DELETE | SDK `Postings().Unfile` | `hey label remove`, TUI `g` | covered |
-| `/postings/folders.json` | POST | SDK `Postings().CreateFolder` | `hey label create`, TUI `g` | covered |
+| `/postings/filings.json` | POST | SDK `Postings().File` | `hey label add`, TUI `b/B` | covered |
+| `/postings/filings.json` | DELETE | SDK `Postings().Unfile` | `hey label remove`, TUI `b/B` | covered |
+| `/postings/folders.json` | POST | SDK `Postings().CreateFolder` | `hey label create`, TUI `b/B` | covered |
 | `/collections.json` | GET | SDK `Collections().List` | `hey collections`, Mail TUI navigation | covered |
 | `/collections/{id}.json` | GET | SDK `Collections().GetPage` | `hey collection <id>`, Mail TUI collections | covered |
 | `/collections` | POST | SDK `Collections().Create` | `hey collection create` | covered |
 | `/collections/{id}.json` | PATCH | SDK `Collections().Update` | `hey collection update` | covered |
-| `/topics/{id}/collecting` | POST | SDK `Collections().AddTopic` | `hey collection add`, TUI `k` | covered |
-| `/topics/{id}/collecting` | DELETE | SDK `Collections().RemoveTopic` | `hey collection remove`, TUI `k` | covered |
-| `/advanced_search.json` | GET | SDK `Search().Search`, `Search().SearchPage` | `hey search`, TUI `/` | covered |
+| `/topics/{id}/collecting` | POST | SDK `Collections().AddTopic` | `hey collection add`, TUI `n/N` | covered |
+| `/topics/{id}/collecting` | DELETE | SDK `Collections().RemoveTopic` | `hey collection remove`, TUI `n/N` | covered |
+| `/advanced_search.json` | GET | SDK `Search().Search`, `Search().SearchPage` | `hey search`, TUI `/` or `s/S` | covered |
 | `/advanced_search_filters.json` | GET | SDK `Search().Filters` | `hey search filters` | covered |
 | `/clearances.json` | GET | SDK `Clearances().Summary`, `Pending`, `PendingPage`, `PendingCount` | `hey screener list`, TUI ctrl+s | covered |
 | `/clearances/{id}` | PATCH | SDK `Clearances().Screen` | `hey screener approve`/`deny` (one ID), TUI `y`/`n` | covered |
@@ -73,15 +73,15 @@ since `Topics().Get` already carries the entry list.
 | `/entries/{id}/replies` | POST | SDK `Entries().CreateReply` | `hey reply <topic-id>` | covered |
 | `/topics/{id}.json` | GET | SDK `Topics().Get` | `hey forward <topic-id>`, `hey reply <topic-id>`, TUI `r` | covered |
 | `/entries/{id}/forwards/new.json` | GET | SDK `Entries().NewForward` | `hey forward <topic-id>` | covered |
-| `/bulk_replies/new.json` | GET | SDK `BulkReplies().Draft` | `hey bulk-reply preview`, `hey bulk-reply send`, TUI `b` | covered |
+| `/bulk_replies/new.json` | GET | SDK `BulkReplies().Draft` | `hey bulk-reply preview`, `hey bulk-reply send`, TUI `ctrl+b` | covered |
 | `/bulk_replies.json` | POST | SDK `BulkReplies().Send` | `hey bulk-reply send`, TUI bulk reply | covered |
-| `/bulk_replies/{id}/undo_send` | POST | SDK `BulkReplies().Undo` | `hey bulk-reply undo`, TUI `u` | covered |
-| `/bulk_replies/{id}` | GET (redirect target) | SDK `BulkReplies().Undo` redirect handling | `hey bulk-reply undo`, TUI `u` | covered |
-| `/postings/seen.json` | POST | SDK `Postings().MarkSeen` | `hey seen <id>`, TUI opening a thread | covered |
-| `/postings/unseen.json` | POST | SDK `Postings().MarkUnseen` | `hey unseen <id>` | covered |
-| `/postings/moves.json` | POST | SDK `Postings().Move`, `MoveToFeed`, `MoveToSetAside`, `MoveToReplyLater`, `MoveToPaperTrail` | `hey move <id> --to <box>`, TUI `m` | covered |
-| `/postings/trash.json` | POST | SDK `Postings().MoveToTrash` | `hey trash <id>`, TUI `t` | covered |
-| `/postings/spam.json` | POST | SDK `Postings().MarkSpam` | `hey spam <id>`, TUI `s` | covered |
+| `/bulk_replies/{id}/undo_send` | POST | SDK `BulkReplies().Undo` | `hey bulk-reply undo`, TUI `ctrl+u` | covered |
+| `/bulk_replies/{id}` | GET (redirect target) | SDK `BulkReplies().Undo` redirect handling | `hey bulk-reply undo`, TUI `ctrl+u` | covered |
+| `/postings/seen.json` | POST | SDK `Postings().MarkSeen` | `hey seen <id>`, TUI `e/E` and opening a thread | covered |
+| `/postings/unseen.json` | POST | SDK `Postings().MarkUnseen` | `hey unseen <id>`, TUI `u/U` | covered |
+| `/postings/moves.json` | POST | SDK `Postings().Move`, `MoveToFeed`, `MoveToSetAside`, `MoveToReplyLater`, `MoveToPaperTrail` | `hey move <id> --to <box>`, TUI `v/V` | covered |
+| `/postings/trash.json` | POST | SDK `Postings().MoveToTrash` | `hey trash <id>`, TUI `t/T` | covered |
+| `/postings/spam.json` | POST | SDK `Postings().MarkSpam` | `hey spam <id>`, TUI `!` | covered |
 | `/postings/mutings.json` | POST | SDK `Postings().Mute` | `hey ignore <id>`, TUI `-` | covered |
 | `/postings/mutings.json` | DELETE | SDK `Postings().Unmute` | `hey stop-ignoring <id>`, TUI `+` | covered |
 | `/calendar/habits.json` | POST | SDK `Habits().Create` | `hey habit create`, Calendar TUI `a` | covered |

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Accounts and individual email addresses.
 Switching cancels requests from the previous account and reloads the active section;
 Calendar and Journal remain identity-wide.
 
-Navigate between Mail, Contacts, Calendar, and Journal. Mail navigation includes HEY boxes plus separate Labels and Collections tabs. Press Shift+L or Shift+K to choose one. Every list keeps going: scroll towards the bottom of a box, label, or collection and the next threads are read in behind you, so there are no pages to step through. Use `/` to search, Enter to open a thread, `r` to reply, `f` to forward, `m` to move, `g` to manage labels, `k` to add or remove the selected thread from collections, `t` to trash, `s` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press `b` to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with `u` while HEY's undo window remains open. Search results retain the matching-message summary and keep going as you scroll, like every other list.
+Navigate between Mail, Contacts, Calendar, and Journal. Mail navigation includes HEY boxes plus separate Labels and Collections tabs; Shift+K opens Collections directly, while Labels remains available from the navigation row. Every list keeps going: scroll towards the bottom of a box, label, or collection and the next threads are read in behind you, so there are no pages to step through. The mail actions use HEY's web shortcuts in either letter case: `/` or `s` searches, `r` replies, `f` forwards, `v` moves, `b` manages labels, `n` adds or removes the selected thread from collections, `e` marks seen, `u` marks unseen, `i` moves to the Imbox, `l` moves to Reply Later, `a` moves to Set Aside, `d` moves to The Feed, `p` moves to Paper Trail, and `t` trashes. Press `!` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press Ctrl+B to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with Ctrl+U while HEY's undo window remains open. Search results retain the matching-message summary and keep going as you scroll, like every other list.
 
 The mail list follows the server. HEY tells the TUI when a box changed over the same
 Action Cable connection `hey watch` uses, and the box on screen is read again a moment
@@ -223,7 +223,7 @@ scroll, the same way the mail list does.
 The Imbox can wear cover art, the way the HEY web app does: everything you have already
 read goes under it, so the box ends at what still wants your attention instead of trailing
 off into a month of receipts. The divider stays and says how much is under there — press
-`v` to peek, `v` again to close it.
+`x` to peek, `x` again to close it.
 
 Press Ctrl+V to choose one: `blobs`, `grid`, `peace`, `terrazzo`, `topo` or `waves`, the
 same six covers redrawn as characters, so they work in any terminal rather than only the

--- a/internal/tui/bulk_reply_test.go
+++ b/internal/tui/bulk_reply_test.go
@@ -117,7 +117,7 @@ func selectTwoThreads(view *mailView) {
 
 func TestTUIBulkReplyRequiresExplicitSelection(t *testing.T) {
 	view, state := tuiBulkReplyServer(t)
-	if cmd := view.HandleContentKey(keyPress("b")); cmd != nil {
+	if cmd := view.HandleContentKey(keyPress("ctrl+b")); cmd != nil {
 		t.Fatal("bulk reply without a selection should not make a request")
 	}
 	if view.notice != "Select threads with space before starting a bulk reply" {
@@ -138,7 +138,7 @@ func TestTUIBulkReplySelectionAndPreviewShowExactRecipients(t *testing.T) {
 		t.Errorf("selected rows are not marked: %q", rendered)
 	}
 
-	msg := runCmd(view.HandleContentKey(keyPress("b")))
+	msg := runCmd(view.HandleContentKey(keyPress("ctrl+b")))
 	loaded, ok := msg.(bulkReplyDraftLoadedMsg)
 	if !ok || loaded.err != nil {
 		t.Fatalf("draft command returned %#v", msg)
@@ -213,7 +213,7 @@ func TestTUIBulkReplyPreviewReportsSkippedThreads(t *testing.T) {
 	view, state := tuiBulkReplyServer(t)
 	state.draft = `{"content":"","entries":[{"id":501,"topic_id":700,"topic_name":"Quarterly planning","addressed":{"directly":[{"id":31,"email_address":"jane@example.com"}]}}]}`
 	selectTwoThreads(view)
-	loaded := runCmd(view.HandleContentKey(keyPress("b"))).(bulkReplyDraftLoadedMsg)
+	loaded := runCmd(view.HandleContentKey(keyPress("ctrl+b"))).(bulkReplyDraftLoadedMsg)
 	view.Update(loaded)
 	if !strings.Contains(view.View(), "1 replyable thread · 1 skipped") {
 		t.Errorf("preview = %q", view.View())
@@ -223,7 +223,7 @@ func TestTUIBulkReplyPreviewReportsSkippedThreads(t *testing.T) {
 func TestTUIBulkReplyReviewsThenSendsAndOffersUndo(t *testing.T) {
 	view, state := tuiBulkReplyServer(t)
 	selectTwoThreads(view)
-	view.Update(runCmd(view.HandleContentKey(keyPress("b"))))
+	view.Update(runCmd(view.HandleContentKey(keyPress("ctrl+b"))))
 
 	if cmd := view.HandleContentKey(keyPress("enter")); cmd == nil {
 		t.Error("enter should focus the bulk reply editor")
@@ -244,10 +244,10 @@ func TestTUIBulkReplyReviewsThenSendsAndOffersUndo(t *testing.T) {
 	if bulkReplyModal(view) != nil || len(view.postingList.selectedIDs()) != 0 {
 		t.Error("successful send should close the form and clear selection")
 	}
-	if view.lastBulkReplyID != 900 || !strings.Contains(view.notice, "2 bulk replies queued with undo available") || !strings.Contains(view.notice, "press u to undo") {
+	if view.lastBulkReplyID != 900 || !strings.Contains(view.notice, "2 bulk replies queued with undo available") || !strings.Contains(view.notice, "press ctrl+u to undo") {
 		t.Errorf("delivery state = id:%d notice:%q", view.lastBulkReplyID, view.notice)
 	}
-	if !slices.ContainsFunc(view.HelpBindings(), func(b helpBinding) bool { return b.key == "u" }) {
+	if !slices.ContainsFunc(view.HelpBindings(), func(b helpBinding) bool { return b.key == "ctrl+u" }) {
 		t.Errorf("help does not offer undo: %v", view.HelpBindings())
 	}
 
@@ -283,7 +283,7 @@ func TestTUIBulkReplyEmptyDraftNeverSends(t *testing.T) {
 			state.draft = `{"content":"","entries":[]}`
 			state.draftStatus = test.status
 			selectTwoThreads(view)
-			loaded := runCmd(view.HandleContentKey(keyPress("b"))).(bulkReplyDraftLoadedMsg)
+			loaded := runCmd(view.HandleContentKey(keyPress("ctrl+b"))).(bulkReplyDraftLoadedMsg)
 			view.Update(loaded)
 			if bulkReplyModal(view) != nil || !strings.Contains(view.notice, "nothing was sent") {
 				t.Errorf("empty draft state = form:%v notice:%q", bulkReplyModal(view), view.notice)
@@ -299,7 +299,7 @@ func TestTUIBulkReplySendFailureKeepsEditor(t *testing.T) {
 	view, state := tuiBulkReplyServer(t)
 	state.sendStatus = http.StatusUnprocessableEntity
 	selectTwoThreads(view)
-	view.Update(runCmd(view.HandleContentKey(keyPress("b"))))
+	view.Update(runCmd(view.HandleContentKey(keyPress("ctrl+b"))))
 	view.HandleContentKey(keyPress("enter"))
 	typeText(view, "Thanks everyone")
 	sent := runCmd(view.HandleContentKey(ctrlS())).(bulkReplySentMsg)
@@ -316,7 +316,7 @@ func TestTUIBulkReplyImmediateDeliveryHasNoUndo(t *testing.T) {
 	view, state := tuiBulkReplyServer(t)
 	state.delivery = `{"id":901,"entries_count":2,"delayed":false}`
 	selectTwoThreads(view)
-	view.Update(runCmd(view.HandleContentKey(keyPress("b"))))
+	view.Update(runCmd(view.HandleContentKey(keyPress("ctrl+b"))))
 	view.HandleContentKey(keyPress("enter"))
 	typeText(view, "Thanks")
 	view.Update(runCmd(view.HandleContentKey(ctrlS())))
@@ -328,7 +328,7 @@ func TestTUIBulkReplyImmediateDeliveryHasNoUndo(t *testing.T) {
 func TestTUIBulkReplyUndoSuccessAndExpiry(t *testing.T) {
 	view, _ := tuiBulkReplyServer(t)
 	view.lastBulkReplyID = 900
-	undone, ok := runCmd(view.HandleContentKey(keyPress("u"))).(bulkReplyUndoneMsg)
+	undone, ok := runCmd(view.HandleContentKey(keyPress("ctrl+u"))).(bulkReplyUndoneMsg)
 	if !ok || undone.err != nil {
 		t.Fatalf("undo returned %#v", undone)
 	}
@@ -340,7 +340,7 @@ func TestTUIBulkReplyUndoSuccessAndExpiry(t *testing.T) {
 	view, state := tuiBulkReplyServer(t)
 	state.undoStatus = http.StatusUnprocessableEntity
 	view.lastBulkReplyID = 900
-	undone = runCmd(view.HandleContentKey(keyPress("u"))).(bulkReplyUndoneMsg)
+	undone = runCmd(view.HandleContentKey(keyPress("ctrl+u"))).(bulkReplyUndoneMsg)
 	if undone.err == nil {
 		t.Fatal("expired undo should fail")
 	}
@@ -354,7 +354,7 @@ func TestTUIBulkReplyCanCancelPreviewAndEditor(t *testing.T) {
 	for _, advance := range []bool{false, true} {
 		view, _ := tuiBulkReplyServer(t)
 		selectTwoThreads(view)
-		view.Update(runCmd(view.HandleContentKey(keyPress("b"))))
+		view.Update(runCmd(view.HandleContentKey(keyPress("ctrl+b"))))
 		if advance {
 			view.HandleContentKey(keyPress("enter"))
 		}

--- a/internal/tui/collections_test.go
+++ b/internal/tui/collections_test.go
@@ -126,7 +126,7 @@ func TestMailViewCollectionMembershipAddsAndRemoves(t *testing.T) {
 		v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindCollection, Name: "Kitchen remodel"})
 		v.postingList.postings[0].TopicID = 501
 
-		v.HandleContentKey(keyPress("k"))
+		v.HandleContentKey(keyPress("n"))
 		if collectionModal(v) == nil || !v.CapturingInput() {
 			t.Fatal("collection picker should capture input")
 		}
@@ -150,7 +150,7 @@ func TestMailViewCollectionMembershipAddsAndRemoves(t *testing.T) {
 		v.postingList.postings[0].TopicID = 501
 		v.postingList.postings[0].Collections = []mail.Collection{collection}
 
-		v.HandleContentKey(keyPress("k"))
+		v.HandleContentKey(keyPress("n"))
 		done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
 		if recorded.method != http.MethodDelete || recorded.path != "/topics/501/collecting" || recorded.rawQueries[len(recorded.rawQueries)-1] != "collection_id=12" {
 			t.Errorf("request = %s %s?%v", recorded.method, recorded.path, recorded.rawQueries)
@@ -169,7 +169,7 @@ func TestMailViewCollectionMembershipFailureKeepsState(t *testing.T) {
 	v.postingList.postings[0].TopicID = 501
 	v.postingList.postings[0].Collections = []mail.Collection{collection}
 
-	v.HandleContentKey(keyPress("k"))
+	v.HandleContentKey(keyPress("n"))
 	done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
 	v.Update(done)
 	if v.pendingMutations != 0 || len(v.postingList.postings[0].Collections) != 1 {
@@ -184,7 +184,7 @@ func TestMailViewCollectionMembershipRequiresTopicID(t *testing.T) {
 	v, recorded := mailWithTestServer(t, http.StatusNoContent)
 	v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindCollection, Name: "Kitchen remodel"})
 
-	if cmd := v.HandleContentKey(keyPress("k")); cmd != nil {
+	if cmd := v.HandleContentKey(keyPress("n")); cmd != nil {
 		t.Fatal("unresolved posting should not start a mutation")
 	}
 	if collectionModal(v) != nil || v.notice != "This item does not identify an email thread" || len(recorded.requests) != 0 {
@@ -205,7 +205,7 @@ func TestMailViewCollectionDiscoveryFailurePreservesKnownCollections(t *testing.
 	if sourceIndex(v.boxes, 12, mail.KindCollection) == 0 || v.collectionDiscoveryErr == "" {
 		t.Errorf("sources = %+v error = %q", v.boxes, v.collectionDiscoveryErr)
 	}
-	if !strings.Contains(v.notice, "press k to retry") {
+	if !strings.Contains(v.notice, "press n to retry") {
 		t.Errorf("notice = %q", v.notice)
 	}
 }
@@ -265,7 +265,7 @@ func TestMailViewRemovingFromCurrentCollectionRefreshesIt(t *testing.T) {
 	v.postingList.postings[0].TopicID = 501
 	v.postingList.postings[0].Collections = []mail.Collection{collection}
 
-	v.HandleContentKey(keyPress("k"))
+	v.HandleContentKey(keyPress("n"))
 	done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
 	refresh, consumed := v.Update(done)
 	if !consumed || refresh == nil || v.requests.kind != mailRequestPostings || v.postingIndex(100) >= 0 {
@@ -277,7 +277,7 @@ func TestMailViewCollectionPendingMutationBlocksAccountSwitch(t *testing.T) {
 	v, _ := mailWithTestServer(t, http.StatusNoContent)
 	v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindCollection, Name: "Kitchen remodel"})
 	v.postingList.postings[0].TopicID = 501
-	v.HandleContentKey(keyPress("k"))
+	v.HandleContentKey(keyPress("n"))
 	cmd := v.HandleContentKey(keyPress("enter"))
 	if cmd == nil || !v.AccountSwitchBlocked() {
 		t.Fatal("collection write should block account switching until completion")
@@ -291,7 +291,7 @@ func TestMailViewCollectionPendingMutationBlocksAccountSwitch(t *testing.T) {
 func TestMailViewCollectionDiscoveryRetryKey(t *testing.T) {
 	v := mailWithPostings()
 	v.collectionDiscoveryErr = "unavailable"
-	cmd := v.HandleContentKey(keyPress("k"))
+	cmd := v.HandleContentKey(keyPress("n"))
 	if cmd == nil || !v.requests.loading || v.notice != "Retrying collections…" {
 		t.Errorf("retry = cmd:%v loading:%v notice:%q", cmd != nil, v.requests.loading, v.notice)
 	}
@@ -311,7 +311,7 @@ func TestMailViewCollectionActionUsesTopicNotPostingID(t *testing.T) {
 	v.boxes = []mail.Source{{Kind: mail.KindBox, ID: 1, BoxKind: hey.BoxKindImbox, Name: "Imbox"}, {ID: 12, Kind: mail.KindCollection, Name: "Kitchen remodel"}}
 	v.postingList.setPostings([]mail.Posting{{ID: 100, TopicID: 501}})
 
-	v.HandleContentKey(keyPress("k"))
+	v.HandleContentKey(keyPress("n"))
 	done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
 	if path != "/topics/501/collecting" || done.postingID != 100 {
 		t.Errorf("path = %q posting ID = %d", path, done.postingID)
@@ -374,7 +374,7 @@ func TestMailViewCollectionPickerEscapeMakesNoRequest(t *testing.T) {
 	v, recorded := mailWithTestServer(t, http.StatusNoContent)
 	v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindCollection, Name: "Kitchen remodel"})
 	v.postingList.postings[0].TopicID = 501
-	v.HandleContentKey(keyPress("k"))
+	v.HandleContentKey(keyPress("n"))
 	if cmd := v.HandleContentKey(keyPress("esc")); cmd != nil {
 		t.Fatal("escape should not return a command")
 	}
@@ -452,7 +452,7 @@ func TestMailViewCollectionNoticeSanitizesName(t *testing.T) {
 	v, _ := mailWithTestServer(t, http.StatusNoContent)
 	v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindCollection, Name: "Kitchen\x1b]2;owned\a\nremodel"})
 	v.postingList.postings[0].TopicID = 501
-	v.HandleContentKey(keyPress("k"))
+	v.HandleContentKey(keyPress("n"))
 	done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
 	v.Update(done)
 	if strings.Contains(v.notice, "\x1b") || strings.Contains(v.notice, "\nremodel") {
@@ -491,7 +491,7 @@ func TestMailViewCollectionEmptySourceHasNothingMoreToRead(t *testing.T) {
 func TestMailViewCollectionPickerNoCollections(t *testing.T) {
 	v := mailWithPostings()
 	v.postingList.postings[0].TopicID = 501
-	v.HandleContentKey(keyPress("k"))
+	v.HandleContentKey(keyPress("n"))
 	if collectionModal(v) != nil || v.notice != "No collections available" {
 		t.Errorf("picker = %v notice = %q", collectionModal(v) != nil, v.notice)
 	}
@@ -610,7 +610,7 @@ func TestMailViewCollectionListErrorNoticeIsRecoverable(t *testing.T) {
 	bindings := v.HelpBindings()
 	found := false
 	for _, binding := range bindings {
-		if binding.key == "k" && binding.desc == "retry collections" {
+		if binding.key == "n" && binding.desc == "retry collections" {
 			found = true
 		}
 	}
@@ -656,7 +656,7 @@ func TestMailViewCollectionActionCompletionMessageCarriesIdentity(t *testing.T) 
 	v, _ := mailWithTestServer(t, http.StatusNoContent)
 	v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindCollection, Name: "Kitchen remodel"})
 	v.postingList.postings[0].TopicID = 501
-	v.HandleContentKey(keyPress("k"))
+	v.HandleContentKey(keyPress("n"))
 	done := runCmd(v.HandleContentKey(keyPress("enter"))).(collectionActionDoneMsg)
 	if done.sourceID != v.currentBoxID() || done.sourceKind != v.currentSourceKind() || done.collection.ID != 12 || !done.added {
 		t.Errorf("completion = %+v", done)
@@ -676,7 +676,7 @@ func TestMailViewCollectionMutationUsesOneRequest(t *testing.T) {
 	v := newMailView(vc)
 	v.boxes = []mail.Source{{Kind: mail.KindBox, ID: 1, BoxKind: hey.BoxKindImbox, Name: "Imbox"}, {ID: 12, Kind: mail.KindCollection, Name: "Kitchen remodel"}}
 	v.postingList.setPostings([]mail.Posting{{ID: 100, TopicID: 501}})
-	v.HandleContentKey(keyPress("k"))
+	v.HandleContentKey(keyPress("n"))
 	runCmd(v.HandleContentKey(keyPress("enter")))
 	if requests.Load() != 1 {
 		t.Errorf("requests = %d, want 1", requests.Load())

--- a/internal/tui/compose_test.go
+++ b/internal/tui/compose_test.go
@@ -424,23 +424,27 @@ func TestForwardCompletionNoticeIsVisibleInThread(t *testing.T) {
 	}
 }
 
-func TestForwardKeyInThreadLoadsContext(t *testing.T) {
-	v := mailWithPostings()
-	v.inThread = true
-	v.topicID = 123
-	cmd := v.HandleContentKey(keyPress("f"))
-	if cmd == nil || !v.requests.loading || v.requests.kind != mailRequestForward {
-		t.Fatal("'f' in a thread should start loading the forward context")
+func TestForwardKeysInThreadLoadContext(t *testing.T) {
+	for _, key := range []string{"f", "F"} {
+		v := mailWithPostings()
+		v.inThread = true
+		v.topicID = 123
+		cmd := v.HandleContentKey(keyPress(key))
+		if cmd == nil || !v.requests.loading || v.requests.kind != mailRequestForward {
+			t.Fatalf("%q in a thread should start loading the forward context", key)
+		}
 	}
 }
 
-func TestReplyKeyInThreadLoadsContext(t *testing.T) {
-	v := mailWithPostings()
-	v.inThread = true
-	v.topicID = 123
-	cmd := v.HandleContentKey(keyPress("r"))
-	if cmd == nil || !v.requests.loading {
-		t.Fatal("'r' in a thread should start loading the reply context")
+func TestReplyKeysInThreadLoadContext(t *testing.T) {
+	for _, key := range []string{"r", "R"} {
+		v := mailWithPostings()
+		v.inThread = true
+		v.topicID = 123
+		cmd := v.HandleContentKey(keyPress(key))
+		if cmd == nil || !v.requests.loading || v.requests.kind != mailRequestReply {
+			t.Fatalf("%q in a thread should start loading the reply context", key)
+		}
 	}
 }
 

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -326,6 +326,38 @@ func (c *contentList) markSeen(index int) {
 	c.resort()
 }
 
+// markUnseen moves a posting to the front of "New for You", including one the reader is
+// deliberately taking out of "Bubbled Up". HEY gives the restored posting a fresh
+// observation time, so it follows the bubbled-up rows and precedes every other unseen row.
+func (c *contentList) markUnseen(index int) {
+	c.postings[index].Seen = false
+	c.postings[index].BubbledUp = false
+	if c.hideSeenState {
+		return
+	}
+
+	var cursorID int64
+	if p := c.selectedPosting(); p != nil {
+		cursorID = p.ID
+	}
+	posting := c.postings[index]
+	c.postings = append(c.postings[:index], c.postings[index+1:]...)
+	insertAt := 0
+	for insertAt < len(c.postings) && sectionOf(c.postings[insertAt]) == sectionBubbledUp {
+		insertAt++
+	}
+	c.postings = append(c.postings, mail.Posting{})
+	copy(c.postings[insertAt+1:], c.postings[insertAt:])
+	c.postings[insertAt] = posting
+	for i := range c.postings {
+		if c.postings[i].ID == cursorID {
+			c.cursor = i
+			break
+		}
+	}
+	c.settleCover()
+}
+
 // resort re-partitions the list after a posting changes its seen state and
 // keeps the cursor on the same posting.
 func (c *contentList) resort() {
@@ -638,7 +670,7 @@ func (c *contentList) view() string {
 // The threads themselves are not rendered at all — that is the whole point of a
 // cover, and it is why the art can have every row the postings did not use.
 func (c *contentList) coverView(hidden, rowsUsed int) string {
-	hint := fmt.Sprintf("%d hidden · v to peek", hidden)
+	hint := fmt.Sprintf("%d hidden · x to peek", hidden)
 	header := coverHeader(sectionPreviouslySeen.label(), hint, c.width)
 
 	rows := c.height - rowsUsed - 1
@@ -659,7 +691,7 @@ func sectionHeader(label string, width int) string {
 }
 
 // coverHeader is a section label with a hint on its right, where the HEY web app
-// puts the cover's buttons: "Previously Seen ──── 34 hidden · v to peek".
+// puts the cover's buttons: "Previously Seen ──── 34 hidden · x to peek".
 func coverHeader(label, hint string, width int) string {
 	rule := lipgloss.NewStyle().Foreground(colorChrome)
 	fill := width - lipgloss.Width(label) - lipgloss.Width(hint) - 4

--- a/internal/tui/covers_test.go
+++ b/internal/tui/covers_test.go
@@ -556,7 +556,7 @@ func TestCoverHidesPreviouslySeen(t *testing.T) {
 	if !strings.Contains(view, sectionPreviouslySeen.label()) {
 		t.Error("covered list dropped the Previously Seen divider")
 	}
-	if !strings.Contains(view, "3 hidden · v to peek") {
+	if !strings.Contains(view, "3 hidden · x to peek") {
 		t.Error("covered list gave no hint about what is under the cover")
 	}
 	for _, posting := range list.postings[1:] {
@@ -627,7 +627,7 @@ func TestCoverDropsTheArtBeforeTheDivider(t *testing.T) {
 	list := coveredList(coverTopo, coverMinRows+2, false, false, true)
 
 	view := list.view()
-	if !strings.Contains(view, "1 hidden · v to peek") {
+	if !strings.Contains(view, "1 hidden · x to peek") {
 		t.Error("a short covered list lost its divider")
 	}
 	if rows := strings.Count(view, "\n") + 1; rows > coverMinRows+2 {
@@ -643,7 +643,7 @@ func TestCoverWithNothingUnread(t *testing.T) {
 		t.Errorf("itemCount = %d, want 0", got)
 	}
 	view := list.view()
-	if !strings.Contains(view, "2 hidden · v to peek") {
+	if !strings.Contains(view, "2 hidden · x to peek") {
 		t.Error("an all-read Imbox does not say what is under the cover")
 	}
 	if rows := strings.Count(view, "\n") + 1; rows != 20 {
@@ -681,6 +681,26 @@ func TestMarkingSeenSlidesAThreadUnderTheCover(t *testing.T) {
 	}
 	if ids := list.selectedIDs(); len(ids) != 0 {
 		t.Errorf("selection %v survived under the cover", ids)
+	}
+}
+
+func TestMarkingUnseenPullsAThreadAboveTheCover(t *testing.T) {
+	list := coveredList(coverTopo, 24, true, true)
+	list.toggleCoverPeek()
+	list.cursor = 1
+
+	list.markUnseen(1)
+	list.toggleCoverPeek()
+
+	if got := list.itemCount(); got != 1 {
+		t.Errorf("itemCount = %d, want the unseen thread reachable", got)
+	}
+	posting := list.selectedPosting()
+	if posting == nil || posting.ID != 2 || posting.Seen || posting.BubbledUp {
+		t.Errorf("selected posting above cover = %+v", posting)
+	}
+	if !strings.Contains(list.view(), "Read thread B") {
+		t.Errorf("unseen thread is not visible above cover: %q", list.view())
 	}
 }
 
@@ -764,7 +784,7 @@ func TestPickingACoverTakesTheCursorOutFromUnderIt(t *testing.T) {
 	if ids := v.postingList.selectedIDs(); len(ids) != 0 {
 		t.Errorf("a bulk reply would aim at %v, threads the reader put away", ids)
 	}
-	if cmd := v.HandleContentKey(keyPress("b")); cmd != nil {
+	if cmd := v.HandleContentKey(keyPress("ctrl+b")); cmd != nil {
 		t.Error("a bulk reply started on a selection that is under the cover")
 	}
 }

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -139,6 +139,7 @@ const (
 	postingActionNone postingActionEffect = iota
 	postingActionRemove
 	postingActionSeen
+	postingActionUnseen
 	postingActionIgnore
 	postingActionStopIgnoring
 )
@@ -477,7 +478,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 			v.notice = fmt.Sprintf("%d bulk %s queued with undo available", count, replyNoun(count))
 			if msg.delivery.Id > 0 {
 				v.lastBulkReplyID = msg.delivery.Id
-				v.notice += " — press u to undo"
+				v.notice += " — press ctrl+u to undo"
 			}
 		}
 		if msg.skipped > 0 {
@@ -541,11 +542,11 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 
 	case postingActionDoneMsg:
 		v.finishMutation()
-		if msg.err != nil {
-			return func() tea.Msg { return errMsg{msg.err} }, true
-		}
 		if msg.boxID != v.currentBoxID() || (msg.sourceKind != "" && msg.sourceKind != v.currentSourceKind()) {
 			return nil, true
+		}
+		if msg.err != nil {
+			return func() tea.Msg { return errMsg{msg.err} }, true
 		}
 		v.notice = msg.action
 		idx := v.postingIndex(msg.postingID)
@@ -556,6 +557,8 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 				v.removePostingAt(idx)
 			case postingActionSeen:
 				v.postingList.markSeen(idx)
+			case postingActionUnseen:
+				v.postingList.markUnseen(idx)
 			case postingActionIgnore:
 				v.postingList.postings[idx].Muted = true
 			case postingActionStopIgnoring:
@@ -715,11 +718,11 @@ func firstTimeSenderNoun(count int) string {
 func (v *mailView) updateSourceDiscoveryNotice() {
 	switch {
 	case v.folderDiscoveryErr != "" && v.collectionDiscoveryErr != "":
-		v.notice = "Could not load labels or collections — press g or k to retry"
+		v.notice = "Could not load labels or collections — press b or n to retry"
 	case v.folderDiscoveryErr != "":
-		v.notice = "Could not load labels — press g to retry"
+		v.notice = "Could not load labels — press b to retry"
 	case v.collectionDiscoveryErr != "":
-		v.notice = "Could not load collections — press k to retry"
+		v.notice = "Could not load collections — press n to retry"
 	case v.notice == "Retrying labels…" || v.notice == "Retrying collections…":
 		v.notice = ""
 	}
@@ -757,26 +760,28 @@ func (v *mailView) HelpBindings() []helpBinding {
 	if selected := v.postingList.selectedPosting(); selected != nil && selected.Muted {
 		ignoreBinding = helpBinding{"+", "stop ignoring"}
 	}
-	folderBinding := helpBinding{"g", "labels"}
+	folderBinding := helpBinding{"b", "labels"}
 	if v.folderDiscoveryErr != "" {
-		folderBinding = helpBinding{"g", "retry labels"}
+		folderBinding = helpBinding{"b", "retry labels"}
 	}
-	collectionBinding := helpBinding{"k", "collections"}
+	collectionBinding := helpBinding{"n", "collections"}
 	if v.collectionDiscoveryErr != "" {
-		collectionBinding = helpBinding{"k", "retry collections"}
+		collectionBinding = helpBinding{"n", "retry collections"}
 	}
 	bindings := []helpBinding{
 		{"/", "search"},
 		{"ctrl+s", "screener"},
 		{"c", "compose"},
 		{"space", "select"},
-		{"b", "bulk reply"},
+		{"ctrl+b", "bulk reply"},
 		{"r", "reply"},
 		{"f", "forward"},
-		{"m", "move"},
+		{"v", "move"},
 		folderBinding,
 		collectionBinding,
 		{"e", "seen"},
+		{"u", "unseen"},
+		{"i", "imbox"},
 		{"l", "reply later"},
 		{"a", "set aside"},
 		{"d", "feed"},
@@ -784,14 +789,14 @@ func (v *mailView) HelpBindings() []helpBinding {
 	bindings = append(bindings,
 		helpBinding{"p", "paper trail"},
 		helpBinding{"t", "trash"},
-		helpBinding{"s", "spam"},
+		helpBinding{"!", "spam"},
 		ignoreBinding,
 		helpBinding{"ctrl+r", "reload"},
 	)
 	if v.postingList.cover != coverNone {
-		peek := helpBinding{"v", "peek under cover"}
+		peek := helpBinding{"x", "peek under cover"}
 		if v.postingList.coverPeeked {
-			peek = helpBinding{"v", "cover"}
+			peek = helpBinding{"x", "cover"}
 		}
 		bindings = append(bindings, peek)
 	}
@@ -799,7 +804,7 @@ func (v *mailView) HelpBindings() []helpBinding {
 		bindings = append(bindings, helpBinding{"ctrl+v", "cover art"})
 	}
 	if v.lastBulkReplyID != 0 {
-		bindings = append(bindings, helpBinding{"u", "undo bulk reply"})
+		bindings = append(bindings, helpBinding{"ctrl+u", "undo bulk reply"})
 	}
 	return modifiersLast(bindings)
 }
@@ -835,7 +840,7 @@ func (v *mailView) SubnavItems() ([]navItem, int, string, bool) {
 	}
 	items := boxNavItems(boxes)
 	if v.hasLabels() {
-		items = append(items, navItem{shortcut: "L", label: "Labels"})
+		items = append(items, navItem{label: "Labels"})
 		if v.currentSourceKind() == mail.KindFolder {
 			selected = len(items) - 1
 		}
@@ -971,11 +976,11 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 
 	if v.inThread {
 		switch msg.String() {
-		case "r":
+		case "r", "R":
 			if v.topicID != 0 {
 				return v.loadReplyContext(v.topicID, v.topicName)
 			}
-		case "f":
+		case "f", "F":
 			if v.topicID != 0 {
 				return v.loadForwardContext(v.topicID, v.topicName)
 			}
@@ -1005,7 +1010,8 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		case tea.KeyEnter:
 			return v.openSelected()
 		default:
-			if msg.String() == "/" {
+			switch msg.String() {
+			case "/", "s", "S":
 				return v.startSearch()
 			}
 		}
@@ -1022,25 +1028,25 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		return v.openSelected()
 	default:
 		switch msg.String() {
-		case "/":
+		case "/", "s", "S":
 			return v.startSearch()
 		case "c":
 			return v.startCompose()
 		case " ", "space":
 			v.postingList.toggleSelected()
 			return nil
-		case "b":
+		case "ctrl+b":
 			return v.startBulkReply()
-		case "u":
+		case "ctrl+u":
 			return v.undoBulkReply()
-		case "m":
+		case "v", "V":
 			v.startMove()
 			return nil
-		case "g":
+		case "b", "B":
 			return v.startFolderPicker()
-		case "k":
+		case "n", "N":
 			return v.startCollectionPicker()
-		case "v":
+		case "x":
 			v.postingList.toggleCoverPeek()
 			return nil
 		case "ctrl+v":
@@ -1161,11 +1167,6 @@ func (v *mailView) handleBoxShortcut(key string) tea.Cmd {
 		return nil
 	}
 	switch key {
-	case "L":
-		if v.hasLabels() {
-			v.openLabels()
-			return func() tea.Msg { return nil }
-		}
 	case "K":
 		if v.hasCollections() {
 			v.openCollections()
@@ -1726,31 +1727,45 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 	boxID := v.currentBoxID()
 
 	switch key {
-	case "l":
+	case "l", "L":
 		return v.moveSelectedToKnownBox("Reply Later", hey.BoxKindLater, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToReplyLater(v.vc.ctx, p.ID)
 		})
-	case "a":
+	case "a", "A":
 		return v.moveSelectedToKnownBox("Set Aside", hey.BoxKindSetAside, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToSetAside(v.vc.ctx, p.ID)
 		})
-	case "e":
+	case "e", "E":
 		return v.doPostingAction("Thread marked as seen", postingActionSeen, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MarkSeen(v.vc.ctx, []int64{p.ID})
 		})
-	case "d":
+	case "u", "U":
+		if p.Muted {
+			v.notice = "Stop ignoring this thread to mark it unseen"
+			return nil
+		}
+		if !p.Seen && !p.BubbledUp {
+			v.notice = "Thread is already unseen"
+			return nil
+		}
+		return v.doPostingAction("Thread marked as unseen", postingActionUnseen, boxID, p.ID, func() error {
+			return v.vc.sdk.Postings().MarkUnseen(v.vc.ctx, []int64{p.ID})
+		})
+	case "i", "I":
+		return v.moveSelectedToImbox(boxID, p.ID)
+	case "d", "D":
 		return v.moveSelectedToKnownBox("The Feed", hey.BoxKindFeed, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToFeed(v.vc.ctx, p.ID)
 		})
-	case "p":
+	case "p", "P":
 		return v.moveSelectedToKnownBox("Paper Trail", hey.BoxKindTrail, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToPaperTrail(v.vc.ctx, p.ID)
 		})
-	case "t":
+	case "t", "T":
 		return v.doPostingAction("Thread moved to Trash", postingActionRemove, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToTrash(v.vc.ctx, p.ID)
 		})
-	case "s":
+	case "!":
 		return v.doPostingAction("Thread marked as spam", postingActionRemove, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MarkSpam(v.vc.ctx, p.ID)
 		})
@@ -1770,19 +1785,32 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 		return v.doPostingAction("Stopped ignoring thread", postingActionStopIgnoring, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().Unmute(v.vc.ctx, p.ID)
 		})
-	case "r":
+	case "r", "R":
 		topicID := p.TopicID
 		if topicID == 0 {
 			topicID = p.ID
 		}
 		return v.loadReplyContext(topicID, p.Summary)
-	case "f":
+	case "f", "F":
 		topicID := p.TopicID
 		if topicID == 0 {
 			topicID = p.ID
 		}
 		return v.loadForwardContext(topicID, p.Summary)
 	}
+	return nil
+}
+
+func (v *mailView) moveSelectedToImbox(boxID, postingID int64) tea.Cmd {
+	for _, source := range v.boxes {
+		if source.Kind == mail.KindBox && source.BoxKind == hey.BoxKindImbox {
+			imboxID := source.ID
+			return v.moveSelectedToKnownBox("Imbox", hey.BoxKindImbox, boxID, postingID, func() error {
+				return v.vc.sdk.Postings().Move(v.vc.ctx, imboxID, postingID)
+			})
+		}
+	}
+	v.notice = "Imbox is unavailable"
 	return nil
 }
 

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -471,12 +471,18 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 		notice string
 	}{
 		{"reply later", "l", "/postings/moves.json", 4, postingActionRemove, "Thread moved to Reply Later"},
+		{"reply later uppercase", "L", "/postings/moves.json", 4, postingActionRemove, "Thread moved to Reply Later"},
 		{"set aside", "a", "/postings/moves.json", 3, postingActionRemove, "Thread moved to Set Aside"},
+		{"set aside uppercase", "A", "/postings/moves.json", 3, postingActionRemove, "Thread moved to Set Aside"},
 		{"seen", "e", "/postings/seen.json", 0, postingActionSeen, "Thread marked as seen"},
+		{"seen uppercase", "E", "/postings/seen.json", 0, postingActionSeen, "Thread marked as seen"},
 		{"feed", "d", "/postings/moves.json", 2, postingActionRemove, "Thread moved to The Feed"},
+		{"feed uppercase", "D", "/postings/moves.json", 2, postingActionRemove, "Thread moved to The Feed"},
 		{"paper trail", "p", "/postings/moves.json", 5, postingActionRemove, "Thread moved to Paper Trail"},
+		{"paper trail uppercase", "P", "/postings/moves.json", 5, postingActionRemove, "Thread moved to Paper Trail"},
 		{"trash", "t", "/postings/trash.json", 0, postingActionRemove, "Thread moved to Trash"},
-		{"spam", "s", "/postings/spam.json", 0, postingActionRemove, "Thread marked as spam"},
+		{"trash uppercase", "T", "/postings/trash.json", 0, postingActionRemove, "Thread moved to Trash"},
+		{"spam", "!", "/postings/spam.json", 0, postingActionRemove, "Thread marked as spam"},
 		{"ignore", "-", "/postings/mutings.json", 0, postingActionIgnore, "Thread ignored"},
 	}
 
@@ -540,6 +546,93 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 	}
 }
 
+func TestMailViewUnseenKeysRestoreSeenAndBubbledUpThreads(t *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		key       string
+		bubbledUp bool
+	}{
+		{"lowercase", "u", false},
+		{"uppercase", "U", false},
+		{"bubbled up", "u", true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			v, recorded := mailWithTestServer(t, http.StatusNoContent)
+			v.postingList.postings[0].Seen = !testCase.bubbledUp
+			v.postingList.postings[0].BubbledUp = testCase.bubbledUp
+			v.postingList.resort()
+			v.postingList.cursor = v.postingIndex(100)
+
+			done, ok := runCmd(v.HandleContentKey(keyPress(testCase.key))).(postingActionDoneMsg)
+			if !ok || done.err != nil || done.effect != postingActionUnseen {
+				t.Fatalf("unseen command returned %#v", done)
+			}
+			if recorded.method != http.MethodPost || recorded.path != "/postings/unseen.json" {
+				t.Errorf("request = %s %s, want POST /postings/unseen.json", recorded.method, recorded.path)
+			}
+			if len(recorded.body.PostingIDs) != 1 || recorded.body.PostingIDs[0] != 100 {
+				t.Errorf("posting_ids = %v, want [100]", recorded.body.PostingIDs)
+			}
+
+			v.Update(done)
+			posting := v.postingList.selectedPosting()
+			if posting == nil || posting.ID != 100 || posting.Seen || posting.BubbledUp {
+				t.Errorf("selected posting after unseen = %+v", posting)
+			}
+			if v.postingList.postings[0].ID != 100 {
+				t.Errorf("unseen posting did not move to New for You: %+v", v.postingList.postings)
+			}
+			if v.notice != "Thread marked as unseen" {
+				t.Errorf("notice = %q", v.notice)
+			}
+		})
+	}
+}
+
+func TestMailViewUnseenSkipsThreadsTheServerLeavesAlone(t *testing.T) {
+	tests := []struct {
+		name    string
+		posting mail.Posting
+		notice  string
+	}{
+		{"already unseen", mail.Posting{ID: 100}, "Thread is already unseen"},
+		{"ignored", mail.Posting{ID: 100, Seen: true, Muted: true}, "Stop ignoring this thread to mark it unseen"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, recorded := mailWithTestServer(t, http.StatusNoContent)
+			v.postingList.postings[0] = tt.posting
+			if cmd := v.HandleContentKey(keyPress("u")); cmd != nil {
+				t.Fatal("unseen should not start a request")
+			}
+			if len(recorded.requests) != 0 {
+				t.Errorf("requests = %v, want none", recorded.requests)
+			}
+			if v.notice != tt.notice {
+				t.Errorf("notice = %q, want %q", v.notice, tt.notice)
+			}
+		})
+	}
+}
+
+func TestMailViewUnseenFailureKeepsSeenState(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusInternalServerError)
+	v.postingList.postings[0].Seen = true
+
+	done := runCmd(v.HandleContentKey(keyPress("u"))).(postingActionDoneMsg)
+	if done.err == nil {
+		t.Fatal("unseen failure should carry an error")
+	}
+	cmd, _ := v.Update(done)
+	if _, ok := runCmd(cmd).(errMsg); !ok {
+		t.Fatal("unseen failure should report an error")
+	}
+	posting := v.postingList.postings[v.postingIndex(100)]
+	if !posting.Seen || posting.BubbledUp {
+		t.Errorf("failed unseen changed posting state: %+v", posting)
+	}
+}
+
 func TestMailViewStopIgnoringCallsDeleteAndKeepsThreadVisible(t *testing.T) {
 	v, recorded := mailWithTestServer(t, http.StatusNoContent)
 	v.postingList.postings[0].Muted = true
@@ -596,6 +689,37 @@ func TestMailViewIgnoreActionsSkipThreadsAlreadyInRequestedState(t *testing.T) {
 	}
 }
 
+func TestMailViewImboxKeysMoveToImbox(t *testing.T) {
+	for _, key := range []string{"i", "I"} {
+		t.Run(key, func(t *testing.T) {
+			v, recorded := mailWithTestServer(t, http.StatusNoContent)
+			v.boxIndex = sourceIndex(v.boxes, 2, mail.KindBox)
+
+			done, ok := runCmd(v.HandleContentKey(keyPress(key))).(postingActionDoneMsg)
+			if !ok || done.err != nil || done.effect != postingActionRemove {
+				t.Fatalf("move-to-Imbox command returned %#v", done)
+			}
+			if recorded.path != "/postings/moves.json" || recorded.body.BoxID == nil || *recorded.body.BoxID != 1 {
+				t.Errorf("request = %s body=%+v", recorded.path, recorded.body)
+			}
+			v.Update(done)
+			if v.postingIndex(100) >= 0 || v.notice != "Thread moved to Imbox" {
+				t.Errorf("posting present=%v notice=%q", v.postingIndex(100) >= 0, v.notice)
+			}
+		})
+	}
+}
+
+func TestMailViewImboxKeyDoesNotMoveWithinImbox(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	if cmd := v.HandleContentKey(keyPress("i")); cmd != nil {
+		t.Fatal("move within Imbox should not start a request")
+	}
+	if len(recorded.requests) != 0 || v.notice != "Already in Imbox" {
+		t.Errorf("requests=%v notice=%q", recorded.requests, v.notice)
+	}
+}
+
 func TestMailViewMovePickerMovesToSelectedBox(t *testing.T) {
 	v, recorded := mailWithTestServer(t, http.StatusNoContent)
 	v.boxes = []mail.Source{
@@ -607,7 +731,7 @@ func TestMailViewMovePickerMovesToSelectedBox(t *testing.T) {
 		{Kind: mail.KindBox, ID: 6, BoxKind: hey.BoxKindBubbleUp, Name: "Bubble Up"},
 	}
 
-	if cmd := v.HandleContentKey(keyPress("m")); cmd != nil {
+	if cmd := v.HandleContentKey(keyPress("v")); cmd != nil {
 		t.Fatal("opening the move picker should not start a request")
 	}
 	if !v.CapturingInput() || moveModal(v) == nil {
@@ -654,7 +778,7 @@ func TestMailViewMovePickerKeepsBoxWithCollidingLabelID(t *testing.T) {
 	}
 	v.boxIndex = 1
 
-	v.HandleContentKey(keyPress("m"))
+	v.HandleContentKey(keyPress("v"))
 	if moveModal(v) == nil || len(moveModal(v).destinations) != 1 {
 		t.Fatalf("move destinations = %+v", moveModal(v))
 	}
@@ -672,7 +796,7 @@ func TestMailViewMovePickerSelectsWithArrowKeys(t *testing.T) {
 		{Kind: mail.KindBox, ID: 3, BoxKind: hey.BoxKindSetAside, Name: "Set Aside"},
 	}
 
-	v.HandleContentKey(keyPress("m"))
+	v.HandleContentKey(keyPress("v"))
 	v.HandleContentKey(keyPress("down"))
 	msg := runCmd(v.HandleContentKey(keyPress("enter")))
 	if done, ok := msg.(postingActionDoneMsg); !ok || done.err != nil {
@@ -690,7 +814,7 @@ func TestMailViewMovePickerCancelsWithoutRequest(t *testing.T) {
 		{Kind: mail.KindBox, ID: 2, BoxKind: hey.BoxKindFeed, Name: "The Feed"},
 	}
 
-	v.HandleContentKey(keyPress("m"))
+	v.HandleContentKey(keyPress("v"))
 	if cmd := v.HandleContentKey(keyPress("esc")); cmd != nil {
 		t.Fatal("canceling the move picker should not return a command")
 	}
@@ -986,14 +1110,14 @@ func TestMailViewFolderDiscoveryFailurePreservesMailAndRetries(t *testing.T) {
 	if !consumed || firstPostings == nil || len(v.boxes) != 1 || v.folderDiscoveryErr == "" {
 		t.Fatalf("folder failure state = consumed:%v command:%v sources:%+v error:%q", consumed, firstPostings != nil, v.boxes, v.folderDiscoveryErr)
 	}
-	if !strings.Contains(v.notice, "press g to retry") {
+	if !strings.Contains(v.notice, "press b to retry") {
 		t.Errorf("notice = %q", v.notice)
 	}
 	v.Update(runCmd(firstPostings))
 
-	retry := v.HandleContentKey(keyPress("g"))
+	retry := v.HandleContentKey(keyPress("b"))
 	if retry == nil || !v.requests.loading {
-		t.Fatal("g should retry failed folder discovery")
+		t.Fatal("b should retry failed folder discovery")
 	}
 	recovered := runCmd(retry).(mailSourcesLoadedMsg)
 	v.Update(recovered)
@@ -1034,7 +1158,7 @@ func TestMailViewFolderPickerFilesAndUnfilesThread(t *testing.T) {
 		v, recorded := mailWithTestServer(t, http.StatusNoContent)
 		v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindFolder, Name: "Receipts"})
 
-		v.HandleContentKey(keyPress("g"))
+		v.HandleContentKey(keyPress("b"))
 		if folderModal(v) == nil || !v.CapturingInput() {
 			t.Fatal("folder picker should capture input")
 		}
@@ -1063,7 +1187,7 @@ func TestMailViewFolderPickerFilesAndUnfilesThread(t *testing.T) {
 		v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindFolder, Name: "Receipts"})
 		v.postingList.postings[0].Folders = []mail.Folder{{ID: 12, Name: "Receipts"}}
 
-		v.HandleContentKey(keyPress("g"))
+		v.HandleContentKey(keyPress("b"))
 		if view := v.View(); !strings.Contains(view, "[x] Receipts") || !strings.Contains(view, "Remove all labels") {
 			t.Errorf("folder picker view = %q", view)
 		}
@@ -1084,7 +1208,7 @@ func TestMailViewFolderPickerFilesAndUnfilesThread(t *testing.T) {
 		v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindFolder, Name: "Receipts"})
 		v.postingList.postings[0].Folders = []mail.Folder{{ID: 12, Name: "Receipts"}}
 
-		v.HandleContentKey(keyPress("g"))
+		v.HandleContentKey(keyPress("b"))
 		v.HandleContentKey(keyPress("down"))
 		v.HandleContentKey(keyPress("down"))
 		done, ok := runCmd(v.HandleContentKey(keyPress("enter"))).(folderActionDoneMsg)
@@ -1104,7 +1228,7 @@ func TestMailViewFolderPickerFilesAndUnfilesThread(t *testing.T) {
 func TestMailViewFolderPickerCreatesFolder(t *testing.T) {
 	v, recorded := mailWithTestServer(t, http.StatusNoContent)
 
-	v.HandleContentKey(keyPress("g"))
+	v.HandleContentKey(keyPress("b"))
 	if cmd := v.HandleContentKey(keyPress("enter")); cmd == nil || folderModal(v) == nil || !folderModal(v).creating {
 		t.Fatal("selecting create should focus the folder name input")
 	}
@@ -1136,7 +1260,7 @@ func TestMailViewFolderPickerScrollsAndSanitizesNames(t *testing.T) {
 		v.boxes = append(v.boxes, mail.Source{ID: id + 100, Kind: mail.KindFolder, Name: name})
 	}
 
-	v.HandleContentKey(keyPress("g"))
+	v.HandleContentKey(keyPress("b"))
 	for range 19 {
 		v.HandleContentKey(keyPress("down"))
 	}
@@ -1180,7 +1304,7 @@ func TestMailViewFolderActionFailureKeepsThread(t *testing.T) {
 	v, _ := mailWithTestServer(t, http.StatusInternalServerError)
 	v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindFolder, Name: "Receipts"})
 
-	v.HandleContentKey(keyPress("g"))
+	v.HandleContentKey(keyPress("b"))
 	done, ok := runCmd(v.HandleContentKey(keyPress("enter"))).(folderActionDoneMsg)
 	if !ok || done.err == nil {
 		t.Fatalf("folder action returned %#v, want an error", done)
@@ -1199,7 +1323,7 @@ func TestMailViewFolderActionFailureKeepsThread(t *testing.T) {
 
 func TestMailViewFolderPickerRequiresNameAndCancels(t *testing.T) {
 	v := mailWithPostings()
-	v.HandleContentKey(keyPress("g"))
+	v.HandleContentKey(keyPress("b"))
 	v.HandleContentKey(keyPress("enter"))
 	if cmd := v.HandleContentKey(keyPress("enter")); cmd != nil {
 		t.Fatal("empty folder name should not submit")
@@ -1389,26 +1513,27 @@ func TestMailViewIgnoresPostingCompletionAfterBoxSwitch(t *testing.T) {
 	}
 }
 
-func TestMailViewReportsPostingFailureAfterBoxSwitch(t *testing.T) {
+func TestMailViewIgnoresUnseenFailureAfterBoxSwitch(t *testing.T) {
 	v, _ := mailWithTestServer(t, http.StatusInternalServerError)
+	v.postingList.postings[0].Seen = true
 
-	msg := runCmd(v.HandleContentKey(keyPress("t")))
+	msg := runCmd(v.HandleContentKey(keyPress("u")))
 	done, ok := msg.(postingActionDoneMsg)
 	if !ok || done.err == nil {
 		t.Fatalf("posting command returned %#v, want an action error", msg)
 	}
 	v.SubnavRight()
 	v.Update(currentPostingsLoaded(v, []mail.Posting{{ID: 200, Summary: "Other box"}}))
-	errCmd, consumed := v.Update(done)
+	cmd, consumed := v.Update(done)
 
-	if !consumed || errCmd == nil {
-		t.Fatal("failed action should still return an error after a box switch")
-	}
-	if _, ok := runCmd(errCmd).(errMsg); !ok {
-		t.Error("failed action should produce errMsg")
+	if !consumed || cmd != nil {
+		t.Fatal("failed action from the old box should be ignored")
 	}
 	if len(v.postingList.postings) != 1 || v.postingList.postings[0].ID != 200 {
 		t.Errorf("failed action changed the new box: %v", v.postingList.postings)
+	}
+	if v.pendingMutations != 0 {
+		t.Errorf("pending mutations = %d, want 0", v.pendingMutations)
 	}
 }
 
@@ -2463,6 +2588,85 @@ func TestSearchMatchToPostingPreservesActionAndThreadIDs(t *testing.T) {
 
 // --- Help bindings ---
 
+func TestMailViewHaystackSearchAndMessageAliases(t *testing.T) {
+	for _, key := range []string{"/", "s", "S"} {
+		t.Run("search "+key, func(t *testing.T) {
+			v := mailWithPostings()
+			v.HandleContentKey(keyPress(key))
+			if searchModal(v) == nil {
+				t.Fatalf("%q did not open search", key)
+			}
+		})
+	}
+
+	for _, testCase := range []struct {
+		key  string
+		kind mailRequestKind
+	}{
+		{"r", mailRequestReply}, {"R", mailRequestReply},
+		{"f", mailRequestForward}, {"F", mailRequestForward},
+	} {
+		t.Run("message "+testCase.key, func(t *testing.T) {
+			v := mailWithPostings()
+			if cmd := v.HandleContentKey(keyPress(testCase.key)); cmd == nil || v.requests.kind != testCase.kind {
+				t.Fatalf("%q did not start request %v", testCase.key, testCase.kind)
+			}
+		})
+	}
+}
+
+func TestMailViewHaystackPickerAliases(t *testing.T) {
+	for _, key := range []string{"v", "V"} {
+		v := mailWithPostings()
+		v.HandleContentKey(keyPress(key))
+		if moveModal(v) == nil {
+			t.Errorf("%q did not open move picker", key)
+		}
+	}
+	for _, key := range []string{"b", "B"} {
+		v := mailWithPostings()
+		v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindFolder, Name: "Receipts"})
+		v.HandleContentKey(keyPress(key))
+		if folderModal(v) == nil {
+			t.Errorf("%q did not open labels picker", key)
+		}
+	}
+	for _, key := range []string{"n", "N"} {
+		v := mailWithPostings()
+		v.boxes = append(v.boxes, mail.Source{ID: 12, Kind: mail.KindCollection, Name: "Kitchen remodel"})
+		v.postingList.postings[0].TopicID = 100
+		v.HandleContentKey(keyPress(key))
+		if collectionModal(v) == nil {
+			t.Errorf("%q did not open collections picker", key)
+		}
+	}
+}
+
+func TestMailViewCoverPeekUsesX(t *testing.T) {
+	v := mailWithPostings()
+	v.postingList.setCover(coverTopo)
+	v.HandleContentKey(keyPress("x"))
+	if !v.postingList.coverPeeked {
+		t.Fatal("x did not lift the cover")
+	}
+	v.HandleContentKey(keyPress("x"))
+	if v.postingList.coverPeeked {
+		t.Fatal("x did not replace the cover")
+	}
+}
+
+func TestMailViewRemovedPostingAliasesStayUnused(t *testing.T) {
+	for _, key := range []string{"m", "g", "k"} {
+		v := mailWithPostings()
+		if cmd := v.HandleContentKey(keyPress(key)); cmd != nil {
+			t.Errorf("removed alias %q returned a command", key)
+		}
+		if v.modal != nil {
+			t.Errorf("removed alias %q opened %T", key, v.modal)
+		}
+	}
+}
+
 func TestMailViewHelpBindings(t *testing.T) {
 	v := mailWithPostings()
 	bindings := v.HelpBindings()
@@ -2474,7 +2678,7 @@ func TestMailViewHelpBindings(t *testing.T) {
 	for _, b := range bindings {
 		keys[b.key] = true
 	}
-	for _, expected := range []string{"/", "r", "f", "m", "g", "e", "l", "a", "t", "s", "-"} {
+	for _, expected := range []string{"/", "r", "f", "v", "b", "n", "e", "u", "i", "l", "a", "t", "!", "-"} {
 		if !keys[expected] {
 			t.Errorf("missing help binding for key %q", expected)
 		}
@@ -2518,7 +2722,7 @@ func TestMailViewHelpBindingsStopIgnoringForIgnoredThread(t *testing.T) {
 
 func TestMailViewHelpBindingsInMovePicker(t *testing.T) {
 	v := mailWithPostings()
-	v.HandleContentKey(keyPress("m"))
+	v.HandleContentKey(keyPress("v"))
 
 	bindings := v.HelpBindings()
 	if len(bindings) != 3 || bindings[0].key != "↑↓" || bindings[1].key != "enter" || bindings[2].key != "esc" {
@@ -2528,7 +2732,7 @@ func TestMailViewHelpBindingsInMovePicker(t *testing.T) {
 
 func TestMailViewHelpBindingsInFolderPicker(t *testing.T) {
 	v := mailWithPostings()
-	v.HandleContentKey(keyPress("g"))
+	v.HandleContentKey(keyPress("b"))
 
 	bindings := v.HelpBindings()
 	if len(bindings) != 3 || bindings[0].key != "↑↓" || bindings[1].key != "enter" || bindings[2].key != "esc" {
@@ -2616,8 +2820,8 @@ func TestMailViewLabelsTabAndPicker(t *testing.T) {
 	v := mailWithLabels()
 
 	items, selected, _, _ := v.SubnavItems()
-	if last := items[len(items)-1]; last.label != "Labels" || last.shortcut != "L" {
-		t.Fatalf("the last tab should be Labels with the L shortcut: %+v", items)
+	if last := items[len(items)-1]; last.label != "Labels" || last.shortcut != "" {
+		t.Fatalf("the last tab should be Labels without the Reply Later shortcut: %+v", items)
 	}
 	if len(items) != len(testBoxes())+1 {
 		t.Errorf("labels should not appear as their own tabs: %+v", items)
@@ -2670,12 +2874,9 @@ func TestMailViewLabelsTabAndPicker(t *testing.T) {
 		t.Error("left from Labels should return to the last box tab")
 	}
 
-	// Shift+L opens the picker from anywhere in the mail section.
-	if cmd := v.handleBoxShortcut("L"); cmd == nil || labelsModal(v) == nil {
-		t.Error("the L shortcut should open the Labels picker")
-	}
-	if cmd := v.handleBoxShortcut("L"); cmd != nil {
-		t.Error("the L shortcut should be inert while the picker is open")
+	// Shift+L belongs to Reply Later, so Labels navigation does not capture it.
+	if cmd := v.handleBoxShortcut("L"); cmd != nil || labelsModal(v) != nil {
+		t.Error("the Labels tab captured the Reply Later shortcut")
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -388,10 +388,10 @@ func TestMovePickerOwnsNavigationKeys(t *testing.T) {
 	m := modelWithBoxes()
 	m.focus = rowContent
 
-	updated, _ := m.Update(keyPress("m"))
+	updated, _ := m.Update(keyPress("v"))
 	m = updated.(model)
 	if moveModal(m.mailView) == nil || !m.mailView.CapturingInput() {
-		t.Fatal("m should open the move picker")
+		t.Fatal("v should open the move picker")
 	}
 
 	updated, _ = m.Update(keyPress("tab"))
@@ -740,6 +740,42 @@ func TestContentListMovesSeenPostingToItsSection(t *testing.T) {
 	}
 	if got := cl.selectedPosting(); got == nil || got.ID != 1 {
 		t.Errorf("cursor should follow the moved posting: %+v", got)
+	}
+}
+
+func TestContentListMovesSeenAndBubbledUpPostingsToNewForYou(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		posting mail.Posting
+	}{
+		{"seen", mail.Posting{ID: 3, Name: "Previously read", Seen: true}},
+		{"bubbled up", mail.Posting{ID: 3, Name: "Bubbled reminder", BubbledUp: true}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cl := &contentList{}
+			cl.setPostings([]mail.Posting{
+				{ID: 1, Name: "Already new"},
+				testCase.posting,
+				{ID: 4, Name: "Older read", Seen: true},
+				{ID: 9, Name: "Keep bubbled", BubbledUp: true},
+			})
+			cl.cursor = slices.IndexFunc(cl.postings, func(p mail.Posting) bool { return p.ID == 3 })
+
+			cl.markUnseen(cl.cursor)
+
+			wantOrder := []int64{9, 3, 1, 4}
+			gotOrder := make([]int64, len(cl.postings))
+			for i, posting := range cl.postings {
+				gotOrder[i] = posting.ID
+			}
+			index := slices.IndexFunc(cl.postings, func(p mail.Posting) bool { return p.ID == 3 })
+			if !slices.Equal(gotOrder, wantOrder) || cl.postings[index].Seen || cl.postings[index].BubbledUp {
+				t.Errorf("posting order after unseen = %v, want %v; postings=%+v", gotOrder, wantOrder, cl.postings)
+			}
+			if selected := cl.selectedPosting(); selected == nil || selected.ID != 3 {
+				t.Errorf("cursor did not follow posting: %+v", selected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Aligns the mail TUI with the keyboard shortcuts people already use in HEY on the web. It adds mark-unseen support and preserves TUI-only actions behind non-conflicting chords and keys.

## Behavior

- Accepts HEY's lower/uppercase action pairs for seen, unseen, reply, forward, Move, Labels, Collections, Imbox, Reply Later, Set Aside, Feed, Paper Trail, and Trash.
- Adds `s/S` as Search aliases and moves Spam to `!`.
- Moves bulk reply/undo to `Ctrl+B`/`Ctrl+U` and cover peek to `x`.
- Removes the old `m`, `g`, and `k` posting-action aliases.
- Keeps ignored threads from claiming an unseen state HEY does not apply.
- Restores unseen threads at the front of New for You, after Bubbled Up, while preserving the reader's cursor and cover boundary.

## Scope

No API or SDK changes. The existing typed `Postings().MarkUnseen` operation is used. Existing `-/+`, box-number navigation, `Ctrl+V` cover picker, and unrelated TUI controls remain unchanged.

## Validation

- `make test` — pass
- `make lint` — pass, 0 issues
- Independent read-only review — no actionable findings after two correction rounds

## Risk and review focus

Medium interaction risk because several established TUI keys move. Start with `internal/tui/mail.go` for routing and mutation behavior, then `internal/tui/content.go` for unseen ordering and cover handling. Tests cover aliases, removed conflicts, request endpoints and bodies, success/failure/stale results, muted postings, ordering, cursor, and covers.

## Origin

[Basecamp card: Align mail shortcuts with the HEY web app](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10228609392)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Mail TUI keyboard shortcuts with the HEY web app to reduce switching costs and make actions consistent across platforms. Replaces TUI-only keys, adds unseen support that matches HEY’s behavior, and updates cover-peek and bulk-reply chords.

- Accepts HEY’s lower/uppercase pairs: reply (`r/R`), forward (`f/F`), seen (`e/E`), unseen (`u/U`), Imbox (`i/I`), Reply Later (`l/L`), Set Aside (`a/A`), Feed (`d/D`), Paper Trail (`p/P`), Trash (`t/T`).
- Search uses `/` or `s/S`. Move picker is `v/V`. Labels picker is `b/B`. Collections picker is `n/N`. Spam is `!`. Cover peek is `x`. Bulk reply is `Ctrl+B`; undo is `Ctrl+U`.
- Removes old aliases `m` (move), `g` (labels), `k` (collections). Labels no longer capture Shift+L in subnav; Shift+K opens Collections.
- Marks unseen via the existing `Postings().MarkUnseen` and reorders locally: restored threads appear in New for You after Bubbled Up, preserving cursor and cover boundary. Ignored threads cannot be marked unseen.

**Review focus**
- Start in `internal/tui/mail.go` for key routing, picker aliases, unseen action, and help text; then `internal/tui/content.go` for unseen reordering and cover hints.
- Interaction risk is medium due to moved keys; tests cover all aliases, removed conflicts, unseen ordering, cover behavior, and undo flow.

<sup>Written for commit f550f7721efb121b59182e5a0fb872dc6f3b27cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

