### PR TITLE
Read and manage tracked time from the CLI

### DIFF
--- a/.surface
+++ b/.surface
@@ -248,14 +248,22 @@ hey timetrack category create
 hey timetrack category delete
 hey timetrack category rename
 hey timetrack current
+hey timetrack delete
+hey timetrack edit
+hey timetrack edit --category
+hey timetrack edit --end
+hey timetrack edit --notes
+hey timetrack edit --start
 hey timetrack export
 hey timetrack export --force
 hey timetrack export --output
 hey timetrack list
 hey timetrack list --all
+hey timetrack list --category
 hey timetrack list --limit
 hey timetrack start
 hey timetrack stop
+hey timetrack stop --category
 hey todo
 hey todo add
 hey todo add --date

--- a/README.md
+++ b/README.md
@@ -482,6 +482,9 @@ hey recordings 123 --starts-on 2026-01-01 --ends-on 2026-01-31  # over a date ra
 hey recordings 123 --count      # how many entries, across every type
 ```
 
+`hey calendars` names the account each calendar belongs to when there is more than one, since
+that is what tells two calendars of the same name apart.
+
 Calendar IDs come from `hey calendars`. `--starts-on` defaults to today and `--ends-on` to
 thirty days after it; both want `YYYY-MM-DD`, and an unreadable date or an `--ends-on`
 before `--starts-on` is a usage error rather than an empty result. `hey recordings` groups
@@ -517,8 +520,14 @@ Habit IDs come from calendar recordings. Weekdays use `0` for Sunday through `6`
 ```bash
 hey timetrack start                # start tracking
 hey timetrack stop                 # stop tracking
+hey timetrack stop --category "Client work"   # stop and file it in one request
 hey timetrack current              # show active track
-hey timetrack list                 # list all tracks
+hey timetrack list                 # completed tracks, newest first
+hey timetrack list --all --json    # every page
+hey timetrack list --category 42   # only one category's tracks
+hey timetrack edit 1042 --end 2026-08-22T17:30
+hey timetrack edit 1042 --category "Client work" --notes "Invoice review"
+hey timetrack delete 1042
 hey timetrack export > tracked-time.csv
 hey timetrack export --output tracked-time.csv
 hey timetrack categories           # list categories
@@ -526,6 +535,19 @@ hey timetrack category create "Client work"
 hey timetrack category rename 123 "Planning"
 hey timetrack category delete 123
 ```
+
+`hey timetrack list` reads HEY's tracked time index: completed tracks, newest-ended first,
+with the day, the times, how long each took, the category and the notes. The track that is
+running is not in it — `hey timetrack current` is where that lives. One page arrives by
+default; `--limit` reads on until it has that many and `--all` reads the lot. `--category`
+takes an ID from `hey timetrack categories`.
+
+`hey timetrack edit` changes only the fields whose flags you give. `--start` and `--end`
+want `YYYY-MM-DDTHH:MM` in your own time zone, or a full RFC 3339 instant when the zone
+matters. A category is given as a title, and HEY creates the category if it has none by
+that title — on `edit` and on `stop --category` alike. There is no clearing a category that
+way: a blank title leaves the track filed where it was. Editing a track completes it, so
+`edit` is for tracks that have already finished.
 
 The time tracking export contains every completed entry, newest first, with Start, End, Duration, Category, and Notes columns. Ongoing time tracking is excluded. `--output` preserves an existing file unless `--force` is set.
 

--- a/internal/cmd/calendar_commands_test.go
+++ b/internal/cmd/calendar_commands_test.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
@@ -67,6 +69,29 @@ func TestCalendarsCommand(t *testing.T) {
 	items, ok := response.Data.([]any)
 	if !ok || len(items) != 2 {
 		t.Fatalf("data = %#v, want two calendars", response.Data)
+	}
+}
+
+// Two accounts both keep a "Maybe", so the table names the account they belong to. With one
+// account it would be the reader's own address written down the column, so it stays away.
+func TestCalendarsNamesTheAccountOnlyWhenThereAreSeveral(t *testing.T) {
+	if spansAccounts([]generated.Calendar{
+		{Id: 7, Name: "Maybe", OwnerEmailAddress: "amelia@example.com"},
+		{Id: 9, Name: "Work", OwnerEmailAddress: "amelia@example.com"},
+	}) {
+		t.Error("one account should not be named")
+	}
+
+	if !spansAccounts([]generated.Calendar{
+		{Id: 7, Name: "Maybe", OwnerEmailAddress: "amelia@example.com"},
+		{Id: 11, Name: "Maybe", OwnerEmailAddress: "amelia@example.org"},
+	}) {
+		t.Error("two accounts should be named")
+	}
+
+	// The personal calendar has no owner address, and one on its own is not two accounts.
+	if spansAccounts([]generated.Calendar{{Id: 1}, {Id: 7, OwnerEmailAddress: "amelia@example.com"}}) {
+		t.Error("a calendar with no account made the list look like several")
 	}
 }
 
@@ -366,20 +391,6 @@ func TestTimetrackStopWithoutActiveTrack(t *testing.T) {
 	}
 	if requests.Load() != 1 {
 		t.Errorf("requests = %d, want only the lookup", requests.Load())
-	}
-}
-
-func TestTimetrackListCommand(t *testing.T) {
-	recordings := `{"Calendar::TimeTrack":[{"id":1,"title":"First"},{"id":2,"title":"Second"}],"Calendar::Todo":[{"id":3,"title":"Todo"}]}`
-	response, err := runJSONCommand(t, personalCalendarHandler(t, recordings), "timetrack", "list", "--limit", "1")
-	if err != nil {
-		t.Fatalf("execute timetrack list: %v", err)
-	}
-	if response.Summary != "1 time tracks" {
-		t.Errorf("summary = %q", response.Summary)
-	}
-	if response.Notice != "Showing 1 of 2 results. Use --all to see everything." {
-		t.Errorf("notice = %q", response.Notice)
 	}
 }
 

--- a/internal/cmd/calendars.go
+++ b/internal/cmd/calendars.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/output"
 )
@@ -43,14 +45,29 @@ func (c *calendarsCommand) run(cmd *cobra.Command, args []string) error {
 	calendars := unwrapCalendars(payload)
 
 	if writer.IsStyled() {
+		// The account is named only when there is more than one, since it is what tells two
+		// calendars of the same name apart — a reader with a work account and a personal one has
+		// two called "Maybe" and nothing else to go on. With one account it would be their own
+		// address written down the column.
+		accounts := spansAccounts(calendars)
+
 		table := newTable(cmd.OutOrStdout())
-		table.addRow([]string{"ID", "Name", "Kind", "Owned"})
+		header := []string{"ID", "Name", "Kind", "Owned"}
+		if accounts {
+			header = append(header, "Account")
+		}
+		table.addRow(header)
+
 		for _, cal := range calendars {
 			owned := "no"
 			if cal.Owned {
 				owned = "yes"
 			}
-			table.addRow([]string{fmt.Sprintf("%d", cal.Id), cal.Name, cal.Kind, owned})
+			row := []string{fmt.Sprintf("%d", cal.Id), cal.Name, cal.Kind, owned}
+			if accounts {
+				row = append(row, cal.OwnerEmailAddress)
+			}
+			table.addRow(row)
 		}
 		table.print()
 		return nil
@@ -64,4 +81,20 @@ func (c *calendarsCommand) run(cmd *cobra.Command, args []string) error {
 			Description: "List recordings for a calendar",
 		}),
 	)
+}
+
+// spansAccounts is whether the list covers more than one HEY account, which is the only time
+// naming them tells the reader anything.
+func spansAccounts(calendars []generated.Calendar) bool {
+	seen := ""
+	for _, calendar := range calendars {
+		if calendar.OwnerEmailAddress == "" {
+			continue
+		}
+		if seen != "" && calendar.OwnerEmailAddress != seen {
+			return true
+		}
+		seen = calendar.OwnerEmailAddress
+	}
+	return false
 }

--- a/internal/cmd/timetrack.go
+++ b/internal/cmd/timetrack.go
@@ -1,18 +1,26 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
 	safefiles "github.com/basecamp/hey-cli/internal/attachments"
 	"github.com/basecamp/hey-cli/internal/output"
 	"github.com/basecamp/hey-cli/internal/terminal"
 )
+
+const maxTimeTrackPages = 100
 
 type timetrackCommand struct {
 	cmd *cobra.Command
@@ -24,7 +32,7 @@ func newTimetrackCommand() *timetrackCommand {
 		Use:   "timetrack",
 		Short: "Track time",
 		Annotations: map[string]string{
-			"agent_notes": "Subcommands: start, stop, current, list, export, categories, category. Use current to check if tracking is active before start/stop. Export writes CSV to stdout or safely saves it with --output.",
+			"agent_notes": "Subcommands: start, stop, current, list, edit, delete, export, categories, category. Use current to check if tracking is active before start/stop. Stop takes --category to file the track as it stops it. List, edit and delete work on completed tracks and take the IDs list reports. Export writes CSV to stdout or safely saves it with --output.",
 		},
 	}
 
@@ -32,6 +40,8 @@ func newTimetrackCommand() *timetrackCommand {
 	timetrackCommand.cmd.AddCommand(newTimetrackStopCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackCurrentCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackListCommand().cmd)
+	timetrackCommand.cmd.AddCommand(newTimetrackEditCommand().cmd)
+	timetrackCommand.cmd.AddCommand(newTimetrackDeleteCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackExportCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackCategoriesCommand().cmd)
 	timetrackCommand.cmd.AddCommand(newTimetrackCategoryCommand().cmd)
@@ -81,7 +91,8 @@ func (c *timetrackStartCommand) run(cmd *cobra.Command, args []string) error {
 // stop
 
 type timetrackStopCommand struct {
-	cmd *cobra.Command
+	cmd      *cobra.Command
+	category string
 }
 
 func newTimetrackStopCommand() *timetrackStopCommand {
@@ -89,10 +100,18 @@ func newTimetrackStopCommand() *timetrackStopCommand {
 	timetrackStopCommand.cmd = &cobra.Command{
 		Use:   "stop",
 		Short: "Stop time tracking",
+		Long: `Stop the running time track.
+
+--category files the track under a category as it stops it, in the one request, and HEY
+creates the category if it has none by that title. There is no clearing a category this
+way: a blank title leaves the track filed where it was.`,
 		Example: `  hey timetrack stop
+  hey timetrack stop --category "Client work"
   hey timetrack stop --json`,
 		RunE: timetrackStopCommand.run,
 	}
+
+	timetrackStopCommand.cmd.Flags().StringVar(&timetrackStopCommand.category, "category", "", "Category title to file the stopped track under, created if HEY has none by that title")
 
 	return timetrackStopCommand
 }
@@ -112,11 +131,20 @@ func (c *timetrackStopCommand) run(cmd *cobra.Command, args []string) error {
 		return apierr.ErrNotFound("time track", "active")
 	}
 
-	if err = sdk.TimeTracks().Stop(ctx, track.Id); err != nil {
+	category := strings.TrimSpace(c.category)
+	if cmd.Flags().Changed("category") && category == "" {
+		return apierr.ErrUsage("--category needs a title; a blank one does not clear a category")
+	}
+
+	if err = sdk.TimeTracks().StopAndFile(ctx, track.Id, category); err != nil {
 		return apierr.FromSDK(err)
 	}
 
-	return writeMutation(cmd, "Time tracking stopped", nil)
+	summary := "Time tracking stopped"
+	if category != "" {
+		summary = fmt.Sprintf("Time tracking stopped and filed under %q", category)
+	}
+	return writeMutation(cmd, summary, nil)
 }
 
 // current
@@ -176,24 +204,35 @@ func (c *timetrackCurrentCommand) run(cmd *cobra.Command, args []string) error {
 // list
 
 type timetrackListCommand struct {
-	cmd   *cobra.Command
-	limit int
-	all   bool
+	cmd      *cobra.Command
+	limit    int
+	all      bool
+	category int64
 }
 
 func newTimetrackListCommand() *timetrackListCommand {
 	timetrackListCommand := &timetrackListCommand{}
 	timetrackListCommand.cmd = &cobra.Command{
 		Use:   "list",
-		Short: "List time tracks",
+		Short: "List completed time tracks",
+		Long: `List completed time tracks, newest first, with how long each one took.
+
+The track that is running is not here — read that with hey timetrack current. One page
+arrives by default; --limit reads on until it has that many, and --all reads the lot.`,
+		Annotations: map[string]string{
+			"agent_notes": "Reads HEY's tracked time index, newest-ended first. Category is a title and is empty for an unfiled track. --category takes a category ID from hey timetrack categories.",
+		},
 		Example: `  hey timetrack list
   hey timetrack list --limit 10
-  hey timetrack list --json`,
+  hey timetrack list --all --json
+  hey timetrack list --category 42`,
 		RunE: timetrackListCommand.run,
+		Args: cobra.NoArgs,
 	}
 
 	timetrackListCommand.cmd.Flags().IntVar(&timetrackListCommand.limit, "limit", 0, "Maximum number of time tracks to show")
 	timetrackListCommand.cmd.Flags().BoolVar(&timetrackListCommand.all, "all", false, "Fetch all results (override --limit)")
+	timetrackListCommand.cmd.Flags().Int64Var(&timetrackListCommand.category, "category", 0, "Only tracks filed under this category ID")
 
 	return timetrackListCommand
 }
@@ -202,20 +241,27 @@ func (c *timetrackListCommand) run(cmd *cobra.Command, args []string) error {
 	if err := requireAuth(); err != nil {
 		return err
 	}
+	if cmd.Flags().Changed("category") && c.category <= 0 {
+		return apierr.ErrUsage("--category takes a category ID; list them with hey timetrack categories")
+	}
 
 	ctx := cmd.Context()
-	resp, err := listPersonalRecordings(ctx)
+	first, err := c.readPage(ctx, "")
+	if err != nil {
+		return err
+	}
+	collected, err := collectPages(ctx, first, pageRequest{Limit: c.limit, All: c.all, MaxPages: maxTimeTrackPages}, c.readPage)
 	if err != nil {
 		return err
 	}
 
-	tracks := filterRecordingsByType(resp, "Calendar::TimeTrack")
-
-	total := len(tracks)
+	tracks := collected.Items
+	more := collected.Cursor != ""
 	if c.limit > 0 && !c.all && len(tracks) > c.limit {
 		tracks = tracks[:c.limit]
+		more = true
 	}
-	notice := output.TruncationNotice(len(tracks), total)
+	notice := timetrackListNotice(len(tracks), collected.Read, more, collected.Truncated)
 
 	if writer.IsStyled() {
 		if len(tracks) == 0 {
@@ -224,24 +270,294 @@ func (c *timetrackListCommand) run(cmd *cobra.Command, args []string) error {
 		}
 
 		table := newTable(cmd.OutOrStdout())
-		table.addRow([]string{"ID", "Title", "Start", "End"})
-		for _, t := range tracks {
-			table.addRow([]string{fmt.Sprintf("%d", t.Id), t.Title, formatTimestamp(t.StartsAt), formatTimestamp(t.EndsAt)})
+		table.addRow([]string{"ID", "Day", "Start", "End", "Length", "Category", "Notes"})
+		for _, track := range tracks {
+			table.addRow([]string{
+				strconv.FormatInt(track.Id, 10),
+				track.StartsAt.Local().Format(dateLayout),
+				formatClock(track.StartsAt),
+				timetrackEndClock(track.StartsAt, track.EndsAt),
+				formatTrackedLength(trackedLength(track)),
+				truncate(track.Category, 24),
+				truncate(track.Notes, 40),
+			})
 		}
 		table.print()
 		if notice != "" {
-			fmt.Fprintln(cmd.OutOrStdout(), notice)
+			fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n", notice)
 		}
 		return nil
 	}
+	if stderrNotice := paginationNoticeForStderr(writer.EffectiveFormat(), notice); stderrNotice != "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), stderrNotice)
+	}
 
 	return writeOK(tracks,
-		output.WithSummary(fmt.Sprintf("%d time tracks", len(tracks))),
+		output.WithSummary(fmt.Sprintf("%d %s", len(tracks), timeTrackNoun(len(tracks)))),
 		output.WithNotice(notice),
+		output.WithMeta("pages_fetched", collected.Read),
 		output.WithBreadcrumbs(output.Breadcrumb{
-			Action:      "start",
-			Command:     "hey timetrack start",
-			Description: "Start time tracking",
+			Action:      "edit",
+			Command:     "hey timetrack edit <id>",
+			Description: "Edit a time track",
+		}),
+	)
+}
+
+func (c *timetrackListCommand) readPage(ctx context.Context, cursor string) (pageResult[generated.Recording], error) {
+	params := &generated.ListTimeTracksParams{}
+	if cursor != "" {
+		params.Page = &cursor
+	}
+	if c.category > 0 {
+		params.CategoryId = &c.category
+	}
+
+	page, err := sdk.TimeTracks().ListPage(ctx, params)
+	if err != nil {
+		return pageResult[generated.Recording]{}, c.readError(err)
+	}
+	if page == nil {
+		return pageResult[generated.Recording]{}, nil
+	}
+	return pageResult[generated.Recording]{Items: page.TimeTracks, Cursor: page.NextPage}, nil
+}
+
+// readError names the category HEY could not find. An id no category has answers 404 for
+// the whole list, which otherwise reads as somebody's tracked time having gone missing.
+func (c *timetrackListCommand) readError(err error) error {
+	converted := apierr.FromSDK(err)
+	if c.category > 0 && apierr.AsError(converted).Code == apierr.CodeNotFound {
+		return apierr.ErrNotFound("time track category", strconv.FormatInt(c.category, 10))
+	}
+	return converted
+}
+
+// timetrackListNotice says why the list stopped, because a list that quietly ended looks
+// like the whole of somebody's tracked time.
+func timetrackListNotice(shown, pages int, more, truncated bool) string {
+	switch {
+	case truncated:
+		return fmt.Sprintf("Stopped after %d pages, at %d %s. Narrow the list with --category.", pages, shown, timeTrackNoun(shown))
+	case more:
+		return fmt.Sprintf("Showing %d %s. Use --all to see everything.", shown, timeTrackNoun(shown))
+	default:
+		return ""
+	}
+}
+
+func timeTrackNoun(count int) string {
+	if count == 1 {
+		return "time track"
+	}
+	return "time tracks"
+}
+
+// trackedLength is how long a track took, computed from the two instants HEY serves
+// rather than read off a field: the index carries no duration of its own.
+func trackedLength(track generated.Recording) time.Duration {
+	return max(track.EndsAt.Sub(track.StartsAt), 0)
+}
+
+// formatTrackedLength reads a stretch of time the way a stopwatch does, hours and all.
+// Dropping the hours until there is one makes 0:45 either three quarters of a minute or
+// three quarters of an hour, and moves the columns after it.
+func formatTrackedLength(length time.Duration) string {
+	seconds := int(max(length, 0).Seconds())
+	return fmt.Sprintf("%d:%02d:%02d", seconds/3600, seconds/60%60, seconds%60)
+}
+
+// formatClock is a time of day on the reader's own clock. HEY serves every JSON timestamp in
+// UTC, so a track kept at noon in Zagreb arrives as 11:00 and reads as an hour it was not — and
+// with the day beside it, a late enough track lands on the wrong date entirely.
+func formatClock(ts time.Time) string {
+	if ts.IsZero() {
+		return ""
+	}
+	return ts.Local().Format("15:04")
+}
+
+// timetrackEndClock is the end of a track next to the day it started on. A track that ran
+// past midnight ended on another day, so that one carries its date rather than reading as
+// an end before its own start.
+func timetrackEndClock(startsAt, endsAt time.Time) string {
+	// Compared on the reader's clock, since that is the day the Day column shows: a track can
+	// cross midnight in one zone and not in another.
+	if !endsAt.IsZero() && endsAt.Local().Format(dateLayout) != startsAt.Local().Format(dateLayout) {
+		return endsAt.Local().Format("2006-01-02T15:04")
+	}
+	return formatClock(endsAt)
+}
+
+// edit
+
+type timetrackEditCommand struct {
+	cmd      *cobra.Command
+	start    string
+	end      string
+	category string
+	notes    string
+}
+
+func newTimetrackEditCommand() *timetrackEditCommand {
+	timetrackEditCommand := &timetrackEditCommand{}
+	timetrackEditCommand.cmd = &cobra.Command{
+		Use:   "edit <id>",
+		Short: "Edit a completed time track",
+		Long: `Edit a time track. Only the fields whose flags are given change.
+
+Timestamps are YYYY-MM-DDTHH:MM in your own time zone, or a full RFC 3339 instant when
+the zone matters. --category files the track under a category title, which HEY creates if
+it has none by that title; a blank title does not clear one. Editing a track completes it,
+so this is for tracks that have already finished.`,
+		Example: `  hey timetrack edit 1042 --end 2026-08-22T17:30
+  hey timetrack edit 1042 --category "Client work" --notes "Invoice review"
+  hey timetrack edit 1042 --start 2026-08-22T09:00 --end 2026-08-22T11:15`,
+		RunE: timetrackEditCommand.run,
+		Args: usageExactOneArg(),
+	}
+
+	timetrackEditCommand.cmd.Flags().StringVar(&timetrackEditCommand.start, "start", "", "New start, as YYYY-MM-DDTHH:MM in your time zone")
+	timetrackEditCommand.cmd.Flags().StringVar(&timetrackEditCommand.end, "end", "", "New end, as YYYY-MM-DDTHH:MM in your time zone")
+	timetrackEditCommand.cmd.Flags().StringVar(&timetrackEditCommand.category, "category", "", "Category title to file the track under, created if HEY has none by that title")
+	timetrackEditCommand.cmd.Flags().StringVar(&timetrackEditCommand.notes, "notes", "", "New notes")
+
+	return timetrackEditCommand
+}
+
+func (c *timetrackEditCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	trackID, err := parsePositiveID(args[0], "time track")
+	if err != nil {
+		return err
+	}
+	payload, err := c.payload(cmd)
+	if err != nil {
+		return err
+	}
+
+	track, err := sdk.TimeTracks().Update(cmd.Context(), trackID, generated.UpdateTimeTrackJSONRequestBody{CalendarTimeTrack: payload})
+	if err != nil {
+		return timetrackUpdateError(err)
+	}
+	return writeMutationLine(cmd,
+		fmt.Sprintf("Time track %d updated.", trackID),
+		"Time track updated",
+		track,
+		output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "list",
+			Command:     "hey timetrack list",
+			Description: "List completed time tracks",
+		}),
+	)
+}
+
+func (c *timetrackEditCommand) payload(cmd *cobra.Command) (generated.UpdateTimeTrackPayload, error) {
+	payload := generated.UpdateTimeTrackPayload{}
+	changed := false
+
+	if cmd.Flags().Changed("start") {
+		startsAt, err := parseTimestampArg("--start", c.start)
+		if err != nil {
+			return payload, err
+		}
+		payload.StartsAt = &startsAt
+		changed = true
+	}
+	if cmd.Flags().Changed("end") {
+		endsAt, err := parseTimestampArg("--end", c.end)
+		if err != nil {
+			return payload, err
+		}
+		payload.EndsAt = &endsAt
+		changed = true
+	}
+	if cmd.Flags().Changed("category") {
+		payload.CategoryTitle = strings.TrimSpace(c.category)
+		if payload.CategoryTitle == "" {
+			return payload, apierr.ErrUsage("--category needs a title; a blank one does not clear a category")
+		}
+		changed = true
+	}
+	if cmd.Flags().Changed("notes") {
+		payload.Notes = c.notes
+		if strings.TrimSpace(payload.Notes) == "" {
+			return payload, apierr.ErrUsage("--notes needs text; a blank one does not clear the notes")
+		}
+		changed = true
+	}
+	if !changed {
+		return payload, apierr.ErrUsage("provide at least one of --start, --end, --category, or --notes")
+	}
+	return payload, nil
+}
+
+// parseTimestampArg reads a moment typed on the command line, on the caller's own clock
+// unless they spelled out an offset, and hands it over in UTC — which needs no zone name
+// and is exact.
+func parseTimestampArg(label, value string) (time.Time, error) {
+	for _, layout := range []string{"2006-01-02T15:04", "2006-01-02 15:04", time.RFC3339} {
+		if parsed, err := time.ParseInLocation(layout, strings.TrimSpace(value), time.Local); err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+	return time.Time{}, apierr.ErrUsageHint(
+		fmt.Sprintf("invalid %s: %s", label, value),
+		"timestamps are YYYY-MM-DDTHH:MM in your time zone, for example 2026-08-22T09:00, or a full RFC 3339 instant")
+}
+
+// timetrackUpdateError reads a 400 back as what it is. HEY answers one when it cannot
+// parse a timestamp it was sent, which is somebody's typing rather than a failure here.
+func timetrackUpdateError(err error) error {
+	converted := apierr.FromSDK(err)
+	if apierr.AsError(converted).HTTPStatus == http.StatusBadRequest {
+		return apierr.ErrUsageHint("HEY could not read the time track update",
+			"check --start and --end: timestamps are YYYY-MM-DDTHH:MM, for example 2026-08-22T09:00")
+	}
+	return converted
+}
+
+// delete
+
+type timetrackDeleteCommand struct {
+	cmd *cobra.Command
+}
+
+func newTimetrackDeleteCommand() *timetrackDeleteCommand {
+	timetrackDeleteCommand := &timetrackDeleteCommand{}
+	timetrackDeleteCommand.cmd = &cobra.Command{
+		Use:     "delete <id>",
+		Short:   "Delete a time track",
+		Example: `  hey timetrack delete 1042`,
+		RunE:    timetrackDeleteCommand.run,
+		Args:    usageExactOneArg(),
+	}
+	return timetrackDeleteCommand
+}
+
+func (c *timetrackDeleteCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	trackID, err := parsePositiveID(args[0], "time track")
+	if err != nil {
+		return err
+	}
+	if err = sdk.TimeTracks().Delete(cmd.Context(), trackID); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutationLine(cmd,
+		fmt.Sprintf("Time track %d deleted.", trackID),
+		"Time track deleted",
+		nil,
+		output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "list",
+			Command:     "hey timetrack list",
+			Description: "List completed time tracks",
 		}),
 	)
 }

--- a/internal/cmd/timetrack_test.go
+++ b/internal/cmd/timetrack_test.go
@@ -1,0 +1,404 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// timeTrackIndexHandler serves the tracked time index one page at a time, keyed by the
+// geared_pagination cursor the previous page handed out. It records every page parameter
+// it was asked for, so a test can assert what the command actually walked.
+func timeTrackIndexHandler(t *testing.T, pages map[string]string, asked *[]string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/calendar/time_tracks.json" {
+			t.Errorf("request = %s %s, want GET /calendar/time_tracks.json", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		page := r.URL.Query().Get("page")
+		*asked = append(*asked, page)
+		body, ok := pages[page]
+		if !ok {
+			t.Errorf("unexpected page %q", page)
+			http.NotFound(w, r)
+			return
+		}
+		if next, hasNext := pages[nextCursorFor(page)]; hasNext && next != "" {
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=`+nextCursorFor(page)+`>; rel="next"`)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}
+}
+
+// nextCursorFor is the fixtures' own convention: the page after "" is "b2", after "b2" is
+// "b3", and so on, so a fixture map says how far the list goes.
+func nextCursorFor(page string) string {
+	switch page {
+	case "":
+		return "b2"
+	case "b2":
+		return "b3"
+	default:
+		return "b4"
+	}
+}
+
+const timeTrackFirstPage = `{"time_tracks":[
+  {"id":1042,"type":"Calendar::TimeTrack","title":"Time Track","category":"Client work","notes":"Invoice review","starts_at":"2026-08-21T09:00:00Z","ends_at":"2026-08-21T11:15:00Z","completed_at":"2026-08-21T11:15:00Z"},
+  {"id":1041,"type":"Calendar::TimeTrack","title":"Time Track","notes":"","starts_at":"2026-08-20T22:30:00Z","ends_at":"2026-08-21T00:45:00Z","completed_at":"2026-08-21T00:45:00Z"}
+], "categories":[{"id":42,"title":"Client work"}]}`
+
+const timeTrackSecondPage = `{"time_tracks":[
+  {"id":1040,"type":"Calendar::TimeTrack","title":"Time Track","category":"Planning","starts_at":"2026-08-19T14:00:00Z","ends_at":"2026-08-19T14:30:00Z","completed_at":"2026-08-19T14:30:00Z"}
+], "categories":[{"id":42,"title":"Client work"}]}`
+
+func TestTimetrackListReadsOnePageByDefault(t *testing.T) {
+	var asked []string
+	pages := map[string]string{"": timeTrackFirstPage, "b2": timeTrackSecondPage}
+	response, err := runJSONCommand(t, timeTrackIndexHandler(t, pages, &asked), "timetrack", "list")
+	if err != nil {
+		t.Fatalf("execute timetrack list: %v", err)
+	}
+	if len(asked) != 1 || asked[0] != "" {
+		t.Errorf("pages asked for = %#v, want the first page only", asked)
+	}
+	if response.Summary != "2 time tracks" {
+		t.Errorf("summary = %q, want 2 time tracks", response.Summary)
+	}
+	if response.Notice != "Showing 2 time tracks. Use --all to see everything." {
+		t.Errorf("notice = %q", response.Notice)
+	}
+	tracks, ok := response.Data.([]any)
+	if !ok || len(tracks) != 2 {
+		t.Fatalf("data = %#v, want two time tracks", response.Data)
+	}
+}
+
+func TestTimetrackListAllStopsAtAnEmptyPage(t *testing.T) {
+	var asked []string
+	pages := map[string]string{
+		"":   timeTrackFirstPage,
+		"b2": timeTrackSecondPage,
+		"b3": `{"time_tracks":[],"categories":[]}`,
+	}
+	response, err := runJSONCommand(t, timeTrackIndexHandler(t, pages, &asked), "timetrack", "list", "--all")
+	if err != nil {
+		t.Fatalf("execute timetrack list --all: %v", err)
+	}
+	if strings.Join(asked, ",") != ",b2,b3" {
+		t.Errorf("pages asked for = %#v, want the first three", asked)
+	}
+	if response.Summary != "3 time tracks" {
+		t.Errorf("summary = %q, want 3 time tracks", response.Summary)
+	}
+	if response.Notice != "" {
+		t.Errorf("notice = %q, want none once the list ran out", response.Notice)
+	}
+	if pagesFetched, _ := response.Meta["pages_fetched"].(float64); pagesFetched != 3 {
+		t.Errorf("pages_fetched = %v, want 3", response.Meta["pages_fetched"])
+	}
+}
+
+func TestTimetrackListHonoursLimit(t *testing.T) {
+	var asked []string
+	pages := map[string]string{"": timeTrackFirstPage, "b2": timeTrackSecondPage}
+	response, err := runJSONCommand(t, timeTrackIndexHandler(t, pages, &asked), "timetrack", "list", "--limit", "1")
+	if err != nil {
+		t.Fatalf("execute timetrack list --limit 1: %v", err)
+	}
+	if len(asked) != 1 {
+		t.Errorf("pages asked for = %#v, want one page for one row", asked)
+	}
+	tracks, ok := response.Data.([]any)
+	if !ok || len(tracks) != 1 {
+		t.Fatalf("data = %#v, want one time track", response.Data)
+	}
+	if response.Notice != "Showing 1 time track. Use --all to see everything." {
+		t.Errorf("notice = %q", response.Notice)
+	}
+}
+
+func TestTimetrackListStyledShowsLengthAndCategory(t *testing.T) {
+	var asked []string
+	pages := map[string]string{"": timeTrackFirstPage, "b2": timeTrackSecondPage}
+	stdout, err := runStyledCommand(t, timeTrackIndexHandler(t, pages, &asked), "timetrack", "list")
+	if err != nil {
+		t.Fatalf("execute timetrack list --styled: %v", err)
+	}
+	// The clock is the reader's own, not the UTC HEY serves — expectations are derived rather
+	// than written out, or this would only pass in Greenwich.
+	starts := time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC).Local()
+	ends := time.Date(2026, 8, 21, 11, 15, 0, 0, time.UTC).Local()
+	for _, want := range []string{
+		"1042", starts.Format("2006-01-02"), starts.Format("15:04"), ends.Format("15:04"),
+		"2:15:00", "Client work", "Invoice review",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("table missing %q:\n%s", want, stdout)
+		}
+	}
+
+	// A track that crosses midnight on the reader's clock carries the date on its end, so it
+	// cannot read as ending before it started. Whether it crosses at all depends on the zone.
+	overnightStart := time.Date(2026, 8, 20, 22, 30, 0, 0, time.UTC).Local()
+	overnightEnd := time.Date(2026, 8, 21, 0, 45, 0, 0, time.UTC).Local()
+	wantEnd := overnightEnd.Format("15:04")
+	if overnightEnd.Format("2006-01-02") != overnightStart.Format("2006-01-02") {
+		wantEnd = overnightEnd.Format("2006-01-02T15:04")
+	}
+	if !strings.Contains(stdout, wantEnd) {
+		t.Errorf("overnight end %q not shown:\n%s", wantEnd, stdout)
+	}
+	if !strings.Contains(stdout, "Use --all to see everything.") {
+		t.Errorf("notice missing:\n%s", stdout)
+	}
+}
+
+func TestTimetrackListFiltersByCategory(t *testing.T) {
+	var requests atomic.Int32
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if got := r.URL.Query().Get("category_id"); got != "42" {
+			t.Errorf("category_id = %q, want 42", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, timeTrackSecondPage)
+	}), "timetrack", "list", "--category", "42")
+	if err != nil {
+		t.Fatalf("execute timetrack list --category: %v", err)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d, want 1", requests.Load())
+	}
+	if response.Summary != "1 time track" {
+		t.Errorf("summary = %q", response.Summary)
+	}
+}
+
+func TestTimetrackListUnknownCategory(t *testing.T) {
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}), "timetrack", "list", "--category", "999")
+	if err == nil || !strings.Contains(err.Error(), `time track category "999" not found`) {
+		t.Fatalf("error = %v, want the category reported as missing", err)
+	}
+}
+
+func TestTimetrackListRejectsCategoryZero(t *testing.T) {
+	var requests atomic.Int32
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+	}), "timetrack", "list", "--category", "0")
+	if err == nil || !strings.Contains(err.Error(), "--category takes a category ID") {
+		t.Fatalf("error = %v, want a usage error", err)
+	}
+	if requests.Load() != 0 {
+		t.Errorf("requests = %d, want none", requests.Load())
+	}
+}
+
+func TestTimetrackListNotice(t *testing.T) {
+	tests := []struct {
+		name      string
+		shown     int
+		pages     int
+		more      bool
+		truncated bool
+		want      string
+	}{
+		{name: "complete list", shown: 3, pages: 2},
+		{name: "more to read", shown: 2, pages: 1, more: true, want: "Showing 2 time tracks. Use --all to see everything."},
+		{name: "page cap", shown: 500, pages: 100, more: true, truncated: true, want: "Stopped after 100 pages, at 500 time tracks. Narrow the list with --category."},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := timetrackListNotice(test.shown, test.pages, test.more, test.truncated); got != test.want {
+				t.Errorf("notice = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFormatTrackedLength(t *testing.T) {
+	tests := []struct {
+		name string
+		of   time.Duration
+		want string
+	}{
+		{name: "seconds", of: 45 * time.Second, want: "0:00:45"},
+		{name: "minutes", of: 2*time.Hour + 15*time.Minute, want: "2:15:00"},
+		{name: "past a day", of: 26*time.Hour + time.Second, want: "26:00:01"},
+		{name: "backwards", of: -time.Hour, want: "0:00:00"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := formatTrackedLength(test.of); got != test.want {
+				t.Errorf("length = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTimetrackStopFilesUnderCategory(t *testing.T) {
+	var body map[string]any
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "ongoing"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":1043,"type":"Calendar::TimeTrack","starts_at":"2026-08-22T09:00:00Z"}`)
+		case r.Method == http.MethodPut && r.URL.Path == "/calendar/time_tracks/1043.json":
+			if decodeErr := json.NewDecoder(r.Body).Decode(&body); decodeErr != nil {
+				t.Errorf("decode stop body: %v", decodeErr)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":1043,"type":"Calendar::TimeTrack"}`)
+		default:
+			t.Errorf("request = %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}), "timetrack", "stop", "--category", "Client work")
+	if err != nil {
+		t.Fatalf("execute timetrack stop --category: %v", err)
+	}
+	if response.Summary != `Time tracking stopped and filed under "Client work"` {
+		t.Errorf("summary = %q", response.Summary)
+	}
+	payload, ok := body["calendar_time_track"].(map[string]any)
+	if !ok {
+		t.Fatalf("body = %#v, want a calendar_time_track payload", body)
+	}
+	if payload["category_title"] != "Client work" {
+		t.Errorf("category_title = %#v, want Client work", payload["category_title"])
+	}
+	if payload["ends_at"] == nil {
+		t.Error("ends_at missing, so the track was never stopped")
+	}
+}
+
+func TestTimetrackStopRejectsBlankCategory(t *testing.T) {
+	var requests atomic.Int32
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1043,"type":"Calendar::TimeTrack"}`)
+	}), "timetrack", "stop", "--category", "  ")
+	if err == nil || !strings.Contains(err.Error(), "does not clear a category") {
+		t.Fatalf("error = %v, want a usage error", err)
+	}
+}
+
+func TestTimetrackEditSendsOnlyTheFlagsGiven(t *testing.T) {
+	var body map[string]any
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/calendar/time_tracks/1042.json" {
+			t.Errorf("request = %s %s, want PUT /calendar/time_tracks/1042.json", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if decodeErr := json.NewDecoder(r.Body).Decode(&body); decodeErr != nil {
+			t.Errorf("decode edit body: %v", decodeErr)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1042,"type":"Calendar::TimeTrack","notes":"Invoice review"}`)
+	}), "timetrack", "edit", "1042", "--notes", "Invoice review", "--end", "2026-08-22T17:30")
+	if err != nil {
+		t.Fatalf("execute timetrack edit: %v", err)
+	}
+	if response.Summary != "Time track updated" {
+		t.Errorf("summary = %q", response.Summary)
+	}
+	payload, ok := body["calendar_time_track"].(map[string]any)
+	if !ok {
+		t.Fatalf("body = %#v, want a calendar_time_track payload", body)
+	}
+	if payload["notes"] != "Invoice review" {
+		t.Errorf("notes = %#v", payload["notes"])
+	}
+	wantEnd := time.Date(2026, 8, 22, 17, 30, 0, 0, time.Local).UTC().Format(time.RFC3339)
+	if payload["ends_at"] != wantEnd {
+		t.Errorf("ends_at = %#v, want %q", payload["ends_at"], wantEnd)
+	}
+	if _, sent := payload["starts_at"]; sent {
+		t.Errorf("starts_at = %#v, want it left alone", payload["starts_at"])
+	}
+	if _, sent := payload["category_title"]; sent {
+		t.Errorf("category_title = %#v, want it left alone", payload["category_title"])
+	}
+}
+
+func TestTimetrackEditNeedsAFlag(t *testing.T) {
+	var requests atomic.Int32
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+	}), "timetrack", "edit", "1042")
+	if err == nil || !strings.Contains(err.Error(), "provide at least one of --start, --end, --category, or --notes") {
+		t.Fatalf("error = %v, want a usage error", err)
+	}
+	if requests.Load() != 0 {
+		t.Errorf("requests = %d, want none", requests.Load())
+	}
+}
+
+func TestTimetrackEditRejectsUnreadableTimestamp(t *testing.T) {
+	var requests atomic.Int32
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+	}), "timetrack", "edit", "1042", "--start", "yesterday morning")
+	if err == nil || !strings.Contains(err.Error(), "invalid --start") {
+		t.Fatalf("error = %v, want a usage error", err)
+	}
+	if requests.Load() != 0 {
+		t.Errorf("requests = %d, want none", requests.Load())
+	}
+}
+
+func TestTimetrackEditReadsBadRequestAsUsage(t *testing.T) {
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad timestamp", http.StatusBadRequest)
+	}), "timetrack", "edit", "1042", "--end", "2026-08-22T17:30")
+	if err == nil || !strings.Contains(err.Error(), "HEY could not read the time track update") {
+		t.Fatalf("error = %v, want the 400 read back as a usage problem", err)
+	}
+}
+
+func TestTimetrackDelete(t *testing.T) {
+	var requests atomic.Int32
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Method != http.MethodDelete || r.URL.Path != "/calendar/time_tracks/1042.json" {
+			t.Errorf("request = %s %s, want DELETE /calendar/time_tracks/1042.json", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}), "timetrack", "delete", "1042")
+	if err != nil {
+		t.Fatalf("execute timetrack delete: %v", err)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d, want 1", requests.Load())
+	}
+	if response.Summary != "Time track deleted" {
+		t.Errorf("summary = %q", response.Summary)
+	}
+}
+
+func TestTimetrackDeleteRejectsBadID(t *testing.T) {
+	var requests atomic.Int32
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+	}), "timetrack", "delete", "nope")
+	if err == nil || !strings.Contains(err.Error(), "invalid time track ID") {
+		t.Fatalf("error = %v, want a usage error", err)
+	}
+	if requests.Load() != 0 {
+		t.Errorf("requests = %d, want none", requests.Load())
+	}
+}


### PR DESCRIPTION
What the TUI calendar work in #280 turned up that the CLI was on the wrong side of.

## `hey timetrack list` answered nothing

It read the personal calendar's recordings and filtered to `Calendar::TimeTrack`. Verified against production: a 90-day window of that read returns **no time tracks at all**, and three years back still misses older ones. Now it reads the tracked-time index.

| | before | after |
|---|---|---|
| read | personal calendar's recordings — empty on production | the tracked-time index, paged with `collectPages` |
| `--limit` / `--all` | sliced one in-memory window | decide how many pages are read |
| columns | `ID · Title · Start · End` — `Title` is the constant `"Time Track"` on every row | `ID · Day · Start · End · Length · Category · Notes` |
| times | UTC, as HEY serves them | the reader's own clock |
| length | — | computed to the second |

Against production, where the old code printed nothing:

```
ID        Day         Start  End    Length   Category  Notes
79730766  2024-11-24  12:25  16:10  3:44:36  Family    Famili bday dinner
```

**The times.** HEY serves every JSON timestamp in UTC, so noon in Zagreb arrived as 11:00 — and with the day in the next column, a late enough track landed on the wrong date. `3:44:36` is computed from the two instants; the CSV export could only offer HEY's words for it (`3 hrs 44 min`).

## New, because rows carry ids now

```bash
hey timetrack list --category 72853        # filter; an unknown id reads as not-found
hey timetrack stop --category "Client work"  # stop and file it, one request
hey timetrack edit 79730766 --start 2026-08-21T09:00 --notes "Invoice review"
hey timetrack delete 79730766
```

`edit` is a genuine partial — only the flags given are sent.

`stop --category` says what the title does rather than leaving it to be found: it **creates** a category HEY has none by that name, and a blank does **not** clear one, so a blank is refused instead of quietly doing nothing.

## `hey calendars` names the account

Two accounts each keep a "Maybe":

```
before                                after
240333  Maybe  maybe  yes             240333  Maybe  maybe  yes  amelia@example.com
637279  Maybe  maybe  yes             637279  Maybe  maybe  yes  amelia@example.org
```

The column appears only when the list spans more than one account — otherwise it is the reader's own address written down the page.

## Worth knowing

- **The timezone fix is local to this table.** `formatTimestamp` in `sdk.go` does not convert either, so `hey recordings` and friends still print UTC wall-clock. That contradicts the rule in AGENTS.md, but flipping it touches every command that prints a timestamp and wants its own PR.
- **`timetrack list` now shows one page by default** and says there is more, matching `hey contacts list`. A behaviour change from "everything in the window" — though that window was returning nothing.
- Tests run under `TZ=UTC`, `Pacific/Auckland` and `America/New_York`, since the expectations are derived rather than written out.
- Not touched: `tests/smoke/` has no coverage for `edit`/`delete`. Worth a follow-up.

`make tidy-check`, `make lint`, `make coverage` (83.4%) and `make build` clean.
