### PR TITLE
Keep emoji aligned in day-view events

### DIFF
--- a/internal/tui/calendar_test.go
+++ b/internal/tui/calendar_test.go
@@ -1774,6 +1774,25 @@ func TestDayViewGivesASingleEventTheWholeGrid(t *testing.T) {
 	}
 }
 
+func TestDayViewKeepsEmojiTitlesAligned(t *testing.T) {
+	placed := placedEvent{
+		rec:      Recording{ID: 1, Title: "Soul Cycle 🚴‍♀️", CalendarColor: "green"},
+		startCol: 8, endCol: 20,
+	}
+
+	for _, sel := range []selection{{}, {eventKey: placed.rec.key()}} {
+		grid := stripANSI(renderDayGrid([][]placedEvent{{placed}}, 40, 4, 18, -1, styleMuted, sel))
+		if !strings.Contains(grid, "🚴‍♀️") {
+			t.Errorf("the joined emoji was split across rows:\n%s", grid)
+		}
+		for row, line := range strings.Split(strings.TrimSuffix(grid, "\n"), "\n") {
+			if width := lipgloss.Width(line); width != 40 {
+				t.Errorf("grid row %d is %d columns wide, want 40: %q", row, width, line)
+			}
+		}
+	}
+}
+
 // An event is drawn in the color of the calendar it is filed on, so which calendar it
 // belongs to is answered by looking at it. HEY leaves the personal calendar's color out of
 // its JSON, and those fall back to the theme's own accent rather than to no fill.

--- a/internal/tui/calendar_views.go
+++ b/internal/tui/calendar_views.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	habitvalues "github.com/basecamp/hey-cli/internal/habit"
 	"github.com/basecamp/hey-cli/internal/terminal"
@@ -762,13 +763,13 @@ func renderDayGrid(lanes [][]placedEvent, gridWidth, colWidth, rows, nowCol int,
 	// carrying, for the last two, the color of the calendar the event is filed on.
 	// They are styled separately so an event's name stands out of its border the way a
 	// subject stands out of the mail list's rules.
-	grid := make([][]rune, height)
+	grid := make([][]string, height)
 	cells := make([][]dayCell, height)
 	for row := range height {
-		grid[row] = make([]rune, gridWidth)
+		grid[row] = make([]string, gridWidth)
 		cells[row] = make([]dayCell, gridWidth)
 		for col := range gridWidth {
-			grid[row][col] = ' '
+			grid[row][col] = " "
 		}
 	}
 
@@ -783,7 +784,7 @@ func renderDayGrid(lanes [][]placedEvent, gridWidth, colWidth, rows, nowCol int,
 	for row := range height {
 		for col := 0; col < gridWidth; col += colWidth {
 			if cells[row][col].kind == cellEmpty {
-				grid[row][col] = hourRule
+				grid[row][col] = string(hourRule)
 				cells[row][col] = dayCell{kind: cellRule}
 			}
 		}
@@ -800,7 +801,7 @@ func renderDayGrid(lanes [][]placedEvent, gridWidth, colWidth, rows, nowCol int,
 			if cells[row][nowCol].kind == cellTitle {
 				continue
 			}
-			grid[row][nowCol] = nowRule
+			grid[row][nowCol] = string(nowRule)
 			cells[row][nowCol].now = true
 		}
 	}
@@ -823,7 +824,7 @@ func renderDayGrid(lanes [][]placedEvent, gridWidth, colWidth, rows, nowCol int,
 				flush()
 				cell = cells[row][col]
 			}
-			seg.WriteRune(grid[row][col])
+			seg.WriteString(grid[row][col])
 		}
 		flush()
 		b.WriteString("\n")
@@ -888,7 +889,7 @@ func titleColumn(startCol, endCol, nowCol int) int {
 	return at - 1
 }
 
-func drawDayLane(grid [][]rune, cells [][]dayCell, lane []placedEvent, rowOffset, rows, nowCol int, sel selection) {
+func drawDayLane(grid [][]string, cells [][]dayCell, lane []placedEvent, rowOffset, rows, nowCol int, sel selection) {
 	top := rowOffset
 	bottom := rowOffset + rows - 1
 
@@ -917,7 +918,7 @@ func drawDayLane(grid [][]rune, cells [][]dayCell, lane []placedEvent, rowOffset
 		// in the color left the box reading as an outline around empty grid.
 		for row := top; row <= bottom; row++ {
 			for col := sc; col < ec; col++ {
-				grid[row][col] = ' '
+				grid[row][col] = " "
 				cells[row][col] = at(fill, row, col)
 			}
 		}
@@ -928,7 +929,7 @@ func drawDayLane(grid [][]rune, cells [][]dayCell, lane []placedEvent, rowOffset
 		// came out as a single bar from three to seven.
 		if sc == previousEnd && sc < ec {
 			for row := top; row <= bottom; row++ {
-				grid[row][sc] = eventEdge
+				grid[row][sc] = string(eventEdge)
 				cells[row][sc] = at(edged, row, sc)
 			}
 		}
@@ -937,20 +938,55 @@ func drawDayLane(grid [][]rune, cells [][]dayCell, lane []placedEvent, rowOffset
 		// The title reads downwards, centred in the block: a name at the top of a
 		// full-height column reads as an event that starts there and stops. It is
 		// clipped rather than shrinking the block, since the block is the span.
-		titleRunes := []rune(terminal.SanitizeLine(pe.rec.Title))
+		// Each user-perceived character gets one row, keeping emoji sequences together.
+		titleGlyphs := verticalTitleGlyphs(terminal.SanitizeLine(pe.rec.Title))
 		rows := bottom - top + 1
-		titleRow := top + max((rows-len(titleRunes))/2, 0)
+		titleRow := top + max((rows-len(titleGlyphs))/2, 0)
 		titleCol := titleColumn(sc, ec, nowCol)
 
-		for i, r := range titleRunes {
+		for i, glyph := range titleGlyphs {
 			row := titleRow + i
 			if row > bottom {
 				break
 			}
-			grid[row][titleCol] = r
-			cells[row][titleCol] = at(titled, row, titleCol)
+
+			text, width := glyph.text, glyph.width
+			if width > ec-sc {
+				text, width = "…", 1
+			}
+			col := min(max(titleCol, sc), ec-width)
+			grid[row][col] = text
+			for occupied := col; occupied < col+width; occupied++ {
+				cells[row][occupied] = at(titled, row, occupied)
+				if occupied > col {
+					grid[row][occupied] = ""
+				}
+			}
 		}
 	}
+}
+
+type titleGlyph struct {
+	text  string
+	width int
+}
+
+// verticalTitleGlyphs returns the visible characters that make up a vertical event title.
+// A joined emoji or a base letter with combining marks stays together on one row, along with
+// the number of terminal cells it occupies.
+func verticalTitleGlyphs(title string) []titleGlyph {
+	glyphs := make([]titleGlyph, 0, len(title))
+	for title != "" {
+		text, width := ansi.FirstGraphemeCluster(title, ansi.GraphemeWidth)
+		if text == "" {
+			break
+		}
+		title = title[len(text):]
+		if width > 0 {
+			glyphs = append(glyphs, titleGlyph{text: text, width: width})
+		}
+	}
+	return glyphs
 }
 
 // =============================================


### PR DESCRIPTION
## Summary

- keep joined emoji and combining characters together in vertical day-view titles
- reserve each grapheme’s terminal-cell width inside the existing event block
- cover selected and unselected emoji titles with an alignment regression test

## Testing

- `TZ=Etc/UTC GOWORK=off go test ./...`
- `GOWORK=off make build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns emoji and combining characters in day-view vertical event titles. Previously joined emoji could split across rows and misalign the grid; now we render grapheme clusters and reserve each cluster’s terminal-cell width inside the existing block.

**Notes for review**
- Change day grid from runes to strings to place multi-cell glyphs while preserving cell styling.
- Add `verticalTitleGlyphs` using `github.com/charmbracelet/x/ansi` to group grapheme clusters and measure width; clamp placement and ellipsize clusters that exceed the block.
- Keep hour/now rules and event edges visually unchanged; only title placement logic changed.
- Add a regression test ensuring joined emoji remain intact and each grid row keeps its configured width in selected and unselected states.

<sup>Written for commit 6cdd46f56ed5b1d7c6638c8132ebe20d3243e558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

