### PR TITLE
Run gosec during release preflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 .PHONY: build test test-unit test-e2e test-smoke preview-callback coverage fmt fmt-check vet lint tidy tidy-check \
-	race-test vuln secrets replace-check check-toolchain check security \
+	race-test vuln gosec secrets replace-check check-toolchain check security \
 	release-check release test-release bench bench-save bench-compare \
 	check-surface update-surface check-surface-compat check-size check-lint-lockstep \
 	check-release-lockstep update-nix-hash tools clean install help
 
 BINARY := $(CURDIR)/bin/hey
+GOSEC_VERSION := v2.28.0
 COVERAGE_FLOOR ?= 70.8
 COVERAGE_PROFILE ?= coverage.out
 COVERAGE_FUNCTIONS ?= coverage.func.txt
@@ -38,12 +39,13 @@ help:
 	@echo "  make check-lint-lockstep  Verify golangci-lint pins agree across workflows"
 	@echo "  make race-test       Run unit tests with race detector"
 	@echo "  make vuln            Run govulncheck"
+	@echo "  make gosec           Run gosec static security analysis"
 	@echo "  make secrets         Run gitleaks secret scan"
 	@echo "  make replace-check   Guard against replace directives in go.mod"
 	@echo ""
 	@echo "  make check           fmt-check + vet + lint + test-unit + tidy-check"
-	@echo "  make security        lint + vuln + secrets"
-	@echo "  make release-check   check + replace-check + vuln + race-test"
+	@echo "  make security        lint + vuln + gosec + secrets"
+	@echo "  make release-check   check + replace-check + vuln + gosec + race-test"
 	@echo "  make release         Run release preflight and tag (VERSION=v1.2.3 [DRY_RUN=1])"
 	@echo "  make test-release    Dry-run the goreleaser pipeline (snapshot, no publish/sign)"
 	@echo ""
@@ -142,6 +144,10 @@ race-test: check-toolchain
 vuln:
 	govulncheck ./...
 
+# Run the same pinned gosec version as the security workflow.
+gosec:
+	GOWORK=off go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) ./...
+
 # Run gitleaks secret scan. The scan is part of the security gate, so a missing
 # binary or config fails it rather than passing it by skipping.
 secrets:
@@ -214,10 +220,10 @@ update-nix-hash:
 	if [ $$RC -ne 0 ] && [ $$RC -ne 2 ]; then exit $$RC; fi
 
 # Security suite
-security: lint vuln secrets
+security: lint vuln gosec secrets
 
 # Release preflight
-release-check: check replace-check vuln race-test check-surface-compat check-size
+release-check: check replace-check vuln gosec race-test check-surface-compat check-size
 
 # Release (delegates to script)
 release:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,7 +26,7 @@ make release VERSION=0.2.0 DRY_RUN=1
 
 1. Validates the version, that you are on the default branch with a clean tree
    synced to origin, and that `go.mod` has no `replace` directives
-2. Runs `make release-check`
+2. Runs `make release-check`, including the same pinned gosec version used by the release workflow
 3. For **stable** versions only: runs `scripts/update-nix-flake.sh` (verifies the
    Nix build via Docker and recomputes `vendorHash` if needed) and
    `scripts/stamp-plugin-version.sh`, commits `nix/package.nix` and
@@ -227,9 +227,12 @@ and dispatch; no new release needed.
 ## Local dry runs
 
 ```bash
-make release VERSION=0.2.0 DRY_RUN=1   # preflight only
+make release VERSION=0.2.0 DRY_RUN=1   # preflight, including govulncheck and gosec
 make test-release                      # goreleaser snapshot, no publish/sign
 ```
+
+The dry-run preflight runs the same gosec version as `.github/workflows/security.yml`;
+`make check-release-lockstep` fails if those pins drift.
 
 `make test-release` needs `syft` on PATH for the SBOM step (`mise use syft`); it
 blanks the signing env so notarization is skipped, and the stable metadata

--- a/internal/tui/topic_remote_unix.go
+++ b/internal/tui/topic_remote_unix.go
@@ -91,7 +91,7 @@ func topicRuntimeDir() (string, error) {
 }
 
 func ensurePrivateDirectory(path string) (string, error) {
-	if err := os.Mkdir(path, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+	if err := os.Mkdir(path, 0o700); err != nil && !errors.Is(err, os.ErrExist) { // #nosec G703 -- path is a fixed child of an absolute, validated private runtime directory
 		return "", fmt.Errorf("create HEY TUI runtime directory: %w", err)
 	}
 	if err := validatePrivateDirectory(path); err != nil {
@@ -101,7 +101,7 @@ func ensurePrivateDirectory(path string) (string, error) {
 }
 
 func validatePrivateDirectory(path string) error {
-	info, err := os.Lstat(path)
+	info, err := os.Lstat(path) // #nosec G703 -- inspecting the absolute runtime path is the validation gate before any socket use
 	if err != nil {
 		return err
 	}

--- a/scripts/check-release-lockstep.sh
+++ b/scripts/check-release-lockstep.sh
@@ -9,7 +9,9 @@
 #      that will cut the tag.
 #   2. .pre-commit-config.yaml's golangci-lint rev == the CI pin, so a commit
 #      hook and CI cannot disagree on a finding.
-#   3. Every scripts/*.sh named in docs, workflows, the Makefile, goreleaser
+#   3. The Makefile's gosec version == the securego/gosec action version in
+#      security.yml, so the local release preflight runs the release scanner.
+#   4. Every scripts/*.sh named in docs, workflows, the Makefile, goreleaser
 #      config, other scripts or tests exists, and every scripts/*.sh is named
 #      somewhere other than in itself — a renamed or orphaned script fails here
 #      rather than at the moment a release step or a README command reaches
@@ -80,7 +82,20 @@ if [ -f .pre-commit-config.yaml ]; then
   fi
 fi
 
-# --- 3. scripts/*.sh referenced <-> existing ---
+# --- 3. gosec: Makefile vs security.yml ---
+MAKE_GOSEC=$(sed -nE 's/^GOSEC_VERSION[[:space:]]*:?=[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/p' Makefile 2>/dev/null | head -1)
+CI_GOSEC=$(sed -nE 's|.*uses:[[:space:]]*securego/gosec@.*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+).*|\1|p' .github/workflows/security.yml 2>/dev/null | head -1)
+if [ -z "$MAKE_GOSEC" ]; then
+  fail "no GOSEC_VERSION pin in Makefile"
+elif [ -z "$CI_GOSEC" ]; then
+  fail "no securego/gosec version pin in .github/workflows/security.yml"
+elif [ "$MAKE_GOSEC" != "$CI_GOSEC" ]; then
+  fail "gosec pins disagree: Makefile has ${MAKE_GOSEC}, security.yml has ${CI_GOSEC}"
+else
+  echo "gosec pin in lockstep (${CI_GOSEC})"
+fi
+
+# --- 4. scripts/*.sh referenced <-> existing ---
 shopt -s nullglob
 existing=()
 for f in scripts/*.sh; do existing+=("$(basename "$f")"); done

--- a/tests/e2e/check_release_lockstep.bats
+++ b/tests/e2e/check_release_lockstep.bats
@@ -11,6 +11,7 @@ setup() {
   cd "$WORK"
 
   printf '[tools]\ngo = "1.26.6"\ngoreleaser = "2.15.4"\n' > .mise.toml
+  printf 'GOSEC_VERSION := v2.28.0\n' > Makefile
   cat > .pre-commit-config.yaml <<'YAML'
 repos:
   - repo: https://github.com/golangci/golangci-lint
@@ -26,6 +27,12 @@ jobs:
         with:
           version: v2.11.1
       - run: scripts/check-release-lockstep.sh
+YAML
+  cat > .github/workflows/security.yml <<'YAML'
+jobs:
+  gosec:
+    steps:
+      - uses: securego/gosec@abc # v2.28.0
 YAML
   cat > .github/workflows/release.yml <<'YAML'
 jobs:
@@ -57,6 +64,7 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"goreleaser pin in lockstep (v2.15.4)"* ]]
   [[ "$output" == *"pre-commit golangci-lint rev in lockstep (v2.11.1)"* ]]
+  [[ "$output" == *"gosec pin in lockstep (v2.28.0)"* ]]
   [[ "$output" == *"release lockstep check passed"* ]]
 }
 
@@ -82,6 +90,15 @@ teardown() {
   run scripts/check-release-lockstep.sh
   [ "$status" -eq 1 ]
   [[ "$output" == *"golangci-lint pins disagree across workflows"* ]]
+}
+
+@test "fails when the local and workflow gosec versions drift" {
+  sed -i.bak 's/GOSEC_VERSION := v2.28.0/GOSEC_VERSION := v2.27.0/' Makefile && rm -f Makefile.bak
+  run scripts/check-release-lockstep.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"gosec pins disagree"* ]]
+  [[ "$output" == *"v2.27.0"* ]]
+  [[ "$output" == *"v2.28.0"* ]]
 }
 
 @test "fails when a workflow names a script that does not exist" {


### PR DESCRIPTION
## Summary
- document the validated runtime-directory paths at the two gosec G703 call sites
- run pinned gosec v2.28.0 from `make release-check` and `make security`
- enforce lockstep between the local gosec pin and the security workflow
- document that release dry runs include gosec

## Context
The v0.2.1 tag workflow failed only in Go security analysis because gosec could not follow the runtime-directory validation into `os.Mkdir` and `os.Lstat`. The GitHub release and assets were not published. The pushed v0.2.1 tag will not be moved or reused; after this lands and the main security workflow passes, the release will continue as v0.2.2.

## Validation
- exact pinned `securego/gosec` action container: 0 findings
- `GOWORK=off make gosec`: 0 findings
- `bats tests/e2e/check_release_lockstep.bats`: 15 passing
- `make check-release-lockstep`
- targeted topic-remote TUI tests
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `gosec` during release preflight and local security, pinned to v2.28.0, and annotate validated runtime-dir paths to resolve false `G703` without changing behavior.

- Old: `make security` and `make release-check` did not run `gosec`. New: both include `gosec`; dry runs and releases now fail on `gosec` findings.
- Enforces lockstep between `GOSEC_VERSION` in `Makefile` and the `securego/gosec` pin in `.github/workflows/security.yml`; `scripts/check-release-lockstep.sh` and new e2e tests fail on drift.
- Adds `#nosec G703` at `os.Mkdir` and `os.Lstat` in `internal/tui/topic_remote_unix.go` with justification; no runtime behavior change.
- Updates `RELEASING.md` to document that preflight includes the pinned `gosec`.

<sup>Written for commit 7edf6f67f8b2b62bf4da0e8bef25ec14b0caacb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

