### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hey",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "HEY integration for Claude Code. Read email, manage todos, track time.",
   "author": {
     "name": "37signals",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
   pname = "hey";
   # Bumped by `make update-nix-hash VERSION=vX.Y.Z` before each stable
   # release; scripts/release.sh refuses to tag until it matches.
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = lib.cleanSource ./..;
 


### PR DESCRIPTION
## Summary

- stamp the Nix package version as 0.2.1
- stamp the Claude plugin version as 0.2.1
- prepare protected `main` for the `v0.2.1` release tag

## Validation

- `TZ=Etc/UTC GOWORK=off make release VERSION=0.2.1 DRY_RUN=1`
- Nix build verified by `scripts/update-nix-flake.sh 0.2.1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares v0.2.1 by bumping `hey` version metadata in the Nix package and Claude plugin from 0.2.0 to 0.2.1. No behavior changes; this enables tagging and distribution.

- Verify versions are 0.2.1 in `.claude-plugin/plugin.json` and `nix/package.nix`. To stage the release: `TZ=Etc/UTC GOWORK=off make release VERSION=0.2.1 DRY_RUN=1`; verify Nix build with `scripts/update-nix-flake.sh 0.2.1`.

<sup>Written for commit 028838a546e038142888939a58b5383d1de52c78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

