### PR TITLE
Open TUI topics from desktop links

### DIFF
--- a/.surface
+++ b/.surface
@@ -276,6 +276,10 @@ hey todo list --limit
 hey todo uncomplete
 hey trash
 hey tui
+hey tui --instance
+hey tui --remote
+hey tui --topic
+hey tui --topic-title
 hey unseen
 hey unshare
 hey upgrade

--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ Accounts and individual email addresses.
 Switching cancels requests from the previous account and reloads the active section;
 Calendar and Journal remain identity-wide.
 
+`hey tui --topic 123` starts on thread 123. Desktop integrations can send the same
+thread to an existing TUI with `hey tui --topic 123 --remote`; `--account` selects the
+thread's linked account before it opens. An integration that owns a dedicated TUI window
+uses the same `--instance <name>` on both commands, keeping its remote requests separate
+from manually launched TUIs.
+
 Navigate between Mail, Contacts, Calendar, and Journal. The context-sensitive shortcut bar is visible by default; press `?` to hide or restore it, and the choice is remembered across restarts. Mail navigation includes HEY boxes plus separate Labels and Collections tabs; Shift+L opens Labels directly and Shift+K opens Collections. Every list keeps going: scroll towards the bottom of a box, label, or collection and the next threads are read in behind you, so there are no pages to step through. The mail actions use HEY's web shortcuts in either letter case (except `l`, whose uppercase belongs to Labels): `/` or `s` searches, `r` replies, `f` forwards, `v` moves, `b` manages labels, `n` adds or removes the selected thread from collections, `e` marks seen, `u` marks unseen, `i` moves to the Imbox, `l` moves to Reply Later, `a` moves to Set Aside, `d` moves to The Feed, `p` moves to Paper Trail, and `t` trashes. Press `!` to mark as spam, `-` to ignore, and `+` to stop ignoring. Select threads with Space and press Ctrl+B to preview every bulk-reply recipient before writing and sending one reply to all selected threads. A delayed bulk reply can be recalled with Ctrl+U while HEY's undo window remains open. Search results retain the matching-message summary and keep going as you scroll, like every other list. While writing a new message, reply, or forward, press Ctrl+T to open the searchable Snippets picker. HEY never chooses a default: Enter inserts the selected snippet at the body cursor, Escape returns without changing the draft, and the picker can be reopened to insert another snippet.
 
 The mail list follows the server. HEY tells the TUI when a box changed over the same

--- a/docs/omarchy.md
+++ b/docs/omarchy.md
@@ -187,8 +187,9 @@ attention model puts new mail in one place — and sends the toast itself throug
   multiple threads rather than choosing one for the reader.
 - **No persistent state file.** Nothing is remembered but the last toast's id, in the
   shell's memory. A running TUI listens for topic requests on a mode-0600, instance-named
-  socket under `XDG_RUNTIME_DIR` and removes it when the TUI exits; turning toasts on is nothing more
-  than setting the plugin key.
+  socket in `$XDG_RUNTIME_DIR/hey-cli`, with an owner-only temporary directory as the
+  fallback, and removes it when the TUI exits; turning toasts on is nothing more than
+  setting the plugin key.
 - **Mail text never reads as an option.** A subject or sender can start with a dash, and
   `notify-send` parses one wherever it appears; a leading word joiner (U+2060) makes the
   argument a plain positional and is invisible on screen.

--- a/docs/omarchy.md
+++ b/docs/omarchy.md
@@ -179,11 +179,16 @@ attention model puts new mail in one place — and sends the toast itself throug
 - **DND is honoured.** The toast goes out under `--app-name HEY`: Omarchy's default
   app-name `omarchy-action` deliberately bypasses notification silencing, so identifying
   as HEY is what makes SUPER+CTRL+comma mute the toasts (into history) like any other app.
-- **Click focuses the TUI.** `--exec omarchy-launch-or-focus-tui --app-id=org.omarchy.hey
-  hey tui` — the shell runs it daemon-side, so it survives shell restarts — with the bar's
-  envelope as the glyph.
-- **No state file.** Nothing is remembered but the last toast's id, in the shell's memory;
-  turning toasts on is nothing more than setting the key.
+- **A single click opens its thread.** The plugin reads the topic id from the posting's
+  `app_url`, sends it to the named Omarchy TUI with
+  `hey tui --instance omarchy --topic <id> --remote`, then focuses the
+  `org.omarchy.hey` window. When no TUI is running, the same click launches
+  `hey tui --instance omarchy --topic <id>` directly. A grouped toast focuses the Imbox because it represents
+  multiple threads rather than choosing one for the reader.
+- **No persistent state file.** Nothing is remembered but the last toast's id, in the
+  shell's memory. A running TUI listens for topic requests on a mode-0600, instance-named
+  socket under `XDG_RUNTIME_DIR` and removes it when the TUI exits; turning toasts on is nothing more
+  than setting the plugin key.
 - **Mail text never reads as an option.** A subject or sender can start with a dash, and
   `notify-send` parses one wherever it appears; a leading word joiner (U+2060) makes the
   argument a plain positional and is invisible on screen.
@@ -215,7 +220,7 @@ new --run-async 'notify-send -a HEY "New mail in HEY"'` is the one-liner.
   desktop-shaped in the CLI at all: the plugin composes `hey box`, `hey watch`, `hey
   screener` and `hey seen`, and a user can run any of them by hand. What counts as new
   mail is a watch event — HEY semantics, decided once — and what to do about it (a toast
-  under the shell's app-name, a glyph, a click that focuses the TUI) is the plugin's.
+  under the shell's app-name, a glyph, a click that opens `hey tui --topic`) is the plugin's.
   (Two earlier cuts were built and superseded before release: a `hey omarchy poll` — one
   Imbox read that also diffed a fingerprint file to toast — that was ten minutes stale by
   construction and an Omarchy-named command on a general CLI; and a `hey watch --notify`

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -19,7 +19,7 @@ func stubRunTUI(t *testing.T) *int {
 	t.Helper()
 	calls := 0
 	orig := runTUI
-	runTUI = func(*hey.Client, *hey.Client, string, tui.Watchers) error {
+	runTUI = func(*hey.Client, *hey.Client, string, tui.Watchers, tui.Options) error {
 		calls++
 		return nil
 	}
@@ -100,6 +100,49 @@ func TestHeyTuiOpensTUIWhenAuthenticated(t *testing.T) {
 	}
 	if *tuiCalls != 2 {
 		t.Errorf("TUI opened %d times, want 2", *tuiCalls)
+	}
+}
+
+func TestHeyTuiTopicStartsAtTheRequestedThread(t *testing.T) {
+	isolateAgents(t)
+	server := quietServer(t)
+	original := runTUI
+	var options tui.Options
+	runTUI = func(_ *hey.Client, _ *hey.Client, _ string, _ tui.Watchers, got tui.Options) error {
+		options = got
+		return nil
+	}
+	t.Cleanup(func() { runTUI = original })
+
+	if _, _, err := runAuthCommand(t, t.TempDir(), server.URL, "environment-token", false,
+		"tui", "--topic", "5511", "--topic-title", "Lunch on Thursday?", "--instance", "omarchy"); err != nil {
+		t.Fatalf("hey tui --topic: %v", err)
+	}
+	if options.OpenTopic.TopicID != 5511 || options.OpenTopic.Title != "Lunch on Thursday?" || options.Instance != "omarchy" {
+		t.Fatalf("initial topic = %#v", options.OpenTopic)
+	}
+}
+
+func TestHeyTuiRemoteSendsTheTopicWithoutLaunching(t *testing.T) {
+	isolateAgents(t)
+	server := quietServer(t)
+	calls := stubRunTUI(t)
+	original := openTopicInRunningTUI
+	var request tui.TopicRequest
+	var instance string
+	openTopicInRunningTUI = func(gotInstance string, got tui.TopicRequest) error {
+		instance = gotInstance
+		request = got
+		return nil
+	}
+	t.Cleanup(func() { openTopicInRunningTUI = original })
+
+	if _, _, err := runAuthCommand(t, t.TempDir(), server.URL, "environment-token", false,
+		"tui", "--topic", "5511", "--topic-title", "Lunch on Thursday?", "--instance", "omarchy", "--remote"); err != nil {
+		t.Fatalf("hey tui --remote: %v", err)
+	}
+	if request.TopicID != 5511 || request.Title != "Lunch on Thursday?" || instance != "omarchy" || *calls != 0 {
+		t.Fatalf("remote request = %#v, TUI launches = %d", request, *calls)
 	}
 }
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -146,6 +146,34 @@ func TestHeyTuiRemoteSendsTheTopicWithoutLaunching(t *testing.T) {
 	}
 }
 
+func TestHeyTuiRejectsNonPositiveTopicIDs(t *testing.T) {
+	isolateAgents(t)
+	server := quietServer(t)
+	calls := stubRunTUI(t)
+	original := openTopicInRunningTUI
+	remoteCalls := 0
+	openTopicInRunningTUI = func(string, tui.TopicRequest) error {
+		remoteCalls++
+		return nil
+	}
+	t.Cleanup(func() { openTopicInRunningTUI = original })
+
+	for _, args := range [][]string{
+		{"tui", "--topic", "0"},
+		{"tui", "--topic", "-1"},
+		{"tui", "--remote", "--topic", "0"},
+		{"tui", "--remote", "--topic", "-1"},
+	} {
+		_, _, err := runAuthCommand(t, t.TempDir(), server.URL, "environment-token", false, args...)
+		if err == nil || !strings.Contains(err.Error(), "topic ID must be positive") {
+			t.Errorf("hey %s error = %v, want positive topic ID usage error", strings.Join(args, " "), err)
+		}
+	}
+	if *calls != 0 || remoteCalls != 0 {
+		t.Fatalf("invalid topics launched TUI %d times and made %d remote calls", *calls, remoteCalls)
+	}
+}
+
 func TestBareHeyMachineFlagsShowHelpEvenOnTerminal(t *testing.T) {
 	isolateAgents(t)
 	stubInteractive(t, true)

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -1,8 +1,17 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
+	"strconv"
+
 	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/tui"
 )
+
+var openTopicInRunningTUI = tui.OpenTopicInRunningTUI
 
 type tuiCommand struct {
 	cmd *cobra.Command
@@ -17,15 +26,43 @@ func newHeyCommand() *tuiCommand {
 }
 
 func newTuiRunner(use string, hidden bool) *cobra.Command {
-	return &cobra.Command{
+	var topicID int64
+	var topicTitle string
+	var instance string
+	var remote bool
+	command := &cobra.Command{
 		Use:    use,
 		Short:  "Launch the interactive terminal UI",
 		Hidden: hidden,
+		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if remote && topicID == 0 {
+				return apierr.ErrUsage("--remote requires --topic")
+			}
+			request := tui.TopicRequest{TopicID: topicID, Title: topicTitle}
+			if accountID, err := strconv.ParseInt(cfg.AccountID, 10, 64); err == nil && accountID > 0 {
+				request.AccountID = accountID
+			}
+			if remote {
+				if err := openTopicInRunningTUI(instance, request); err != nil {
+					if errors.Is(err, tui.ErrNoRunningTUI) {
+						return fmt.Errorf("no running HEY TUI")
+					}
+					return err
+				}
+				return nil
+			}
 			if err := requireAuth(); err != nil {
 				return err
 			}
-			return runTUI(rootSDK, sdk, cfg.AccountID, tuiWatchers())
+			return runTUI(rootSDK, sdk, cfg.AccountID, tuiWatchers(), tui.Options{OpenTopic: request, Instance: instance})
 		},
 	}
+	command.Flags().Int64Var(&topicID, "topic", 0, "Open a thread by topic ID")
+	command.Flags().StringVar(&topicTitle, "topic-title", "", "Set the title of a directly opened thread")
+	_ = command.Flags().MarkHidden("topic-title")
+	command.Flags().StringVar(&instance, "instance", "", "Name this TUI for remote topic requests")
+	_ = command.Flags().MarkHidden("instance")
+	command.Flags().BoolVar(&remote, "remote", false, "Send the topic to a running TUI and exit")
+	return command
 }

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -36,7 +36,11 @@ func newTuiRunner(use string, hidden bool) *cobra.Command {
 		Hidden: hidden,
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if remote && topicID == 0 {
+			topicSet := cmd.Flags().Changed("topic")
+			if topicSet && topicID <= 0 {
+				return apierr.ErrUsage("topic ID must be positive")
+			}
+			if remote && !topicSet {
 				return apierr.ErrUsage("--remote requires --topic")
 			}
 			request := tui.TopicRequest{TopicID: topicID, Title: topicTitle}

--- a/internal/tui/accounts_test.go
+++ b/internal/tui/accounts_test.go
@@ -244,6 +244,8 @@ func TestTopicRequestSwitchesToItsMailAccountBeforeOpening(t *testing.T) {
 	m := newModelWithMailAccounts(root, root, "all", Watchers{})
 	m.mailAccountsLoaded = true
 	m.mailAccounts = []mailAccountChoice{{label: "All Accounts"}, {id: 2, label: "jane@company.example"}}
+	m.section = sectionCalendar
+	m.activeView = m.calendarView
 
 	updated, cmd := m.Update(TopicRequest{TopicID: 5511, AccountID: 2})
 	m = updated.(model)
@@ -253,8 +255,8 @@ func TestTopicRequestSwitchesToItsMailAccountBeforeOpening(t *testing.T) {
 	switchMsg := cmd().(mailAccountSwitchedMsg)
 	updated, initCmd := m.Update(switchMsg)
 	m = updated.(model)
-	if initCmd == nil || m.mailAccount.id != 2 || m.pendingTopic == nil {
-		t.Fatalf("topic account switch did not wait for mail: account=%d pending=%v", m.mailAccount.id, m.pendingTopic != nil)
+	if initCmd == nil || m.mailAccount.id != 2 || m.pendingTopic == nil || m.section != sectionMail || m.activeView != m.mailView {
+		t.Fatalf("topic account switch did not start mail: account=%d pending=%v section=%d", m.mailAccount.id, m.pendingTopic != nil, m.section)
 	}
 
 	updated, openCmd := m.Update(mailSourcesLoadedMsg{})
@@ -270,6 +272,33 @@ func TestTopicRequestSwitchesToItsMailAccountBeforeOpening(t *testing.T) {
 	m = updated.(model)
 	if failCmd != nil || m.mailAccountsLoaded || m.pendingTopic == nil || m.pendingTopic.AccountID != 1 {
 		t.Fatalf("account discovery failure weakened the topic request: cmd=%v loaded=%v pending=%#v", failCmd != nil, m.mailAccountsLoaded, m.pendingTopic)
+	}
+}
+
+func TestNewCurrentAccountTopicInvalidatesPendingAccountSwitch(t *testing.T) {
+	m := newModel()
+	m.mailAccount = mailAccountChoice{id: 1, label: "jane@example.com"}
+	m.mailSourcesLoaded = true
+	m.mailAccountRequestID = 41
+	m.mailAccountSwitching = true
+	pending := TopicRequest{TopicID: 5511, AccountID: 2}
+	m.pendingTopic = &pending
+	oldMailView := m.mailView
+
+	updated, openCmd := m.Update(TopicRequest{TopicID: 6612, AccountID: 1})
+	m = updated.(model)
+	if openCmd == nil || m.mailAccountSwitching || m.mailAccountRequestID != 42 || m.pendingTopic != nil {
+		t.Fatalf("new topic did not replace the pending switch: cmd=%v switching=%v request=%d pending=%v",
+			openCmd != nil, m.mailAccountSwitching, m.mailAccountRequestID, m.pendingTopic != nil)
+	}
+
+	updated, staleCmd := m.Update(mailAccountSwitchedMsg{
+		requestID: 41,
+		account:   mailAccountChoice{id: 2, label: "jane@company.example"},
+	})
+	m = updated.(model)
+	if staleCmd != nil || m.mailAccount.id != 1 || m.mailView != oldMailView {
+		t.Fatalf("stale switch replaced the current topic: cmd=%v account=%d rebuilt=%v", staleCmd != nil, m.mailAccount.id, m.mailView != oldMailView)
 	}
 }
 

--- a/internal/tui/accounts_test.go
+++ b/internal/tui/accounts_test.go
@@ -233,6 +233,53 @@ func TestAccountSwitchRebuildsViewsAndCancelsOldGeneration(t *testing.T) {
 	}
 }
 
+func TestTopicRequestSwitchesToItsMailAccountBeforeOpening(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":1,"accounts":[{"id":1,"status":"active"},{"id":2,"status":"active"}]}`)
+	}))
+	t.Cleanup(server.Close)
+	root := hey.NewClient(&hey.Config{BaseURL: server.URL}, &hey.StaticTokenProvider{Token: "token"}, hey.WithMaxRetries(0))
+	m := newModelWithMailAccounts(root, root, "all", Watchers{})
+	m.mailAccountsLoaded = true
+	m.mailAccounts = []mailAccountChoice{{label: "All Accounts"}, {id: 2, label: "jane@company.example"}}
+
+	updated, cmd := m.Update(TopicRequest{TopicID: 5511, AccountID: 2})
+	m = updated.(model)
+	if cmd == nil || !m.mailAccountSwitching || m.pendingTopic == nil {
+		t.Fatal("topic request did not start its account switch")
+	}
+	switchMsg := cmd().(mailAccountSwitchedMsg)
+	updated, initCmd := m.Update(switchMsg)
+	m = updated.(model)
+	if initCmd == nil || m.mailAccount.id != 2 || m.pendingTopic == nil {
+		t.Fatalf("topic account switch did not wait for mail: account=%d pending=%v", m.mailAccount.id, m.pendingTopic != nil)
+	}
+
+	updated, openCmd := m.Update(mailSourcesLoadedMsg{})
+	m = updated.(model)
+	if openCmd == nil || m.pendingTopic != nil || m.section != sectionMail {
+		t.Fatalf("topic was not opened after mail loaded: pending=%v section=%d", m.pendingTopic != nil, m.section)
+	}
+}
+
+func TestTopicRequestDoesNotDiscardAnAccountSensitiveAction(t *testing.T) {
+	m := newModel()
+	m.mailAccountsLoaded = true
+	m.mailSourcesLoaded = true
+	m.mailAccounts = []mailAccountChoice{{label: "All Accounts"}, {id: 2, label: "jane@company.example"}}
+	m.mailView.pendingMutations = 1
+
+	updated, cmd := m.Update(TopicRequest{TopicID: 5511, AccountID: 2})
+	m = updated.(model)
+	if cmd == nil || m.mailAccountSwitching || m.pendingTopic != nil {
+		t.Fatalf("topic request disturbed a pending action: switching=%v pending=%v", m.mailAccountSwitching, m.pendingTopic != nil)
+	}
+	if _, ok := cmd().(notifyMsg); !ok {
+		t.Fatal("blocked topic request did not explain why")
+	}
+}
+
 func TestFailedAccountSwitchPreservesCurrentViews(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/tui/accounts_test.go
+++ b/internal/tui/accounts_test.go
@@ -309,10 +309,35 @@ func TestTopicRequestDoesNotDiscardAnAccountSensitiveAction(t *testing.T) {
 	m.mailAccounts = []mailAccountChoice{{label: "All Accounts"}, {id: 2, label: "jane@company.example"}}
 	m.mailView.pendingMutations = 1
 
+	for _, accountID := range []int64{2, 0} {
+		updated, cmd := m.Update(TopicRequest{TopicID: 5511, AccountID: accountID})
+		m = updated.(model)
+		if cmd == nil || m.mailAccountSwitching || m.pendingTopic != nil || m.section != sectionMail {
+			t.Fatalf("account %d topic request disturbed a pending action: switching=%v pending=%v section=%d",
+				accountID, m.mailAccountSwitching, m.pendingTopic != nil, m.section)
+		}
+		if _, ok := cmd().(notifyMsg); !ok {
+			t.Fatalf("blocked account %d topic request did not explain why", accountID)
+		}
+	}
+}
+
+func TestTopicRequestDoesNotDiscardAnotherSectionsForm(t *testing.T) {
+	m := newModel()
+	m.mailAccountsLoaded = true
+	m.mailSourcesLoaded = true
+	m.mailAccounts = []mailAccountChoice{{label: "All Accounts"}, {id: 2, label: "jane@company.example"}}
+	m.section = sectionContacts
+	m.activeView = m.contactsView
+	if cmd := m.contactsView.HandleContentKey(keyPress("a")); cmd == nil || !m.contactsView.CapturingInput() {
+		t.Fatal("contact form did not open")
+	}
+
 	updated, cmd := m.Update(TopicRequest{TopicID: 5511, AccountID: 2})
 	m = updated.(model)
-	if cmd == nil || m.mailAccountSwitching || m.pendingTopic != nil {
-		t.Fatalf("topic request disturbed a pending action: switching=%v pending=%v", m.mailAccountSwitching, m.pendingTopic != nil)
+	if cmd == nil || m.mailAccountSwitching || m.pendingTopic != nil || m.section != sectionContacts || m.activeView != m.contactsView || !m.contactsView.CapturingInput() {
+		t.Fatalf("topic request discarded the contact form: switching=%v pending=%v section=%d capturing=%v",
+			m.mailAccountSwitching, m.pendingTopic != nil, m.section, m.contactsView.CapturingInput())
 	}
 	if _, ok := cmd().(notifyMsg); !ok {
 		t.Fatal("blocked topic request did not explain why")

--- a/internal/tui/accounts_test.go
+++ b/internal/tui/accounts_test.go
@@ -262,21 +262,14 @@ func TestTopicRequestSwitchesToItsMailAccountBeforeOpening(t *testing.T) {
 	if openCmd == nil || m.pendingTopic != nil || m.section != sectionMail {
 		t.Fatalf("topic was not opened after mail loaded: pending=%v section=%d", m.pendingTopic != nil, m.section)
 	}
-}
 
-func TestTopicRequestKeepsItsAccountWhenDiscoveryFails(t *testing.T) {
-	m := newModel()
-	m.mailAccount = mailAccountChoice{id: 1, label: "first@example.com"}
-	request := TopicRequest{TopicID: 5511, AccountID: 2}
+	request := TopicRequest{TopicID: 6612, AccountID: 1}
 	m.pendingTopic = &request
-
-	updated, cmd := m.Update(mailAccountsLoadedMsg{err: errors.New("identity unavailable")})
+	m.mailAccountsLoaded = false
+	updated, failCmd := m.Update(mailAccountsLoadedMsg{err: errors.New("identity unavailable")})
 	m = updated.(model)
-	if cmd != nil {
-		t.Fatal("account discovery failure tried to open the topic")
-	}
-	if m.mailAccountsLoaded || m.pendingTopic == nil || m.pendingTopic.AccountID != 2 {
-		t.Fatalf("account discovery failure weakened the topic request: loaded=%v pending=%#v", m.mailAccountsLoaded, m.pendingTopic)
+	if failCmd != nil || m.mailAccountsLoaded || m.pendingTopic == nil || m.pendingTopic.AccountID != 1 {
+		t.Fatalf("account discovery failure weakened the topic request: cmd=%v loaded=%v pending=%#v", failCmd != nil, m.mailAccountsLoaded, m.pendingTopic)
 	}
 }
 

--- a/internal/tui/accounts_test.go
+++ b/internal/tui/accounts_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -260,6 +261,22 @@ func TestTopicRequestSwitchesToItsMailAccountBeforeOpening(t *testing.T) {
 	m = updated.(model)
 	if openCmd == nil || m.pendingTopic != nil || m.section != sectionMail {
 		t.Fatalf("topic was not opened after mail loaded: pending=%v section=%d", m.pendingTopic != nil, m.section)
+	}
+}
+
+func TestTopicRequestKeepsItsAccountWhenDiscoveryFails(t *testing.T) {
+	m := newModel()
+	m.mailAccount = mailAccountChoice{id: 1, label: "first@example.com"}
+	request := TopicRequest{TopicID: 5511, AccountID: 2}
+	m.pendingTopic = &request
+
+	updated, cmd := m.Update(mailAccountsLoadedMsg{err: errors.New("identity unavailable")})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("account discovery failure tried to open the topic")
+	}
+	if m.mailAccountsLoaded || m.pendingTopic == nil || m.pendingTopic.AccountID != 2 {
+		t.Fatalf("account discovery failure weakened the topic request: loaded=%v pending=%#v", m.mailAccountsLoaded, m.pendingTopic)
 	}
 }
 

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -377,7 +377,10 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		return v.loadMoreSearchResults(), true
 
 	case topicLoadedMsg:
-		if msg.boxID != v.currentBoxID() {
+		// A zero box identifies a topic opened directly rather than selected from
+		// the current list. It remains valid while sources load or another section
+		// is on screen.
+		if msg.boxID != 0 && msg.boxID != v.currentBoxID() {
 			return nil, true
 		}
 		if cmd, ok := v.requests.settle(newRequestResult(msg.requestID, msg.err)); !ok {
@@ -2144,6 +2147,9 @@ func (v *mailView) fetchTopic(ctx context.Context, requestID uint64, boxID, topi
 		var images [][]byte
 		if wantImages {
 			images = newImageBudget().fetchImages(ctx, v.vc.imageFetcher, imageURLs)
+		}
+		if title == "" {
+			title = entries[0].Summary
 		}
 
 		return topicLoadedMsg{

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -1650,6 +1650,21 @@ func TestMailViewEnterOpensSelectedThread(t *testing.T) {
 	}
 }
 
+func TestMailViewDirectTopicDerivesItsTitleAndIgnoresTheCurrentBox(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusOK)
+
+	loaded, ok := runCmd(v.requestTopic(0, 100, 0, "")).(topicLoadedMsg)
+	if !ok {
+		t.Fatal("direct topic did not return topicLoadedMsg")
+	}
+	if loaded.title != "Hello world" || loaded.boxID != 0 {
+		t.Fatalf("direct topic = title %q box %d", loaded.title, loaded.boxID)
+	}
+	if _, consumed := v.Update(loaded); !consumed || !v.inThread || v.topicID != 100 {
+		t.Fatalf("direct topic was not opened: consumed=%v open=%v id=%d", consumed, v.inThread, v.topicID)
+	}
+}
+
 func TestMailViewDownloadsImageDataOnlyForKittyRenderer(t *testing.T) {
 	var imageRequests atomic.Int64
 	imageData := testPNG(t)

--- a/internal/tui/topic_remote_other.go
+++ b/internal/tui/topic_remote_other.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build !unix && !windows
 
 package tui
 

--- a/internal/tui/topic_remote_unix.go
+++ b/internal/tui/topic_remote_unix.go
@@ -1,0 +1,137 @@
+//go:build !windows
+
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// ErrNoRunningTUI means no active HEY TUI accepted a topic request.
+var ErrNoRunningTUI = errors.New("no running HEY TUI")
+
+const topicSocketFilename = "hey-tui.sock"
+
+func topicSocketPath(instance string) string {
+	name := topicSocketFilename
+	if suffix := topicInstanceSuffix(instance); suffix != "" {
+		name = "hey-tui-" + suffix + ".sock"
+	}
+	if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
+		return filepath.Join(runtimeDir, name)
+	}
+	uid := "user"
+	if current, err := user.Current(); err == nil && current.Uid != "" {
+		uid = current.Uid
+	}
+	return filepath.Join(os.TempDir(), "hey-tui-"+uid+"-"+name)
+}
+
+func topicInstanceSuffix(instance string) string {
+	var suffix strings.Builder
+	for _, char := range instance {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '-' || char == '_' {
+			suffix.WriteRune(char)
+		}
+		if suffix.Len() == 32 {
+			break
+		}
+	}
+	return suffix.String()
+}
+
+// OpenTopicInRunningTUI sends a thread to the active named TUI.
+func OpenTopicInRunningTUI(instance string, request TopicRequest) error {
+	if request.TopicID <= 0 {
+		return fmt.Errorf("topic ID must be positive")
+	}
+	dialer := net.Dialer{Timeout: 250 * time.Millisecond}
+	connection, err := dialer.DialContext(context.Background(), "unix", topicSocketPath(instance))
+	if err != nil {
+		return ErrNoRunningTUI
+	}
+	defer connection.Close()
+	_ = connection.SetDeadline(time.Now().Add(time.Second))
+	if err := json.NewEncoder(connection).Encode(request); err != nil {
+		return fmt.Errorf("send topic to HEY TUI: %w", err)
+	}
+	var response struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.NewDecoder(io.LimitReader(connection, 1024)).Decode(&response); err != nil {
+		return fmt.Errorf("read HEY TUI response: %w", err)
+	}
+	if !response.OK {
+		return fmt.Errorf("HEY TUI refused the topic request")
+	}
+	return nil
+}
+
+func startTopicListener(instance string, send func(tea.Msg)) (net.Listener, error) {
+	path := topicSocketPath(instance)
+	dialer := net.Dialer{Timeout: 50 * time.Millisecond}
+	if connection, err := dialer.DialContext(context.Background(), "unix", path); err == nil {
+		_ = connection.Close()
+		return nil, nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("remove stale HEY TUI socket: %w", err)
+	}
+	listener, err := new(net.ListenConfig).Listen(context.Background(), "unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("listen for HEY TUI topics: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = listener.Close()
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("protect HEY TUI socket: %w", err)
+	}
+	go serveTopicRequests(listener, send)
+	return listener, nil
+}
+
+func serveTopicRequests(listener net.Listener, send func(tea.Msg)) {
+	for {
+		connection, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		go handleTopicRequest(connection, send)
+	}
+}
+
+func handleTopicRequest(connection net.Conn, send func(tea.Msg)) {
+	defer connection.Close()
+	_ = connection.SetDeadline(time.Now().Add(time.Second))
+	var request TopicRequest
+	if err := json.NewDecoder(io.LimitReader(connection, 4096)).Decode(&request); err != nil || request.TopicID <= 0 {
+		_ = json.NewEncoder(connection).Encode(struct {
+			OK bool `json:"ok"`
+		}{})
+		return
+	}
+	send(request)
+	_ = json.NewEncoder(connection).Encode(struct {
+		OK bool `json:"ok"`
+	}{OK: true})
+}
+
+func closeTopicListener(instance string, listener net.Listener) {
+	if listener == nil {
+		return
+	}
+	_ = listener.Close()
+	_ = os.Remove(topicSocketPath(instance))
+}

--- a/internal/tui/topic_remote_unix.go
+++ b/internal/tui/topic_remote_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build unix
 
 package tui
 
@@ -10,46 +10,112 @@ import (
 	"io"
 	"net"
 	"os"
-	"os/user"
 	"path/filepath"
-	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/gofrs/flock"
 )
 
 // ErrNoRunningTUI means no active HEY TUI accepted a topic request.
 var ErrNoRunningTUI = errors.New("no running HEY TUI")
 
-const topicSocketFilename = "hey-tui.sock"
+const (
+	topicRuntimeDirname = "hey-cli"
+	topicSocketFilename = "hey-tui.sock"
+)
 
-func topicSocketPath(instance string) string {
-	name := topicSocketFilename
-	if suffix := topicInstanceSuffix(instance); suffix != "" {
-		name = "hey-tui-" + suffix + ".sock"
-	}
-	if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
-		return filepath.Join(runtimeDir, name)
-	}
-	uid := "user"
-	if current, err := user.Current(); err == nil && current.Uid != "" {
-		uid = current.Uid
-	}
-	return filepath.Join(os.TempDir(), "hey-tui-"+uid+"-"+name)
+type ownedTopicListener struct {
+	net.Listener
+	lock       *flock.Flock
+	path       string
+	socketInfo os.FileInfo
+	closeOnce  sync.Once
+	closeErr   error
 }
 
-func topicInstanceSuffix(instance string) string {
-	var suffix strings.Builder
+func topicSocketPath(instance string) (string, error) {
+	name, err := topicSocketName(instance)
+	if err != nil {
+		return "", err
+	}
+	runtimeDir, err := topicRuntimeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(runtimeDir, name), nil
+}
+
+func topicSocketName(instance string) (string, error) {
+	if instance == "" {
+		return topicSocketFilename, nil
+	}
+	if len(instance) > 32 {
+		return "", fmt.Errorf("TUI instance must be at most 32 characters")
+	}
 	for _, char := range instance {
 		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
 			(char >= '0' && char <= '9') || char == '-' || char == '_' {
-			suffix.WriteRune(char)
+			continue
 		}
-		if suffix.Len() == 32 {
-			break
-		}
+		return "", fmt.Errorf("TUI instance may contain only letters, numbers, hyphens, and underscores")
 	}
-	return suffix.String()
+	return "hey-tui-" + instance + ".sock", nil
+}
+
+func topicRuntimeDir() (string, error) {
+	if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
+		if !filepath.IsAbs(runtimeDir) {
+			return "", fmt.Errorf("XDG_RUNTIME_DIR must be an absolute path")
+		}
+		if err := validatePrivateDirectory(runtimeDir); err != nil {
+			return "", fmt.Errorf("protect HEY TUI runtime directory: %w", err)
+		}
+		return ensurePrivateDirectory(filepath.Join(runtimeDir, topicRuntimeDirname))
+	}
+
+	tempDir := os.TempDir()
+	info, err := os.Lstat(tempDir)
+	if err != nil {
+		return "", fmt.Errorf("inspect temporary directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("temporary directory is not a directory")
+	}
+	if info.Mode().Perm()&0o022 != 0 && info.Mode()&os.ModeSticky == 0 {
+		return "", fmt.Errorf("temporary directory is writable by other users without the sticky bit")
+	}
+	return ensurePrivateDirectory(filepath.Join(tempDir, fmt.Sprintf("%s-%d", topicRuntimeDirname, os.Getuid())))
+}
+
+func ensurePrivateDirectory(path string) (string, error) {
+	if err := os.Mkdir(path, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		return "", fmt.Errorf("create HEY TUI runtime directory: %w", err)
+	}
+	if err := validatePrivateDirectory(path); err != nil {
+		return "", fmt.Errorf("validate HEY TUI runtime directory: %w", err)
+	}
+	return path, nil
+}
+
+func validatePrivateDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is not a directory", path)
+	}
+	if info.Mode().Perm() != 0o700 {
+		return fmt.Errorf("%s must have mode 0700", path)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("%s must be owned by the current user", path)
+	}
+	return nil
 }
 
 // OpenTopicInRunningTUI sends a thread to the active named TUI.
@@ -57,8 +123,12 @@ func OpenTopicInRunningTUI(instance string, request TopicRequest) error {
 	if request.TopicID <= 0 {
 		return fmt.Errorf("topic ID must be positive")
 	}
+	path, err := topicSocketPath(instance)
+	if err != nil {
+		return err
+	}
 	dialer := net.Dialer{Timeout: 250 * time.Millisecond}
-	connection, err := dialer.DialContext(context.Background(), "unix", topicSocketPath(instance))
+	connection, err := dialer.DialContext(context.Background(), "unix", path)
 	if err != nil {
 		return ErrNoRunningTUI
 	}
@@ -80,26 +150,74 @@ func OpenTopicInRunningTUI(instance string, request TopicRequest) error {
 }
 
 func startTopicListener(instance string, send func(tea.Msg)) (net.Listener, error) {
-	path := topicSocketPath(instance)
-	dialer := net.Dialer{Timeout: 50 * time.Millisecond}
-	if connection, err := dialer.DialContext(context.Background(), "unix", path); err == nil {
-		_ = connection.Close()
-		return nil, nil
+	path, err := topicSocketPath(instance)
+	if err != nil {
+		return nil, err
 	}
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("remove stale HEY TUI socket: %w", err)
+	ownershipLock := flock.New(path + ".lock")
+	locked, err := ownershipLock.TryLock()
+	if err != nil {
+		return nil, fmt.Errorf("lock HEY TUI topic listener: %w", err)
+	}
+	if !locked {
+		return nil, errors.New("a HEY TUI with this instance is already running")
+	}
+	releaseLock := true
+	defer func() {
+		if releaseLock {
+			_ = ownershipLock.Unlock()
+		}
+	}()
+
+	if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("remove stale HEY TUI socket: %w", removeErr)
 	}
 	listener, err := new(net.ListenConfig).Listen(context.Background(), "unix", path)
 	if err != nil {
 		return nil, fmt.Errorf("listen for HEY TUI topics: %w", err)
 	}
-	if err := os.Chmod(path, 0o600); err != nil {
+	unixListener, ok := listener.(*net.UnixListener)
+	if !ok {
+		_ = listener.Close()
+		return nil, fmt.Errorf("HEY TUI topic listener is not a Unix socket")
+	}
+	unixListener.SetUnlinkOnClose(false)
+	if chmodErr := os.Chmod(path, 0o600); chmodErr != nil {
 		_ = listener.Close()
 		_ = os.Remove(path)
-		return nil, fmt.Errorf("protect HEY TUI socket: %w", err)
+		return nil, fmt.Errorf("protect HEY TUI socket: %w", chmodErr)
 	}
-	go serveTopicRequests(listener, send)
-	return listener, nil
+	socketInfo, err := os.Lstat(path)
+	if err != nil {
+		_ = listener.Close()
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("inspect HEY TUI socket: %w", err)
+	}
+
+	owned := &ownedTopicListener{
+		Listener:   listener,
+		lock:       ownershipLock,
+		path:       path,
+		socketInfo: socketInfo,
+	}
+	releaseLock = false
+	go serveTopicRequests(owned, send)
+	return owned, nil
+}
+
+func (l *ownedTopicListener) Close() error {
+	l.closeOnce.Do(func() {
+		l.closeErr = l.Listener.Close()
+		if info, err := os.Lstat(l.path); err == nil && os.SameFile(l.socketInfo, info) {
+			if err := os.Remove(l.path); err != nil && l.closeErr == nil {
+				l.closeErr = err
+			}
+		}
+		if err := l.lock.Unlock(); err != nil && l.closeErr == nil {
+			l.closeErr = err
+		}
+	})
+	return l.closeErr
 }
 
 func serveTopicRequests(listener net.Listener, send func(tea.Msg)) {
@@ -128,10 +246,8 @@ func handleTopicRequest(connection net.Conn, send func(tea.Msg)) {
 	}{OK: true})
 }
 
-func closeTopicListener(instance string, listener net.Listener) {
-	if listener == nil {
-		return
+func closeTopicListener(listener net.Listener) {
+	if listener != nil {
+		_ = listener.Close()
 	}
-	_ = listener.Close()
-	_ = os.Remove(topicSocketPath(instance))
 }

--- a/internal/tui/topic_remote_unix_test.go
+++ b/internal/tui/topic_remote_unix_test.go
@@ -1,0 +1,61 @@
+//go:build !windows
+
+package tui
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestTopicRemoteRoundTrip(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	received := make(chan TopicRequest, 1)
+	listener, err := startTopicListener("omarchy", func(msg tea.Msg) {
+		request, ok := msg.(TopicRequest)
+		if ok {
+			received <- request
+		}
+	})
+	if err != nil {
+		t.Fatalf("start topic listener: %v", err)
+	}
+	if listener == nil {
+		t.Fatal("topic listener did not start")
+	}
+	t.Cleanup(func() { closeTopicListener("omarchy", listener) })
+
+	want := TopicRequest{TopicID: 5511, AccountID: 42, Title: "Lunch on Thursday?"}
+	if err := OpenTopicInRunningTUI("omarchy", want); err != nil {
+		t.Fatalf("open topic: %v", err)
+	}
+	select {
+	case got := <-received:
+		if got != want {
+			t.Fatalf("request = %#v, want %#v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("topic request was not delivered")
+	}
+}
+
+func TestTopicRemoteInstancesUseSeparateSafeSockets(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	defaultPath := topicSocketPath("")
+	omarchyPath := topicSocketPath("omarchy")
+	if defaultPath == omarchyPath {
+		t.Fatal("named TUI shared the default socket")
+	}
+	if got := topicSocketPath("omarchy/../../other"); got != topicSocketPath("omarchyother") {
+		t.Fatalf("unsafe instance path = %q", got)
+	}
+}
+
+func TestTopicRemoteReportsNoRunningTUI(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	if err := OpenTopicInRunningTUI("omarchy", TopicRequest{TopicID: 5511}); !errors.Is(err, ErrNoRunningTUI) {
+		t.Fatalf("error = %v, want ErrNoRunningTUI", err)
+	}
+}

--- a/internal/tui/topic_remote_unix_test.go
+++ b/internal/tui/topic_remote_unix_test.go
@@ -1,9 +1,13 @@
-//go:build !windows
+//go:build unix
 
 package tui
 
 import (
 	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,7 +15,7 @@ import (
 )
 
 func TestTopicRemoteRoundTrip(t *testing.T) {
-	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	setPrivateRuntimeDir(t)
 	received := make(chan TopicRequest, 1)
 	listener, err := startTopicListener("omarchy", func(msg tea.Msg) {
 		request, ok := msg.(TopicRequest)
@@ -25,7 +29,7 @@ func TestTopicRemoteRoundTrip(t *testing.T) {
 	if listener == nil {
 		t.Fatal("topic listener did not start")
 	}
-	t.Cleanup(func() { closeTopicListener("omarchy", listener) })
+	t.Cleanup(func() { closeTopicListener(listener) })
 
 	want := TopicRequest{TopicID: 5511, AccountID: 42, Title: "Lunch on Thursday?"}
 	if err := OpenTopicInRunningTUI("omarchy", want); err != nil {
@@ -41,21 +45,122 @@ func TestTopicRemoteRoundTrip(t *testing.T) {
 	}
 }
 
-func TestTopicRemoteInstancesUseSeparateSafeSockets(t *testing.T) {
-	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
-	defaultPath := topicSocketPath("")
-	omarchyPath := topicSocketPath("omarchy")
+func TestTopicRemoteInstancesUseDistinctValidatedSockets(t *testing.T) {
+	setPrivateRuntimeDir(t)
+	defaultPath := mustTopicSocketPath(t, "")
+	omarchyPath := mustTopicSocketPath(t, "omarchy")
 	if defaultPath == omarchyPath {
 		t.Fatal("named TUI shared the default socket")
 	}
-	if got := topicSocketPath("omarchy/../../other"); got != topicSocketPath("omarchyother") {
-		t.Fatalf("unsafe instance path = %q", got)
+	for _, instance := range []string{"omarchy/../../other", strings.Repeat("a", 33), "."} {
+		if _, err := topicSocketPath(instance); err == nil {
+			t.Errorf("instance %q was accepted", instance)
+		}
+	}
+}
+
+func TestTopicRemoteFallbackUsesPrivatePerUserDirectory(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv("TMPDIR", t.TempDir())
+	path := mustTopicSocketPath(t, "omarchy")
+	parent := filepath.Dir(path)
+	if parent == os.TempDir() {
+		t.Fatalf("socket was placed directly in shared temporary directory: %s", path)
+	}
+	info, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("stat private runtime directory: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("private runtime directory mode = %04o, want 0700", got)
+	}
+}
+
+func TestTopicRemoteRejectsInsecureRuntimeDirectory(t *testing.T) {
+	runtimeDir := t.TempDir()
+	if err := os.Chmod(runtimeDir, 0o755); err != nil {
+		t.Fatalf("make runtime directory insecure: %v", err)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	if _, err := topicSocketPath("omarchy"); err == nil {
+		t.Fatal("insecure XDG_RUNTIME_DIR was accepted")
+	}
+}
+
+func TestTopicRemoteListenerOwnershipIsExclusive(t *testing.T) {
+	setPrivateRuntimeDir(t)
+	first, err := startTopicListener("omarchy", func(tea.Msg) {})
+	if err != nil || first == nil {
+		t.Fatalf("start first listener: listener=%v err=%v", first != nil, err)
+	}
+	defer closeTopicListener(first)
+
+	second, err := startTopicListener("omarchy", func(tea.Msg) {})
+	if err == nil || second != nil {
+		closeTopicListener(second)
+		t.Fatalf("second listener did not report the owned instance: listener=%v err=%v", second != nil, err)
+	}
+	if err := Run(nil, nil, "all", Watchers{}, Options{Instance: "omarchy"}); err == nil {
+		t.Fatal("Run silently started a TUI without owning its requested instance")
+	}
+
+	closeTopicListener(first)
+	third, err := startTopicListener("omarchy", func(tea.Msg) {})
+	if err != nil || third == nil {
+		t.Fatalf("start listener after owner closed: listener=%v err=%v", third != nil, err)
+	}
+	closeTopicListener(third)
+}
+
+func TestTopicRemoteListenerDoesNotRemoveAReplacementPath(t *testing.T) {
+	setPrivateRuntimeDir(t)
+	listener, err := startTopicListener("omarchy", func(tea.Msg) {})
+	if err != nil || listener == nil {
+		t.Fatalf("start listener: listener=%v err=%v", listener != nil, err)
+	}
+	path := mustTopicSocketPath(t, "omarchy")
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove listener path: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+		t.Fatalf("write replacement path: %v", err)
+	}
+	closeTopicListener(listener)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("listener cleanup removed replacement path: %v", err)
 	}
 }
 
 func TestTopicRemoteReportsNoRunningTUI(t *testing.T) {
-	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	setPrivateRuntimeDir(t)
 	if err := OpenTopicInRunningTUI("omarchy", TopicRequest{TopicID: 5511}); !errors.Is(err, ErrNoRunningTUI) {
 		t.Fatalf("error = %v, want ErrNoRunningTUI", err)
 	}
 }
+
+func TestRunReportsTopicListenerConfigurationErrors(t *testing.T) {
+	err := Run(nil, nil, "all", Watchers{}, Options{Instance: "invalid/name"})
+	if err == nil {
+		t.Fatal("Run accepted an invalid listener instance")
+	}
+}
+
+func setPrivateRuntimeDir(t *testing.T) {
+	t.Helper()
+	runtimeDir := t.TempDir()
+	if err := os.Chmod(runtimeDir, 0o700); err != nil {
+		t.Fatalf("protect runtime directory: %v", err)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+}
+
+func mustTopicSocketPath(t *testing.T, instance string) string {
+	t.Helper()
+	path, err := topicSocketPath(instance)
+	if err != nil {
+		t.Fatalf("topic socket path: %v", err)
+	}
+	return path
+}
+
+var _ net.Listener = (*ownedTopicListener)(nil)

--- a/internal/tui/topic_remote_windows.go
+++ b/internal/tui/topic_remote_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package tui
+
+import (
+	"errors"
+	"net"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// ErrNoRunningTUI means no active HEY TUI accepted a topic request.
+var ErrNoRunningTUI = errors.New("no running HEY TUI")
+
+// OpenTopicInRunningTUI reports that remote topic opening is unavailable.
+func OpenTopicInRunningTUI(string, TopicRequest) error {
+	return ErrNoRunningTUI
+}
+
+func startTopicListener(string, func(tea.Msg)) (net.Listener, error) {
+	return nil, nil
+}
+
+func closeTopicListener(string, net.Listener) {}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -272,6 +272,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateHelpBindings()
 			return m, nil
 		}
+		if m.pendingTopic != nil {
+			m.section = sectionMail
+		}
 		updated, initCmd := m.applyMailAccount(msg.account, msg.client)
 		next, ok := updated.(model)
 		if !ok {
@@ -1055,6 +1058,11 @@ func (m model) openTopic(request TopicRequest) (tea.Model, tea.Cmd) {
 		m.mailAccountErr = fmt.Sprintf("Mail account %d is not available", request.AccountID)
 		m.updateHelpBindings()
 		return m, nil
+	}
+	if m.mailAccountSwitching {
+		m.mailAccountRequestID++
+		m.mailAccountSwitching = false
+		m.updateHelpBindings()
 	}
 	if !m.mailSourcesLoaded {
 		m.pendingTopic = &request

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -237,18 +237,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case mailAccountsLoadedMsg:
-		m.mailAccountsLoaded = true
 		if msg.err != nil {
 			m.mailAccountDiscoveryErr = errorNotice("Could not load the mail accounts", msg.err)
 			m.updateHelpBindings()
-			if m.pendingTopic != nil {
-				request := *m.pendingTopic
-				request.AccountID = 0
-				m.pendingTopic = nil
-				return m.openTopic(request)
-			}
 			return m, nil
 		}
+		m.mailAccountsLoaded = true
 		m.mailAccountDiscoveryErr = ""
 		m.mailAccounts = msg.accounts
 		m.mailAccountUnavailable = msg.selectedUnavailable
@@ -1113,10 +1107,11 @@ func Run(rootSDK, sdk *hey.Client, selected string, watchers Watchers, options O
 	m.help.setHidden(config.HelpHidden())
 	m.saveHelpHidden = config.SaveHelpHidden
 	p := tea.NewProgram(m)
-	listener, listenErr := startTopicListener(options.Instance, p.Send)
-	if listenErr == nil {
-		defer closeTopicListener(options.Instance, listener)
+	listener, err := startTopicListener(options.Instance, p.Send)
+	if err != nil {
+		return err
 	}
-	_, err := p.Run()
+	defer closeTopicListener(listener)
+	_, err = p.Run()
 	return err
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1037,11 +1037,16 @@ func (m model) openTopic(request TopicRequest) (tea.Model, tea.Cmd) {
 	if request.TopicID <= 0 {
 		return m, nil
 	}
+	capturingInput := false
+	if m.activeView != m.screenerView {
+		capturer, ok := m.activeView.(inputCapturer)
+		capturingInput = ok && capturer.CapturingInput()
+	}
+	if m.hasPendingMutation() || capturingInput {
+		m.pendingTopic = nil
+		return m, notify("Finish the current action before opening another thread")
+	}
 	if request.AccountID > 0 && m.mailAccount.id != request.AccountID {
-		if m.hasPendingMutation() || m.mailView.CapturingInput() {
-			m.pendingTopic = nil
-			return m, notify("Finish the current mail action before opening another account")
-		}
 		m.pendingTopic = &request
 		if !m.mailAccountsLoaded {
 			return m, nil

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -17,6 +17,7 @@ import (
 
 	attachmentfiles "github.com/basecamp/hey-cli/internal/attachments"
 	"github.com/basecamp/hey-cli/internal/config"
+	"github.com/basecamp/hey-cli/internal/terminal"
 )
 
 // --- Shared messages ---
@@ -27,6 +28,20 @@ func (e errMsg) Error() string { return e.err.Error() }
 
 type ctrlCResetMsg struct{}
 type spinnerTickMsg struct{}
+
+// TopicRequest identifies a thread to open in the TUI. AccountID selects a
+// linked account when the request comes from another process.
+type TopicRequest struct {
+	TopicID   int64  `json:"topic_id"`
+	AccountID int64  `json:"account_id,omitempty"`
+	Title     string `json:"title,omitempty"`
+}
+
+// Options configures the TUI's initial destination.
+type Options struct {
+	OpenTopic TopicRequest
+	Instance  string
+}
 
 // --- Model ---
 
@@ -78,6 +93,8 @@ type model struct {
 
 	// Linked mail accounts
 	mailAccounts            []mailAccountChoice
+	mailAccountsLoaded      bool
+	mailSourcesLoaded       bool
 	mailAccount             mailAccountChoice
 	mailAccountCursor       int
 	mailAccountPicker       bool
@@ -98,6 +115,7 @@ type model struct {
 	spinnerPhase float64
 	err          error
 	ctrlCOnce    bool
+	pendingTopic *TopicRequest
 }
 
 func newModel() model {
@@ -209,6 +227,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case notifyMsg:
 		return m, m.showToast(msg)
 
+	case TopicRequest:
+		return m.openTopic(msg)
+
 	case toastExpiredMsg:
 		if msg.id == m.toastID {
 			m.toast = notifyMsg{}
@@ -216,9 +237,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case mailAccountsLoadedMsg:
+		m.mailAccountsLoaded = true
 		if msg.err != nil {
 			m.mailAccountDiscoveryErr = errorNotice("Could not load the mail accounts", msg.err)
 			m.updateHelpBindings()
+			if m.pendingTopic != nil {
+				request := *m.pendingTopic
+				request.AccountID = 0
+				m.pendingTopic = nil
+				return m.openTopic(request)
+			}
 			return m, nil
 		}
 		m.mailAccountDiscoveryErr = ""
@@ -233,6 +261,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.mailAccountCursor = msg.selected
 		}
 		m.updateHelpBindings()
+		if m.pendingTopic != nil {
+			request := *m.pendingTopic
+			return m.openTopic(request)
+		}
 		return m, nil
 
 	case mailAccountSwitchedMsg:
@@ -242,10 +274,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.mailAccountSwitching = false
 		if msg.err != nil {
 			m.mailAccountErr = errorNotice("Could not switch account", msg.err)
+			m.pendingTopic = nil
 			m.updateHelpBindings()
 			return m, nil
 		}
-		return m.applyMailAccount(msg.account, msg.client)
+		updated, initCmd := m.applyMailAccount(msg.account, msg.client)
+		next, ok := updated.(model)
+		if !ok {
+			return m, initCmd
+		}
+		m = next
+		if m.pendingTopic == nil {
+			return m, initCmd
+		}
+		request := *m.pendingTopic
+		m.pendingTopic = nil
+		opened, topicCmd := m.openTopic(request)
+		return opened, tea.Batch(initCmd, topicCmd)
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -387,13 +432,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// HEY serves The Screener's stream name with its count, and the sources read asks
 		// for both, so this is where the watch is opened first.
 		watch := m.startScreenerWatch(msg.screenerStream)
+		var cmd tea.Cmd
 		if m.activeView != m.mailView {
-			cmd, _ := m.mailView.Update(msg)
-			return m, tea.Batch(m.stampViewCmd(cmd), watch)
+			cmd, _ = m.mailView.Update(msg)
+			cmd = m.stampViewCmd(cmd)
+		} else {
+			cmd, _ = m.activeView.Update(msg)
+			cmd = m.syncLoading(cmd)
+			m.updateHelpBindings()
 		}
-		cmd, _ := m.activeView.Update(msg)
-		cmd = m.syncLoading(cmd)
-		m.updateHelpBindings()
+		m.mailSourcesLoaded = true
+		if m.pendingTopic != nil {
+			request := *m.pendingTopic
+			opened, topicCmd := m.openTopic(request)
+			return opened, tea.Batch(cmd, watch, topicCmd)
+		}
 		return m, tea.Batch(cmd, watch)
 
 	case screenerCountLoadedMsg:
@@ -512,6 +565,7 @@ func (m model) applyMailAccount(account mailAccountChoice, client *hey.Client) (
 		m.activeView = m.journalView
 	}
 	m.mailAccount = account
+	m.mailSourcesLoaded = false
 	m.mailAccountPicker = false
 	m.mailAccountUnavailable = false
 	m.mailAccountErr = ""
@@ -982,6 +1036,46 @@ func (m model) switchSection(sec section) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m model) openTopic(request TopicRequest) (tea.Model, tea.Cmd) {
+	if request.TopicID <= 0 {
+		return m, nil
+	}
+	if request.AccountID > 0 && m.mailAccount.id != request.AccountID {
+		if m.hasPendingMutation() || m.mailView.CapturingInput() {
+			m.pendingTopic = nil
+			return m, notify("Finish the current mail action before opening another account")
+		}
+		m.pendingTopic = &request
+		if !m.mailAccountsLoaded {
+			return m, nil
+		}
+		for _, account := range m.mailAccounts {
+			if account.id != request.AccountID {
+				continue
+			}
+			m.mailAccountRequestID++
+			m.mailAccountSwitching = true
+			return m, switchMailAccount(m.vc.ctx, m.rootSDK, account, m.mailAccountRequestID)
+		}
+		m.pendingTopic = nil
+		m.mailAccountErr = fmt.Sprintf("Mail account %d is not available", request.AccountID)
+		m.updateHelpBindings()
+		return m, nil
+	}
+	if !m.mailSourcesLoaded {
+		m.pendingTopic = &request
+		return m, nil
+	}
+	m.pendingTopic = nil
+	m.section = sectionMail
+	m.focus = rowContent
+	m.activeView = m.mailView
+	m.activeView.Resize(m.vc.width, m.vc.height)
+	m.updateHelpBindings()
+	title := terminal.SanitizeLine(request.Title)
+	return m, m.syncLoading(m.mailView.requestTopic(0, request.TopicID, 0, title))
+}
+
 func (m model) handleSectionKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.Key().Code {
 	case tea.KeyLeft:
@@ -1009,12 +1103,20 @@ func (m model) handleSubnavKey(msg tea.KeyPressMsg) tea.Cmd {
 // --- Shared utilities ---
 
 // Run starts the TUI with the resolved mail account, the identity root client used for
-// interactive account switching, and the watchers that tell it when things changed.
-func Run(rootSDK, sdk *hey.Client, selected string, watchers Watchers) error {
+// interactive account switching, the live watchers, and an optional initial thread.
+func Run(rootSDK, sdk *hey.Client, selected string, watchers Watchers, options Options) error {
 	m := newModelWithMailAccounts(rootSDK, sdk, selected, watchers)
+	if options.OpenTopic.TopicID > 0 {
+		request := options.OpenTopic
+		m.pendingTopic = &request
+	}
 	m.help.setHidden(config.HelpHidden())
 	m.saveHelpHidden = config.SaveHelpHidden
 	p := tea.NewProgram(m)
+	listener, listenErr := startTopicListener(options.Instance, p.Send)
+	if listenErr == nil {
+		defer closeTopicListener(options.Instance, listener)
+	}
 	_, err := p.Run()
 	return err
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -115,6 +115,37 @@ func TestInitReturnsCmd(t *testing.T) {
 	}
 }
 
+func TestTopicRequestSwitchesToMailAndStartsTheThreadRead(t *testing.T) {
+	m := sizedModel()
+	m.mailSourcesLoaded = true
+	m.section = sectionCalendar
+	m.activeView = m.calendarView
+
+	updated, cmd := m.Update(TopicRequest{TopicID: 5511})
+	m = updated.(model)
+	if m.section != sectionMail || m.activeView != m.mailView || m.focus != rowContent {
+		t.Fatalf("topic request left the TUI at section=%d focus=%d view=%T", m.section, m.focus, m.activeView)
+	}
+	if cmd == nil {
+		t.Fatal("topic request did not start a thread read")
+	}
+}
+
+func TestTopicRequestWaitsForMailSourcesBeforeReading(t *testing.T) {
+	m := sizedModel()
+	updated, cmd := m.Update(TopicRequest{TopicID: 5511})
+	m = updated.(model)
+	if cmd != nil || m.pendingTopic == nil {
+		t.Fatalf("topic started before mail sources loaded: cmd=%v pending=%v", cmd != nil, m.pendingTopic != nil)
+	}
+
+	updated, cmd = m.Update(mailSourcesLoadedMsg{})
+	m = updated.(model)
+	if cmd == nil || m.pendingTopic != nil {
+		t.Fatalf("topic did not start after mail sources loaded: cmd=%v pending=%v", cmd != nil, m.pendingTopic != nil)
+	}
+}
+
 func TestQuestionMarkTogglesHelpAndResizesContent(t *testing.T) {
 	m := modelWithBoxes()
 	visibleHeight := m.vc.height

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strconv"
 	"strings"
@@ -128,6 +129,29 @@ func TestTopicRequestSwitchesToMailAndStartsTheThreadRead(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("topic request did not start a thread read")
+	}
+}
+
+func TestTopicRequestSanitizesAnUntrustedTitle(t *testing.T) {
+	m := sizedModel()
+	mailView, _ := mailWithTestServer(t, http.StatusOK)
+	m.mailView = mailView
+	m.activeView = mailView
+	m.mailSourcesLoaded = true
+	m.loading = true
+
+	_, cmd := m.Update(TopicRequest{TopicID: 100, Title: "\x1b[31mRed\x1b[0m\nalert"})
+	msg := runCmd(cmd)
+	stamped, ok := msg.(viewGenerationMsg)
+	if !ok {
+		t.Fatalf("topic request returned %T, want viewGenerationMsg", msg)
+	}
+	loaded, ok := stamped.msg.(topicLoadedMsg)
+	if !ok {
+		t.Fatalf("topic request returned %T, want topicLoadedMsg", stamped.msg)
+	}
+	if loaded.title != "Red alert" {
+		t.Fatalf("sanitized title = %q, want %q", loaded.title, "Red alert")
 	}
 }
 


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.98.0
## Summary

- add `hey tui --topic <id>` to launch the TUI directly into an email thread
- add `--remote` so desktop integrations can send a topic to an already-running TUI
- carry the linked account and sanitized display title with the topic request
- wait for mail sources and account switches before reading the thread
- preserve in-progress mail actions instead of discarding them for a cross-account deep link

## Runtime behavior

A running TUI listens on a mode-0600, instance-named Unix socket in an owner-only runtime directory, so an Omarchy-owned window stays separate from manually launched TUIs. When `XDG_RUNTIME_DIR` is unavailable, the socket uses a validated mode-0700 per-user temporary directory. A lifetime lock gives each instance one owner, cleanup removes only the socket that listener created, and invalid or colliding instance names are refused. The socket carries a bounded JSON topic request and is removed when the TUI exits. Windows retains direct `--topic` launches and reports no running TUI for `--remote`.

## Validation

- `GOWORK=off make fmt-check vet lint` — passed
- focused command and TUI tests — passed
- focused socket and hostile-title tests under `go test -race` — passed
- security re-review — no findings after hardening runtime-directory ownership, instance validation, listener locking and cleanup, bounded IPC, title sanitization, and account fail-closed behavior
- manual smoke test — launched the named Omarchy TUI directly into one real HEY thread, then remotely switched that same single window to another thread

`GOWORK=off make test` reaches two existing calendar failures (`TestDayLabelsCoverTodosAndHabits`, `TestWeekDrawsTheHabitsKeptEachDay`) that reproduce unchanged from `main` in a clean detached worktree. The changed command/TUI packages otherwise compile, and all deep-link-focused tests pass.

## Integration

This enables basecamp/omarchy-hey-plugin#6 to open a clicked toast or panel notification directly in the TUI. Grouped toasts continue to open the Imbox because they represent multiple threads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens specific TUI threads from desktop links and adds a secure per‑instance remote‑open path. Protects active work: topic requests no longer interrupt in‑progress mail actions or cross‑section forms; the TUI notifies and keeps the current state.

- CLI: `hey tui --topic <id>` starts on a thread; `--remote` sends to a running TUI and exits (requires `--topic`); `--instance <name>` targets a named TUI; hidden `--topic-title` carries a sanitized title; global `--account` selects the linked account; rejects non‑positive topic IDs; prints “no running HEY TUI” if none is active.
- Runtime (Unix): a per‑user, mode‑0600 Unix socket in `$XDG_RUNTIME_DIR/hey-cli` (or a private, 0700, per‑user temp fallback) accepts bounded JSON topic requests with short deadlines; instance names are validated (<=32 chars, [A‑Za‑z0‑9_-]); a lock ensures one listener per instance; cleanup removes only the socket it created and does not clobber a replacement path. Windows and non‑Unix report no running TUI for remote requests but still support direct `--topic` launches.
- TUI: topic requests can carry a linked account; the TUI switches accounts and waits for mail sources before reading; it ignores the current box for direct topics; missing titles are derived from the first entry and supplied titles are sanitized; pending deep links persist through account discovery failures and clear only after a failed switch; if an action or form is active, the TUI explains why and defers the open instead of discarding work.

<sup>Written for commit d7e5321a8e30cdfc698cd298dbc3ebd84b6ba7d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

