### PR TITLE
Manage email workflows from the CLI

### DIFF
--- a/.surface
+++ b/.surface
@@ -243,3 +243,24 @@ hey watch --run-async
 hey watch --run-sync
 hey watch --since
 hey watch --timeout
+hey workflow
+hey workflow add
+hey workflow add --stage
+hey workflow add --to
+hey workflow create
+hey workflow delete
+hey workflow move
+hey workflow move --to
+hey workflow move --workflow
+hey workflow remove
+hey workflow remove --from
+hey workflow stage
+hey workflow stage create
+hey workflow stage delete
+hey workflow stage update
+hey workflow stage update --name
+hey workflow update
+hey workflow update --name
+hey workflows
+hey workflows --all
+hey workflows --limit

--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ hey boxes --quiet --jq '.[].id'
 Listing commands also answer `--markdown` for a table, `--styled` to force the human
 rendering when the output is piped, `--ids-only` for one ID per line, and `--count` for a
 bare number. `--ids-only` and `--count` need list data, so they work on `hey boxes`,
-`hey box`, `hey labels`, `hey label`, `hey collections`, `hey collection`, `hey drafts`, `hey search`,
-`hey contacts list`, `hey screener list`, `hey screener history`, `hey calendars`,
+`hey box`, `hey labels`, `hey label`, `hey collections`, `hey collection`, `hey workflows`,
+`hey workflow`, `hey drafts`, `hey search`, `hey contacts list`, `hey screener list`, `hey screener history`, `hey calendars`,
 `hey recordings`, `hey todo list`, `hey timetrack list` and `hey journal list`. The
 data-only formats print any pagination notice on stderr, so the IDs on stdout stay
 pipeable.
@@ -308,6 +308,15 @@ hey collection create "Kitchen remodel" --summary "Plans and decisions"
 hey collection update 321 --name "Kitchen renovation"
 hey collection add 987 --to 321      # add a topic ID to a collection
 hey collection remove 987 --from 321 # remove a topic ID from a collection
+hey workflows                       # list workflows, account IDs, and workflow IDs
+hey workflow 654                    # list a workflow's stages and stage IDs
+hey workflow create "Hiring" --account 12345
+hey workflow update 654 --name "Recruiting"
+hey workflow stage create 654       # add an Untitled stage
+hey workflow stage update 654 321 --name "Interviewing"
+hey workflow add 987 --to 654 --stage 321       # add a topic ID to a stage
+hey workflow move 987 --workflow 654 --to 322   # move it to another stage
+hey workflow remove 987 --from 654              # remove it from the workflow
 hey search "quarterly planning"    # search threads and matching messages
 hey search --from jane@example.com --date last_30_days  # refine a search
 hey search filters                 # list available refinement values
@@ -376,6 +385,8 @@ The Screener is where first-time senders wait. `hey screener list` returns clear
 Organization actions take the `id` values returned by `hey box --json`, `hey label --json`, or `hey search --json`. Reading, replying to, and forwarding a thread take its `topic_id` instead, which `hey box --json`, `hey label --json`, `hey collection --json` and `hey search --json` all carry alongside `id`. `hey box` also returns `next_page` and accepts `--page <next_page>` to continue a box listing; it keeps `next_history_url` for the sync clients that read it, and `--page` accepts that URL as readily as the cursor inside it. Label IDs come from `hey labels`; `hey label` returns `next_page` and `total_count`, accepts `--page <next_page>` for continuation, and supports `--all` for complete traversal. HEY creates a label while adding it to at least one thread, so `hey label create` requires thread item IDs.
 
 Collection IDs come from `hey collections`. `hey collection` returns both each posting `id` and its `topic_id`, plus `next_page` and `total_count`. Collection membership commands take `topic_id`; posting organization commands continue to take `id`. Creating a collection returns a confirmed mutation, and `hey collections` provides its ID for subsequent commands. Collection updates accept a non-empty name, summary, or both.
+
+Workflow IDs come from `hey workflows`, which includes the linked account ID for each workflow. `hey workflow <id>` returns stages in position order; `--ids-only` and `--count` apply to those stages. Creating a workflow needs one linked mail account, selected with `--account` when more than one is available. HEY creates new stages as `Untitled`, so create the stage, read its ID with `hey workflow <id>`, then rename it. Workflow membership commands take `topic_id`. Adding a thread creates its workflow membership before selecting the requested stage; if stage selection fails, the thread remains in the workflow's first stage and the command reports the error.
 
 `hey box <name|id>`, `hey label <id>` and `hey collection <id>` list the same postings and answer the same formats: `--json`, `--styled`, `--markdown`, `--ids-only`, and `--count`. The data-only formats print the pagination notice and any `next_page` cursor on stderr, so the IDs on stdout stay pipeable. `--json` differs only in what wraps the postings: a box answers with HEY's box payload, a label and a collection with the source and its `total_count`.
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/actioncable-go v0.0.0-20260821132720-3f7811951537
-	github.com/basecamp/hey-sdk/go v0.11.0
+	github.com/basecamp/hey-sdk/go v0.12.0
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/actioncable-go v0.0.0-20260821132720-3f7811951537 h1:OE1VMvKkpI+Vo7aP5IDRG6PNXW2IVMlLUWLgBcybGNc=
 github.com/basecamp/actioncable-go v0.0.0-20260821132720-3f7811951537/go.mod h1:9+DEydJMniIKraEsd4fDJpFEnqlLUJ6XhAswxRBaITk=
-github.com/basecamp/hey-sdk/go v0.11.0 h1:j0iUWG2Wa42a8Arb79TRv90TKtrkvESRLI7bqwZIG9I=
-github.com/basecamp/hey-sdk/go v0.11.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
+github.com/basecamp/hey-sdk/go v0.12.0 h1:ZOe3hQmuCeJcUGC0qptyRHXiy0fJ4Cyh5tk/buO8SY4=
+github.com/basecamp/hey-sdk/go v0.12.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -21,7 +21,7 @@ var curatedCategories = []struct {
 	},
 	{
 		heading: "EMAIL",
-		names:   []string{"boxes", "box", "labels", "label", "collections", "collection", "search", "contacts", "screener", "threads", "share", "unshare", "attachments", "compose", "reply", "bulk-reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"},
+		names:   []string{"boxes", "box", "labels", "label", "collections", "collection", "workflows", "workflow", "search", "contacts", "screener", "threads", "share", "unshare", "attachments", "compose", "reply", "bulk-reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -32,7 +32,7 @@ func TestCuratedCommandHelpUsesUserFacingLanguage(t *testing.T) {
 
 func TestEmailCommandHelpKeepsPostingAsAnInternalTerm(t *testing.T) {
 	root := newRootCmd()
-	for _, name := range []string{"boxes", "box", "labels", "label", "search", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"} {
+	for _, name := range []string{"boxes", "box", "labels", "label", "workflows", "workflow", "search", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"} {
 		t.Run(name, func(t *testing.T) {
 			command, _, err := root.Find([]string{name})
 			if err != nil {
@@ -103,6 +103,8 @@ EMAIL
   label          View and manage an email label
   collections    List your email collections
   collection     View and manage an email collection
+  workflows      List your email workflows
+  workflow       View and manage an email workflow
   search         Search email threads and messages
   contacts       Manage contacts
   screener       Decide who gets to email you

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -187,6 +187,8 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newLabelCommand().cmd)
 	root.AddCommand(newCollectionsCommand().cmd)
 	root.AddCommand(newCollectionCommand().cmd)
+	root.AddCommand(newWorkflowsCommand().cmd)
+	root.AddCommand(newWorkflowCommand().cmd)
 	root.AddCommand(newSearchCommand().cmd)
 	root.AddCommand(newContactsCommand().cmd)
 	root.AddCommand(newScreenerCommand().cmd)

--- a/internal/cmd/workflow.go
+++ b/internal/cmd/workflow.go
@@ -242,40 +242,20 @@ func workflowDetailFromSDK(workflow *generated.Workflow) workflowDetailView {
 }
 
 func writeWorkflowMarkdown(cmd *cobra.Command, workflow workflowDetailView) error {
-	fmt.Fprintf(cmd.OutOrStdout(), "# %s\n\n", workflowMarkdownCell(terminal.SanitizeLine(workflow.Name)))
-	fmt.Fprintf(cmd.OutOrStdout(), "**ID:** %d\n\n", workflow.ID)
+	var document strings.Builder
+	fmt.Fprintf(&document, "# %s\n\n", markdownSafeText(workflow.Name))
+	fmt.Fprintf(&document, "**ID:** %d\n\n", workflow.ID)
 	if len(workflow.Stages) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "(no stages)")
-		return nil
-	}
-	fmt.Fprintln(cmd.OutOrStdout(), "| stage_id | name |")
-	fmt.Fprintln(cmd.OutOrStdout(), "| --- | --- |")
-	for _, stage := range workflow.Stages {
-		fmt.Fprintf(cmd.OutOrStdout(), "| %d | %s |\n", stage.ID, workflowMarkdownCell(terminal.SanitizeLine(stage.Name)))
-	}
-	return nil
-}
-
-func workflowMarkdownCell(value string) string {
-	var escaped strings.Builder
-	for index := 0; index < len(value); {
-		start := index
-		for index < len(value) && value[index] == '\\' {
-			index++
-		}
-		if index < len(value) && value[index] == '|' {
-			escaped.WriteString(strings.Repeat(`\`, 2*(index-start)+1))
-			escaped.WriteByte('|')
-			index++
-			continue
-		}
-		escaped.WriteString(value[start:index])
-		if index < len(value) {
-			escaped.WriteByte(value[index])
-			index++
+		document.WriteString("(no stages)\n")
+	} else {
+		document.WriteString("| stage_id | name |\n")
+		document.WriteString("| --- | --- |\n")
+		for _, stage := range workflow.Stages {
+			fmt.Fprintf(&document, "| %d | %s |\n", stage.ID, markdownSafeText(stage.Name))
 		}
 	}
-	return escaped.String()
+	_, err := fmt.Fprint(cmd.OutOrStdout(), document.String())
+	return err
 }
 
 type workflowCreateCommand struct {

--- a/internal/cmd/workflow.go
+++ b/internal/cmd/workflow.go
@@ -1,0 +1,693 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/output"
+	"github.com/basecamp/hey-cli/internal/terminal"
+)
+
+type workflowListItem struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	AccountID   int64  `json:"account_id"`
+	AccountName string `json:"account_name,omitempty"`
+}
+
+type workflowStageView struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+type workflowDetailView struct {
+	ID        int64               `json:"id"`
+	Name      string              `json:"name"`
+	AppURL    string              `json:"app_url,omitempty"`
+	Stages    []workflowStageView `json:"stages"`
+	CreatedAt time.Time           `json:"created_at,omitempty,omitzero"`
+	UpdatedAt time.Time           `json:"updated_at,omitempty,omitzero"`
+}
+
+type workflowsCommand struct {
+	cmd   *cobra.Command
+	limit int
+	all   bool
+}
+
+func newWorkflowsCommand() *workflowsCommand {
+	workflowsCommand := &workflowsCommand{}
+	workflowsCommand.cmd = &cobra.Command{
+		Use:   "workflows",
+		Short: "List your email workflows",
+		Annotations: map[string]string{
+			"agent_notes": "Returns workflow IDs, names, and linked account IDs. Use an ID with hey workflow; use --account to limit the list to one linked mail account.",
+		},
+		Example: `  hey workflows
+  hey workflows --account 12345
+  hey workflows --limit 10
+  hey workflows --json`,
+		RunE: workflowsCommand.run,
+		Args: cobra.NoArgs,
+	}
+	workflowsCommand.cmd.Flags().IntVar(&workflowsCommand.limit, "limit", 0, "Maximum number of workflows to show")
+	workflowsCommand.cmd.Flags().BoolVar(&workflowsCommand.all, "all", false, "Show every workflow (override --limit)")
+	return workflowsCommand
+}
+
+func (c *workflowsCommand) run(cmd *cobra.Command, _ []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	workflows, err := listWorkflows(cmd.Context())
+	if err != nil {
+		return err
+	}
+	total := len(workflows)
+	if c.limit > 0 && !c.all && len(workflows) > c.limit {
+		workflows = workflows[:c.limit]
+	}
+	notice := output.TruncationNotice(len(workflows), total)
+
+	if writer.IsStyled() {
+		table := newTable(cmd.OutOrStdout())
+		table.addRow([]string{"ID", "Name", "Account ID", "Account"})
+		for _, workflow := range workflows {
+			table.addRow([]string{
+				fmt.Sprintf("%d", workflow.ID),
+				terminal.SanitizeLine(workflow.Name),
+				fmt.Sprintf("%d", workflow.AccountID),
+				terminal.SanitizeLine(workflow.AccountName),
+			})
+		}
+		table.print()
+		if notice != "" {
+			fmt.Fprintln(cmd.OutOrStdout(), notice)
+		}
+		return nil
+	}
+	if stderrNotice := paginationNoticeForStderr(writer.EffectiveFormat(), notice); stderrNotice != "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), stderrNotice)
+	}
+
+	return writeOK(workflows,
+		output.WithSummary(fmt.Sprintf("%d %s", len(workflows), workflowNoun(len(workflows)))),
+		output.WithNotice(notice),
+		output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "view",
+			Command:     "hey workflow <id>",
+			Description: "View a workflow and its stages",
+		}),
+	)
+}
+
+func listWorkflows(ctx context.Context) ([]workflowListItem, error) {
+	if accountID, ok := sdk.AccountID(); ok {
+		return listAccountWorkflows(ctx, accountID)
+	}
+
+	identity, err := rootSDK.Identity().GetIdentity(ctx)
+	if err != nil {
+		return nil, apierr.FromSDK(err)
+	}
+	if identity == nil {
+		return nil, apierr.ErrAPI(0, "HEY returned no identity data")
+	}
+
+	items := make([]workflowListItem, 0)
+	for _, account := range identity.Accounts {
+		if !linkedAccountAccessible(account) {
+			continue
+		}
+		accountItems, err := listAccountWorkflows(ctx, account.Id)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, accountItems...)
+	}
+	return items, nil
+}
+
+func listAccountWorkflows(ctx context.Context, accountID int64) ([]workflowListItem, error) {
+	workflows, err := rootSDK.Workflows().List(ctx, accountID)
+	if err != nil {
+		return nil, apierr.FromSDK(err)
+	}
+	items := make([]workflowListItem, 0, len(workflows))
+	for _, workflow := range workflows {
+		items = append(items, workflowListItem{
+			ID:          workflow.ID,
+			Name:        workflow.Name,
+			AccountID:   accountID,
+			AccountName: workflow.AccountName,
+		})
+	}
+	return items, nil
+}
+
+type workflowCommand struct {
+	cmd *cobra.Command
+}
+
+func newWorkflowCommand() *workflowCommand {
+	workflowCommand := &workflowCommand{}
+	workflowCommand.cmd = &cobra.Command{
+		Use:   "workflow <id>",
+		Short: "View and manage an email workflow",
+		Annotations: map[string]string{
+			"agent_notes": "The workflow ID comes from hey workflows. Detail returns stage IDs in position order. Subcommands create, update, delete, stage, add, move, and remove workflows and their threads.",
+		},
+		Example: `  hey workflow 123
+  hey workflow 123 --json
+  hey workflow 123 --ids-only`,
+		RunE: workflowCommand.run,
+		Args: usageExactOneArg(),
+	}
+	workflowCommand.cmd.AddCommand(newWorkflowCreateCommand().cmd)
+	workflowCommand.cmd.AddCommand(newWorkflowUpdateCommand().cmd)
+	workflowCommand.cmd.AddCommand(newWorkflowDeleteCommand().cmd)
+	workflowCommand.cmd.AddCommand(newWorkflowStageCommand().cmd)
+	workflowCommand.cmd.AddCommand(newWorkflowAddCommand().cmd)
+	workflowCommand.cmd.AddCommand(newWorkflowMoveCommand().cmd)
+	workflowCommand.cmd.AddCommand(newWorkflowRemoveCommand().cmd)
+	return workflowCommand
+}
+
+func (c *workflowCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	workflowID, err := parsePositiveID(args[0], "workflow")
+	if err != nil {
+		return err
+	}
+
+	workflow, err := sdk.Workflows().Get(cmd.Context(), workflowID)
+	if err != nil {
+		return apierr.FromSDK(err)
+	}
+	if workflow == nil {
+		return apierr.ErrNotFound("workflow", args[0])
+	}
+	detail := workflowDetailFromSDK(workflow)
+
+	switch writer.EffectiveFormat() {
+	case output.FormatStyled:
+		fmt.Fprintf(cmd.OutOrStdout(), "Workflow: %s (%d)\n\n", terminal.SanitizeLine(detail.Name), detail.ID)
+		table := newTable(cmd.OutOrStdout())
+		table.addRow([]string{"Stage ID", "Name"})
+		for _, stage := range detail.Stages {
+			table.addRow([]string{fmt.Sprintf("%d", stage.ID), terminal.SanitizeLine(stage.Name)})
+		}
+		table.print()
+		return nil
+	case output.FormatIDs, output.FormatCount:
+		return writeOK(detail.Stages,
+			output.WithSummary(fmt.Sprintf("%d %s", len(detail.Stages), stageNoun(len(detail.Stages)))),
+		)
+	case output.FormatMarkdown:
+		return writeWorkflowMarkdown(cmd, detail)
+	default:
+		return writeOK(detail,
+			output.WithSummary(fmt.Sprintf("Workflow %d with %d %s", detail.ID, len(detail.Stages), stageNoun(len(detail.Stages)))),
+			output.WithBreadcrumbs(
+				output.Breadcrumb{Action: "add", Command: "hey workflow add <topic-id> --to <workflow-id> --stage <stage-id>", Description: "Add a thread to a stage"},
+				output.Breadcrumb{Action: "move", Command: "hey workflow move <topic-id> --workflow <workflow-id> --to <stage-id>", Description: "Move a thread to another stage"},
+			),
+		)
+	}
+}
+
+func workflowDetailFromSDK(workflow *generated.Workflow) workflowDetailView {
+	stages := make([]workflowStageView, 0, len(workflow.Stages))
+	for _, stage := range workflow.Stages {
+		stages = append(stages, workflowStageView{ID: stage.Id, Name: stage.Name})
+	}
+	return workflowDetailView{
+		ID:        workflow.Id,
+		Name:      workflow.Name,
+		AppURL:    workflow.AppUrl,
+		Stages:    stages,
+		CreatedAt: workflow.CreatedAt,
+		UpdatedAt: workflow.UpdatedAt,
+	}
+}
+
+func writeWorkflowMarkdown(cmd *cobra.Command, workflow workflowDetailView) error {
+	fmt.Fprintf(cmd.OutOrStdout(), "# %s\n\n", workflowMarkdownCell(terminal.SanitizeLine(workflow.Name)))
+	fmt.Fprintf(cmd.OutOrStdout(), "**ID:** %d\n\n", workflow.ID)
+	if len(workflow.Stages) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "(no stages)")
+		return nil
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "| stage_id | name |")
+	fmt.Fprintln(cmd.OutOrStdout(), "| --- | --- |")
+	for _, stage := range workflow.Stages {
+		fmt.Fprintf(cmd.OutOrStdout(), "| %d | %s |\n", stage.ID, workflowMarkdownCell(terminal.SanitizeLine(stage.Name)))
+	}
+	return nil
+}
+
+func workflowMarkdownCell(value string) string {
+	var escaped strings.Builder
+	for index := 0; index < len(value); {
+		start := index
+		for index < len(value) && value[index] == '\\' {
+			index++
+		}
+		if index < len(value) && value[index] == '|' {
+			escaped.WriteString(strings.Repeat(`\`, 2*(index-start)+1))
+			escaped.WriteByte('|')
+			index++
+			continue
+		}
+		escaped.WriteString(value[start:index])
+		if index < len(value) {
+			escaped.WriteByte(value[index])
+			index++
+		}
+	}
+	return escaped.String()
+}
+
+type workflowCreateCommand struct {
+	cmd *cobra.Command
+}
+
+func newWorkflowCreateCommand() *workflowCreateCommand {
+	workflowCreateCommand := &workflowCreateCommand{}
+	workflowCreateCommand.cmd = &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create an email workflow",
+		Example: `  hey workflow create "Hiring"
+  hey workflow create "Sales pipeline" --account 12345`,
+		RunE: workflowCreateCommand.run,
+		Args: usageExactOneArg(),
+	}
+	return workflowCreateCommand
+}
+
+func (c *workflowCreateCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	name := strings.TrimSpace(args[0])
+	if name == "" {
+		return apierr.ErrUsage("workflow name is required")
+	}
+	accountID, err := workflowCreationAccountID(cmd.Context())
+	if err != nil {
+		return err
+	}
+	if err := sdk.Workflows().Create(cmd.Context(), name, accountID); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutation(cmd, fmt.Sprintf("Workflow %q created", name), nil,
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "list", Command: "hey workflows", Description: "Find the new workflow ID"}),
+	)
+}
+
+func workflowCreationAccountID(ctx context.Context) (int64, error) {
+	if accountID, ok := sdk.AccountID(); ok {
+		return accountID, nil
+	}
+	identity, err := rootSDK.Identity().GetIdentity(ctx)
+	if err != nil {
+		return 0, apierr.FromSDK(err)
+	}
+	if identity == nil {
+		return 0, apierr.ErrAPI(0, "HEY returned no identity data")
+	}
+	var accountID int64
+	for _, account := range identity.Accounts {
+		if !linkedAccountAccessible(account) {
+			continue
+		}
+		if accountID != 0 {
+			return 0, apierr.ErrUsageHint("workflow creation requires one linked mail account", "select one with --account <id> or `hey accounts use <id>`")
+		}
+		accountID = account.Id
+	}
+	if accountID == 0 {
+		return 0, apierr.ErrAPI(0, "HEY returned no available linked mail account")
+	}
+	return accountID, nil
+}
+
+type workflowUpdateCommand struct {
+	cmd  *cobra.Command
+	name string
+}
+
+func newWorkflowUpdateCommand() *workflowUpdateCommand {
+	workflowUpdateCommand := &workflowUpdateCommand{}
+	workflowUpdateCommand.cmd = &cobra.Command{
+		Use:     "update <id>",
+		Aliases: []string{"edit", "rename"},
+		Short:   "Rename an email workflow",
+		Example: `  hey workflow update 123 --name "Recruiting"`,
+		RunE:    workflowUpdateCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	workflowUpdateCommand.cmd.Flags().StringVar(&workflowUpdateCommand.name, "name", "", "New workflow name (required)")
+	return workflowUpdateCommand
+}
+
+func (c *workflowUpdateCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	workflowID, err := parsePositiveID(args[0], "workflow")
+	if err != nil {
+		return err
+	}
+	name := strings.TrimSpace(c.name)
+	if name == "" {
+		return apierr.ErrUsage("workflow name is required (use --name <name>)")
+	}
+	if err := sdk.Workflows().Update(cmd.Context(), workflowID, name); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutation(cmd, fmt.Sprintf("Workflow %d renamed to %q", workflowID, name), nil)
+}
+
+type workflowDeleteCommand struct {
+	cmd *cobra.Command
+}
+
+func newWorkflowDeleteCommand() *workflowDeleteCommand {
+	workflowDeleteCommand := &workflowDeleteCommand{}
+	workflowDeleteCommand.cmd = &cobra.Command{
+		Use:     "delete <id>",
+		Short:   "Delete an email workflow",
+		Example: `  hey workflow delete 123`,
+		RunE:    workflowDeleteCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return workflowDeleteCommand
+}
+
+func (c *workflowDeleteCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	workflowID, err := parsePositiveID(args[0], "workflow")
+	if err != nil {
+		return err
+	}
+	if err := sdk.Workflows().Delete(cmd.Context(), workflowID); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutation(cmd, fmt.Sprintf("Workflow %d deleted", workflowID), nil)
+}
+
+type workflowStageCommand struct {
+	cmd *cobra.Command
+}
+
+func newWorkflowStageCommand() *workflowStageCommand {
+	workflowStageCommand := &workflowStageCommand{}
+	workflowStageCommand.cmd = &cobra.Command{
+		Use:   "stage",
+		Short: "Manage workflow stages",
+		Annotations: map[string]string{
+			"agent_notes": "Create adds an Untitled stage; use hey workflow <id> to find its stage ID, then update it with --name.",
+		},
+	}
+	workflowStageCommand.cmd.AddCommand(newWorkflowStageCreateCommand().cmd)
+	workflowStageCommand.cmd.AddCommand(newWorkflowStageUpdateCommand().cmd)
+	workflowStageCommand.cmd.AddCommand(newWorkflowStageDeleteCommand().cmd)
+	return workflowStageCommand
+}
+
+type workflowStageCreateCommand struct {
+	cmd *cobra.Command
+}
+
+func newWorkflowStageCreateCommand() *workflowStageCreateCommand {
+	workflowStageCreateCommand := &workflowStageCreateCommand{}
+	workflowStageCreateCommand.cmd = &cobra.Command{
+		Use:     "create <workflow-id>",
+		Short:   "Add an Untitled stage to a workflow",
+		Example: `  hey workflow stage create 123`,
+		RunE:    workflowStageCreateCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return workflowStageCreateCommand
+}
+
+func (c *workflowStageCreateCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	workflowID, err := parsePositiveID(args[0], "workflow")
+	if err != nil {
+		return err
+	}
+	if err := sdk.Workflows().CreateStage(cmd.Context(), workflowID); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutation(cmd, fmt.Sprintf("Untitled stage added to workflow %d", workflowID), nil,
+		output.WithBreadcrumbs(output.Breadcrumb{Action: "view", Command: fmt.Sprintf("hey workflow %d", workflowID), Description: "Find the new stage ID"}),
+	)
+}
+
+type workflowStageUpdateCommand struct {
+	cmd  *cobra.Command
+	name string
+}
+
+func newWorkflowStageUpdateCommand() *workflowStageUpdateCommand {
+	workflowStageUpdateCommand := &workflowStageUpdateCommand{}
+	workflowStageUpdateCommand.cmd = &cobra.Command{
+		Use:     "update <workflow-id> <stage-id>",
+		Aliases: []string{"edit", "rename"},
+		Short:   "Rename a workflow stage",
+		Example: `  hey workflow stage update 123 456 --name "Interviewing"`,
+		RunE:    workflowStageUpdateCommand.run,
+		Args:    usageExactArgs(2),
+	}
+	workflowStageUpdateCommand.cmd.Flags().StringVar(&workflowStageUpdateCommand.name, "name", "", "New stage name (required)")
+	return workflowStageUpdateCommand
+}
+
+func (c *workflowStageUpdateCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	workflowID, err := parsePositiveID(args[0], "workflow")
+	if err != nil {
+		return err
+	}
+	stageID, err := parsePositiveID(args[1], "stage")
+	if err != nil {
+		return err
+	}
+	name := strings.TrimSpace(c.name)
+	if name == "" {
+		return apierr.ErrUsage("stage name is required (use --name <name>)")
+	}
+	if err := sdk.Workflows().UpdateStage(cmd.Context(), workflowID, stageID, name); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutation(cmd, fmt.Sprintf("Stage %d renamed to %q", stageID, name), nil)
+}
+
+type workflowStageDeleteCommand struct {
+	cmd *cobra.Command
+}
+
+func newWorkflowStageDeleteCommand() *workflowStageDeleteCommand {
+	workflowStageDeleteCommand := &workflowStageDeleteCommand{}
+	workflowStageDeleteCommand.cmd = &cobra.Command{
+		Use:     "delete <workflow-id> <stage-id>",
+		Short:   "Delete a workflow stage",
+		Example: `  hey workflow stage delete 123 456`,
+		RunE:    workflowStageDeleteCommand.run,
+		Args:    usageExactArgs(2),
+	}
+	return workflowStageDeleteCommand
+}
+
+func (c *workflowStageDeleteCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	workflowID, err := parsePositiveID(args[0], "workflow")
+	if err != nil {
+		return err
+	}
+	stageID, err := parsePositiveID(args[1], "stage")
+	if err != nil {
+		return err
+	}
+	if err := sdk.Workflows().DeleteStage(cmd.Context(), workflowID, stageID); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutation(cmd, fmt.Sprintf("Stage %d deleted from workflow %d", stageID, workflowID), nil)
+}
+
+type workflowAddCommand struct {
+	cmd   *cobra.Command
+	to    string
+	stage string
+}
+
+func newWorkflowAddCommand() *workflowAddCommand {
+	workflowAddCommand := &workflowAddCommand{}
+	workflowAddCommand.cmd = &cobra.Command{
+		Use:   "add <topic-id>...",
+		Short: "Add email threads to a workflow stage",
+		Example: `  hey workflow add 501 --to 123 --stage 456
+  hey workflow add 501 502 --to 123 --stage 456`,
+		RunE: workflowAddCommand.run,
+		Args: usageMinOneArg(),
+	}
+	workflowAddCommand.cmd.Flags().StringVar(&workflowAddCommand.to, "to", "", "Workflow ID (required)")
+	workflowAddCommand.cmd.Flags().StringVar(&workflowAddCommand.stage, "stage", "", "Stage ID (required)")
+	return workflowAddCommand
+}
+
+func (c *workflowAddCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	workflowID, err := parseRequiredWorkflowFlag(c.to, "--to <workflow-id>")
+	if err != nil {
+		return err
+	}
+	stageID, err := parseRequiredStageFlag(c.stage, "--stage <stage-id>")
+	if err != nil {
+		return err
+	}
+	topicIDs, err := parsePositiveTopicIDs(args)
+	if err != nil {
+		return err
+	}
+	for _, topicID := range topicIDs {
+		if err := sdk.Workflows().StageTopic(cmd.Context(), topicID, workflowID, stageID); err != nil {
+			return apierr.FromSDK(err)
+		}
+	}
+	return writeMutation(cmd, fmt.Sprintf("%d %s added to workflow %d stage %d", len(topicIDs), threadNoun(len(topicIDs)), workflowID, stageID), nil)
+}
+
+type workflowMoveCommand struct {
+	cmd      *cobra.Command
+	workflow string
+	to       string
+}
+
+func newWorkflowMoveCommand() *workflowMoveCommand {
+	workflowMoveCommand := &workflowMoveCommand{}
+	workflowMoveCommand.cmd = &cobra.Command{
+		Use:   "move <topic-id>...",
+		Short: "Move email threads to another workflow stage",
+		Example: `  hey workflow move 501 --workflow 123 --to 789
+  hey workflow move 501 502 --workflow 123 --to 789`,
+		RunE: workflowMoveCommand.run,
+		Args: usageMinOneArg(),
+	}
+	workflowMoveCommand.cmd.Flags().StringVar(&workflowMoveCommand.workflow, "workflow", "", "Workflow ID (required)")
+	workflowMoveCommand.cmd.Flags().StringVar(&workflowMoveCommand.to, "to", "", "Destination stage ID (required)")
+	return workflowMoveCommand
+}
+
+func (c *workflowMoveCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	workflowID, err := parseRequiredWorkflowFlag(c.workflow, "--workflow <workflow-id>")
+	if err != nil {
+		return err
+	}
+	stageID, err := parseRequiredStageFlag(c.to, "--to <stage-id>")
+	if err != nil {
+		return err
+	}
+	topicIDs, err := parsePositiveTopicIDs(args)
+	if err != nil {
+		return err
+	}
+	for _, topicID := range topicIDs {
+		if err := sdk.Workflows().MoveTopic(cmd.Context(), topicID, workflowID, stageID); err != nil {
+			return apierr.FromSDK(err)
+		}
+	}
+	return writeMutation(cmd, fmt.Sprintf("%d %s moved to workflow %d stage %d", len(topicIDs), threadNoun(len(topicIDs)), workflowID, stageID), nil)
+}
+
+type workflowRemoveCommand struct {
+	cmd  *cobra.Command
+	from string
+}
+
+func newWorkflowRemoveCommand() *workflowRemoveCommand {
+	workflowRemoveCommand := &workflowRemoveCommand{}
+	workflowRemoveCommand.cmd = &cobra.Command{
+		Use:   "remove <topic-id>...",
+		Short: "Remove email threads from a workflow",
+		Example: `  hey workflow remove 501 --from 123
+  hey workflow remove 501 502 --from 123`,
+		RunE: workflowRemoveCommand.run,
+		Args: usageMinOneArg(),
+	}
+	workflowRemoveCommand.cmd.Flags().StringVar(&workflowRemoveCommand.from, "from", "", "Workflow ID (required)")
+	return workflowRemoveCommand
+}
+
+func (c *workflowRemoveCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	workflowID, err := parseRequiredWorkflowFlag(c.from, "--from <workflow-id>")
+	if err != nil {
+		return err
+	}
+	topicIDs, err := parsePositiveTopicIDs(args)
+	if err != nil {
+		return err
+	}
+	for _, topicID := range topicIDs {
+		if err := sdk.Workflows().UnstageTopic(cmd.Context(), topicID, workflowID); err != nil {
+			return apierr.FromSDK(err)
+		}
+	}
+	return writeMutation(cmd, fmt.Sprintf("%d %s removed from workflow %d", len(topicIDs), threadNoun(len(topicIDs)), workflowID), nil)
+}
+
+func parseRequiredWorkflowFlag(value, usage string) (int64, error) {
+	if strings.TrimSpace(value) == "" {
+		return 0, apierr.ErrUsage("workflow is required (use " + usage + ")")
+	}
+	return parsePositiveID(value, "workflow")
+}
+
+func parseRequiredStageFlag(value, usage string) (int64, error) {
+	if strings.TrimSpace(value) == "" {
+		return 0, apierr.ErrUsage("stage is required (use " + usage + ")")
+	}
+	return parsePositiveID(value, "stage")
+}
+
+func workflowNoun(count int) string {
+	if count == 1 {
+		return "workflow"
+	}
+	return "workflows"
+}
+
+func stageNoun(count int) string {
+	if count == 1 {
+		return "stage"
+	}
+	return "stages"
+}

--- a/internal/cmd/workflow_test.go
+++ b/internal/cmd/workflow_test.go
@@ -158,9 +158,30 @@ func TestWorkflowCommandOutputFormats(t *testing.T) {
 	}
 }
 
-func TestWorkflowMarkdownCellEscapesPipesAfterBackslashes(t *testing.T) {
-	if got, want := workflowMarkdownCell(`Applied\|Screen`), `Applied\\\|Screen`; got != want {
-		t.Errorf("workflowMarkdownCell = %q, want %q", got, want)
+func TestWorkflowMarkdownEscapesMetadata(t *testing.T) {
+	cmd := newWorkflowCommand().cmd
+	var output strings.Builder
+	cmd.SetOut(&output)
+	if err := writeWorkflowMarkdown(cmd, workflowDetailView{
+		ID:   8801,
+		Name: `[Hiring](https://example.invalid)`,
+		Stages: []workflowStageView{{
+			ID:   5512,
+			Name: `[Applied](https://example.invalid)`,
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(output.String(), "[Hiring](") || !strings.Contains(output.String(), `\[Hiring\]\(https\:\/\/example\.invalid\)`) {
+		t.Errorf("unsafe Markdown output: %q", output.String())
+	}
+}
+
+func TestWorkflowMarkdownSurfacesWriteFailure(t *testing.T) {
+	cmd := newWorkflowCommand().cmd
+	cmd.SetOut(failingWriter{})
+	if err := writeWorkflowMarkdown(cmd, workflowDetailView{ID: 8801, Name: "Hiring"}); err == nil {
+		t.Fatal("expected the write failure")
 	}
 }
 

--- a/internal/cmd/workflow_test.go
+++ b/internal/cmd/workflow_test.go
@@ -1,0 +1,399 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+const workflowIdentityJSON = `{
+	"id":1,
+	"accounts":[
+		{"id":1,"name":"Personal","purpose":"home","status":"active"},
+		{"id":2,"name":"Work","purpose":"work","status":"active"}
+	],
+	"all_users":[],
+	"senders":[]
+}`
+
+func TestWorkflowsCommandListsEveryLinkedAccount(t *testing.T) {
+	response, err := runJSONCommand(t, workflowHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/autocompletable/accounts/1/workflows":
+			_, _ = io.WriteString(w, `[["101","Home projects","Personal"]]`)
+		case "/autocompletable/accounts/2/workflows":
+			_, _ = io.WriteString(w, `[["202","Hiring","Work"],["203","Sales pipeline","Work"]]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}), "workflows")
+	if err != nil {
+		t.Fatalf("execute workflows: %v", err)
+	}
+	if response.Summary != "3 workflows" {
+		t.Errorf("summary = %q", response.Summary)
+	}
+	items := response.Data.([]any)
+	if len(items) != 3 {
+		t.Fatalf("items = %#v", items)
+	}
+	first := items[0].(map[string]any)
+	if first["id"] != float64(101) || first["account_id"] != float64(1) || first["account_name"] != "Personal" {
+		t.Errorf("first workflow = %#v", first)
+	}
+}
+
+func TestWorkflowsCommandHonorsSelectedAccount(t *testing.T) {
+	var listed []string
+	response, err := runJSONCommand(t, workflowHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		listed = append(listed, r.URL.Path)
+		if r.URL.Path != "/autocompletable/accounts/2/workflows" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.WriteString(w, `[["202","Hiring","Work"]]`)
+	}), "workflows", "--account", "2")
+	if err != nil {
+		t.Fatalf("execute account-scoped workflows: %v", err)
+	}
+	if len(listed) != 1 || len(response.Data.([]any)) != 1 {
+		t.Errorf("listed = %v, response = %#v", listed, response)
+	}
+}
+
+func TestWorkflowsCommandLimitAndFormats(t *testing.T) {
+	handler := workflowHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/autocompletable/accounts/") {
+			_, _ = io.WriteString(w, `[["101","Home projects","Personal"],["102","Travel plans","Personal"]]`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	response, err := runJSONCommand(t, handler, "workflows", "--limit", "1")
+	if err != nil {
+		t.Fatalf("execute workflows --limit: %v", err)
+	}
+	if response.Summary != "1 workflow" || response.Notice != "Showing 1 of 4 results. Use --all to see everything." {
+		t.Errorf("response = %#v", response)
+	}
+
+	ids, err := runFormattedCommand(t, handler, []string{"--ids-only"}, "workflows", "--limit", "1", "--all")
+	if err != nil || ids != "101\n102\n101\n102\n" {
+		t.Errorf("ids = %q, err = %v", ids, err)
+	}
+	count, err := runFormattedCommand(t, handler, []string{"--count"}, "workflows")
+	if err != nil || count != "4\n" {
+		t.Errorf("count = %q, err = %v", count, err)
+	}
+	markdown, err := runFormattedCommand(t, handler, []string{"--markdown"}, "workflows", "--limit", "1")
+	if err != nil || !strings.Contains(markdown, "| account_id |") || !strings.Contains(markdown, "Home projects") {
+		t.Errorf("markdown = %q, err = %v", markdown, err)
+	}
+	styled, err := runStyledCommand(t, handler, "workflows", "--limit", "1")
+	if err != nil || !strings.Contains(styled, "Account ID") || !strings.Contains(styled, "Home projects") {
+		t.Errorf("styled = %q, err = %v", styled, err)
+	}
+}
+
+func TestWorkflowsCommandPreservesEmptyList(t *testing.T) {
+	response, err := runJSONCommand(t, workflowHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `[]`)
+	}), "workflows")
+	if err != nil {
+		t.Fatalf("execute workflows: %v", err)
+	}
+	items, ok := response.Data.([]any)
+	if !ok || len(items) != 0 || response.Summary != "0 workflows" {
+		t.Errorf("response = %#v", response)
+	}
+}
+
+func TestWorkflowCommandReturnsStagesInPositionOrder(t *testing.T) {
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/workflows/8801.json" {
+			t.Errorf("request = %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":8801,"name":"Hiring","app_url":"/workflows/8801","stages":[{"id":5512,"name":"Applied"},{"id":5513,"name":"Interviewing"}]}`)
+	}), "workflow", "8801")
+	if err != nil {
+		t.Fatalf("execute workflow: %v", err)
+	}
+	if response.Summary != "Workflow 8801 with 2 stages" {
+		t.Errorf("summary = %q", response.Summary)
+	}
+	detail := response.Data.(map[string]any)
+	stages := detail["stages"].([]any)
+	if stages[0].(map[string]any)["id"] != float64(5512) || stages[1].(map[string]any)["name"] != "Interviewing" {
+		t.Errorf("stages = %#v", stages)
+	}
+}
+
+func TestWorkflowCommandOutputFormats(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":8801,"name":"Hiring","stages":[{"id":5512,"name":"Applied"},{"id":5513,"name":"Interviewing"}]}`)
+	})
+	ids, err := runFormattedCommand(t, handler, []string{"--ids-only"}, "workflow", "8801")
+	if err != nil || ids != "5512\n5513\n" {
+		t.Errorf("ids = %q, err = %v", ids, err)
+	}
+	count, err := runFormattedCommand(t, handler, []string{"--count"}, "workflow", "8801")
+	if err != nil || count != "2\n" {
+		t.Errorf("count = %q, err = %v", count, err)
+	}
+	markdown, err := runFormattedCommand(t, handler, []string{"--markdown"}, "workflow", "8801")
+	if err != nil || !strings.Contains(markdown, "# Hiring") || !strings.Contains(markdown, "| 5512 | Applied |") {
+		t.Errorf("markdown = %q, err = %v", markdown, err)
+	}
+	styled, err := runStyledCommand(t, handler, "workflow", "8801")
+	if err != nil || !strings.Contains(styled, "Workflow: Hiring (8801)") || !strings.Contains(styled, "Interviewing") {
+		t.Errorf("styled = %q, err = %v", styled, err)
+	}
+}
+
+func TestWorkflowMarkdownCellEscapesPipesAfterBackslashes(t *testing.T) {
+	if got, want := workflowMarkdownCell(`Applied\|Screen`), `Applied\\\|Screen`; got != want {
+		t.Errorf("workflowMarkdownCell = %q, want %q", got, want)
+	}
+}
+
+func TestWorkflowStyledOutputSanitizesNames(t *testing.T) {
+	dangerous := "Hiring\x1b[31m\nspoofed"
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":8801,"name":"Hiring\u001b[31m\nspoofed","stages":[{"id":5512,"name":"Applied\u001b[2J"}]}`)
+	})
+	styled, err := runStyledCommand(t, handler, "workflow", "8801")
+	if err != nil {
+		t.Fatalf("styled workflow: %v", err)
+	}
+	if strings.Contains(styled, "\x1b[31m") || strings.Contains(styled, "\nspoofed") || !strings.Contains(styled, "Hiring spoofed") {
+		t.Errorf("unsafe styled output for %q: %q", dangerous, styled)
+	}
+}
+
+func TestWorkflowCreateUsesTheOnlyLinkedAccount(t *testing.T) {
+	oneAccountIdentity := `{
+		"id":1,
+		"accounts":[{"id":1,"name":"Personal","purpose":"home","status":"active"}],
+		"all_users":[],
+		"senders":[]
+	}`
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/identity.json":
+			_, _ = io.WriteString(w, oneAccountIdentity)
+		case "/workflows":
+			if r.Method != http.MethodPost {
+				t.Errorf("method = %s", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if r.Form.Get("workflow[name]") != "Hiring" || r.Form.Get("account_id") != "1" {
+				t.Errorf("form = %v", r.Form)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}), "workflow", "create", "Hiring")
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	if response.Summary != `Workflow "Hiring" created` || response.Data != nil {
+		t.Errorf("response = %#v", response)
+	}
+}
+
+func TestWorkflowCreateRequiresAnAccountWhenSeveralAreAvailable(t *testing.T) {
+	var writes atomic.Int32
+	_, err := runJSONCommand(t, workflowHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		writes.Add(1)
+	}), "workflow", "create", "Hiring")
+	if err == nil || !strings.Contains(err.Error(), "requires one linked mail account") {
+		t.Fatalf("error = %v", err)
+	}
+	if writes.Load() != 0 {
+		t.Errorf("writes = %d", writes.Load())
+	}
+}
+
+func TestWorkflowMutationCommands(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		method      string
+		path        string
+		wantSummary string
+		check       func(*testing.T, url.Values)
+	}{
+		{
+			name: "update", args: []string{"workflow", "update", "8801", "--name", "Recruiting"},
+			method: http.MethodPatch, path: "/workflows/8801", wantSummary: `Workflow 8801 renamed to "Recruiting"`,
+			check: func(t *testing.T, form url.Values) {
+				if form.Get("workflow[name]") != "Recruiting" {
+					t.Errorf("form = %v", form)
+				}
+			},
+		},
+		{name: "delete", args: []string{"workflow", "delete", "8801"}, method: http.MethodDelete, path: "/workflows/8801", wantSummary: "Workflow 8801 deleted"},
+		{name: "create stage", args: []string{"workflow", "stage", "create", "8801"}, method: http.MethodPost, path: "/workflows/8801/stages", wantSummary: "Untitled stage added to workflow 8801"},
+		{
+			name: "update stage", args: []string{"workflow", "stage", "update", "8801", "5512", "--name", "Applied"},
+			method: http.MethodPatch, path: "/workflows/8801/stages/5512", wantSummary: `Stage 5512 renamed to "Applied"`,
+			check: func(t *testing.T, form url.Values) {
+				if form.Get("workflow_stage[name]") != "Applied" {
+					t.Errorf("form = %v", form)
+				}
+			},
+		},
+		{name: "delete stage", args: []string{"workflow", "stage", "delete", "8801", "5512"}, method: http.MethodDelete, path: "/workflows/8801/stages/5512", wantSummary: "Stage 5512 deleted from workflow 8801"},
+		{
+			name: "move", args: []string{"workflow", "move", "4471829", "--workflow", "8801", "--to", "5513"},
+			method: http.MethodPatch, path: "/topics/4471829/workflows/8801/stagings", wantSummary: "1 thread moved to workflow 8801 stage 5513",
+			check: func(t *testing.T, form url.Values) {
+				if form.Get("workflow_staging[workflow_stage_id]") != "5513" {
+					t.Errorf("form = %v", form)
+				}
+			},
+		},
+		{name: "remove", args: []string{"workflow", "remove", "4471829", "--from", "8801"}, method: http.MethodDelete, path: "/topics/4471829/workflows/8801/stagings", wantSummary: "1 thread removed from workflow 8801"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tt.method || r.URL.Path != tt.path {
+					t.Errorf("request = %s %s, want %s %s", r.Method, r.URL.Path, tt.method, tt.path)
+					http.NotFound(w, r)
+					return
+				}
+				if err := r.ParseForm(); err != nil {
+					t.Fatal(err)
+				}
+				if tt.check != nil {
+					tt.check(t, r.Form)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}), tt.args...)
+			if err != nil {
+				t.Fatalf("execute %v: %v", tt.args, err)
+			}
+			if response.Summary != tt.wantSummary || response.Data != nil {
+				t.Errorf("response = %#v", response)
+			}
+		})
+	}
+}
+
+func TestWorkflowAddCreatesAndMovesTheStaging(t *testing.T) {
+	var requests atomic.Int32
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := requests.Add(1)
+		if r.URL.Path != "/topics/4471829/workflows/8801/stagings" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if request == 1 {
+			if r.Method != http.MethodPost {
+				t.Errorf("first method = %s", r.Method)
+			}
+		} else {
+			if r.Method != http.MethodPatch {
+				t.Errorf("second method = %s", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if r.Form.Get("workflow_staging[workflow_stage_id]") != "5512" {
+				t.Errorf("form = %v", r.Form)
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}), "workflow", "add", "4471829", "--to", "8801", "--stage", "5512")
+	if err != nil {
+		t.Fatalf("add to workflow: %v", err)
+	}
+	if requests.Load() != 2 || response.Summary != "1 thread added to workflow 8801 stage 5512" {
+		t.Errorf("requests = %d, response = %#v", requests.Load(), response)
+	}
+}
+
+func TestWorkflowAddSurfacesStageSelectionError(t *testing.T) {
+	var requests atomic.Int32
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.Error(w, "invalid stage", http.StatusUnprocessableEntity)
+	}), "workflow", "add", "4471829", "--to", "8801", "--stage", "9999")
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "validation") {
+		t.Fatalf("error = %v", err)
+	}
+	if requests.Load() != 2 {
+		t.Errorf("requests = %d, want create and stage selection", requests.Load())
+	}
+}
+
+func TestWorkflowCommandValidation(t *testing.T) {
+	tests := [][]string{
+		{"workflow", "0"},
+		{"workflow", "update", "bad", "--name", "Hiring"},
+		{"workflow", "update", "1"},
+		{"workflow", "create", "   "},
+		{"workflow", "stage", "create", "-1"},
+		{"workflow", "stage", "update", "1", "0", "--name", "Applied"},
+		{"workflow", "stage", "update", "1", "2"},
+		{"workflow", "stage", "delete", "1", "bad"},
+		{"workflow", "add", "501", "--stage", "2"},
+		{"workflow", "add", "501", "--to", "1"},
+		{"workflow", "add", "501", "501", "--to", "1", "--stage", "2"},
+		{"workflow", "move", "501", "--to", "2"},
+		{"workflow", "move", "bad", "--workflow", "1", "--to", "2"},
+		{"workflow", "remove", "501"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			var requests atomic.Int32
+			_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+			}), args...)
+			if err == nil {
+				t.Fatalf("expected %v to fail", args)
+			}
+			if requests.Load() != 0 {
+				t.Errorf("requests = %d", requests.Load())
+			}
+		})
+	}
+}
+
+func TestWorkflowCommandSurfacesAPIErrors(t *testing.T) {
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "missing", http.StatusNotFound)
+	}), "workflow", "8801")
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "not found") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func workflowHandler(t *testing.T, fallback http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/identity.json" {
+			_, _ = io.WriteString(w, workflowIdentityJSON)
+			return
+		}
+		fallback(w, r)
+	}
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-R/0Ztesu+mttXxBilvUtZeU6iB6jdeVhHmnI0LjdVU8=";
+  vendorHash = "sha256-kNjpfSUd5V8HDyHd2VhdzpPHfPEA0vU0DGNXx+iYyaU=";
 
   subPackages = [ "cmd/hey" ];
 

--- a/tests/smoke/workflows_test.go
+++ b/tests/smoke/workflows_test.go
@@ -1,0 +1,286 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type smokeWorkflow struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	AccountID   int64  `json:"account_id"`
+	AccountName string `json:"account_name"`
+}
+
+type smokeWorkflowDetail struct {
+	ID     int64  `json:"id"`
+	Name   string `json:"name"`
+	Stages []struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
+	} `json:"stages"`
+}
+
+func TestWorkflowsAndWorkflow(t *testing.T) {
+	response := heyJSON(t, "workflows")
+	workflows := dataAs[[]smokeWorkflow](t, response)
+	if response.Summary == "" {
+		t.Error("workflows response omitted summary")
+	}
+	if len(workflows) == 0 {
+		skipf(t, "no workflows available for workflow detail validation")
+	}
+
+	workflow := workflows[0]
+	detail := dataAs[smokeWorkflowDetail](t, heyJSON(t, "workflow", strconv.FormatInt(workflow.ID, 10)))
+	if detail.ID != workflow.ID || detail.Name != workflow.Name || detail.Stages == nil {
+		t.Errorf("workflow detail = %+v, want %+v with stages", detail, workflow)
+	}
+}
+
+func TestWorkflowOutputFormats(t *testing.T) {
+	workflows := dataAs[[]smokeWorkflow](t, heyJSON(t, "workflows"))
+	for _, args := range [][]string{
+		{"workflows", "--quiet"},
+		{"workflows", "--ids-only"},
+		{"workflows", "--count"},
+		{"workflows", "--markdown"},
+		{"workflows", "--styled"},
+	} {
+		_, stderr, code := hey(t, args...)
+		if code != 0 {
+			t.Errorf("hey %s failed (exit %d): %s", strings.Join(args, " "), code, stderr)
+		}
+	}
+	if len(workflows) == 0 {
+		skipf(t, "no workflows available for detail output validation")
+	}
+	id := strconv.FormatInt(workflows[0].ID, 10)
+	for _, args := range [][]string{
+		{"workflow", id, "--quiet"},
+		{"workflow", id, "--ids-only"},
+		{"workflow", id, "--count"},
+		{"workflow", id, "--markdown"},
+		{"workflow", id, "--styled"},
+	} {
+		_, stderr, code := hey(t, args...)
+		if code != 0 {
+			t.Errorf("hey %s failed (exit %d): %s", strings.Join(args, " "), code, stderr)
+		}
+	}
+}
+
+func TestWorkflowMutations(t *testing.T) {
+	uid := uniqueID()
+	subject := fmt.Sprintf("Disposable workflow test %s", uid)
+	_, stderr, code := hey(t, "compose",
+		"--to", smokeEmail,
+		"--subject", subject,
+		"-m", "This disposable thread verifies workflow stages.",
+		"--json",
+	)
+	if code != 0 {
+		skipf(t, "could not create a disposable thread (exit %d): %s", code, stderr)
+	}
+	t.Cleanup(func() { cleanupThreadBySubject(t, subject) })
+
+	_, topicID, accountID, err := waitForPostingAndTopicIDsBySubject(t, subject)
+	if err != nil {
+		t.Fatalf("could not find disposable thread: %v", err)
+	}
+	if topicID == 0 || accountID == 0 {
+		skipf(t, "disposable thread did not expose topic and account IDs")
+	}
+
+	workflowName := "Smoke workflow " + uid
+	workflowWriteAvailableJSON(t, "workflow", "create", workflowName, "--account", strconv.FormatInt(accountID, 10))
+	workflowID, err := waitForWorkflowIDByName(t, workflowName, accountID, true)
+	if err != nil || workflowID == 0 {
+		t.Fatalf("created workflow lookup = %d, %v", workflowID, err)
+	}
+	cleanupWorkflowID := workflowID
+	t.Cleanup(func() {
+		if cleanupWorkflowID != 0 {
+			_, _, _ = hey(t, "workflow", "delete", strconv.FormatInt(cleanupWorkflowID, 10), "--json")
+		}
+	})
+
+	updatedName := workflowName + " updated"
+	workflowWriteJSON(t, "workflow", "update", strconv.FormatInt(workflowID, 10), "--name", updatedName)
+	if updatedID, err := waitForWorkflowIDByName(t, updatedName, accountID, true); err != nil || updatedID != workflowID {
+		t.Fatalf("updated workflow lookup = %d, %v; want %d", updatedID, err, workflowID)
+	}
+
+	detail := workflowDetail(t, workflowID)
+	if len(detail.Stages) == 0 {
+		t.Fatal("new workflow has no initial stage")
+	}
+	initialStageID := detail.Stages[0].ID
+	knownStages := make(map[int64]bool, len(detail.Stages))
+	for _, stage := range detail.Stages {
+		knownStages[stage.ID] = true
+	}
+
+	workflowWriteJSON(t, "workflow", "stage", "create", strconv.FormatInt(workflowID, 10))
+	newStageID, err := waitForNewWorkflowStage(t, workflowID, knownStages)
+	if err != nil || newStageID == 0 {
+		t.Fatalf("new stage lookup = %d, %v", newStageID, err)
+	}
+	stageName := "Interviewing " + uid
+	workflowWriteJSON(t, "workflow", "stage", "update", strconv.FormatInt(workflowID, 10), strconv.FormatInt(newStageID, 10), "--name", stageName)
+	if !workflowHasStage(t, workflowID, newStageID, stageName) {
+		t.Fatalf("workflow %d did not retain renamed stage %d", workflowID, newStageID)
+	}
+
+	workflowWriteJSON(t, "workflow", "add", strconv.FormatInt(topicID, 10), "--to", strconv.FormatInt(workflowID, 10), "--stage", strconv.FormatInt(newStageID, 10))
+	if !workflowStageContainsSubject(t, workflowID, newStageID, subject) {
+		t.Errorf("workflow stage %d does not contain %q after add", newStageID, subject)
+	}
+
+	workflowWriteJSON(t, "workflow", "move", strconv.FormatInt(topicID, 10), "--workflow", strconv.FormatInt(workflowID, 10), "--to", strconv.FormatInt(initialStageID, 10))
+	if !workflowStageContainsSubject(t, workflowID, initialStageID, subject) {
+		t.Errorf("workflow stage %d does not contain %q after move", initialStageID, subject)
+	}
+
+	workflowWriteJSON(t, "workflow", "remove", strconv.FormatInt(topicID, 10), "--from", strconv.FormatInt(workflowID, 10))
+	if strings.Contains(html.UnescapeString(fetchHTML(t, baseURL+"/workflows/"+strconv.FormatInt(workflowID, 10))), subject) {
+		t.Errorf("workflow still contains %q after remove", subject)
+	}
+
+	workflowWriteJSON(t, "workflow", "stage", "delete", strconv.FormatInt(workflowID, 10), strconv.FormatInt(newStageID, 10))
+	if workflowHasStage(t, workflowID, newStageID, stageName) {
+		t.Errorf("workflow still contains deleted stage %d", newStageID)
+	}
+
+	workflowWriteJSON(t, "workflow", "delete", strconv.FormatInt(workflowID, 10))
+	cleanupWorkflowID = 0
+	if found, err := waitForWorkflowIDByName(t, updatedName, accountID, false); err != nil || found != 0 {
+		t.Fatalf("deleted workflow lookup = %d, %v", found, err)
+	}
+}
+
+func TestWorkflowRejectsInvalidIDs(t *testing.T) {
+	for _, args := range [][]string{
+		{"workflow", "0"},
+		{"workflow", "stage", "delete", "1", "bad"},
+		{"workflow", "add", "1", "--to", "0", "--stage", "2"},
+		{"workflow", "move", "1", "--workflow", "2", "--to", "0"},
+		{"workflow", "remove", "bad", "--from", "2"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			heyFail(t, args...)
+		})
+	}
+}
+
+func workflowWriteAvailableJSON(t *testing.T, args ...string) Response {
+	t.Helper()
+	args = append(args, "--json")
+	stdout, stderr, code := hey(t, args...)
+	if code != 0 {
+		skipf(t, "workflow writes unavailable (exit %d): %s", code, stderr)
+	}
+	return decodeWorkflowWrite(t, stdout)
+}
+
+func workflowWriteJSON(t *testing.T, args ...string) Response {
+	t.Helper()
+	args = append(args, "--json")
+	stdout, stderr, code := hey(t, args...)
+	if code != 0 {
+		t.Fatalf("hey %s failed (exit %d): %s", strings.Join(args, " "), code, stderr)
+	}
+	return decodeWorkflowWrite(t, stdout)
+}
+
+func decodeWorkflowWrite(t *testing.T, stdout string) Response {
+	t.Helper()
+	var response Response
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("invalid workflow response: %v: %s", err, stdout)
+	}
+	return response
+}
+
+func workflowDetail(t *testing.T, workflowID int64) smokeWorkflowDetail {
+	t.Helper()
+	return dataAs[smokeWorkflowDetail](t, heyJSON(t, "workflow", strconv.FormatInt(workflowID, 10)))
+}
+
+func waitForWorkflowIDByName(t *testing.T, name string, accountID int64, wantPresent bool) (int64, error) {
+	t.Helper()
+	var lastErr error
+	for range 10 {
+		stdout, stderr, code := hey(t, "workflows", "--all", "--account", strconv.FormatInt(accountID, 10), "--json")
+		if code != 0 {
+			lastErr = fmt.Errorf("list workflows (exit %d): %s", code, stderr)
+		} else {
+			var response Response
+			if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+				lastErr = err
+			} else {
+				var workflows []smokeWorkflow
+				if err := json.Unmarshal(response.Data, &workflows); err != nil {
+					lastErr = err
+				} else {
+					var found int64
+					for _, workflow := range workflows {
+						if workflow.Name == name {
+							found = workflow.ID
+							break
+						}
+					}
+					if (wantPresent && found != 0) || (!wantPresent && found == 0) {
+						return found, nil
+					}
+					lastErr = fmt.Errorf("workflow %q presence = %v, want %v", name, found != 0, wantPresent)
+				}
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return 0, lastErr
+}
+
+func waitForNewWorkflowStage(t *testing.T, workflowID int64, known map[int64]bool) (int64, error) {
+	t.Helper()
+	for range 10 {
+		for _, stage := range workflowDetail(t, workflowID).Stages {
+			if !known[stage.ID] {
+				return stage.ID, nil
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return 0, fmt.Errorf("workflow %d did not list a new stage", workflowID)
+}
+
+func workflowHasStage(t *testing.T, workflowID, stageID int64, name string) bool {
+	t.Helper()
+	for _, stage := range workflowDetail(t, workflowID).Stages {
+		if stage.ID == stageID && stage.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowStageContainsSubject(t *testing.T, workflowID, stageID int64, subject string) bool {
+	t.Helper()
+	page := html.UnescapeString(fetchHTML(t, baseURL+"/workflows/"+strconv.FormatInt(workflowID, 10)))
+	marker := fmt.Sprintf(`id="container_workflow_stage_%d"`, stageID)
+	start := strings.Index(page, marker)
+	if start < 0 {
+		return false
+	}
+	rest := page[start+len(marker):]
+	if end := strings.Index(rest, `<section class="workflow__stage `); end >= 0 {
+		rest = rest[:end]
+	}
+	return strings.Contains(rest, subject)
+}


### PR DESCRIPTION
<!-- pr-review-readiness-head: bcdcd4f5c17e7f5350a8d9d0219fe4a68caa3edc -->

Add CLI support for listing and managing HEY email workflows, their stages, and thread membership so people and agents can move email through a process without opening the web app. This is CLI-only; the TUI and listing threads inside a stage remain outside this change.

**Review readiness:** ✅ Yes  
**Risk:** 🟡 Medium — workflow membership uses sequential server mutations, including HEY’s create-then-select staging behavior.  
**Decision:** Confirm the command hierarchy and explicit `Untitled` stage creation are the right public CLI surface for the API HEY currently provides.

<details>
<summary>✅ Change — workflows and stages are fully manageable from the CLI</summary>

### Before

```text
CLI user or agent
└── inspect or change an email workflow
    └── ❌ no workflow commands
```

### After

```text
CLI user or agent
├── workflows                         list across linked accounts
├── workflow <id>                     list stages in position order
├── workflow create/update/delete     manage workflows
├── workflow stage create/update/delete
└── workflow add/move/remove           manage thread membership  ← CHANGED
```

Lists return workflow, account, and stage IDs for chaining. Workflow creation selects the configured account, or the only available account; with several linked accounts it asks for `--account <id>` rather than choosing silently.

![Terminal recording of workflow list, detail, and command help](https://vhs.charm.sh/vhs-13NmsVQcNiyIZzkir7RGny.gif)

</details>

<details>
<summary>✅ Evidence — unit, race, strict smoke, coverage, and vulnerability checks pass</summary>

- ✅ Unit coverage exercises linked-account listing, formats, detail ordering, every write route/form, validation, sanitization, and create-then-select failure behavior.
- ✅ Strict Haystack smoke coverage creates a disposable thread and workflow, renames the workflow, creates and renames a stage, adds/moves/removes the thread with browser-page verification, deletes the stage and workflow, and cleans up.
- ✅ The terminal recording shows the list/detail output and discoverable command hierarchy.

```text
GOWORK=off make check
# pass

GOWORK=off make race-test
# pass

cd tests/smoke
GOWORK=off HEY_SMOKE_STRICT=1 go test -v -run 'TestWorkflow' -count=1
# pass

GOWORK=off make coverage
# 82.1%, floor 70.8%

GOWORK=off govulncheck ./...
# no called vulnerabilities
```

</details>

<details>
<summary>✅ Scope — CLI commands, SDK pin, docs, and tests; no TUI or stage-content read</summary>

Included:
- `workflows` list with `--limit`, `--all`, every standard output format, and linked-account IDs.
- `workflow <id>` detail with stage IDs and standard formats.
- Workflow and stage CRUD.
- Add, move, and remove one or more topic IDs.
- HEY SDK v0.12.0, its refreshed Nix vendor hash, root help, public surface snapshot, README examples, unit tests, and smoke tests.

Not included:
- TUI workflow views.
- Listing a stage’s threads in machine output; HEY’s workflow JSON currently exposes stage metadata, not staged topics.
- Creating a stage with a name in one request. HEY creates `Untitled`, and the SDK receives no new stage ID, so the CLI exposes the honest create → detail → rename flow.

</details>

<details>
<summary>➖ Delivery — no migration or configuration; SDK v0.12.0 is already released</summary>

No feature flag, migration, backfill, service, credential, or runtime dependency is added. Existing linked-account selection continues to govern requests. Rollback is a normal CLI rollback; server data needs no conversion.

</details>

<details>
<summary>⚠️ Review decision — focus on public command shape and partial membership failures</summary>

1. Review `workflows` / `workflow` and nested `workflow stage` as the public hierarchy.
2. Review the membership boundary: `add` creates membership before selecting the requested stage, so a failed selection leaves the thread in the first stage and reports the error. Multi-topic writes also stop at the first failed topic, as other non-bulk SDK operations do.

Compatibility is additive. Existing users, records, permissions, account defaults, and commands remain unchanged.

</details>

<details>
<summary>✅ Review path — command behavior, focused proof, then public surface</summary>

1. [`internal/cmd/workflow.go`](https://github.com/basecamp/hey-cli/blob/bcdcd4f5c17e7f5350a8d9d0219fe4a68caa3edc/internal/cmd/workflow.go) — command hierarchy, account behavior, output, validation, and writes.
2. [`internal/cmd/workflow_test.go`](https://github.com/basecamp/hey-cli/blob/bcdcd4f5c17e7f5350a8d9d0219fe4a68caa3edc/internal/cmd/workflow_test.go) — focused endpoint and output proof.
3. [`tests/smoke/workflows_test.go`](https://github.com/basecamp/hey-cli/blob/bcdcd4f5c17e7f5350a8d9d0219fe4a68caa3edc/tests/smoke/workflows_test.go) — real-server lifecycle and browser verification.
4. [`README.md`](https://github.com/basecamp/hey-cli/blob/bcdcd4f5c17e7f5350a8d9d0219fe4a68caa3edc/README.md), [`.surface`](https://github.com/basecamp/hey-cli/blob/bcdcd4f5c17e7f5350a8d9d0219fe4a68caa3edc/.surface), root/help files, `go.mod`/`go.sum`, and [`nix/package.nix`](https://github.com/basecamp/hey-cli/blob/bcdcd4f5c17e7f5350a8d9d0219fe4a68caa3edc/nix/package.nix) — documented public surface, SDK v0.12.0 pin, and reproducible Nix dependencies.

**Origin and supporting links:** [Basecamp card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892855) · [SDK staging PR #106](https://github.com/basecamp/hey-sdk/pull/106) · [SDK v0.12.0](https://github.com/basecamp/hey-sdk/releases/tag/v0.12.0)

</details>
