### PR TITLE
Pin that non-ASCII digits are joiner bases

### DIFF
--- a/internal/terminal/sanitize.go
+++ b/internal/terminal/sanitize.go
@@ -153,7 +153,11 @@ func (p *pass) keep(r rune) {
 // isBase reports a rune a joiner can join: non-ASCII text that is neither a space, a
 // mark, a format character nor punctuation. The marks on a base ride along with it; a
 // tag or any other format character ends it, so a joiner after one has nothing to join;
-// and a dash or a quotation mark is not something letters join to.
+// and a dash or a quotation mark is not something letters join to. Non-ASCII digits stay
+// bases on purpose: Persian writes a ZWNJ between a number and its suffix — "۱۰‌ها" —
+// so a digit is something a joiner legitimately rides against, and dropping it there
+// would rewrite the word (the Unicode core spec's chapter on joining controls makes the
+// same point about removing them blindly).
 func isBase(r rune) bool {
 	return joinable(r) && !isCombiningMark(r) && !unicode.Is(unicode.Cf, r) && !unicode.IsPunct(r)
 }

--- a/internal/terminal/sanitize_test.go
+++ b/internal/terminal/sanitize_test.go
@@ -55,6 +55,7 @@ var sanitizeTests = []struct {
 	{"a mark on an ASCII base does not make it joinable", "e\u0301\u200dé", "e\u0301é"},
 	{"a joiner before a tag character goes", "é\u200d\U000e0020", "é\U000e0020"},
 	{"a joiner before punctuation goes", "é\u200d—", "é—"},
+	{"Persian digits keep their suffix separator", "۱۰\u200cها", "۱۰\u200cها"},
 	{"a joiner after punctuation goes", "«\u200dé", "«é"},
 	{"a tag character is not a base for a joiner", "é\U000e0020\u200dé", "é\U000e0020é"},
 


### PR DESCRIPTION
Follow-up to #267's punctuation exclusion: non-ASCII digits stay joiner bases on purpose — Persian writes a ZWNJ between a number and its suffix (`۱۰‌ها`), and dropping it there rewrites the word. The choice lived only in a review reply; now `isBase`'s comment says why and the table pins `"۱۰‌ها"` unchanged. The Unicode core spec's joining-controls discussion (ch. 23) makes the same point about removing them blindly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins non-ASCII digits as joiner bases in the sanitizer to preserve the ZWNJ between numbers and suffixes in Persian. Behavior is unchanged: `isBase` still excludes punctuation but treats non-ASCII digits as bases, so "۱۰\u200cها" stays unchanged.

**Review notes**
- Adds a comment in `isBase` explaining the non-ASCII digit choice and referencing Unicode joining controls.
- Adds a test case asserting "۱۰\u200cها" remains unchanged.
- No migration required; ASCII and punctuation handling are unaffected.

<sup>Written for commit d411c78d554fb456a34da2d42a96769b90205e11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

