### PR TITLE
Catch the smoke suite up so the strict gate runs green

### DIFF
--- a/tests/smoke/auth_test.go
+++ b/tests/smoke/auth_test.go
@@ -2,7 +2,6 @@ package smoke_test
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 )
 
@@ -18,26 +17,24 @@ func TestAuthStatus(t *testing.T) {
 	}
 }
 
+// TestMain authenticates with a browser session cookie, and auth token refuses
+// to print a cookie as a bearer token: HEY sends it as a Cookie header, so
+// handing it out as "Authorization: Bearer" would 401 with nothing to explain
+// it. The refusal is the command's behavior under this suite's auth method.
 func TestAuthToken(t *testing.T) {
-	stdout, stderr, code := hey(t, "auth", "token")
-	if code != 0 {
-		t.Fatalf("auth token failed (exit %d): %s", code, stderr)
+	_, stderr, code := hey(t, "auth", "token")
+	if code != 3 {
+		t.Fatalf("expected auth token to refuse the session cookie with exit 3, got exit %d: %s", code, stderr)
 	}
-	stdout = strings.TrimSpace(stdout)
-	if stdout == "" {
-		t.Error("expected auth token to output a non-empty token")
-	}
+	assertContains(t, stderr, "browser session cookie")
 }
 
 func TestAuthTokenStored(t *testing.T) {
-	stdout, stderr, code := hey(t, "auth", "token", "--stored")
-	if code != 0 {
-		t.Fatalf("auth token --stored failed (exit %d): %s", code, stderr)
+	_, stderr, code := hey(t, "auth", "token", "--stored")
+	if code != 3 {
+		t.Fatalf("expected auth token --stored to refuse the session cookie with exit 3, got exit %d: %s", code, stderr)
 	}
-	stdout = strings.TrimSpace(stdout)
-	if stdout == "" {
-		t.Error("expected auth token --stored to output a non-empty token")
-	}
+	assertContains(t, stderr, "browser session cookie")
 }
 
 func TestAuthRefresh(t *testing.T) {

--- a/tests/smoke/boxes_test.go
+++ b/tests/smoke/boxes_test.go
@@ -189,7 +189,20 @@ func TestMovePosting(t *testing.T) {
 		}
 	}
 	if postingID == 0 {
-		skipf(t, "no seen postings in Imbox to move without changing unread state")
+		if len(imbox.Postings) == 0 {
+			skipf(t, "no postings in Imbox to move")
+		}
+		// No seen posting to borrow: mark one seen and put its unread
+		// state back afterwards. The restore runs after the move-back
+		// cleanup below, so the posting is home before it goes unseen.
+		postingID = imbox.Postings[0].ID
+		heyOK(t, "seen", intStr(postingID), "--json")
+		t.Cleanup(func() {
+			_, cleanupStderr, cleanupCode := hey(t, "unseen", intStr(postingID), "--json")
+			if cleanupCode != 0 {
+				t.Logf("could not restore posting %d to unseen: %s", postingID, cleanupStderr)
+			}
+		})
 	}
 
 	stdout, stderr, code := hey(t, "move", intStr(postingID), "--to", "feedbox", "--json")
@@ -232,7 +245,9 @@ func TestMoveRejectsBubbleUp(t *testing.T) {
 }
 
 func TestBoxNoArgument(t *testing.T) {
-	heyFail(t, "box", "--json")
+	// box is a command group: bare "hey box" shows its help.
+	stdout := heyOK(t, "box")
+	assertContains(t, stdout, "hey box view")
 }
 
 func TestBoxInvalidName(t *testing.T) {

--- a/tests/smoke/helpers_test.go
+++ b/tests/smoke/helpers_test.go
@@ -180,9 +180,16 @@ func dataAs[T any](t *testing.T, resp Response) T {
 	return v
 }
 
-// cliEnv returns the environment variables used for all CLI invocations.
+// cliEnv returns the environment variables used for all CLI invocations. The
+// caller's HEY_TOKEN is dropped: the suite authenticates with the cookie TestMain
+// stored, and an inherited token would silently stand in for it on every command.
 func cliEnv() []string {
-	env := os.Environ()
+	env := make([]string, 0, len(os.Environ())+6)
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, "HEY_TOKEN=") {
+			env = append(env, kv)
+		}
+	}
 	env = append(env,
 		"HEY_BASE_URL="+baseURL,
 		"XDG_CONFIG_HOME="+configDir,


### PR DESCRIPTION
The strict smoke gate (`HEY_SMOKE_STRICT=1 make test-smoke`) had never been run. Running it today against a current haystack dev server surfaced three stale tests and one structural skip — all test-side; no CLI behavior changed.

- **`TestAuthToken` / `TestAuthTokenStored`** — `hey auth token` refuses to print a browser session cookie as a bearer token since 45b0263, and the smoke suite authenticates with exactly that cookie (`auth login --cookie` in `TestMain`). The refusal *is* the command's behavior under this suite's auth method, so the tests now assert it: exit 3 and the cookie message. The happy path can't be smoke-tested while the harness logs in by cookie.
- **`TestBoxNoArgument`** — `box` became a command group in #276, so bare `hey box` shows help and exits 0. The test now asserts the help names `hey box view` instead of expecting a failure.
- **`TestMovePosting`** — skipped forever waiting for a seen posting the seed data never provides (it runs before `TestSeenUnseen` marks anything seen). When no seen posting exists it now marks one seen itself and restores the unread state in a cleanup registered *before* the move-back cleanup, so LIFO ordering brings the posting home to the Imbox before it goes unseen.

Gate result with these fixes, against haystack `1e966b5e2d` (current master — the checkout needed updating: collections/Screener/journal-feed/calendar-period JSON all landed server-side this week):

- baseline `make test-smoke`: PASS, 156 runs, 0 skips
- `HEY_SMOKE_STRICT=1 make test-smoke`: PASS, 135s, 0 skips, 0 failures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the smoke suite with current CLI behavior and hardens the test harness so the strict smoke gate runs green. No CLI behavior changed; all updates are test-side and env-side.

- Auth token: previously expected a printed bearer token; now asserts refusal under cookie auth (exit 3 with “browser session cookie”).
- Box: previously expected bare “hey box” to fail; now expects help output (exit 0) and mentions “hey box view”.
- Move: previously skipped when no seen posting; now marks one seen, moves it, then restores unseen after the move-back cleanup.
- Env isolation: previously inherited `HEY_TOKEN`, which could mask cookie auth and produce false positives; now filters `HEY_TOKEN` from the test env so the suite always uses the stored cookie.

Result: both make test-smoke and HEY_SMOKE_STRICT=1 make test-smoke pass against a current haystack dev server (156 runs, no skips, no failures).

<sup>Written for commit f3997d943c574347518e2c97b4bf5677c1a01732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

