### PR TITLE
Restore j/k navigation in TUI lists

### DIFF
--- a/internal/tui/contacts.go
+++ b/internal/tui/contacts.go
@@ -371,6 +371,11 @@ func (v *contactsView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		}
 	default:
 		switch msg.String() {
+		case "k":
+			v.list.moveUp()
+		case "j":
+			v.list.moveDown()
+			return v.loadMoreContacts()
 		case "a":
 			return v.startAddContact()
 		case "r":

--- a/internal/tui/contacts_test.go
+++ b/internal/tui/contacts_test.go
@@ -159,6 +159,35 @@ func TestContactsViewGrowsUntilTheListRunsOut(t *testing.T) {
 	}
 }
 
+func TestContactsViewNavigationAcceptsJAndK(t *testing.T) {
+	view, _ := contactsWithTestServer(t)
+	view.loaded = true
+	view.list.setContacts(testContactRows(3))
+
+	view.HandleContentKey(keyPress("j"))
+	if view.list.cursor != 1 {
+		t.Errorf("after j: cursor = %d, want 1", view.list.cursor)
+	}
+
+	view.HandleContentKey(keyPress("k"))
+	if view.list.cursor != 0 {
+		t.Errorf("after k: cursor = %d, want 0", view.list.cursor)
+	}
+}
+
+func TestContactsViewJReadsThePageBelowNearTheBottom(t *testing.T) {
+	view, _ := contactsWithTestServer(t)
+	view.loaded = true
+	view.nextPage = 2
+	view.list.setSize(80, 4)
+	view.list.setContacts(testContactRows(40))
+	view.list.cursor = len(view.list.contacts) - loadMoreThreshold - 1
+
+	if cmd := view.HandleContentKey(keyPress("j")); cmd == nil || !view.loadingMore {
+		t.Fatal("j near the bottom should read the next contacts page")
+	}
+}
+
 func TestContactsViewReadsThePageBelowTheCursorOnce(t *testing.T) {
 	view, _ := contactsWithTestServer(t)
 	view.loaded = true

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -1034,6 +1034,11 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 			return v.openSelected()
 		default:
 			switch msg.String() {
+			case "k":
+				v.searchList.moveUp()
+			case "j":
+				v.searchList.moveDown()
+				return v.loadMoreSearchResults()
 			case "/", "s", "S":
 				return v.startSearch()
 			}
@@ -1051,6 +1056,11 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 		return v.openSelected()
 	default:
 		switch msg.String() {
+		case "k":
+			v.postingList.moveUp()
+		case "j":
+			v.postingList.moveDown()
+			return v.loadMorePostings()
 		case "/", "s", "S":
 			return v.startSearch()
 		case "c":

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -2038,22 +2038,81 @@ func TestMailViewIgnoresReplyLoadAfterThreadExit(t *testing.T) {
 	}
 }
 
-func TestMailViewContentKeyUpDown(t *testing.T) {
+func TestMailViewContentNavigationKeys(t *testing.T) {
+	for _, keys := range []struct {
+		name string
+		down string
+		up   string
+	}{
+		{name: "arrows", down: "down", up: "up"},
+		{name: "vim", down: "j", up: "k"},
+	} {
+		t.Run(keys.name, func(t *testing.T) {
+			v := mailWithPostings()
+
+			if v.postingList.cursor != 0 {
+				t.Fatalf("initial cursor = %d, want 0", v.postingList.cursor)
+			}
+
+			v.HandleContentKey(keyPress(keys.down))
+			if v.postingList.cursor != 1 {
+				t.Errorf("after %s: cursor = %d, want 1", keys.down, v.postingList.cursor)
+			}
+
+			v.HandleContentKey(keyPress(keys.up))
+			if v.postingList.cursor != 0 {
+				t.Errorf("after %s: cursor = %d, want 0", keys.up, v.postingList.cursor)
+			}
+		})
+	}
+}
+
+func TestMailViewSearchNavigationAcceptsJAndK(t *testing.T) {
 	v := mailWithPostings()
+	v.searchActive = true
+	v.searchList.setPostings(testPostings())
 
-	if v.postingList.cursor != 0 {
-		t.Fatalf("initial cursor = %d, want 0", v.postingList.cursor)
+	v.HandleContentKey(keyPress("j"))
+	if v.searchList.cursor != 1 {
+		t.Errorf("after j: cursor = %d, want 1", v.searchList.cursor)
 	}
 
-	v.HandleContentKey(keyPress("down"))
-	if v.postingList.cursor != 1 {
-		t.Errorf("after down: cursor = %d, want 1", v.postingList.cursor)
+	v.HandleContentKey(keyPress("k"))
+	if v.searchList.cursor != 0 {
+		t.Errorf("after k: cursor = %d, want 0", v.searchList.cursor)
+	}
+}
+
+func TestMailViewJLoadsMoreListResults(t *testing.T) {
+	postings := make([]mail.Posting, 20)
+	for i := range postings {
+		postings[i] = mail.Posting{ID: int64(i + 1), Seen: true}
 	}
 
-	v.HandleContentKey(keyPress("up"))
-	if v.postingList.cursor != 0 {
-		t.Errorf("after up: cursor = %d, want 0", v.postingList.cursor)
-	}
+	t.Run("mail", func(t *testing.T) {
+		v := mailWithPostings()
+		v.postingList.hideSeenState = true
+		v.postingList.setPostings(postings)
+		v.postingList.cursor = len(postings) - loadMoreThreshold - 1
+		v.postingPaging.nextPage = "cursor-2"
+
+		if cmd := v.HandleContentKey(keyPress("j")); cmd == nil || !v.postingPaging.loading {
+			t.Fatal("j near the bottom should read the next mail page")
+		}
+	})
+
+	t.Run("search", func(t *testing.T) {
+		v := mailWithPostings()
+		v.searchActive = true
+		v.searchQuery = "quarterly planning"
+		v.searchList.setPostings(postings)
+		v.searchList.cursor = len(postings) - loadMoreThreshold - 1
+		v.searchNextPage = 2
+
+		if cmd := v.HandleContentKey(keyPress("j")); cmd == nil || !v.searchLoadingMore {
+			t.Fatal("j near the bottom should read the next search page")
+		}
+	})
 }
 
 func TestMailViewContentKeyInThread(t *testing.T) {
@@ -2707,7 +2766,7 @@ func TestMailViewCoverPeekUsesX(t *testing.T) {
 }
 
 func TestMailViewRemovedPostingAliasesStayUnused(t *testing.T) {
-	for _, key := range []string{"m", "g", "k"} {
+	for _, key := range []string{"m", "g"} {
 		v := mailWithPostings()
 		if cmd := v.HandleContentKey(keyPress(key)); cmd != nil {
 			t.Errorf("removed alias %q returned a command", key)


### PR DESCRIPTION
<!-- pr-review-readiness-head: 6cd8df630c2e87c0c942c812b86498df052432f5 -->

Restore the familiar `j`/`k` down/up aliases for readers navigating Mail, Mail search, and Contacts lists. The fix is deliberately limited to list contexts so typing, calendar movement, and an open thread's message-to-message shortcuts keep their existing behavior.

**Review readiness:** ✅ Yes  
**Risk:** 🟢 Low — the change adds aliases beside existing arrow-key paths without changing API requests or stored data  
**Decision:** None

<details>
<summary>✅ Change — j/k once again navigate the primary TUI lists</summary>

### Before

```text
Mail, Mail search, or Contacts list
└── press j or k
    └── ❌ selection does not move
```

### After

```text
Mail, Mail search, or Contacts list
├── press j
│   └── ✅ move down and load the next page when needed  ← CHANGED
└── press k
    └── ✅ move up  ← CHANGED
```

Commit `1708122` replaced Bubble's standard lists, whose default keymap included `j`/`k`, with custom handlers that only wired arrow keys. The aliases now call the same movement and pagination paths as those arrows.

</details>

<details>
<summary>✅ Evidence — failing-before tests, passing-after tests, and a TUI recording cover the regression</summary>

- ✅ **Failing before:** the new regression tests applied to exact base [`b0c675c`](https://github.com/basecamp/hey-cli/commit/b0c675ce710177cbc9a4d33cf48964a59627d494) exit 1: Mail, Mail search, and Contacts remain on the first row after `j`; each `j` pagination assertion also fails.
- ✅ **Passing after:** the same focused tests pass at exact head `6cd8df6`.
- ✅ Focused race tests pass, including existing single-message scrolling and multi-message thread-jump coverage.
- ✅ `GOWORK=off make build` succeeds.
- ✅ [TUI recording attached to the Basecamp card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10230033554): the cursor starts on the first thread, moves down twice with `j`, then up once with `k`.
- ⚠️ On this workstation, `GOWORK=off make test` reaches two calendar rendering failures also present on the exact base: `TestDayLabelsCoverTodosAndHabits` and `TestWeekDrawsTheHabitsKeptEachDay`. All internal tests excluding those two local failures pass; GitHub’s exact-head checks remain authoritative.

```text
# Exact base with this PR's regression tests copied in
GOWORK=off go test ./internal/tui -run 'Test(MailView(ContentNavigationKeys|SearchNavigationAcceptsJAndK|JLoadsMoreListResults)|ContactsView(NavigationAcceptsJAndK|JReadsThePageBelowNearTheBottom))$' -count=1
FAIL

# Exact PR head
GOWORK=off go test ./internal/tui -run 'Test(MailView(ContentNavigationKeys|SearchNavigationAcceptsJAndK|JLoadsMoreListResults)|ContactsView(NavigationAcceptsJAndK|JReadsThePageBelowNearTheBottom))$' -count=1
ok github.com/basecamp/hey-cli/internal/tui

GOWORK=off go test -race ./internal/tui -run 'Test(MailView(ContentNavigationKeys|SearchNavigationAcceptsJAndK|JLoadsMoreListResults|RemovedPostingAliasesStayUnused|HaystackPickerAliases)|ContactsView(NavigationAcceptsJAndK|JReadsThePageBelowNearTheBottom)|ThreadJK(eepsLineScrollingForOneMessage|JumpsBetweenMessages))$' -count=1
ok github.com/basecamp/hey-cli/internal/tui

GOWORK=off go test ./internal/... -skip 'Test(DayLabelsCoverTodosAndHabits|WeekDrawsTheHabitsKeptEachDay)$' -count=1
ok all tested packages
```

</details>

<details>
<summary>✅ Scope — aliases are confined to list navigation</summary>

Included: Mail lists, Mail search results, Contacts lists, and their downward pagination behavior.

Preserved: arrow keys; lowercase `j`/`k` message navigation inside open threads; uppercase `J` for Journal; uppercase `K` for Collections; text input and picker handling; Calendar's spatial arrow navigation.

Not included: adding the aliases to every modal picker or changing the help bar.

</details>

<details>
<summary>➖ Delivery — no migration, configuration, or cleanup required</summary>

This is a client-side keybinding correction. Rollback is the single commit revert; no server or stored-data changes are involved.

</details>

<details>
<summary>✅ Review decision — confirm the context boundaries and pagination parity</summary>

Review whether the new branches remain below thread/form handling and whether `j` follows the same load-more path as Down. No unresolved product decision remains.

</details>

<details>
<summary>✅ Review path — start with key routing, then regression coverage</summary>

1. [Mail key routing](https://github.com/basecamp/hey-cli/blob/6cd8df630c2e87c0c942c812b86498df052432f5/internal/tui/mail.go#L1026-L1063) — list/search aliases and pagination parity.
2. [Contacts key routing](https://github.com/basecamp/hey-cli/blob/6cd8df630c2e87c0c942c812b86498df052432f5/internal/tui/contacts.go#L362-L378) — contacts aliases and pagination parity.
3. [Mail regression tests](https://github.com/basecamp/hey-cli/blob/6cd8df630c2e87c0c942c812b86498df052432f5/internal/tui/mail_test.go#L2041-L2116) and [Contacts regression tests](https://github.com/basecamp/hey-cli/blob/6cd8df630c2e87c0c942c812b86498df052432f5/internal/tui/contacts_test.go#L162-L189) — movement and page-boundary proof.

**Origin and supporting links:** [Basecamp bug card with attached TUI recording](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10230033554)

</details>
