### PR TITLE
Make CLI help easier to scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,25 @@ That command is for cosign v3. With cosign v2.6–v2.x add `--new-bundle-format=
 
 </details>
 
+## Help and reference
+
+The root help groups commands by the work they do and keeps the common output flags concise:
+
+```bash
+hey --help                # browse the command summary
+hey compose --help        # see a command's usage, flags, and examples
+hey commands              # list the complete executable command catalog
+```
+
+Cross-cutting references are available as help topics:
+
+```bash
+hey help output            # output formats, selectors, and jq filtering
+hey help exit-codes        # stable process exit statuses
+hey help environment       # supported HEY_* environment variables
+hey help linked-accounts   # account selection and precedence
+```
+
 ## Upgrading
 
 ```bash

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -17,7 +17,7 @@ var curatedCategories = []struct {
 }{
 	{
 		heading: "CORE COMMANDS",
-		names:   []string{"tui", "boxes", "box", "threads", "search", "compose", "reply", "contacts", "calendars", "todo", "journal"},
+		names:   []string{"tui", "box", "threads", "reply", "compose", "search", "contacts", "boxes", "calendars", "todo", "journal"},
 	},
 	{
 		heading: "MAIL",

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -20,15 +20,27 @@ var curatedCategories = []struct {
 		names:   []string{"tui"},
 	},
 	{
-		heading: "EMAIL",
-		names:   []string{"boxes", "box", "labels", "label", "collections", "collection", "workflows", "workflow", "clips", "clip", "snippets", "snippet", "search", "contacts", "screener", "threads", "share", "unshare", "attachments", "compose", "reply", "bulk-reply", "forward", "drafts", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"},
+		heading: "MAIL",
+		names:   []string{"boxes", "box", "search", "contacts", "screener", "threads", "attachments", "watch"},
+	},
+	{
+		heading: "WRITE & SHARE",
+		names:   []string{"compose", "reply", "bulk-reply", "forward", "drafts", "share", "unshare"},
+	},
+	{
+		heading: "SAVED CONTENT",
+		names:   []string{"clips", "clip", "snippets", "snippet"},
+	},
+	{
+		heading: "ORGANIZE",
+		names:   []string{"labels", "label", "collections", "collection", "workflows", "workflow", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
 	},
 	{
 		heading: "CALENDAR & TASKS",
 		names:   []string{"calendars", "recordings", "todo", "habit", "timetrack", "journal"},
 	},
 	{
-		heading: "AUTH & CONFIG",
+		heading: "ACCOUNT & SYSTEM",
 		names:   []string{"auth", "accounts", "config", "setup", "doctor", "upgrade", "version"},
 	},
 }
@@ -36,6 +48,42 @@ var curatedCategories = []struct {
 type helpEntry struct {
 	name string
 	desc string
+}
+
+func configureHelpCommand(root *cobra.Command) {
+	root.InitDefaultHelpCmd()
+	help, _, err := root.Find([]string{"help"})
+	if err != nil {
+		panic(err)
+	}
+	help.Hidden = true
+	help.ValidArgsFunction = completeHelpReference
+}
+
+func completeHelpReference(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	target := cmd.Root()
+	if len(args) > 0 {
+		found, _, err := target.Find(args)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		target = found
+	}
+
+	var completions []cobra.Completion
+	for _, sub := range target.Commands() {
+		if sub.Hidden || (!sub.IsAvailableCommand() && !sub.IsAdditionalHelpTopicCommand()) {
+			continue
+		}
+		if strings.HasPrefix(sub.Name(), toComplete) {
+			completions = append(completions, cobra.CompletionWithDesc(sub.Name(), sub.Short))
+		}
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+func isHelpReference(cmd *cobra.Command) bool {
+	return cmd.Name() == "help" || cmd.IsAdditionalHelpTopicCommand()
 }
 
 // customHelpFunc returns a help function that renders styled help for all
@@ -49,6 +97,10 @@ func customHelpFunc(defaultHelp func(*cobra.Command, []string)) func(*cobra.Comm
 		}
 		if cmd == cmd.Root() {
 			renderRootHelp(cmd.OutOrStdout(), cmd)
+			return
+		}
+		if cmd.IsAdditionalHelpTopicCommand() {
+			renderHelpTopic(cmd)
 			return
 		}
 		renderCommandHelp(cmd)
@@ -97,24 +149,40 @@ func renderRootHelp(w io.Writer, cmd *cobra.Command) {
 		}
 	}
 
+	// HELP TOPICS
+	b.WriteString("\n")
+	b.WriteString(bold.format("HELP TOPICS") + "\n")
+	for _, name := range curatedHelpTopics {
+		topic := registered[name]
+		if topic == nil {
+			continue
+		}
+		fmt.Fprintf(&b, "  %-15s  %s\n", topic.Name(), topic.Short)
+	}
+
 	// FLAGS — the global flags, as registered on the root command
 	b.WriteString("\n")
 	b.WriteString(bold.format("FLAGS") + "\n")
 	for _, f := range globalFlags(cmd) {
-		writeFlagLine(&b, f.Shorthand, "--"+f.Name, f.Usage)
+		description := f.Usage
+		if concise, ok := rootFlagDescriptions[f.Name]; ok {
+			description = concise
+		}
+		writeFlagLine(&b, f.Shorthand, "--"+f.Name, description)
 	}
 	// Cobra owns --help and --version, so neither is a persistent flag to read.
-	writeFlagLine(&b, "", "--help", "Show help")
+	writeFlagLine(&b, "h", "--help", "Show help")
 	writeFlagLine(&b, "", "--version", "Show version")
 
 	// EXAMPLES
 	b.WriteString("\n")
 	b.WriteString(bold.format("EXAMPLES") + "\n")
 	examples := []string{
-		"$ hey boxes",
+		"$ hey tui",
 		"$ hey box imbox",
-		"$ hey threads 123",
 		`$ hey compose --to alice@example.com --subject "Lunch plans" -m "Are you free Friday?"`,
+		"$ hey todo list",
+		"$ hey threads 123 --json",
 	}
 	for _, ex := range examples {
 		b.WriteString(italic.format("  "+ex) + "\n")
@@ -123,10 +191,15 @@ func renderRootHelp(w io.Writer, cmd *cobra.Command) {
 	// LEARN MORE
 	b.WriteString("\n")
 	b.WriteString(bold.format("LEARN MORE") + "\n")
-	b.WriteString("  hey commands      List all available commands\n")
-	b.WriteString("  hey <command> -h  Help for any command\n")
+	b.WriteString("  hey commands          List all available commands\n")
+	b.WriteString("  hey help <topic>      Read a help topic\n")
+	b.WriteString("  hey <command> --help  Help for any command\n")
 
 	fmt.Fprint(w, b.String())
+}
+
+func renderHelpTopic(cmd *cobra.Command) {
+	fmt.Fprintln(cmd.OutOrStdout(), cmd.Long)
 }
 
 // renderCommandHelp renders styled help for any non-root command, reading
@@ -148,10 +221,11 @@ func renderCommandHelp(cmd *cobra.Command) {
 	// USAGE
 	b.WriteString("\n")
 	b.WriteString(bold.format("USAGE") + "\n")
-	if cmd.HasAvailableSubCommands() && !cmd.Runnable() {
-		b.WriteString("  " + cmd.CommandPath() + " <command> [flags]\n")
-	} else {
+	if cmd.Runnable() {
 		b.WriteString("  " + cmd.UseLine() + "\n")
+	}
+	if cmd.HasAvailableSubCommands() {
+		b.WriteString("  " + cmd.CommandPath() + " <command> [flags]\n")
 	}
 
 	// ALIASES
@@ -236,6 +310,21 @@ func renderCommandHelp(cmd *cobra.Command) {
 // flags rather than choosing them, so a flag registered without a place
 // here still gets listed, at the end.
 var globalFlagReadingOrder = []string{"account", "json", "jq", "markdown", "quiet", "ids-only", "count", "styled", "html", "stats", "base-url", "verbose"}
+
+var rootFlagDescriptions = map[string]string{
+	"account":  "Select a linked mail account",
+	"json":     "Output a JSON response envelope",
+	"jq":       "Filter JSON with a jq expression",
+	"markdown": "Output Markdown",
+	"quiet":    "Output result data without the response envelope",
+	"ids-only": "Output only IDs, one per line",
+	"count":    "Output only the result count",
+	"styled":   "Force human-readable terminal output",
+	"html":     "Write original HTML",
+	"stats":    "Include request statistics",
+	"base-url": "Override the server URL",
+	"verbose":  "Show request details",
+}
 
 // globalFlags returns the root command's persistent flags — every flag help
 // calls global, described by the registration in root.go — in reading order,

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -16,16 +16,16 @@ var curatedCategories = []struct {
 	names   []string
 }{
 	{
-		heading: "INTERACTIVE",
-		names:   []string{"tui"},
+		heading: "CORE COMMANDS",
+		names:   []string{"tui", "boxes", "box", "threads", "search", "compose", "reply", "contacts", "calendars", "todo", "journal"},
 	},
 	{
 		heading: "MAIL",
-		names:   []string{"boxes", "box", "search", "contacts", "screener", "threads", "attachments", "watch"},
+		names:   []string{"screener", "attachments", "drafts", "watch"},
 	},
 	{
 		heading: "WRITE & SHARE",
-		names:   []string{"compose", "reply", "bulk-reply", "forward", "drafts", "share", "unshare"},
+		names:   []string{"bulk-reply", "forward", "share", "unshare"},
 	},
 	{
 		heading: "SAVED CONTENT",
@@ -37,7 +37,7 @@ var curatedCategories = []struct {
 	},
 	{
 		heading: "CALENDAR & TASKS",
-		names:   []string{"calendars", "recordings", "todo", "habit", "timetrack", "journal"},
+		names:   []string{"recordings", "habit", "timetrack"},
 	},
 	{
 		heading: "ACCOUNT & SYSTEM",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -95,25 +95,28 @@ USAGE
   hey <command> [flags]
   hey tui                 Open the interactive app
 
-INTERACTIVE
-  tui  Launch the interactive terminal UI
+CORE COMMANDS
+  tui        Launch the interactive terminal UI
+  boxes      List your HEY boxes
+  box        List email threads in a box
+  threads    Read a thread
+  search     Search email threads and messages
+  compose    Write and send a new email
+  reply      Reply to a thread
+  contacts   Manage contacts
+  calendars  List calendars
+  todo       Create and manage to-dos
+  journal    Read and write journal entries
 
 MAIL
-  boxes        List your HEY boxes
-  box          List email threads in a box
-  search       Search email threads and messages
-  contacts     Manage contacts
   screener     Decide who gets to email you
-  threads      Read a thread
   attachments  List and save files from a thread
+  drafts       List draft emails
   watch        Follow email threads as they change
 
 WRITE & SHARE
-  compose     Write and send a new email
-  reply       Reply to a thread
   bulk-reply  Reply to multiple email threads
   forward     Forward the latest message in a thread
-  drafts      List draft emails
   share       Get a sharing link for an email thread
   unshare     Turn off an email thread's sharing link
 
@@ -139,12 +142,9 @@ ORGANIZE
   stop-ignoring  Stop ignoring email threads
 
 CALENDAR & TASKS
-  calendars   List calendars
   recordings  List events, to-dos, and other calendar entries
-  todo        Create and manage to-dos
   habit       Create and manage habits
   timetrack   Track time
-  journal     Read and write journal entries
 
 ACCOUNT & SYSTEM
   auth      Sign in, sign out, and check login status
@@ -208,9 +208,16 @@ func TestRootHelpStaysScannable(t *testing.T) {
 		}
 	}
 
+	seen := make(map[string]string)
 	for _, category := range curatedCategories {
 		if len(category.names) > 13 {
 			t.Errorf("%s has %d commands, want no more than 13", category.heading, len(category.names))
+		}
+		for _, name := range category.names {
+			if previous := seen[name]; previous != "" {
+				t.Errorf("%s appears in both %s and %s", name, previous, category.heading)
+			}
+			seen[name] = category.heading
 		}
 	}
 }

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -97,13 +97,13 @@ USAGE
 
 CORE COMMANDS
   tui        Launch the interactive terminal UI
-  boxes      List your HEY boxes
   box        List email threads in a box
   threads    Read a thread
-  search     Search email threads and messages
-  compose    Write and send a new email
   reply      Reply to a thread
+  compose    Write and send a new email
+  search     Search email threads and messages
   contacts   Manage contacts
+  boxes      List your HEY boxes
   calendars  List calendars
   todo       Create and manage to-dos
   journal    Read and write journal entries

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -96,31 +98,38 @@ USAGE
 INTERACTIVE
   tui  Launch the interactive terminal UI
 
-EMAIL
-  boxes          List your HEY boxes
-  box            List email threads in a box
+MAIL
+  boxes        List your HEY boxes
+  box          List email threads in a box
+  search       Search email threads and messages
+  contacts     Manage contacts
+  screener     Decide who gets to email you
+  threads      Read a thread
+  attachments  List and save files from a thread
+  watch        Follow email threads as they change
+
+WRITE & SHARE
+  compose     Write and send a new email
+  reply       Reply to a thread
+  bulk-reply  Reply to multiple email threads
+  forward     Forward the latest message in a thread
+  drafts      List draft emails
+  share       Get a sharing link for an email thread
+  unshare     Turn off an email thread's sharing link
+
+SAVED CONTENT
+  clips     List the newest page of passages clipped from email
+  clip      Save and manage passages from email
+  snippets  List reusable email snippets
+  snippet   Create and manage reusable email snippets
+
+ORGANIZE
   labels         List your email labels
   label          View and manage an email label
   collections    List your email collections
   collection     View and manage an email collection
   workflows      List your email workflows
   workflow       View and manage an email workflow
-  clips          List the newest page of passages clipped from email
-  clip           Save and manage passages from email
-  snippets       List reusable email snippets
-  snippet        Create and manage reusable email snippets
-  search         Search email threads and messages
-  contacts       Manage contacts
-  screener       Decide who gets to email you
-  threads        Read a thread
-  share          Get a sharing link for an email thread
-  unshare        Turn off an email thread's sharing link
-  attachments    List and save files from a thread
-  compose        Write and send a new email
-  reply          Reply to a thread
-  bulk-reply     Reply to multiple email threads
-  forward        Forward the latest message in a thread
-  drafts         List draft emails
   seen           Mark email threads as seen
   unseen         Mark email threads as unseen
   move           Move email threads to another box
@@ -128,7 +137,6 @@ EMAIL
   spam           Mark email threads as spam
   ignore         Ignore email threads
   stop-ignoring  Stop ignoring email threads
-  watch          Follow email threads as they change
 
 CALENDAR & TASKS
   calendars   List calendars
@@ -138,7 +146,7 @@ CALENDAR & TASKS
   timetrack   Track time
   journal     Read and write journal entries
 
-AUTH & CONFIG
+ACCOUNT & SYSTEM
   auth      Sign in, sign out, and check login status
   accounts  List and select linked mail accounts
   config    View and change settings
@@ -147,35 +155,168 @@ AUTH & CONFIG
   upgrade   Upgrade hey to the latest release
   version   Show the installed hey version
 
+HELP TOPICS
+  output           Output formats and filtering
+  exit-codes       Exit status reference
+  environment      Environment variable reference
+  linked-accounts  Linked account selection
+
 FLAGS
-      --account    Select a linked mail account ID or all
-      --json       Output JSON with metadata
-      --jq         Filter JSON with a built-in jq expression
-      --markdown   Output Markdown: a table for a listing, a document for a thread
-      --quiet      Output result data only
+      --account    Select a linked mail account
+      --json       Output a JSON response envelope
+      --jq         Filter JSON with a jq expression
+      --markdown   Output Markdown
+      --quiet      Output result data without the response envelope
       --ids-only   Output only IDs, one per line
-      --count      Output only the count of results
-      --styled     Human rendering, bodies as rendered Markdown — the default on a terminal; forces it when piped
-      --html       Write the original HTML to a pipe or file (threads, journal read, contacts show, contacts note show)
-      --stats      Include request stats in response meta
-      --base-url   Override server URL
+      --count      Output only the result count
+      --styled     Force human-readable terminal output
+      --html       Write original HTML
+      --stats      Include request statistics
+      --base-url   Override the server URL
   -v, --verbose    Show request details
-      --help       Show help
+  -h, --help       Show help
       --version    Show version
 
 EXAMPLES
-  $ hey boxes
+  $ hey tui
   $ hey box imbox
-  $ hey threads 123
   $ hey compose --to alice@example.com --subject "Lunch plans" -m "Are you free Friday?"
+  $ hey todo list
+  $ hey threads 123 --json
 
 LEARN MORE
-  hey commands      List all available commands
-  hey <command> -h  Help for any command
+  hey commands          List all available commands
+  hey help <topic>      Read a help topic
+  hey <command> --help  Help for any command
 `
 
 	if output.String() != expected {
 		t.Fatalf("unexpected root help:\n%s", output.String())
+	}
+}
+
+func TestRootHelpStaysScannable(t *testing.T) {
+	originalColorDisabled := colorDisabled
+	colorDisabled = true
+	t.Cleanup(func() { colorDisabled = originalColorDisabled })
+
+	var output strings.Builder
+	renderRootHelp(&output, newRootCmd())
+	for _, line := range strings.Split(output.String(), "\n") {
+		if len(line) > 100 {
+			t.Errorf("root help line is %d columns, want no more than 100:\n%s", len(line), line)
+		}
+	}
+
+	for _, category := range curatedCategories {
+		if len(category.names) > 13 {
+			t.Errorf("%s has %d commands, want no more than 13", category.heading, len(category.names))
+		}
+	}
+}
+
+func TestHelpTopicsAreDiscoverableReferences(t *testing.T) {
+	root := newRootCmd()
+	catalog := walkCommands(root, "")
+
+	for _, name := range curatedHelpTopics {
+		t.Run(name, func(t *testing.T) {
+			topic, _, err := root.Find([]string{name})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !topic.IsAdditionalHelpTopicCommand() {
+				t.Fatalf("%s is not registered as a help topic", name)
+			}
+
+			var output strings.Builder
+			topic.SetOut(&output)
+			renderHelpTopic(topic)
+			if !strings.Contains(output.String(), topic.Long) {
+				t.Errorf("%s help does not contain its reference text", name)
+			}
+			if strings.Contains(output.String(), "INHERITED FLAGS") || strings.Contains(output.String(), "USAGE") {
+				t.Errorf("%s help contains command scaffolding:\n%s", name, output.String())
+			}
+
+			for _, entry := range catalog {
+				if entry["name"] == name {
+					t.Errorf("help topic %s appears in the executable command catalog", name)
+				}
+			}
+		})
+	}
+}
+
+func TestHelpReferencesSkipRuntimeSetup(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, "hey-cli")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte("not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home)
+	t.Setenv("HEY_TOKEN", "would-authenticate-a-runtime-command")
+	t.Setenv("HEY_ACCOUNT_ID", "999")
+
+	repository := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repository, ".hey"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repository, ".hey", "config.json"), []byte(`{"base_url":"http://127.0.0.1:1"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repository)
+
+	root := newRootCmd()
+	var output strings.Builder
+	root.SetOut(&output)
+	root.SetErr(&output)
+	root.SetArgs([]string{"help", "output"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("help output: %v\n%s", err, output.String())
+	}
+	if !strings.Contains(output.String(), "DEFAULT OUTPUT") {
+		t.Errorf("help topic was not rendered:\n%s", output.String())
+	}
+}
+
+func TestHelpCompletionIncludesCommandsAndTopics(t *testing.T) {
+	root := newRootCmd()
+	help, _, err := root.Find([]string{"help"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completions, directive := help.ValidArgsFunction(help, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("completion directive = %v, want no file completion", directive)
+	}
+
+	joined := strings.Join(completions, "\n")
+	for _, want := range []string{"box\t", "output\t", "exit-codes\t", "environment\t", "linked-accounts\t"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("help completion does not include %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestRunnableParentHelpShowsBothUsageForms(t *testing.T) {
+	root := newRootCmd()
+	search, _, err := root.Find([]string{"search"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output strings.Builder
+	search.SetOut(&output)
+	renderCommandHelp(search)
+	for _, want := range []string{"hey search [query] [flags]", "hey search <command> [flags]"} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("search help does not contain %q:\n%s", want, output.String())
+		}
 	}
 }
 

--- a/internal/cmd/help_topics.go
+++ b/internal/cmd/help_topics.go
@@ -43,7 +43,7 @@ EXIT CODES
   4  The signed-in identity cannot perform the operation.
   5  HEY rate-limited the request.
   6  A network connection failed.
-  7  HEY returned an API or server error.
+  7  An API, server, or local operational failure occurred.
   8  The request matched more than one resource.
 
 JSON failures also carry a machine-readable error code and an actionable hint when one is available.`,

--- a/internal/cmd/help_topics.go
+++ b/internal/cmd/help_topics.go
@@ -1,0 +1,97 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var curatedHelpTopics = []string{"output", "exit-codes", "environment", "linked-accounts"}
+
+func newHelpTopicCommands() []*cobra.Command {
+	return []*cobra.Command{
+		{
+			Use:   "output",
+			Short: "Output formats and filtering",
+			Long: `Choose how hey writes results for people and programs.
+
+DEFAULT OUTPUT
+  At a terminal, hey presents human-readable styled output.
+  When stdout is piped or redirected, hey writes a JSON response envelope.
+
+FORMATS
+  --styled    Force human-readable terminal output.
+  --json      Write the JSON response envelope.
+  --quiet     Write result data without the response envelope.
+  --markdown  Write Markdown suitable for another document.
+  --html      Write original HTML for commands that support it.
+
+FILTERING
+  --jq EXPR   Filter the JSON response with a built-in jq expression.
+  --ids-only  Write result IDs, one per line.
+  --count     Write only the result count.
+  --stats     Include request statistics in JSON metadata.
+
+Formats and selectors apply when a command returns the corresponding data shape. Unsupported combinations return a usage error.`,
+		},
+		{
+			Use:   "exit-codes",
+			Short: "Exit status reference",
+			Long: `Use hey's exit status to handle results in scripts and agents.
+
+EXIT CODES
+  0  The command completed successfully.
+  1  Usage, validation, conflict, or other command error.
+  2  The requested resource was not found.
+  3  Authentication is required or failed.
+  4  The signed-in identity cannot perform the operation.
+  5  HEY rate-limited the request.
+  6  A network connection failed.
+  7  HEY returned an API or server error.
+  8  The request matched more than one resource.
+
+JSON failures also carry a machine-readable error code and an actionable hint when one is available.`,
+		},
+		{
+			Use:   "environment",
+			Short: "Environment variable reference",
+			Long: `Configure hey for the current process with environment variables.
+
+CONNECTION & AUTHENTICATION
+  HEY_TOKEN          Use a bearer token instead of stored credentials.
+  HEY_BASE_URL       Override the HEY server URL.
+  HEY_ACCOUNT_ID     Select a linked mail account ID or all.
+  HEY_NO_KEYRING     Store credentials in the config directory instead of a keyring.
+
+INTERACTION & DIAGNOSTICS
+  HEY_NONINTERACTIVE Disable prompts when set to 1 or true.
+  HEY_DEBUG          Show request details, equivalent to -v.
+
+TUI & SETUP
+  HEY_THEME          Load a TUI theme overlay from a TOML file.
+  HEY_CABLE_URL      Override the Action Cable websocket URL.
+  HEY_SETUP_AGENT    Select claude, codex, all, or none during agent setup.
+
+Command-line flags take precedence over environment values.`,
+		},
+		{
+			Use:   "linked-accounts",
+			Short: "Linked account selection",
+			Long: `Choose a linked mail account for mail commands within one HEY identity.
+
+DISCOVERY & DEFAULTS
+  hey accounts list       List All Accounts and every linked account.
+  hey accounts use ID     Save a linked account as the default mail filter.
+  hey accounts use all    Return to All Accounts.
+
+ONE INVOCATION
+  hey --account ID boxes
+  HEY_ACCOUNT_ID=ID hey search "quarterly planning"
+
+SELECTION ORDER
+  1. --account
+  2. HEY_ACCOUNT_ID
+  3. A trusted repository .hey/config.json
+  4. The global default for the active server
+  5. All Accounts
+
+Compose and contact creation use an individually selected account. Replies and forwards use the thread's account. Calendar, task, time tracking, and journal commands remain identity-wide.`,
+		},
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -62,6 +62,9 @@ func newRootCmd() *cobra.Command {
 				Stderr:   cmd.ErrOrStderr(),
 				JQFilter: jqFlag,
 			})
+			if isHelpReference(cmd) {
+				return nil
+			}
 			if err := validateHTMLFlag(cmd); err != nil {
 				return err
 			}
@@ -136,7 +139,9 @@ func newRootCmd() *cobra.Command {
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-			maybeRefreshSkills(cmd)
+			if !isHelpReference(cmd) {
+				maybeRefreshSkills(cmd)
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -221,12 +226,14 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newTuiCommand().cmd)
 	root.AddCommand(newHeyCommand().cmd)
 	root.AddCommand(newSkillCommand().cmd)
+	root.AddCommand(newHelpTopicCommands()...)
 	root.AddCommand(newCommandsCommand())
 	root.AddCommand(newCompletionCommand())
 	root.AddCommand(newDoctorCommand())
 	root.AddCommand(newConfigCommand().cmd)
 	root.AddCommand(newUpgradeCommand().cmd)
 	root.AddCommand(newVersionCommand().cmd)
+	configureHelpCommand(root)
 
 	return root
 }


### PR DESCRIPTION
<!-- pr-review-readiness-head: ebff1843d1920856abc2cad706f9b69099dc0a40 -->

Make the top-level help faster to scan by putting frequent email workflows first, separating specialized commands into task-oriented groups, and adding references for cross-cutting CLI behavior. Existing commands, flags, output behavior, and the executable command catalog remain compatible.

**Review readiness:** ✅ Yes  
**Risk:** 🟢 Low — this changes help presentation and adds non-runnable help topics without changing command execution.  
**Decision:** None

<details>
<summary>✅ Change — common email commands lead and detailed references remain discoverable</summary>

### Before

```text
hey --help
├── INTERACTIVE
│   └── tui
└── EMAIL
    ├── 34 commands in one group
    ├── compose and reply below resource-management pairs
    └── long global flag descriptions
```

### After

```text
hey --help
├── CORE COMMANDS
│   └── tui → box → threads → reply → compose → search  ← CHANGED
├── task-oriented command groups
├── concise root flag summaries
└── HELP TOPICS
    ├── output
    ├── exit-codes
    ├── environment
    └── linked-accounts  ← CHANGED
```

Runnable commands that also own subcommands now show both valid usage forms. Help references bypass runtime configuration, account selection, network access, credential migration, and skill refresh; shell completion includes both commands and help topics after `hey help`.

</details>

<details>
<summary>✅ Evidence — automated checks and the complete rendered help flow pass</summary>

- ✅ `GOWORK=off make check` — unit tests, formatting, lint, surface compatibility, and repository checks passed.
- ✅ `GOWORK=off make build` — built `./bin/hey` for local review.
- ✅ Focused tests pin the categorized output, 100-column limit, unique category membership, topic rendering/catalog exclusion, runtime-hook bypass, topic completion, and dual usage forms.
- ✅ [Rendered help recording](https://vhs.charm.sh/vhs-4mgBdqxhgIrujmE9D46Pl2.gif) — shows the complete root help at this head, from frequency-ordered core commands through flags, examples, and discovery links.

```text
Root help: 99 lines
Longest line: 88 columns (previously 119)
```

</details>

<details>
<summary>✅ Scope — help discovery changes; executable behavior remains compatible</summary>

Included: root command grouping and ordering, concise root-only flag descriptions, four Cobra additional-help topics, broader examples, dual usage lines for runnable parents, safe help execution, completion, tests, and README reference documentation.

Preserved: every existing command and flag, detailed inherited flag descriptions, `hey commands` output, `.surface`, output formats, authentication, account behavior, and TUI behavior.

Non-goal: renaming singular/plural command pairs or introducing a new noun-first command hierarchy.

</details>

<details>
<summary>➖ Delivery — no rollout, migration, configuration, or cleanup work</summary>

The change ships with the CLI binary. Rollback is a normal code revert; no data or external resources are involved.

</details>

<details>
<summary>✅ Review decision — no unresolved decision; focus on hierarchy and reference wording</summary>

Please confirm that the CORE COMMANDS order reflects the normal email workflow and that the four help topics describe the existing behavior at the right level of detail.

</details>

<details>
<summary>✅ Review path — start with the command hierarchy, then references and proof</summary>

1. [`internal/cmd/help.go`](https://github.com/basecamp/hey-cli/blob/ebff1843d1920856abc2cad706f9b69099dc0a40/internal/cmd/help.go) — root hierarchy, concise flag summaries, completion, and rendering.
2. [`internal/cmd/help_topics.go`](https://github.com/basecamp/hey-cli/blob/ebff1843d1920856abc2cad706f9b69099dc0a40/internal/cmd/help_topics.go) — the four user-facing references.
3. [`internal/cmd/help_test.go`](https://github.com/basecamp/hey-cli/blob/ebff1843d1920856abc2cad706f9b69099dc0a40/internal/cmd/help_test.go) — behavior and compatibility proof.
4. [`internal/cmd/root.go`](https://github.com/basecamp/hey-cli/blob/ebff1843d1920856abc2cad706f9b69099dc0a40/internal/cmd/root.go) and [`README.md`](https://github.com/basecamp/hey-cli/blob/ebff1843d1920856abc2cad706f9b69099dc0a40/README.md) — registration, safe lifecycle, and documentation.

**Origin and supporting links:** [Basecamp card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10228971237)

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes root CLI help easier to scan by promoting frequent email workflows, grouping specialized commands, adding `help` topics with completion, and shortening global flag descriptions. Previously, help mixed interactive and 34 email commands with long flag text; now CORE COMMANDS lead, task groups follow, reference topics are discoverable, and command execution is unchanged.

**Review**
- Confirm CORE COMMANDS order reflects normal email flow and includes contacts, boxes, calendars, todo, and journal; ensure MAIL, WRITE & SHARE, SAVED CONTENT, ORGANIZE, and CALENDAR & TASKS stay small and have no duplicates.
- Check root flag summaries use concise text and that `-h` is shown for `--help`.
- Verify `help` topics (output, exit-codes, environment, linked-accounts) render as references, are excluded from `hey commands`, and appear in `hey help` completion alongside commands; exit-codes clarifies operational failure statuses.
- Ensure runnable parents show both usage forms and that help rendering bypasses runtime setup and skill refresh without affecting command runs.

**Rollout**
- No migration or configuration required; commands, flags, and outputs remain compatible.

<sup>Written for commit bfbb4a743496bfccbe225f9ad16f3d2e0be818db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

