### PR TITLE
Write prose in its sanitized form, escape jq keys to ASCII, end a base at punctuation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ handed. The model has three layers, and it is worth knowing which one a change t
   the Markdown renderer, into a red terminal); inline code and fences are verbatim inside
   delimiters longer than any run they hold; destinations percent-encode what would end
   them, keep a query string's `&`, and link only http, https, mailto and relative paths.
-  Every context strips controls first. `markdown.Render` then strips controls and bidi controls from the body, rewrites the
+  Prose goes through `terminal.Sanitize` first and is written in that form; code and destinations strip controls and are measured through the sanitizer (`backtickRun`, `needsPadding`). `markdown.Render` then strips controls and bidi controls from the body, rewrites the
   spans glamour decodes so that its extra entity decode is the identity, shows a
   document nested past twenty levels unrendered rather than handing glamour something
   exponential, and checks its own output: anything but SGR and OSC 8 to an allowed scheme strips all
@@ -195,7 +195,10 @@ handed. The model has three layers, and it is worth knowing which one a change t
   as `jq -r` writes it.
 
 The Markdown in `--json` is standard CommonMark; what a conformant renderer shows for it
-is the literal text and URL the email held, which is what the htmlutil tests assert
+is the literal text and URL the email held — less, in prose, what `terminal.Sanitize`
+removes, since prose is written in its sanitized form so that the renderer's own pass
+over the body cannot uncover a block marker the escaping did not see (`\u200b# heading`);
+the HTML keeps the original. That is what the htmlutil tests assert
 through goldmark. Fuzz targets hold the invariants: `FuzzToMarkdownTerminalSafety` in
 htmlutil and `FuzzContainment` in markdown.
 

--- a/internal/htmlutil/markdown.go
+++ b/internal/htmlutil/markdown.go
@@ -537,7 +537,9 @@ func (m *markdownizer) hardBreak() {
 }
 
 func (m *markdownizer) flushLine() {
-	content := strings.TrimRight(m.line.String(), " \t")
+	// A joiner kept at the end of a prose run for the run after it (sanitizeProse) has
+	// nothing to join once the line ends.
+	content := strings.TrimRight(m.line.String(), " \t\u200c\u200d")
 	breaking := m.breaking
 	m.line.Reset()
 	m.breaking = false

--- a/internal/htmlutil/markdown_safety.go
+++ b/internal/htmlutil/markdown_safety.go
@@ -104,7 +104,27 @@ func sanitizeProse(s, line string) string {
 		strings.HasSuffix(terminal.Sanitize(context+tail+string(last)+"é"), string(last)+"é") {
 		tail += string(last)
 	}
-	return tail
+	return recollapse(tail, line)
+}
+
+// recollapse folds the whitespace the sanitizer uncovered — "\u200b # heading" is
+// " # heading" once the zero width space is gone — the way writeText folded the run
+// before it: runs of whitespace to one space, none at the start of a line, so that a
+// block marker cannot hide behind a space the line-start escape does not look past, and
+// four of them cannot open an indented code block. A space at either edge of the run
+// stays one space between it and its neighbours, as writeSpace would have left it.
+func recollapse(s, line string) string {
+	folded := strings.Join(strings.Fields(s), " ")
+	if folded == "" {
+		return ""
+	}
+	if startsWithSpace(s) && line != "" && !strings.HasSuffix(line, " ") {
+		folded = " " + folded
+	}
+	if endsWithSpace(s) {
+		folded += " "
+	}
+	return folded
 }
 
 // lineContext is the end of a line that the sanitizer's decisions about what follows

--- a/internal/htmlutil/markdown_safety.go
+++ b/internal/htmlutil/markdown_safety.go
@@ -13,7 +13,12 @@ import (
 // own grammar, so each has its own serializer here, and the invariant every one of them
 // keeps is the same: the Markdown parses back to the literal text or URL it was given,
 // with no control character left in it. The text that reads "&#27;[31m" in an email stays
-// those eight characters on screen rather than turning red.
+// those eight characters on screen rather than turning red. Prose is the one context
+// written in its sanitized form — terminal.Sanitize runs over it before anything is
+// escaped — because markdown.Render runs that sanitizer over the whole body before
+// parsing it, and an escape decided on the text as written can be undone by what the
+// sanitizer removes in front of it. Code and destinations are written as they are and
+// only measured through the sanitizer; the HTML keeps the original of everything.
 
 // inlineMetacharacters are the ASCII characters that open Markdown syntax wherever they
 // stand in a line. `&` is not among them because it is written as an entity instead.
@@ -27,10 +32,14 @@ const lineStartMetacharacters = "#>+-="
 // CommonMark decodes anywhere outside code — text, link destinations, info strings.
 var entityReference = regexp.MustCompile(`^&(#[0-9]{1,8}|#[xX][0-9a-fA-F]{1,8}|[A-Za-z][A-Za-z0-9]{1,31});`)
 
-// escapeText serializes a run of prose onto a line that already holds `line`. Controls go
-// first, so that what is left is what gets looked at — "&\x1f#27;" is "&#27;" once the
-// control is gone. Then every metacharacter is backslash-escaped, and at the start of a
-// line so is anything that would begin a block.
+// escapeText serializes a run of prose onto a line that already holds `line`. The
+// sanitizer goes first, so that what is left is what gets looked at — "&\x1f#27;" is
+// "&#27;" once the control is gone, and "\u200b# heading" is "# heading" once the zero
+// width space is. markdown.Render runs the same sanitizer over the whole body before
+// parsing it, so prose is written here in the form it will be parsed in; escaping the
+// text as written and letting the renderer strip an invisible in front of a block marker
+// would hand glamour a heading the email never had. Then every metacharacter is
+// backslash-escaped, and at the start of a line so is anything that would begin a block.
 //
 // Every `&` becomes `&amp;`, which decodes back to `&` in CommonMark and in glamour
 // alike. Escaping only the ampersands that already spell an entity is not enough: text
@@ -39,11 +48,11 @@ var entityReference = regexp.MustCompile(`^&(#[0-9]{1,8}|#[xX][0-9a-fA-F]{1,8}|[
 // line-start checks look at the line being built rather than at the run alone.
 func escapeText(s, line string) string {
 	s = strings.Map(func(r rune) rune {
-		if isControl(r) {
+		if r == '\n' || r == '\t' {
 			return -1
 		}
 		return r
-	}, s)
+	}, terminal.Sanitize(s))
 
 	var b strings.Builder
 	b.Grow(len(s))

--- a/internal/htmlutil/markdown_safety.go
+++ b/internal/htmlutil/markdown_safety.go
@@ -3,6 +3,8 @@ package htmlutil
 import (
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/basecamp/hey-cli/internal/terminal"
 )
@@ -47,12 +49,7 @@ var entityReference = regexp.MustCompile(`^&(#[0-9]{1,8}|#[xX][0-9a-fA-F]{1,8}|[
 // start of the next is an entity once they sit side by side. For the same reason the
 // line-start checks look at the line being built rather than at the run alone.
 func escapeText(s, line string) string {
-	s = strings.Map(func(r rune) rune {
-		if r == '\n' || r == '\t' {
-			return -1
-		}
-		return r
-	}, terminal.Sanitize(s))
+	s = sanitizeProse(s, line)
 
 	var b strings.Builder
 	b.Grow(len(s))
@@ -69,6 +66,68 @@ func escapeText(s, line string) string {
 		b.WriteRune(r)
 	}
 	return b.String()
+}
+
+// sanitizeProse runs terminal.Sanitize over a run of prose the way the renderer will: in
+// the context of the line it joins. Text arrives a node at a time, and HTML can split a
+// joining sequence or a stack of marks across two of them — "👨<span>\u200d👩</span>"
+// — where a run sanitized on its own would lose the joiner for want of a base on its
+// left, and a ninth mark would pass for a first. The context is the last base on the
+// line and what rides on it (lineContext), which is all the sanitizer's decisions look
+// back at. A joiner a run ends with is kept: what follows is not known yet, the next run
+// is judged with it in its context, and one left dangling at the end of a line is
+// trimmed there (flushLine), as the renderer would trim it anyway.
+func sanitizeProse(s, line string) string {
+	s = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' {
+			return -1
+		}
+		return r
+	}, s)
+	context := lineContext(line)
+	whole := terminal.Sanitize(context + s)
+	var tail string
+	switch head := terminal.Sanitize(context); {
+	case strings.HasPrefix(whole, context):
+		// The context as written, a joiner kept at its end included, stands.
+		tail = whole[len(context):]
+	case strings.HasPrefix(whole, head):
+		// A joiner kept at the end of the line found nothing to join; it stays on
+		// the line as the renderer's pass will see and drop it.
+		tail = whole[len(head):]
+	default:
+		return terminal.Sanitize(s)
+	}
+	// A trailing joiner that went for want of a right-hand side is kept for the next
+	// run, but only one a base would have taken: the probe asks the sanitizer itself.
+	if last, _ := utf8.DecodeLastRuneInString(s); isJoiner(last) && !strings.HasSuffix(tail, string(last)) &&
+		strings.HasSuffix(terminal.Sanitize(context+tail+string(last)+"é"), string(last)+"é") {
+		tail += string(last)
+	}
+	return tail
+}
+
+// lineContext is the end of a line that the sanitizer's decisions about what follows
+// look back at: the last rune that is neither a mark nor a joiner, and everything after
+// it. It is bounded, since a line can be long and the context cannot be — the sanitizer
+// keeps at most a handful of marks on a base.
+func lineContext(line string) string {
+	const maxContextRunes = 32
+	end := len(line)
+	for i := 0; i < maxContextRunes && end > 0; i++ {
+		r, size := utf8.DecodeLastRuneInString(line[:end])
+		end -= size
+		if !isCombiningMark(r) && !isJoiner(r) {
+			break
+		}
+	}
+	return line[end:]
+}
+
+func isJoiner(r rune) bool { return r == 0x200c || r == 0x200d }
+
+func isCombiningMark(r rune) bool {
+	return r >= 0x300 && unicode.In(r, unicode.Mn, unicode.Me, unicode.Mc)
 }
 
 // closesOrderedMarker reports whether the line so far — what was already on it and the

--- a/internal/htmlutil/markdown_safety_test.go
+++ b/internal/htmlutil/markdown_safety_test.go
@@ -225,6 +225,12 @@ func TestToMarkdownEscapesWhatTheSanitizerUncovers(t *testing.T) {
 		{"<p>\u00ad- item</p>", "\\- item"},
 		{"<p>\u202e> quoted</p>", "\\> quoted"},
 		{"<p>\x1b[31m# red</p>", "\\# red"},
+		{"<p>\u200b # heading</p>", "\\# heading"},
+		{"<p>\u200b \u200b \u200b \u200b code?</p>", "code?"},
+		{"<p>\u200b \u200b \u200b \u200b 1. item</p>", "1\\. item"},
+		{"<p>a \u200b b</p>", "a b"},
+		{"<p>a<span>\u200b b</span></p>", "a b"},
+		{"<p>a <span>\u200b b</span></p>", "a b"},
 	} {
 		if got := toMarkdown(test.in); got != test.want {
 			t.Errorf("ToMarkdown(%q) = %q, want %q", test.in, got, test.want)

--- a/internal/htmlutil/markdown_safety_test.go
+++ b/internal/htmlutil/markdown_safety_test.go
@@ -215,6 +215,23 @@ func TestToMarkdownInlineCodeSizesItsDelimiters(t *testing.T) {
 // sanitizer drops a zero width space between two runs of backticks, joining them, so
 // the delimiter must be longer than the joined run or the code could be closed from
 // inside by text that only looks shorter.
+// Prose is written in the form the renderer's sanitizer leaves it in, so a character it
+// strips cannot hide a block marker from the line-start escape: "\u200b# heading" is a
+// heading to glamour once the zero width space is gone, unless the hash was escaped.
+func TestToMarkdownEscapesWhatTheSanitizerUncovers(t *testing.T) {
+	for _, test := range []struct{ in, want string }{
+		{"<p>\u200b# heading</p>", "\\# heading"},
+		{"<p>1\u200b. item</p>", "1\\. item"},
+		{"<p>\u00ad- item</p>", "\\- item"},
+		{"<p>\u202e> quoted</p>", "\\> quoted"},
+		{"<p>\x1b[31m# red</p>", "\\# red"},
+	} {
+		if got := toMarkdown(test.in); got != test.want {
+			t.Errorf("ToMarkdown(%q) = %q, want %q", test.in, got, test.want)
+		}
+	}
+}
+
 func TestToMarkdownCodeDelimitersOutlastTheSanitizer(t *testing.T) {
 	for _, test := range []struct{ in, want string }{
 		{"<p><code>``\u200b``</code></p>", "````` ``\u200b`` `````"},

--- a/internal/htmlutil/markdown_safety_test.go
+++ b/internal/htmlutil/markdown_safety_test.go
@@ -232,6 +232,28 @@ func TestToMarkdownEscapesWhatTheSanitizerUncovers(t *testing.T) {
 	}
 }
 
+// Prose is sanitized in the context of the line it joins, so a joining sequence or a
+// stack of marks that HTML splits across two text nodes is judged on the text rather
+// than on the node boundary; a joiner at the end of a line is dropped as the renderer
+// would drop it.
+func TestToMarkdownSanitizesProseAcrossTextNodes(t *testing.T) {
+	for _, test := range []struct{ in, want string }{
+		{"<p>👨<span>\u200d👩</span></p>", "👨\u200d👩"},
+		{"<p>👨<span>\u200d</span><span>👩</span></p>", "👨\u200d👩"},
+		{"<p>क्<span>\u200dष</span></p>", "क्\u200dष"},
+		{"<p>a<span>\u200dé</span></p>", "aé"},
+		{"<p>e\u0301\u0301\u0301\u0301<span>\u0301\u0301\u0301\u0301\u0301</span></p>", "e" + strings.Repeat("\u0301", 8)},
+		{"<p>می\u200c<!--comment-->خواهم</p>", "می\u200cخواهم"},
+		{"<p>می\u200c<wbr>خواهم</p>", "می\u200cخواهم"},
+		{"<p>👨\u200d</p>", "👨"},
+		{"<p>👨<b>\u200d👩</b></p>", "👨**👩**"},
+	} {
+		if got := toMarkdown(test.in); got != test.want {
+			t.Errorf("ToMarkdown(%q) = %q, want %q", test.in, got, test.want)
+		}
+	}
+}
+
 func TestToMarkdownCodeDelimitersOutlastTheSanitizer(t *testing.T) {
 	for _, test := range []struct{ in, want string }{
 		{"<p><code>``\u200b``</code></p>", "````` ``\u200b`` `````"},

--- a/internal/markdown/pipeline_test.go
+++ b/internal/markdown/pipeline_test.go
@@ -24,6 +24,8 @@ func TestRenderShowsWhatToMarkdownWrote(t *testing.T) {
 		"<p><img alt=\"&amp;#27;[31m\" src=\"https://e.com/i.png\"></p>": "&#27;[31m",
 		"<p><a href=\"https://e.com/?a=1&amp;b=2\">q</a></p>":            "https://e.com/?a=1&b=2",
 		"<p><img alt=\"a &amp; b\" src=\"https://e.com/i.png\"></p>":     "a & b",
+		"<p>\u200b# not a heading</p>":                                   "# not a heading",
+		"<p>1\u200b. not a list</p>":                                     "1. not a list",
 	} {
 		out := Render(htmlutil.ToMarkdown(html), 200)
 		if shown := visible(out); !strings.Contains(shown, want) {

--- a/internal/markdown/source.go
+++ b/internal/markdown/source.go
@@ -59,7 +59,9 @@ const maxNestingDepth = 20
 // controls and the confusables terminal.Sanitize describes, keeping newlines and tabs.
 // A body is prose, and the Trojan-source class — a right-to-left override that shows
 // one thing and means another — is no more welcome in it than in a subject line; the
-// JSON keeps the original.
+// HTML keeps the original. ToMarkdown writes prose through the same sanitizer, so over
+// prose this pass is the identity and cannot uncover a block marker the escaping did
+// not see; over code and destinations it strips what ToMarkdown measured around.
 //
 // It runs over the whole source, link destinations included, on purpose: what a link
 // shows and where it goes are then the same text, and a destination that differs from

--- a/internal/output/writer.go
+++ b/internal/output/writer.go
@@ -277,14 +277,17 @@ func sanitizeJSONMap(value map[string]any) map[string]any {
 	}
 
 	sort.Strings(changed)
+	// QuoteToASCII, not Quote: a key the sanitizer would change is shown with every
+	// non-ASCII rune escaped, since Quote leaves a printable rune — a combining mark
+	// past the cap, say — as it is, and the key would reach the terminal unchanged.
 	for _, key := range changed {
-		quoted := strconv.Quote(key)
+		quoted := strconv.QuoteToASCII(key)
 		name := quoted[1 : len(quoted)-1]
 		for {
 			if _, exists := result[name]; !exists {
 				break
 			}
-			name = strconv.Quote(name)
+			name = strconv.QuoteToASCII(name)
 		}
 		result[name] = sanitizeJSONValue(value[key])
 	}

--- a/internal/output/writer_test.go
+++ b/internal/output/writer_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"bytes"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -264,6 +265,34 @@ func TestWriterJQSanitizesTerminalResults(t *testing.T) {
 		}
 		if !strings.Contains(buf.String(), `"safelink31m!"`) {
 			t.Errorf("sanitized value missing: %q", buf.String())
+		}
+	})
+
+	t.Run("a key past the mark cap is shown in ASCII", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := New(Options{Stdout: &buf})
+		zalgo := "Z" + strings.Repeat("\u0336", 9)
+		input := map[string]any{zalgo: "stacked", "Z\u0336": "one mark"}
+		if err := w.writeJQResult(input, true); err != nil {
+			t.Fatal(err)
+		}
+		for _, r := range buf.String() {
+			if r >= 0x80 && r != '\u0336' {
+				t.Fatalf("output carries %U: %q", r, buf.String())
+			}
+		}
+		if strings.Count(buf.String(), "\u0336") != 1 {
+			t.Errorf("the stack past the cap reached the output as it was: %q", buf.String())
+		}
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatal(err)
+		}
+		if len(result) != 2 || result["Z\u0336"] != "one mark" {
+			t.Errorf("fields = %#v, want both, the clean one as it was", result)
+		}
+		if _, ok := result[strings.Trim(strconv.QuoteToASCII(zalgo), "\"")]; !ok {
+			t.Errorf("escaped key missing: %#v", result)
 		}
 	})
 

--- a/internal/terminal/sanitize.go
+++ b/internal/terminal/sanitize.go
@@ -151,10 +151,11 @@ func (p *pass) keep(r rune) {
 }
 
 // isBase reports a rune a joiner can join: non-ASCII text that is neither a space, a
-// mark nor a format character. The marks on a base ride along with it; a tag or any
-// other format character ends it, so a joiner after one has nothing to join.
+// mark, a format character nor punctuation. The marks on a base ride along with it; a
+// tag or any other format character ends it, so a joiner after one has nothing to join;
+// and a dash or a quotation mark is not something letters join to.
 func isBase(r rune) bool {
-	return joinable(r) && !isCombiningMark(r) && !unicode.Is(unicode.Cf, r)
+	return joinable(r) && !isCombiningMark(r) && !unicode.Is(unicode.Cf, r) && !unicode.IsPunct(r)
 }
 
 func (p *pass) drop(i int) {

--- a/internal/terminal/sanitize_test.go
+++ b/internal/terminal/sanitize_test.go
@@ -54,6 +54,8 @@ var sanitizeTests = []struct {
 	{"a joiner before a mark goes", "é\u200d\u0301", "é\u0301"},
 	{"a mark on an ASCII base does not make it joinable", "e\u0301\u200dé", "e\u0301é"},
 	{"a joiner before a tag character goes", "é\u200d\U000e0020", "é\U000e0020"},
+	{"a joiner before punctuation goes", "é\u200d—", "é—"},
+	{"a joiner after punctuation goes", "«\u200dé", "«é"},
 	{"a tag character is not a base for a joiner", "é\U000e0020\u200dé", "é\U000e0020é"},
 
 	// Combining marks are capped at eight on a base.


### PR DESCRIPTION
Follow-up to #260, for the three findings Codex left on its final rebase after it had merged.

- **Prose is written in its sanitized form.** `escapeText` ran the control strip before looking at the text; it now runs `terminal.Sanitize`, so `​# heading` and `1​. item` are escaped as the heading and list marker they become once `markdown.Render` strips the invisible. The renderer's pass over prose is then the identity. Code spans, fences and destinations are still written as they are and only measured through the sanitizer (`backtickRun`, `needsPadding`); the HTML keeps the original of everything. The docs that said "the JSON keeps the original" now say the HTML does. Tests: `TestToMarkdownEscapesWhatTheSanitizerUncovers`, two pipeline cases through `Render(ToMarkdown(…))`.
- **`--jq` object keys** the sanitizer would change are shown through `strconv.QuoteToASCII` rather than `Quote`, which leaves a printable rune — a run of combining marks past the cap — as it was.
- **Punctuation is not a base** for a joiner: `é‍—` loses the joiner like `é‍ ` does.

Fuzz targets run 30 s each; `make check` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes Markdown prose in its sanitized form, re-collapses sanitizer‑uncovered whitespace before escaping, ASCII‑escapes `--jq` keys, and stops punctuation from acting as a joiner base. Previously, renderer-stripped invisibles or spaces could reveal block markers or open indented code, `--jq` keys could print non‑ASCII, and joiners next to punctuation survived.

- html (`internal/htmlutil`): prose is sanitized in the line’s context and whitespace re-collapsed before escape; a trailing joiner is kept for the next run and trimmed at line end. Code spans/fences and link destinations stay verbatim and are only measured through the sanitizer. The renderer’s pass over prose is now an identity; HTML keeps originals.
- output (`internal/output`): `sanitizeJSONMap` uses `strconv.QuoteToASCII` for keys the sanitizer would change; collision handling applies to the ASCII-escaped form. Migration: `--jq` key strings may change when they contain non‑ASCII or capped combining stacks; consumers matching keys must handle ASCII-escaped names.
- terminal (`internal/terminal`): `isBase` excludes punctuation, so joiners adjacent to punctuation are dropped.
- Docs/Tests: docs note prose is sanitized and re-collapsed before escaping and originals are in HTML; tests cover renderer parity, cross–text-node context sanitization, whitespace re-collapse, ASCII-escaped `--jq` keys, and joiner behavior.

<sup>Written for commit 65f9ff366ba2b69e5f21a05ac36514a0eb779755. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

