### PR TITLE
Update release metadata for v0.2.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hey",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "HEY integration for Claude Code. Read email, manage todos, track time.",
   "author": {
     "name": "37signals",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
   pname = "hey";
   # Bumped by `make update-nix-hash VERSION=vX.Y.Z` before each stable
   # release; scripts/release.sh refuses to tag until it matches.
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = lib.cleanSource ./..;
 


### PR DESCRIPTION
## Summary
- stamp the Claude plugin version as 0.2.2
- stamp the Nix package version as 0.2.2
- verify the unchanged Nix vendor hash with a successful Docker build

## Context
v0.2.1 was tagged but not published after its security scan failed. That public tag will not be moved or reused. This prepares the next patch release, v0.2.2, after #292 fixed the findings and added pinned gosec to the release dry-run preflight.

## Validation
- `TZ=Etc/UTC GOWORK=off make release VERSION=0.2.2 DRY_RUN=1`
- `scripts/update-nix-flake.sh 0.2.2` (Nix build succeeded)
- post-merge `main` security workflow for #292 passed, including Go security analysis


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps release metadata from 0.2.1 to 0.2.2 for the Claude plugin and Nix package to prepare the next patch release after v0.2.1 failed a security scan and was not published. No behavior changes; only version strings change.

- Validation: dry-run release for 0.2.2, Nix build succeeded with unchanged vendor hash, and `main` security workflow (including Go analysis) passed after #292.
- Review scope: confirm version stamps in `.claude-plugin/plugin.json` and `nix/package.nix` only.
- Rollout: no migration required.

<sup>Written for commit ff293392e0d2a58ee2fcc108f9869d9b2d5d5082. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

