### PR TITLE
Polish Mail and Screener TUI design

### DIFF
--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -525,7 +525,7 @@ func (c *contentList) view() string {
 	rendered := 0
 	end := min(c.scrollOff+c.visibleItemsFrom(c.scrollOff), c.itemCount())
 
-	cursorMarker, _ := cursorStyles()
+	cursorMarker, cursorText := cursorStyles()
 	selectedGap := selectionStyle(lipgloss.NewStyle())
 	unseenDot := lipgloss.NewStyle().Foreground(colorAlert).Bold(true)
 	selectedMark := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
@@ -534,7 +534,8 @@ func (c *contentList) view() string {
 	// bold sender in the hyperlink color, and the excerpt in the faint
 	// secondary style. Read state shows as the section a row sits in
 	// ("Bubbled Up" / "New for You" / "Previously Seen") plus the alert dot;
-	// the cursor row adds only the selection background.
+	// the cursor row uses the accent foreground that the selection-background
+	// contrast gate guarantees remains legible.
 	subjectBase := lipgloss.NewStyle().Foreground(colorBright).Bold(true)
 	dateBase := lipgloss.NewStyle().Foreground(colorBright)
 	senderBase := lipgloss.NewStyle().Foreground(colorLink).Bold(true)
@@ -562,12 +563,12 @@ func (c *contentList) view() string {
 			rendered++
 		}
 
-		// When the theme has a usable selection, the cursor row paints every
-		// segment — gaps included — with the selection background so it reads
-		// as one highlighted line. The text keeps its base styles.
+		// The cursor text takes the accent foreground that applyTheme checked
+		// against the selection background. Gaps keep only the background so the
+		// two lines read as one highlighted row.
 		emphasize := func(base lipgloss.Style) lipgloss.Style {
 			if isCursor {
-				base = selectionStyle(base)
+				return cursorText
 			}
 			return base
 		}

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -530,13 +530,14 @@ func (c *contentList) view() string {
 	unseenDot := lipgloss.NewStyle().Foreground(colorAlert).Bold(true)
 	selectedMark := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
 
-	// Every row uses the same styles: bold bright subject; date, sender and
-	// excerpt in the faint secondary style. Read state shows as the section a
-	// row sits in ("Bubbled Up" / "New for You" / "Previously Seen") plus the
-	// alert dot; the cursor row renders bold on top of the base styles.
+	// Every row uses the same styles: bold bright subject, a bright date,
+	// bold sender in the hyperlink color, and the excerpt in the faint
+	// secondary style. Read state shows as the section a row sits in
+	// ("Bubbled Up" / "New for You" / "Previously Seen") plus the alert dot;
+	// the cursor row adds only the selection background.
 	subjectBase := lipgloss.NewStyle().Foreground(colorBright).Bold(true)
-	dateBase := styleMuted
-	senderBase := styleMuted
+	dateBase := lipgloss.NewStyle().Foreground(colorBright)
+	senderBase := lipgloss.NewStyle().Foreground(colorLink).Bold(true)
 	excerptBase := styleMuted
 
 	// The date gets its own right-hand column, as in the HEY web app. Both
@@ -561,12 +562,12 @@ func (c *contentList) view() string {
 			rendered++
 		}
 
-		// The cursor row renders bold on top of the base styles and, when the
-		// theme has a usable selection, paints every segment — gaps included —
-		// with the selection background so it reads as one highlighted line.
+		// When the theme has a usable selection, the cursor row paints every
+		// segment — gaps included — with the selection background so it reads
+		// as one highlighted line. The text keeps its base styles.
 		emphasize := func(base lipgloss.Style) lipgloss.Style {
 			if isCursor {
-				base = selectionStyle(base.Bold(true))
+				base = selectionStyle(base)
 			}
 			return base
 		}
@@ -616,12 +617,13 @@ func (c *contentList) view() string {
 		line1.WriteString(gapStyle.Render(strings.Repeat(" ", gap)))
 		line1.WriteString(emphasize(dateBase).Render(date))
 
-		// Line 2: [│]   extension@ Creator Name — excerpt...
+		// Line 2: [│]     extension@ Creator Name — excerpt...
+		// Indented two columns past the subject, as in The Screener.
 		var line2 strings.Builder
 		if isCursor {
-			line2.WriteString(cursorMarker.Render("│") + gapStyle.Render("   "))
+			line2.WriteString(cursorMarker.Render("│") + gapStyle.Render("     "))
 		} else {
-			line2.WriteString("    ")
+			line2.WriteString("      ")
 		}
 
 		name := p.Creator.Name
@@ -644,15 +646,24 @@ func (c *contentList) view() string {
 			excerpt = " — " + p.Summary
 		}
 
-		if lipgloss.Width(sender) > textWidth {
-			sender = truncateToWidth(sender, textWidth)
+		detailWidth := max(textWidth-2, 1) // the indent narrows the second line
+		if lipgloss.Width(sender) > detailWidth {
+			sender = truncateToWidth(sender, detailWidth)
 			excerpt = ""
 		} else {
-			excerpt = truncateToWidth(excerpt, textWidth-lipgloss.Width(sender))
+			excerpt = truncateToWidth(excerpt, detailWidth-lipgloss.Width(sender))
 		}
 
 		line2.WriteString(emphasize(senderBase).Render(sender))
 		line2.WriteString(emphasize(excerptBase).Render(excerpt))
+		if isCursor {
+			// Pad to the full row width so the selection background also
+			// covers the space under the date.
+			pad := prefixWidth + textWidth + 2 + dateCol - 6 - lipgloss.Width(sender) - lipgloss.Width(excerpt)
+			if pad > 0 {
+				line2.WriteString(gapStyle.Render(strings.Repeat(" ", pad)))
+			}
+		}
 
 		fmt.Fprintln(&b, line1.String())
 		fmt.Fprintln(&b, line2.String())

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -556,7 +556,7 @@ func (c *contentList) view() string {
 
 		if label := c.sectionLabelAt(i); label != "" {
 			if c.cover != coverNone && sectionOf(p) == sectionPreviouslySeen {
-				fmt.Fprintln(&b, coverHeader(label, "v to cover", c.width))
+				fmt.Fprintln(&b, coverHeader(label, "x to cover", c.width))
 			} else {
 				fmt.Fprintln(&b, sectionHeader(label, c.width))
 			}

--- a/internal/tui/covers_test.go
+++ b/internal/tui/covers_test.go
@@ -599,7 +599,7 @@ func TestPeekingLiftsTheCover(t *testing.T) {
 	if !strings.Contains(view, list.postings[2].Name) {
 		t.Error("peeking did not reveal the seen threads")
 	}
-	if !strings.Contains(view, "v to cover") {
+	if !strings.Contains(view, "x to cover") {
 		t.Error("a peeked list does not say how to put the cover back")
 	}
 

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // helpBinding is a key-description pair for the help bar.
@@ -93,6 +94,18 @@ func (h helpBar) view() string {
 	lineWidth := 0
 
 	for _, it := range items {
+		if maxWidth > 0 && it.width > maxWidth {
+			if lineWidth > 0 {
+				lines = append(lines, line.String())
+				line.Reset()
+				lineWidth = 0
+			}
+			wrapped := strings.Split(ansi.Wrap(it.str, maxWidth, ""), "\n")
+			lines = append(lines, wrapped[:len(wrapped)-1]...)
+			line.WriteString(wrapped[len(wrapped)-1])
+			lineWidth = lipgloss.Width(wrapped[len(wrapped)-1])
+			continue
+		}
 		if lineWidth > 0 && maxWidth > 0 && lineWidth+sepWidth+it.width > maxWidth {
 			lines = append(lines, line.String())
 			line.Reset()

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -98,7 +98,6 @@ func (h helpBar) view() string {
 			if lineWidth > 0 {
 				lines = append(lines, line.String())
 				line.Reset()
-				lineWidth = 0
 			}
 			wrapped := strings.Split(ansi.Wrap(it.str, maxWidth, ""), "\n")
 			lines = append(lines, wrapped[:len(wrapped)-1]...)

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -77,7 +77,13 @@ func (h helpBar) view() string {
 
 	var items []item
 	for _, b := range h.bindings {
-		rendered := h.styles.helpKey.Render(b.key) + " " + h.styles.helpDesc.Render(b.desc)
+		var rendered string
+		if b.desc == "" {
+			// A pre-styled segment the caller rendered itself.
+			rendered = b.key
+		} else {
+			rendered = h.styles.helpKey.Render(b.key) + " " + h.styles.helpDesc.Render(b.desc)
+		}
 		items = append(items, item{str: rendered, width: lipgloss.Width(rendered)})
 	}
 

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -2156,14 +2156,17 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 func (v *mailView) renderEntries(entries []mail.Entry) (string, []int) {
 	var b strings.Builder
 	offsets := make([]int, 0, len(entries))
+	lineCount := 0
 	sepWidth := max(v.vc.width-4, 40)
 	sep := v.vc.styles.separator.Render(strings.Repeat("─", sepWidth))
 
 	for i, e := range entries {
 		if i > 0 {
 			fmt.Fprintf(&b, "%s\n", sep)
+			lineCount++
 		}
-		offsets = append(offsets, strings.Count(b.String(), "\n"))
+		offsets = append(offsets, lineCount)
+		entryStart := b.Len()
 
 		from := e.Creator.Name
 		if from == "" {
@@ -2188,6 +2191,7 @@ func (v *mailView) renderEntries(entries []mail.Entry) (string, []int) {
 			fmt.Fprintf(&b, "\n%s\n", panel)
 		}
 		b.WriteString("\n")
+		lineCount += strings.Count(b.String()[entryStart:], "\n")
 	}
 
 	return b.String(), offsets

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -1525,7 +1525,6 @@ func (v *mailView) jumpEntry(delta int) {
 				return
 			}
 		}
-		v.topicViewport.GotoBottom()
 		return
 	}
 	for i := len(v.entryOffsets) - 1; i >= 0; i-- {

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -999,11 +999,15 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		case "o":
 			return v.openSelectedAttachment()
 		case "j":
-			v.jumpEntry(1)
-			return nil
+			if len(v.entryOffsets) > 1 {
+				v.jumpEntry(1)
+				return nil
+			}
 		case "k":
-			v.jumpEntry(-1)
-			return nil
+			if len(v.entryOffsets) > 1 {
+				v.jumpEntry(-1)
+				return nil
+			}
 		}
 		var cmd tea.Cmd
 		v.topicViewport, cmd = v.topicViewport.Update(msg)

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -208,6 +208,7 @@ type mailView struct {
 	attachments      []messageAttachment
 	attachmentCursor int
 	imageContent     string
+	entryOffsets     []int // line where each message starts in the thread content
 	inThread         bool
 	threadNotice     string // what the open thread's read did not get; stays until the thread is left
 	contentHeight    int    // the rows the section has, which the thread's notices and viewport share
@@ -743,6 +744,9 @@ func (v *mailView) HelpBindings() []helpBinding {
 	}
 	if v.inThread {
 		bindings := []helpBinding{{"r", "reply"}, {"f", "forward"}}
+		if len(v.entries) > 1 {
+			bindings = append(bindings, helpBinding{"j/k", "next/previous message"})
+		}
 		if len(v.attachments) > 0 {
 			bindings = append(bindings,
 				helpBinding{"[", "previous attachment"},
@@ -994,6 +998,12 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 			return v.saveSelectedAttachment()
 		case "o":
 			return v.openSelectedAttachment()
+		case "j":
+			v.jumpEntry(1)
+			return nil
+		case "k":
+			v.jumpEntry(-1)
+			return nil
 		}
 		var cmd tea.Cmd
 		v.topicViewport, cmd = v.topicViewport.Update(msg)
@@ -1498,8 +1508,35 @@ func (v *mailView) currentAttachmentAction(topicID int64, attachmentID string) b
 	return false
 }
 
+// jumpEntry scrolls the thread to the next or previous message header.
+func (v *mailView) jumpEntry(delta int) {
+	if len(v.entryOffsets) == 0 {
+		return
+	}
+	current := v.topicViewport.YOffset()
+	if delta > 0 {
+		for _, offset := range v.entryOffsets {
+			if offset > current {
+				v.topicViewport.SetYOffset(offset)
+				return
+			}
+		}
+		v.topicViewport.GotoBottom()
+		return
+	}
+	for i := len(v.entryOffsets) - 1; i >= 0; i-- {
+		if v.entryOffsets[i] < current {
+			v.topicViewport.SetYOffset(v.entryOffsets[i])
+			return
+		}
+	}
+	v.topicViewport.GotoTop()
+}
+
 func (v *mailView) rebuildTopicContent() {
-	v.topicContent = v.renderEntries(v.entries) + v.imageContent
+	rendered, offsets := v.renderEntries(v.entries)
+	v.topicContent = rendered + v.imageContent
+	v.entryOffsets = offsets
 	v.topicViewport.SetContent(v.topicContent)
 }
 
@@ -2110,8 +2147,11 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 
 // --- Entry rendering ---
 
-func (v *mailView) renderEntries(entries []mail.Entry) string {
+// renderEntries renders the thread's messages and returns the content along
+// with the line each message header starts on, for j/k jumps.
+func (v *mailView) renderEntries(entries []mail.Entry) (string, []int) {
 	var b strings.Builder
+	offsets := make([]int, 0, len(entries))
 	sepWidth := max(v.vc.width-4, 40)
 	sep := v.vc.styles.separator.Render(strings.Repeat("─", sepWidth))
 
@@ -2119,6 +2159,7 @@ func (v *mailView) renderEntries(entries []mail.Entry) string {
 		if i > 0 {
 			fmt.Fprintf(&b, "%s\n", sep)
 		}
+		offsets = append(offsets, strings.Count(b.String(), "\n"))
 
 		from := e.Creator.Name
 		if from == "" {
@@ -2145,5 +2186,5 @@ func (v *mailView) renderEntries(entries []mail.Entry) string {
 		b.WriteString("\n")
 	}
 
-	return b.String()
+	return b.String(), offsets
 }

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -3091,6 +3091,10 @@ func TestThreadJKJumpsBetweenMessages(t *testing.T) {
 	if got := v.topicViewport.YOffset(); got != v.entryOffsets[2] {
 		t.Errorf("j should jump to the third message: offset %d, want %d", got, v.entryOffsets[2])
 	}
+	v.HandleContentKey(keyPress("j"))
+	if got := v.topicViewport.YOffset(); got != v.entryOffsets[2] {
+		t.Errorf("j at the final message should stay on its header: offset %d, want %d", got, v.entryOffsets[2])
+	}
 	v.HandleContentKey(keyPress("k"))
 	if got := v.topicViewport.YOffset(); got != v.entryOffsets[1] {
 		t.Errorf("k should jump back to the second message: offset %d, want %d", got, v.entryOffsets[1])

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -3006,6 +3006,30 @@ func TestMailViewReadsEveryPageOfAThreadAndMarksUnreadBodies(t *testing.T) {
 	}
 }
 
+func TestThreadJKeepsLineScrollingForOneMessage(t *testing.T) {
+	v := newMailView(testVC())
+	v.vc.width = 80
+	v.vc.height = 10
+	v.topicViewport.SetWidth(80)
+	v.topicViewport.SetHeight(10)
+	v.inThread = true
+	v.entries = []mail.Entry{{
+		ID:      1,
+		Creator: mail.Contact{Name: "Maria Gonzalez"},
+		Body:    htmlutil.ToMarkdown(strings.Repeat("<p>One long message paragraph.</p>", 20)),
+	}}
+	v.rebuildTopicContent()
+
+	v.HandleContentKey(keyPress("j"))
+	if got := v.topicViewport.YOffset(); got != 1 {
+		t.Errorf("j should scroll one line in a one-message thread: offset %d", got)
+	}
+	v.HandleContentKey(keyPress("k"))
+	if got := v.topicViewport.YOffset(); got != 0 {
+		t.Errorf("k should scroll one line back in a one-message thread: offset %d", got)
+	}
+}
+
 func TestThreadJKJumpsBetweenMessages(t *testing.T) {
 	v := newMailView(testVC())
 	v.vc.width = 80

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -3006,6 +3006,38 @@ func TestMailViewReadsEveryPageOfAThreadAndMarksUnreadBodies(t *testing.T) {
 	}
 }
 
+func TestRenderEntriesReportsEveryMessageHeaderOffset(t *testing.T) {
+	v := newMailView(testVC())
+	v.vc.width = 60
+	v.attachments = []messageAttachment{{
+		ID:          "2:1",
+		MessageID:   2,
+		Filename:    "quarterly-plan.pdf",
+		ContentType: "application/pdf",
+	}}
+	entries := []mail.Entry{
+		{ID: 1, Creator: mail.Contact{Name: "Maria Gonzalez"}, Summary: "Opening summary", Body: htmlutil.ToMarkdown("<p>First body.</p><p>Second paragraph.</p>")},
+		{ID: 2, Creator: mail.Contact{Name: "Sam Rivera"}, Body: htmlutil.ToMarkdown("<p>Message with an attachment.</p>")},
+		{ID: 3, Creator: mail.Contact{Name: "Ana Ortiz"}, Summary: "Closing summary"},
+	}
+
+	rendered, offsets := v.renderEntries(entries)
+	searchFrom := 0
+	for i, entry := range entries {
+		name := entry.Creator.Name
+		relative := strings.Index(rendered[searchFrom:], name)
+		if relative < 0 {
+			t.Fatalf("rendered thread is missing header %q: %q", name, rendered)
+		}
+		headerStart := searchFrom + relative
+		want := strings.Count(rendered[:headerStart], "\n")
+		if offsets[i] != want {
+			t.Errorf("offset[%d] = %d, want header line %d", i, offsets[i], want)
+		}
+		searchFrom = headerStart + len(name)
+	}
+}
+
 func TestThreadJKeepsLineScrollingForOneMessage(t *testing.T) {
 	v := newMailView(testVC())
 	v.vc.width = 80

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -2941,7 +2941,8 @@ func TestThreadEntriesCarryTheTimeOfDay(t *testing.T) {
 		{ID: 502, Creator: mail.Contact{Name: "Bob"}, CreatedAt: time.Date(2026, 8, 18, 16, 5, 0, 0, time.UTC)},
 	}
 
-	rendered := stripANSI(v.renderEntries(entries))
+	renderedEntries, _ := v.renderEntries(entries)
+	rendered := stripANSI(renderedEntries)
 
 	for _, want := range []string{
 		formatDisplayDateTime(entries[0].CreatedAt),
@@ -2996,11 +2997,51 @@ func TestMailViewReadsEveryPageOfAThreadAndMarksUnreadBodies(t *testing.T) {
 		t.Errorf("notice = %q", loaded.notice)
 	}
 
-	view := v.renderEntries(loaded.entries)
+	view, _ := v.renderEntries(loaded.entries)
 	if !strings.Contains(view, "body 501") || !strings.Contains(view, "body 503") {
 		t.Errorf("view lacks the read bodies: %q", view)
 	}
 	if !strings.Contains(view, "(body not read: failed)") {
 		t.Errorf("view does not mark the unread body: %q", view)
+	}
+}
+
+func TestThreadJKJumpsBetweenMessages(t *testing.T) {
+	v := newMailView(testVC())
+	v.vc.width = 80
+	v.vc.height = 10
+	v.topicViewport.SetWidth(80)
+	v.topicViewport.SetHeight(10)
+	v.inThread = true
+	v.entries = []mail.Entry{
+		{ID: 1, Creator: mail.Contact{Name: "Maria Gonzalez"}, Body: htmlutil.ToMarkdown(strings.Repeat("<p>First message paragraph.</p>", 8))},
+		{ID: 2, Creator: mail.Contact{Name: "Sam Rivera"}, Body: htmlutil.ToMarkdown(strings.Repeat("<p>Second message paragraph.</p>", 8))},
+		{ID: 3, Creator: mail.Contact{Name: "Ana Ortiz"}, Body: htmlutil.ToMarkdown(strings.Repeat("<p>Third message paragraph.</p>", 8))},
+	}
+	v.rebuildTopicContent()
+
+	if len(v.entryOffsets) != 3 || v.entryOffsets[0] != 0 {
+		t.Fatalf("entry offsets = %v", v.entryOffsets)
+	}
+	if v.entryOffsets[1] <= v.entryOffsets[0] || v.entryOffsets[2] <= v.entryOffsets[1] {
+		t.Fatalf("entry offsets should grow: %v", v.entryOffsets)
+	}
+
+	v.HandleContentKey(keyPress("j"))
+	if got := v.topicViewport.YOffset(); got != v.entryOffsets[1] {
+		t.Errorf("j should jump to the second message: offset %d, want %d", got, v.entryOffsets[1])
+	}
+	v.HandleContentKey(keyPress("j"))
+	if got := v.topicViewport.YOffset(); got != v.entryOffsets[2] {
+		t.Errorf("j should jump to the third message: offset %d, want %d", got, v.entryOffsets[2])
+	}
+	v.HandleContentKey(keyPress("k"))
+	if got := v.topicViewport.YOffset(); got != v.entryOffsets[1] {
+		t.Errorf("k should jump back to the second message: offset %d, want %d", got, v.entryOffsets[1])
+	}
+	v.HandleContentKey(keyPress("k"))
+	v.HandleContentKey(keyPress("k"))
+	if got := v.topicViewport.YOffset(); got != 0 {
+		t.Errorf("k at the first message should go to the top: offset %d", got)
 	}
 }

--- a/internal/tui/screener.go
+++ b/internal/tui/screener.go
@@ -84,8 +84,9 @@ type screenerRow struct {
 	id       int64
 	name     string
 	email    string
-	detail   string // what they sent, or the address they write from
-	trailing string // their address, or the decision and when it was made
+	subject  string // subject of what they sent, or the address they write from
+	summary  string // excerpt of what they sent
+	trailing string // when they wrote, or the decision and when it was made
 }
 
 type screenerPane struct {
@@ -226,6 +227,7 @@ type screenerView struct {
 
 	pendingCount    int
 	confirmingClear bool
+	emphaticNo      bool // undocumented Shift+F toggle: "No" becomes "Fuck no!"
 	notice          string
 	loading         bool
 	requestID       uint64
@@ -374,8 +376,7 @@ func (v *screenerView) HelpBindings() []helpBinding {
 	bindings := []helpBinding{{"↑↓", "navigate"}}
 	if v.tab == screenerPendingTab {
 		bindings = append(bindings,
-			helpBinding{"y", "screen in"},
-			helpBinding{"n", "screen out"},
+			helpBinding{key: v.screenQuestion()},
 			helpBinding{"tab", "screener history"},
 		)
 	} else {
@@ -383,6 +384,19 @@ func (v *screenerView) HelpBindings() []helpBinding {
 	}
 	bindings = append(bindings, helpBinding{"X", "clear all"})
 	return append(bindings, helpBinding{"esc/q", "back to mail"})
+}
+
+// screenQuestion renders the screening prompt for the help bar: the question
+// in chrome, then Yes and No as keys with their hotkey letters underlined.
+func (v *screenerView) screenQuestion() string {
+	question := v.vc.styles.helpDesc.Render("Want to get emails from them?")
+	yes := renderNavLabel("Yes", "Y", v.vc.styles.helpKey)
+	noLabel := "No"
+	if v.emphaticNo {
+		noLabel = "Fuck no!"
+	}
+	no := renderNavLabel(noLabel, "N", v.vc.styles.helpKey)
+	return question + " " + yes + " " + no
 }
 
 func (v *screenerView) SubnavItems() ([]navItem, int, string, bool) {
@@ -404,6 +418,10 @@ func (v *screenerView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	key := msg.String()
+	if key == "F" {
+		v.emphaticNo = !v.emphaticNo
+		return nil
+	}
 	switch msg.Key().Code {
 	case tea.KeyEscape:
 		return v.close()
@@ -575,7 +593,6 @@ func (v *screenerView) explanation() string {
 	for _, line := range lines {
 		b.WriteString(muted.Render("  "+line) + "\n")
 	}
-	b.WriteString(v.vc.styles.title.Render("  Want to get emails from them?") + "\n")
 	return b.String()
 }
 
@@ -676,20 +693,14 @@ func (v *screenerView) readScreenedPage(page string) ([]screenerRow, string, err
 // --- Rendering ---
 
 func pendingScreenerRow(clearance generated.Clearance) screenerRow {
-	detail := clearance.MostRecentEntry.Subject
-	if summary := clearance.MostRecentEntry.Summary; summary != "" {
-		if detail == "" {
-			detail = summary
-		} else {
-			detail += " – " + summary
-		}
-	}
+	subject, summary := clearanceEntryParts(clearance)
 	return screenerRow{
 		id:       clearance.Id,
 		name:     terminal.SanitizeLine(clearance.Petitioner.Name),
 		email:    terminal.SanitizeLine(clearance.Petitioner.EmailAddress),
-		detail:   terminal.SanitizeLine(detail),
-		trailing: terminal.SanitizeLine(clearance.Petitioner.EmailAddress),
+		subject:  subject,
+		summary:  summary,
+		trailing: formatDisplayDate(clearance.MostRecentEntry.CreatedAt),
 	}
 }
 
@@ -698,13 +709,26 @@ func screenedScreenerRow(clearance generated.Clearance) screenerRow {
 	if decided := formatDisplayDate(clearance.UpdatedAt); decided != "" {
 		trailing += " · " + decided
 	}
+	subject, summary := clearanceEntryParts(clearance)
 	return screenerRow{
 		id:       clearance.Id,
 		name:     terminal.SanitizeLine(clearance.Petitioner.Name),
 		email:    terminal.SanitizeLine(clearance.Petitioner.EmailAddress),
-		detail:   terminal.SanitizeLine(clearance.Petitioner.EmailAddress),
+		subject:  subject,
+		summary:  summary,
 		trailing: trailing,
 	}
+}
+
+// clearanceEntryParts returns the subject and excerpt of what the petitioner
+// sent, falling back to their address when HEY serves no entry data.
+func clearanceEntryParts(clearance generated.Clearance) (subject, summary string) {
+	subject = clearance.MostRecentEntry.Subject
+	summary = clearance.MostRecentEntry.Summary
+	if subject == "" && summary == "" {
+		subject = clearance.Petitioner.EmailAddress
+	}
+	return terminal.SanitizeLine(subject), terminal.SanitizeLine(summary)
 }
 
 func screenedVerb(status string) string {
@@ -724,15 +748,26 @@ func screenerRowName(row screenerRow) string {
 	return fmt.Sprintf("clearance %d", row.id)
 }
 
+// screenerRowLabel is the first-line label: the name with the address in
+// angle brackets, as an email From header writes it.
+func screenerRowLabel(row screenerRow) string {
+	if row.name != "" && row.email != "" {
+		return row.name + " <" + row.email + ">"
+	}
+	return screenerRowName(row)
+}
+
 func renderScreenerRows(pane *screenerPane, visible, width int) string {
-	// The cursor row goes through the same helpers as Mail and Contacts so a
-	// theme's selection background tints every segment of it, gaps included.
-	// Every text segment on it takes the accent, as in Mail: the selection is
-	// gated for accent-on-selection contrast, not muted-on-selection.
-	marker, selected := cursorStyles()
+	// Rows mirror the mail lists: a bold bright first line ("Name <address>")
+	// with a bright trailing date, then an indented second line whose subject
+	// takes the hyperlink color and whose excerpt is faint. The cursor row
+	// adds only the bar and the selection background, gaps included.
+	marker, _ := cursorStyles()
 	selectedGap := selectionStyle(lipgloss.NewStyle())
-	normal := lipgloss.NewStyle().Foreground(colorBright)
-	muted := lipgloss.NewStyle().Foreground(colorMuted)
+	labelBase := lipgloss.NewStyle().Foreground(colorBright).Bold(true)
+	trailingBase := lipgloss.NewStyle().Foreground(colorBright)
+	subjectBase := lipgloss.NewStyle().Foreground(colorLink).Bold(true)
+	summaryBase := styleMuted
 
 	var b strings.Builder
 	end := min(pane.scroll+visible, len(pane.rows))
@@ -740,24 +775,61 @@ func renderScreenerRows(pane *screenerPane, visible, width int) string {
 		row := pane.rows[index]
 		isCursor := index == pane.cursor
 
+		emphasize := func(base lipgloss.Style) lipgloss.Style {
+			if isCursor {
+				return selectionStyle(base)
+			}
+			return base
+		}
+		gapStyle := lipgloss.NewStyle()
+		if isCursor {
+			gapStyle = selectedGap
+		}
+
 		trailing := truncateStr(row.trailing, max(width/2, 10))
-		name := truncateStr(screenerRowName(row), max(width-lipgloss.Width(trailing)-6, 10))
-		gap := strings.Repeat(" ", max(width-4-lipgloss.Width(name)-lipgloss.Width(trailing), 1))
-		detail := truncateStr(row.detail, max(width-6, 10))
+		label := truncateStr(screenerRowLabel(row), max(width-lipgloss.Width(trailing)-6, 10))
+		gap := strings.Repeat(" ", max(width-4-lipgloss.Width(label)-lipgloss.Width(trailing), 1))
+
+		// Line 2: Subject — excerpt, colored like a mail row's second line.
+		subject := row.subject
+		var summary string
+		if row.summary != "" {
+			summary = " — " + row.summary
+		}
+		detailWidth := max(width-6, 10)
+		if lipgloss.Width(subject) > detailWidth {
+			subject = truncateStr(subject, detailWidth)
+			summary = ""
+		} else {
+			summary = truncateStr(summary, max(detailWidth-lipgloss.Width(subject), 0))
+		}
 
 		if isCursor {
-			b.WriteString(marker.Render("│") + selectedGap.Render(" ") + selected.Render(name) + selectedGap.Render(gap))
-			if trailing != "" {
-				b.WriteString(selected.Render(trailing))
-			}
-			b.WriteString("\n" + marker.Render("│") + selectedGap.Render("   ") + selected.Render(detail) + "\n")
-			continue
+			b.WriteString(marker.Render("│") + gapStyle.Render(" "))
+		} else {
+			b.WriteString("  ")
 		}
-		b.WriteString("  " + normal.Render(name) + gap)
+		b.WriteString(emphasize(labelBase).Render(label) + gapStyle.Render(gap))
 		if trailing != "" {
-			b.WriteString(muted.Render(trailing))
+			b.WriteString(emphasize(trailingBase).Render(trailing))
 		}
-		b.WriteString("\n    " + muted.Render(detail) + "\n")
+		b.WriteString("\n")
+		if isCursor {
+			b.WriteString(marker.Render("│") + gapStyle.Render("   "))
+		} else {
+			b.WriteString("    ")
+		}
+		b.WriteString(emphasize(subjectBase).Render(subject))
+		b.WriteString(emphasize(summaryBase).Render(summary))
+		if isCursor {
+			// Pad to the first line's width so the selection background
+			// covers the whole row.
+			pad := width - 6 - lipgloss.Width(subject) - lipgloss.Width(summary)
+			if pad > 0 {
+				b.WriteString(gapStyle.Render(strings.Repeat(" ", pad)))
+			}
+		}
+		b.WriteString("\n")
 	}
 	return b.String()
 }

--- a/internal/tui/screener.go
+++ b/internal/tui/screener.go
@@ -761,8 +761,9 @@ func renderScreenerRows(pane *screenerPane, visible, width int) string {
 	// Rows mirror the mail lists: a bold bright first line ("Name <address>")
 	// with a bright trailing date, then an indented second line whose subject
 	// takes the hyperlink color and whose excerpt is faint. The cursor row
-	// adds only the bar and the selection background, gaps included.
-	marker, _ := cursorStyles()
+	// uses the accent foreground that is checked against the selection
+	// background, with the bar and background spanning both lines.
+	marker, selectedText := cursorStyles()
 	selectedGap := selectionStyle(lipgloss.NewStyle())
 	labelBase := lipgloss.NewStyle().Foreground(colorBright).Bold(true)
 	trailingBase := lipgloss.NewStyle().Foreground(colorBright)
@@ -777,7 +778,7 @@ func renderScreenerRows(pane *screenerPane, visible, width int) string {
 
 		emphasize := func(base lipgloss.Style) lipgloss.Style {
 			if isCursor {
-				return selectionStyle(base)
+				return selectedText
 			}
 			return base
 		}

--- a/internal/tui/screener_test.go
+++ b/internal/tui/screener_test.go
@@ -151,6 +151,17 @@ func TestScreenerViewCarriesHeyWording(t *testing.T) {
 	if !strings.Contains(barView, "\x1b[1;4;34;4mY\x1b[m") || !strings.Contains(barView, "\x1b[1;4;34;4mN\x1b[m") {
 		t.Errorf("Y and N should be underlined hotkeys: %q", barView)
 	}
+
+	bar.setWidth(24)
+	barView = bar.view()
+	for _, line := range strings.Split(barView, "\n") {
+		if width := ansi.StringWidth(line); width > 24 {
+			t.Errorf("narrow help line width = %d, want at most 24: %q", width, line)
+		}
+	}
+	if bar.height() != strings.Count(barView, "\n")+1 {
+		t.Errorf("help height = %d, rendered %d rows", bar.height(), strings.Count(barView, "\n")+1)
+	}
 }
 
 func TestScreenerEmptyQueue(t *testing.T) {

--- a/internal/tui/screener_test.go
+++ b/internal/tui/screener_test.go
@@ -122,7 +122,8 @@ func TestScreenerLoadsPendingSenders(t *testing.T) {
 
 func TestScreenerViewCarriesHeyWording(t *testing.T) {
 	view, _ := loadedScreener(t)
-	rendered := plainText(view.View())
+	styled := view.View()
+	rendered := plainText(styled)
 
 	for _, want := range []string{
 		"The people below are trying to email you for the first time.",
@@ -133,6 +134,9 @@ func TestScreenerViewCarriesHeyWording(t *testing.T) {
 		if !strings.Contains(rendered, want) {
 			t.Errorf("screener view is missing %q:\n%s", want, rendered)
 		}
+	}
+	if !strings.Contains(styled, "\x1b[1;94mJane Doe") || !strings.Contains(styled, "\x1b[1;94mQuarterly planning") {
+		t.Errorf("selected sender should use the contrast-checked primary color: %q", styled)
 	}
 
 	// The screening question lives in the help bar, with Yes and No as

--- a/internal/tui/screener_test.go
+++ b/internal/tui/screener_test.go
@@ -112,7 +112,7 @@ func TestScreenerLoadsPendingSenders(t *testing.T) {
 		t.Fatalf("pending = count:%d rows:%d, want 2 and 2", view.pendingCount, len(view.pending.rows))
 	}
 	first := view.pending.rows[0]
-	if first.id != 91 || first.name != "Jane Doe" || first.detail != "Quarterly planning – Can we meet Thursday?" {
+	if first.id != 91 || first.name != "Jane Doe" || first.subject != "Quarterly planning" || first.summary != "Can we meet Thursday?" {
 		t.Errorf("first sender = %+v", first)
 	}
 	if view.loading {
@@ -127,13 +127,25 @@ func TestScreenerViewCarriesHeyWording(t *testing.T) {
 	for _, want := range []string{
 		"The people below are trying to email you for the first time.",
 		"You get to decide if you want to hear from them.",
-		"Want to get emails from them?",
 		"Jane Doe",
 		"Quarterly planning",
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Errorf("screener view is missing %q:\n%s", want, rendered)
 		}
+	}
+
+	// The screening question lives in the help bar, with Yes and No as
+	// underlined hotkeys.
+	bar := newHelpBar(newStyles())
+	bar.setWidth(120)
+	bar.setBindings(view.HelpBindings())
+	barView := bar.view()
+	if !strings.Contains(plainText(barView), "Want to get emails from them? Yes No") {
+		t.Errorf("help bar is missing the screening question: %q", barView)
+	}
+	if !strings.Contains(barView, "\x1b[1;4;34;4mY\x1b[m") || !strings.Contains(barView, "\x1b[1;4;34;4mN\x1b[m") {
+		t.Errorf("Y and N should be underlined hotkeys: %q", barView)
 	}
 }
 
@@ -452,10 +464,10 @@ func TestScreenerKeepsDrawingAfterScreeningOffTheBottom(t *testing.T) {
 	rows := make([]screenerRow, 0, 20)
 	for index := range 20 {
 		rows = append(rows, screenerRow{
-			id:     int64(300 + index),
-			name:   fmt.Sprintf("Sender %02d", index),
-			email:  fmt.Sprintf("sender%02d@example.com", index),
-			detail: "Wants to hear back",
+			id:      int64(300 + index),
+			name:    fmt.Sprintf("Sender %02d", index),
+			email:   fmt.Sprintf("sender%02d@example.com", index),
+			subject: "Wants to hear back",
 		})
 	}
 	view.pending.setRows(rows, "")
@@ -590,7 +602,7 @@ func TestModelRoutesScreenerKeysToTheScreener(t *testing.T) {
 	m.screenerView.Update(screenerPendingLoadedMsg{
 		requestID: m.screenerView.requestID,
 		count:     1,
-		rows:      []screenerRow{{id: 91, name: "Jane Doe", detail: "Quarterly planning"}},
+		rows:      []screenerRow{{id: 91, name: "Jane Doe", subject: "Quarterly planning"}},
 	})
 	m.loading = false
 
@@ -608,3 +620,20 @@ func TestModelRoutesScreenerKeysToTheScreener(t *testing.T) {
 }
 
 var _ tea.Model = model{}
+
+func TestScreenerShiftFTogglesEmphaticNo(t *testing.T) {
+	view, _ := loadedScreener(t)
+
+	view.HandleContentKey(keyPress("F"))
+	if !strings.Contains(plainText(view.screenQuestion()), "Fuck no!") {
+		t.Errorf("Shift+F should swap the No label: %q", view.screenQuestion())
+	}
+	if !strings.Contains(view.screenQuestion(), "\x1b[1;4;34;4mn\x1b[m") {
+		t.Errorf("the n hotkey should stay underlined in the swapped label: %q", view.screenQuestion())
+	}
+
+	view.HandleContentKey(keyPress("F"))
+	if strings.Contains(plainText(view.screenQuestion()), "Fuck no!") {
+		t.Errorf("Shift+F should toggle back to No: %q", view.screenQuestion())
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -25,6 +25,7 @@ var (
 	colorMuted   color.Color = lipgloss.BrightBlack // decorative filler only — see styleMuted
 	colorBright  color.Color = lipgloss.BrightWhite // emphasized text
 	colorAlert               = lipgloss.Red         // attention: Omarchy themes signal alerts with red
+	colorLink                = lipgloss.BrightCyan  // hyperlinks in email bodies (markdown style "14"); subjects match it
 	colorError   color.Color = lipgloss.Red         // errors
 
 	// Interface chrome (rules, tabs, hotkeys) follows eza's convention for

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -25,7 +25,7 @@ var (
 	colorMuted   color.Color = lipgloss.BrightBlack // decorative filler only — see styleMuted
 	colorBright  color.Color = lipgloss.BrightWhite // emphasized text
 	colorAlert               = lipgloss.Red         // attention: Omarchy themes signal alerts with red
-	colorLink                = lipgloss.BrightCyan  // hyperlinks in email bodies (markdown style "14"); subjects match it
+	colorLink    color.Color = lipgloss.BrightCyan  // hyperlinks in email bodies (markdown style "14"); subjects match it
 	colorError   color.Color = lipgloss.Red         // errors
 
 	// Interface chrome (rules, tabs, hotkeys) follows eza's convention for
@@ -54,6 +54,7 @@ func applyTheme(theme Theme) {
 	colorPrimary = theme.Accent
 	colorMuted = theme.Muted
 	colorBright = theme.Bright
+	colorLink = lipgloss.BrightCyan
 	colorError = theme.Error
 	colorSelection = nil
 	if theme.Selection != nil && (theme.Trusted || contrastRatio(theme.Accent, theme.Selection) >= minSelectionContrast) {
@@ -66,6 +67,7 @@ func applyTheme(theme Theme) {
 	// better there.
 	colorOnAccent = lipgloss.Black
 	if nc, ok := theme.Accent.(lipgloss.NoColor); ok {
+		colorLink = nc
 		colorOnAccent = nc
 	} else if theme.Accent != color.Color(lipgloss.BrightBlue) &&
 		contrastRatio(lipgloss.BrightWhite, theme.Accent) > contrastRatio(lipgloss.Black, theme.Accent) {

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -284,7 +284,7 @@ func TestCursorStylesCarryTheSelectionBackground(t *testing.T) {
 	if marker.GetBackground() != want || text.GetBackground() != want || gap.GetBackground() != want {
 		t.Error("every cursor-row segment a section renders through the helpers must carry the selection background")
 	}
-	if renderScreenerRows(&screenerPane{rows: []screenerRow{{detail: "maria@example.com"}}}, 5, 40) == "" {
+	if renderScreenerRows(&screenerPane{rows: []screenerRow{{subject: "maria@example.com"}}}, 5, 40) == "" {
 		t.Error("screener rows should render")
 	}
 }

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -296,6 +296,9 @@ func TestPillTextReadsOnTheAccent(t *testing.T) {
 	if colorOnAccent != color.Color(lipgloss.Black) {
 		t.Errorf("the ANSI accent keeps the classic black pill text, got %v", colorOnAccent)
 	}
+	if colorLink != color.Color(lipgloss.BrightCyan) {
+		t.Errorf("the default theme keeps links cyan, got %v", colorLink)
+	}
 
 	// lupine's dark blue carries black at ~3.7:1; white reads better.
 	lupine := map[string]string{"accent": "#3264eb", "background": "#fafafa",
@@ -314,6 +317,9 @@ func TestPillTextReadsOnTheAccent(t *testing.T) {
 	applyTheme(noColorTheme())
 	if _, ok := colorOnAccent.(lipgloss.NoColor); !ok {
 		t.Errorf("NO_COLOR must keep the pill colorless, got %v", colorOnAccent)
+	}
+	if _, ok := colorLink.(lipgloss.NoColor); !ok {
+		t.Errorf("NO_COLOR must keep links colorless, got %v", colorLink)
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -715,8 +715,12 @@ func TestContentListStylesSeenAndUnseenRows(t *testing.T) {
 	}
 
 	// Seen rows look the same as unseen rows — the section carries the state.
-	if !strings.Contains(seenLine1, "\x1b[1;97m") || !strings.Contains(seenLine1, "\x1b[2m") {
+	// The sender takes the hyperlink color; the date shares the subject color.
+	if !strings.Contains(seenLine1, "\x1b[1;97m") || !strings.Contains(seenLine1, "\x1b[97m") {
 		t.Errorf("seen row should keep the full row styling: %q", seenLine1)
+	}
+	if !strings.Contains(unseenLine2, "\x1b[1;96m") || !strings.Contains(seenLine2, "\x1b[1;96m") {
+		t.Errorf("sender names should be bold hyperlink cyan in both sections: %q / %q", unseenLine2, seenLine2)
 	}
 	if !strings.Contains(unseenLine2, "\x1b[2m") || !strings.Contains(seenLine2, "\x1b[2m") {
 		t.Errorf("second lines should be faint secondary text in both sections: %q / %q", unseenLine2, seenLine2)
@@ -857,10 +861,13 @@ func TestContentListAlignsDateColumn(t *testing.T) {
 	}
 
 	dateCol := lipgloss.Width("Aug 20, 2026")
-	for _, second := range []string{lines[2], lines[5]} {
-		if lipgloss.Width(second) > firstWidth-dateCol-2 {
-			t.Errorf("second line reaches into the date column: %q", second)
-		}
+	// The cursor row (row 0) pads its second line to the full row width so
+	// the selection background also covers the space under the date.
+	if lipgloss.Width(lines[2]) != firstWidth {
+		t.Errorf("cursor row second line width = %d, want the full row width %d", lipgloss.Width(lines[2]), firstWidth)
+	}
+	if lipgloss.Width(lines[5]) > firstWidth-dateCol-2 {
+		t.Errorf("second line text reaches into the date column: %q", lines[5])
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -704,8 +704,8 @@ func TestContentListStylesSeenAndUnseenRows(t *testing.T) {
 	if !strings.Contains(seenHeader, "Previously Seen") {
 		t.Errorf("the seen section should open with its header: %q", seenHeader)
 	}
-	if !strings.Contains(cursorLine1, "\x1b[1;94m") || !strings.Contains(cursorLine1, "│") {
-		t.Errorf("cursor row should show the primary-colored bar: %q", cursorLine1)
+	if !strings.Contains(cursorLine1, "\x1b[1;94mCursor row") || !strings.Contains(cursorLine1, "│") {
+		t.Errorf("cursor row should keep all text in the contrast-checked primary color: %q", cursorLine1)
 	}
 	if !strings.Contains(unseenLine1, "●") || !strings.Contains(unseenLine1, "\x1b[1;31m") {
 		t.Errorf("unseen row should show the unread dot in the alert color: %q", unseenLine1)


### PR DESCRIPTION
Polishes the Mail and Screener TUI so their rows share a clearer two-line hierarchy, while adding message-to-message navigation inside threads. Existing mail actions, account behavior, and server interactions remain unchanged.

## Behavior

- Styles Mail rows with stronger subject, sender, date, and excerpt hierarchy while keeping selected text readable against themed selection backgrounds.
- Redesigns Screener rows around sender, address, subject, excerpt, and date/decision metadata.
- Moves the Screener question into the help bar with underlined Yes/No actions and preserves it on narrow terminals by wrapping oversized help items.
- Adds `j`/`k` jumps between messages in multi-message threads; single-message threads retain normal line scrolling and navigation stops at the first/last message.
- Adds the Screener's undocumented Shift+F wording toggle.
- Keeps link accents colorless under `NO_COLOR`.
- Corrects the revealed-cover hint to say `x to cover`, matching the existing `x` binding; `v/V` remains Move and Ctrl+V remains the TUI-only cover picker.

## Scope

No API, SDK, persistence, dependency, configuration, or deployment changes. The work is limited to TUI rendering, help layout, keyboard navigation, and their tests.

## Validation

- `GOWORK=off make test` — pass
- `GOWORK=off make lint` — pass, 0 issues
- `GOWORK=off make build` — pass
- `git diff --check main...HEAD` — pass
- Local TUI exercise — cover reveal/restore and corrected `x` hint confirmed
- Two independent read-only review passes; all findings resolved, with no actionable findings remaining

## Risk and review focus

Medium interaction and presentation risk. Start with `internal/tui/content.go` and `internal/tui/screener.go` for row hierarchy and selected-state contrast, then `internal/tui/mail.go` for message offsets and `j`/`k` boundaries. Narrow help wrapping and `NO_COLOR` behavior have focused regression coverage.

## Delivery

No rollout steps, migrations, feature flags, or cleanup. Reverting this PR restores the previous presentation and thread navigation.

## Origin

Design pass authored by Jason Zimdars; no external ticket or specification exists for this branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes Mail and Screener TUIs into a consistent two‑line row hierarchy with improved contrast and date alignment, and adds j/k navigation within multi‑message threads for faster reading. Improves readability and selection legibility across themes, moves the Screener prompt to the help bar with underlined Y/N, keeps link accents colorless under NO_COLOR, and corrects the cover hint to x.

- Review notes:
  - Mail list: bright, bold subjects; bright dates; bold sender in hyperlink cyan; muted excerpts; cursor text uses the contrast‑checked accent; second line indented and padded to the row width; section header reads x to cover.
  - Thread view: tracks per‑message header offsets and binds j/k to next/previous message; stops at first/last; single‑message threads keep normal line scrolling; help shows j/k only for multi‑message threads.
  - Screener rows: first line “Name <address>” with date/decision; second line subject (link color) and excerpt; pending shows when they wrote; history shows decision and when; Shift+F toggles the “No” label to “Fuck no!”; the screening question now renders in the help bar with underlined Y/N.
  - Help bar: wraps oversized items to terminal width and accepts pre‑styled segments for composite prompts.
  - Styles: introduces colorLink cyan; under NO_COLOR, links and pill text remain colorless; selection/accent contrast gates remain in place.

<sup>Written for commit bdfdeccba46398a77d617e6bfa969416de16cbad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

