### PR TITLE
Upgrade to Go 1.27

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11.1  # keep in lockstep with test.yml Lint
+          version: v2.13.1  # keep in lockstep with test.yml Lint
           install-only: true
 
       - name: Cache BATS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11.1
+          version: v2.13.1
 
   lint-actions:
     name: GitHub Actions audit

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,3 @@
 [tools]
-go = "1.26.6"
+go = "1.27.0"
 goreleaser = "2.15.4"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_install_hook_types: [pre-commit, pre-push]
 
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.11.1
+    rev: v2.13.1
     hooks:
       - id: golangci-lint
         args: [--timeout=5m]

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ bench-compare:
 # so local and CI findings agree. govulncheck stays @latest on purpose: pinning
 # it only delays new advisories and Go version support.
 tools:
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.1
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
 	go install golang.org/x/vuln/cmd/govulncheck@latest
 	@echo "For gitleaks, install via: brew install gitleaks (or see https://github.com/gitleaks/gitleaks)"
 	@echo "For benchstat: go install golang.org/x/perf/cmd/benchstat@latest"

--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ bench-compare:
 # so local and CI findings agree. govulncheck stays @latest on purpose: pinning
 # it only delays new advisories and Go version support.
 tools:
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.1
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
 	go install golang.org/x/vuln/cmd/govulncheck@latest
 	@echo "For gitleaks, install via: brew install gitleaks (or see https://github.com/gitleaks/gitleaks)"
 	@echo "For benchstat: go install golang.org/x/perf/cmd/benchstat@latest"

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ nix profile install github:basecamp/hey-cli
 go install github.com/basecamp/hey-cli/cmd/hey@latest
 ```
 
-**From source** (requires Go 1.26+; [mise](https://mise.jdx.dev) installs the right version):
+**From source** (requires Go 1.27+; [mise](https://mise.jdx.dev) installs the right version):
 ```bash
-mise install       # install Go 1.26
+mise install       # install Go 1.27
 make install       # build and install into /usr/local/bin/hey
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,9 +60,9 @@ nix profile install github:basecamp/hey-cli
 go install github.com/basecamp/hey-cli/cmd/hey@latest
 ```
 
-**From source** (requires Go 1.26+; [mise](https://mise.jdx.dev) installs the right version):
+**From source** (requires Go 1.27+; [mise](https://mise.jdx.dev) installs the right version):
 ```bash
-mise install       # install Go 1.26
+mise install       # install Go 1.27
 make install       # build and install into /usr/local/bin/hey
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/hey-cli
 
-go 1.26.6
+go 1.27.0
 
 require (
 	charm.land/bubbles/v2 v2.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/hey-cli
 
-go 1.26.6
+go 1.27.0
 
 require (
 	charm.land/bubbles/v2 v2.2.0

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -1,28 +1,28 @@
-{ lib, fetchurl, go_1_26 }:
+{ lib, fetchurl, go_1_27 }:
 
 # The Go toolchain shared by the package build and the dev shell.
 #
-# go.mod's `go` directive is the floor; nixpkgs-unstable lagged it at 1.26.5
-# when this flake was written, so the toolchain is rebuilt from the upstream
+# go.mod's `go` directive is the floor; nixpkgs-unstable lagged it at 1.27rc3
+# when go.mod moved to 1.27.0, so the toolchain is rebuilt from the upstream
 # source tarball until nixpkgs catches up. The override is conditional and
-# drops itself once go_1_26 reaches 1.26.6 — delete this file's override and
-# return go_1_26 directly after a `nix flake update` that makes
+# drops itself once go_1_27 reaches 1.27.0 — delete this file's override and
+# return go_1_27 directly after a `nix flake update` that makes
 # `lib.versionOlder` false. Keep minGo in step with go.mod: a toolchain bump
 # that outpaces flake.lock breaks the build without touching go.mod or go.sum,
 # which is why the nix-build CI job runs on every go.mod change and on tags.
 #
 # Both consumers must use this one derivation. The dev shell once listed
-# go_1_26 directly, which handed `nix develop` a Go older than go.mod's
+# the nixpkgs Go directly, which handed `nix develop` a Go older than go.mod's
 # directive — `make build` then failed under GOTOOLCHAIN=local or offline.
 let
-  minGo = "1.26.6";
+  minGo = "1.27.0";
 in
-if lib.versionOlder go_1_26.version minGo
-then go_1_26.overrideAttrs (_: {
+if lib.versionOlder go_1_27.version minGo
+then go_1_27.overrideAttrs (_: {
   version = minGo;
   src = fetchurl {
     url = "https://go.dev/dl/go${minGo}.src.tar.gz";
-    hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
+    hash = "sha256-cAJAPXzERSnvbSb2mkSBgmM5Xq18FsBaWAiuBH6+sOU=";
   };
 })
-else go_1_26
+else go_1_27

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -1,10 +1,28 @@
-{ go_1_26 }:
+{ lib, fetchurl, go_1_27 }:
 
 # The Go toolchain shared by the package build and the dev shell.
 #
-# Both consumers use this one derivation so the package and `nix develop`
-# cannot drift. flake.lock temporarily selects a NixOS 26.05 snapshot because
-# nixpkgs-unstable still carried Go 1.26.5 when 1.26.6 landed; a normal lock
-# update can return to unstable once it catches up. The nix-build CI job covers
-# every go.mod change and every release tag, so a regression fails closed.
-go_1_26
+# go.mod's `go` directive is the floor; nixpkgs-unstable lagged it at 1.27rc3
+# when go.mod moved to 1.27.0, so the toolchain is rebuilt from the upstream
+# source tarball until nixpkgs catches up. The override is conditional and
+# drops itself once go_1_27 reaches 1.27.0 — delete this file's override and
+# return go_1_27 directly after a `nix flake update` that makes
+# `lib.versionOlder` false. Keep minGo in step with go.mod: a toolchain bump
+# that outpaces flake.lock breaks the build without touching go.mod or go.sum,
+# which is why the nix-build CI job runs on every go.mod change and on tags.
+#
+# Both consumers must use this one derivation. The dev shell once listed
+# the nixpkgs Go directly, which handed `nix develop` a Go older than go.mod's
+# directive — `make build` then failed under GOTOOLCHAIN=local or offline.
+let
+  minGo = "1.27.0";
+in
+if lib.versionOlder go_1_27.version minGo
+then go_1_27.overrideAttrs (_: {
+  version = minGo;
+  src = fetchurl {
+    url = "https://go.dev/dl/go${minGo}.src.tar.gz";
+    hash = "sha256-cAJAPXzERSnvbSb2mkSBgmM5Xq18FsBaWAiuBH6+sOU=";
+  };
+})
+else go_1_27

--- a/scripts/check-lint-lockstep.sh
+++ b/scripts/check-lint-lockstep.sh
@@ -22,7 +22,7 @@ WORKFLOW_DIR=".github/workflows"
 # The oldest golangci-lint every workflow may pin. Raising this is a deliberate
 # act, not housekeeping: move it in the same commit that moves the workflow
 # pins, so the floor and the pins never disagree in a merged tree.
-MIN_VERSION="v2.11.1"
+MIN_VERSION="v2.13.1"
 
 # Compare numerically, field by field, never lexically. As strings v2.9.0
 # sorts *above* v2.11.1 — 9 > 1 — so a lexical test would wave through the exact

--- a/tests/e2e/check_release_lockstep.bats
+++ b/tests/e2e/check_release_lockstep.bats
@@ -14,7 +14,7 @@ setup() {
   cat > .pre-commit-config.yaml <<'YAML'
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.11.1
+    rev: v2.13.1
     hooks:
       - id: golangci-lint
 YAML
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: golangci/golangci-lint-action@abc # v9.3.0
         with:
-          version: v2.11.1
+          version: v2.13.1
       - run: scripts/check-release-lockstep.sh
 YAML
   cat > .github/workflows/release.yml <<'YAML'
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: golangci/golangci-lint-action@abc # v9.3.0
         with:
-          version: v2.11.1
+          version: v2.13.1
           install-only: true
       - run: scripts/publish.sh
   release:
@@ -56,7 +56,7 @@ teardown() {
   run scripts/check-release-lockstep.sh
   [ "$status" -eq 0 ]
   [[ "$output" == *"goreleaser pin in lockstep (v2.15.4)"* ]]
-  [[ "$output" == *"pre-commit golangci-lint rev in lockstep (v2.11.1)"* ]]
+  [[ "$output" == *"pre-commit golangci-lint rev in lockstep (v2.13.1)"* ]]
   [[ "$output" == *"release lockstep check passed"* ]]
 }
 
@@ -70,7 +70,7 @@ teardown() {
 }
 
 @test "fails when the pre-commit golangci-lint rev drifts from CI" {
-  sed -i.bak 's/rev: v2.11.1/rev: v2.1.6/' .pre-commit-config.yaml && rm -f .pre-commit-config.yaml.bak
+  sed -i.bak 's/rev: v2.13.1/rev: v2.1.6/' .pre-commit-config.yaml && rm -f .pre-commit-config.yaml.bak
   run scripts/check-release-lockstep.sh
   [ "$status" -eq 1 ]
   [[ "$output" == *"golangci-lint pins disagree"* ]]
@@ -78,7 +78,7 @@ teardown() {
 }
 
 @test "inherits the golangci-lint workflow lockstep failure" {
-  sed -i.bak 's/version: v2.11.1/version: v2.9.0/' .github/workflows/release.yml && rm -f .github/workflows/release.yml.bak
+  sed -i.bak 's/version: v2.13.1/version: v2.9.0/' .github/workflows/release.yml && rm -f .github/workflows/release.yml.bak
   run scripts/check-release-lockstep.sh
   [ "$status" -eq 1 ]
   [[ "$output" == *"golangci-lint pins disagree across workflows"* ]]

--- a/tests/e2e/check_release_lockstep.bats
+++ b/tests/e2e/check_release_lockstep.bats
@@ -15,7 +15,7 @@ setup() {
   cat > .pre-commit-config.yaml <<'YAML'
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.11.1
+    rev: v2.13.1
     hooks:
       - id: golangci-lint
 YAML
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: golangci/golangci-lint-action@abc # v9.3.0
         with:
-          version: v2.11.1
+          version: v2.13.1
       - run: scripts/check-release-lockstep.sh
 YAML
   cat > .github/workflows/security.yml <<'YAML'
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: golangci/golangci-lint-action@abc # v9.3.0
         with:
-          version: v2.11.1
+          version: v2.13.1
           install-only: true
       - run: scripts/publish.sh
   release:
@@ -63,7 +63,7 @@ teardown() {
   run scripts/check-release-lockstep.sh
   [ "$status" -eq 0 ]
   [[ "$output" == *"goreleaser pin in lockstep (v2.15.4)"* ]]
-  [[ "$output" == *"pre-commit golangci-lint rev in lockstep (v2.11.1)"* ]]
+  [[ "$output" == *"pre-commit golangci-lint rev in lockstep (v2.13.1)"* ]]
   [[ "$output" == *"gosec pin in lockstep (v2.28.0)"* ]]
   [[ "$output" == *"release lockstep check passed"* ]]
 }
@@ -78,7 +78,7 @@ teardown() {
 }
 
 @test "fails when the pre-commit golangci-lint rev drifts from CI" {
-  sed -i.bak 's/rev: v2.11.1/rev: v2.1.6/' .pre-commit-config.yaml && rm -f .pre-commit-config.yaml.bak
+  sed -i.bak 's/rev: v2.13.1/rev: v2.1.6/' .pre-commit-config.yaml && rm -f .pre-commit-config.yaml.bak
   run scripts/check-release-lockstep.sh
   [ "$status" -eq 1 ]
   [[ "$output" == *"golangci-lint pins disagree"* ]]
@@ -86,7 +86,7 @@ teardown() {
 }
 
 @test "inherits the golangci-lint workflow lockstep failure" {
-  sed -i.bak 's/version: v2.11.1/version: v2.9.0/' .github/workflows/release.yml && rm -f .github/workflows/release.yml.bak
+  sed -i.bak 's/version: v2.13.1/version: v2.9.0/' .github/workflows/release.yml && rm -f .github/workflows/release.yml.bak
   run scripts/check-release-lockstep.sh
   [ "$status" -eq 1 ]
   [[ "$output" == *"golangci-lint pins disagree across workflows"* ]]

--- a/tests/smoke/go.mod
+++ b/tests/smoke/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/hey-cli/tests/smoke
 
-go 1.26.1
+go 1.27.0
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d


### PR DESCRIPTION
Bumps the toolchain to Go 1.27.0 across everything that pins it:

- `.mise.toml`, `go.mod`, and `tests/smoke/go.mod` move to 1.27.0. CI workflows read `go-version-file: go.mod`, so they follow on their own.
- `nix/go.nix` moves its base to `go_1_27` with `minGo = "1.27.0"` and the official source-tarball hash. The pinned nixpkgs only carries 1.27rc3, so the file's existing conditional override rebuilds from the upstream tarball and drops itself once nixpkgs catches up — the same pattern it used for 1.26.6.
- golangci-lint moves v2.11.1 → v2.13.1 in lockstep (Makefile `tools`, both workflows, pre-commit, and the `MIN_VERSION` floor in `scripts/check-lint-lockstep.sh`). The old binary was built with Go 1.26 and refuses a 1.27 target; v2.13.1's release binaries are built with Go 1.27.0.
- README's from-source instructions now say Go 1.27+.

`make check` passes in full locally: fmt, vet, lint (0 issues), all tests, tidy-check, surface snapshot, and both lockstep checks. The nix path is unverified locally (no nix on this machine) — the nix-build job is the check for that.

## Dependency

PR #304 is the cached-Go 1.26.6 foundation and should merge first. After it lands, sync this branch with current main before advancing #296. The PR base remains main for now; no history is rewritten while the foundation is under review.