### PR TITLE
Move Nix verification before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,49 @@ jobs:
       - name: Check CLI surface compatibility
         run: scripts/check-surface-compat.sh
 
+  # Pull-request CI catches flake and vendorHash drift where source and
+  # dependencies change. This final build covers the exact stable tag —
+  # including release.sh's version-only metadata commit — before GoReleaser
+  # publishes anything. Prereleases deliberately retain the latest stable Nix
+  # metadata, so their gate is an explicit no-op.
+  nix-verify:
+    name: Verify Nix flake before release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Skip prerelease
+        if: ${{ contains(github.ref_name, '-') }}
+        run: echo "Prerelease — leaving stable Nix metadata unchanged"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ !contains(github.ref_name, '-') }}
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        if: ${{ !contains(github.ref_name, '-') }}
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+
+      # The metadata hooks read the version stamps; this proves the flake's
+      # built artifact agrees with the tag before the release is public.
+      - name: Build and verify
+        if: ${{ !contains(github.ref_name, '-') }}
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          STORE_PATH=$(nix build --no-link --print-out-paths)
+          out=$("$STORE_PATH/bin/hey" --version)
+          echo "$out"
+          [ "$out" = "hey version ${TAG#v}" ] || {
+            echo "::error::Nix flake built ${out#hey version }, expected ${TAG#v}. nix/package.nix was not bumped before tagging."
+            exit 1
+          }
+
   release:
     name: Release
-    needs: [test, security]
+    needs: [test, security, nix-verify]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: release
@@ -428,40 +468,6 @@ jobs:
             echo "::warning::Notarization not yet accepted for ${{ matrix.arch }} (ticket propagation may lag)"
           fi
 
-  # Not continue-on-error: a broken flake is a broken release artifact, so it
-  # must colour the run even though it lands after publication.
-  nix-verify:
-    name: Verify Nix flake
-    needs: [release]
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
-
-      # The version check closes the loop on the pre-publish gates
-      # (release.sh and GoReleaser's check-stable-metadata.sh hook): those read
-      # the metadata, this proves the built artifact — a flake that builds but
-      # still advertises the previous release is broken for
-      # `nix profile install`, and only the tag knows the truth.
-      - name: Build and verify
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          STORE_PATH=$(nix build --no-link --print-out-paths)
-          out=$("$STORE_PATH/bin/hey" --version)
-          echo "$out"
-          [ "$out" = "hey version ${TAG#v}" ] || {
-            echo "::error::Nix flake built ${out#hey version }, expected ${TAG#v}. nix/package.nix was not bumped before tagging."
-            exit 1
-          }
   windows-verify:
     name: Verify Windows signing
     needs: [release]

--- a/.github/workflows/sensitive-change-gate.yml
+++ b/.github/workflows/sensitive-change-gate.yml
@@ -14,6 +14,7 @@ jobs:
         .goreleaser.yaml
         .github/workflows/release.yml
         scripts/release.sh
+        scripts/stamp-nix-version.sh
         scripts/sign-windows.sh
         scripts/install.sh
         scripts/install.ps1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -322,10 +322,11 @@ jobs:
   # Go sources are in the filter too: vendorHash covers the vendored *files*,
   # not go.sum, so a new import from a module already in go.mod changes the
   # hash while leaving go.mod and go.sum alone. The filter exists to skip
-  # docs-only and workflow-only PRs, not Go changes.
+  # docs-only and unrelated workflow-only PRs, not Go changes.
   #
-  # The filter includes this file: a PR that changes only the job would
-  # otherwise skip the job it changed.
+  # The filter includes both workflow files and the release-time version
+  # stamper: a PR that changes how the flake is gated or stamped must not skip
+  # the build it is changing.
   nix-build:
     name: Nix flake builds
     runs-on: ubuntu-latest
@@ -350,8 +351,10 @@ jobs:
               - 'flake.nix'
               - 'flake.lock'
               - 'nix/**'
+              - 'scripts/stamp-nix-version.sh'
               - 'scripts/nix-build-check.sh'
               - 'scripts/extract-nix-vendor-hash.sh'
+              - '.github/workflows/release.yml'
               - '.github/workflows/test.yml'
 
       - name: Install Nix

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,9 +10,8 @@ before:
     # can repair a tag pushed by hand without that commit (both files ship
     # from the tag, not from these archives), so a stable tag whose metadata
     # disagrees with its version fails before anything is published — the
-    # post-publication nix-verify job would otherwise be the first to notice,
-    # after the release is already public. Prereleases and snapshots leave
-    # stable metadata on the latest stable version.
+    # pre-publication nix-verify job would otherwise reject it. Prereleases and
+    # snapshots leave stable metadata on the latest stable version.
     - sh -c '{{ if or .Prerelease .IsSnapshot }}echo "Skipping stable metadata check for {{ .Version }}"{{ else }}scripts/check-stable-metadata.sh {{ .Version }}{{ end }}'
     # Authenticode-sign a copy of the PowerShell installer inside the pipeline
     # so it lands in checksums.txt (cosign-signed, provenance-attested) and on

--- a/Makefile
+++ b/Makefile
@@ -208,11 +208,11 @@ check-release-lockstep:
 	@scripts/check-release-lockstep.sh
 
 # Recompute Nix vendorHash via Docker and update nix/package.nix. Pass
-# VERSION=vX.Y.Z to also bump the package version (scripts/release.sh refuses
-# to tag a stable release until it matches); without it the stored version is
-# kept. 0 = updated, 2 = nothing to do. Anything else is a real failure and
-# must propagate: a blanket `|| true` here would silently undo the script's
-# own fail-closed check.
+# VERSION=vX.Y.Z to also bump the package version; without it the stored
+# version is kept. Releases stamp the version without Docker, then the tag
+# workflow builds the exact flake before publication. 0 = updated, 2 = nothing
+# to do. Anything else is a real failure and must propagate: a blanket
+# `|| true` here would silently undo the script's own fail-closed check.
 update-nix-hash:
 	@V="$(VERSION)"; \
 	if [ "$$V" = dev ]; then V=$$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' nix/package.nix | head -1); fi; \

--- a/scripts/check-stable-metadata.sh
+++ b/scripts/check-stable-metadata.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 # Usage: scripts/check-stable-metadata.sh VERSION
 #
-# Verifies that both pieces of stable release metadata already carry VERSION:
-# .claude-plugin/plugin.json (via stamp-plugin-version.sh --check) and
-# nix/package.nix. release.sh commits both stamps to main before tagging a
-# stable release; GoReleaser runs this check before building, so a stable tag
-# pushed by hand without that commit fails before anything is published.
-# Post-publication, release.yml's nix-verify still builds the flake and asserts
-# the binary's version — this check reads the metadata, that one proves the
+# Verifies that both pieces of stable release metadata already carry VERSION.
+# release.sh commits both stamps to main before tagging a stable release;
+# GoReleaser runs this check before building, so a stable tag pushed by hand
+# without that commit fails before anything is published. release.yml's
+# pre-publication nix-verify job also builds the exact tag and asserts the
+# binary's version — this check reads the metadata, that one proves the
 # artifact.
 
 set -euo pipefail
@@ -15,14 +14,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 VERSION="${1:?Usage: check-stable-metadata.sh VERSION}"
-NIX_PKG="nix/package.nix"
 
 "$SCRIPT_DIR/stamp-plugin-version.sh" --check "$VERSION"
-
-NIX_VERSION=$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' "$NIX_PKG" | head -1)
-if [[ "$NIX_VERSION" != "$VERSION" ]]; then
-  echo "Error: ${NIX_PKG} is at version ${NIX_VERSION}, expected ${VERSION}." >&2
-  echo "  Stable tags must be cut with scripts/release.sh, which bumps the Nix package before tagging." >&2
-  exit 1
-fi
-echo "${NIX_PKG} is at ${VERSION}"
+"$SCRIPT_DIR/stamp-nix-version.sh" --check "$VERSION"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -69,7 +69,7 @@ if [[ -n "$(git status --porcelain)" ]]; then
 fi
 
 # From here on the tree is known clean, so on failure the stable metadata
-# files can be checked out to undo any half-made edits — a failed nix update
+# files can be checked out to undo any half-made edits — a failed Nix version
 # or plugin stamp must not leave a dirty tree that blocks the next attempt.
 # Checkout from HEAD, not the index: a failed release commit (hook, signing)
 # leaves the files staged, and a plain `git checkout --` would restore the
@@ -171,19 +171,11 @@ if [[ "$PRERELEASE" -eq 1 ]]; then
   echo "  nix flake: unchanged"
   echo "  Claude plugin metadata: unchanged"
 else
-  info "Updating Nix flake"
+  info "Stamping Nix version"
   if [[ "$DRY_RUN" -eq 1 ]]; then
     echo "  (skipped — dry run)"
   else
-    NIX_RC=0
-    scripts/update-nix-flake.sh "$VERSION" || NIX_RC=$?
-    if [[ "$NIX_RC" -eq 0 ]]; then
-      : # nix flake updated
-    elif [[ "$NIX_RC" -eq 2 ]]; then
-      echo "  nix flake: no changes needed"
-    else
-      die "scripts/update-nix-flake.sh failed (exit $NIX_RC)"
-    fi
+    scripts/stamp-nix-version.sh "$VERSION"
   fi
 
   info "Stamping plugin version"

--- a/scripts/stamp-nix-version.sh
+++ b/scripts/stamp-nix-version.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Usage: scripts/stamp-nix-version.sh VERSION
+#        scripts/stamp-nix-version.sh --check VERSION
+#
+# Stamps the CLI release version into nix/package.nix without building the
+# flake. Pull-request CI keeps the flake and vendorHash valid as source and
+# dependencies change; the release workflow builds the exact stable tag before
+# publishing it. With --check this only verifies the committed stamp.
+
+set -euo pipefail
+
+CHECK=0
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK=1
+  shift
+fi
+
+VERSION="${1:?Usage: stamp-nix-version.sh [--check] VERSION}"
+NIX_PKG="nix/package.nix"
+
+CURRENT=$(sed -n 's/^[[:space:]]*version = "\([^"]*\)";[[:space:]]*$/\1/p' "$NIX_PKG" | head -1)
+if [[ -z "$CURRENT" ]]; then
+  echo "Error: ${NIX_PKG} has no version literal." >&2
+  exit 1
+fi
+
+if [[ "$CHECK" -eq 1 ]]; then
+  if [[ "$CURRENT" != "$VERSION" ]]; then
+    echo "Error: ${NIX_PKG} is at version ${CURRENT}, expected ${VERSION}." >&2
+    echo "  Stable tags must be cut with scripts/release.sh, which commits the stamp before tagging." >&2
+    exit 1
+  fi
+  echo "${NIX_PKG} is at ${VERSION}"
+  exit 0
+fi
+
+if [[ "$CURRENT" == "$VERSION" ]]; then
+  exit 0
+fi
+
+# Write through a sibling temporary file so a failed rewrite leaves neither a
+# partial tracked file nor an untracked file that blocks the next release.
+TMP=$(mktemp "${NIX_PKG}.XXXXXX")
+trap 'rm -f "$TMP"' EXIT
+awk -v version="$VERSION" '
+  !updated && /^[[:space:]]*version = "[^"]*";/ {
+    sub(/version = "[^"]*"/, "version = \"" version "\"")
+    updated = 1
+  }
+  { print }
+  END { if (!updated) exit 1 }
+' "$NIX_PKG" > "$TMP"
+mv "$TMP" "$NIX_PKG"

--- a/tests/e2e/check_stable_metadata.bats
+++ b/tests/e2e/check_stable_metadata.bats
@@ -3,8 +3,8 @@
 # stable tag's release metadata (.claude-plugin/plugin.json and
 # nix/package.nix) already carries the release version. GoReleaser runs it
 # before building, so a hand-pushed stable tag without the release prep commit
-# fails before anything is published instead of being caught by nix-verify
-# after the release is public.
+# fails before anything is published. The pre-publication nix-verify job then
+# proves that the exact tagged flake builds with the same version.
 
 setup() {
   CHECK="${BATS_TEST_DIRNAME}/../../scripts/check-stable-metadata.sh"

--- a/tests/e2e/release.bats
+++ b/tests/e2e/release.bats
@@ -6,9 +6,11 @@
 # refused before main is touched, and the prep commit must reach origin before
 # the tag that the release workflow builds from.
 #
-# make and update-nix-flake.sh are stubbed; stamp-plugin-version.sh is the real
-# one. A pre-receive hook on the bare origin records every ref it receives, in
-# order, which is the only way to observe the push sequence after the fact.
+# make is stubbed; both metadata stampers are the real ones. A deliberately
+# failing update-nix-flake.sh stub proves that the release path never invokes
+# the Docker-backed hash updater. A pre-receive hook on the bare origin records
+# every ref it receives, in order, which is the only way to observe the push
+# sequence after the fact.
 
 setup() {
   REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
@@ -32,12 +34,14 @@ HOOK
   git checkout -q -b main
 
   mkdir -p scripts nix .claude-plugin
-  cp "$REPO_ROOT/scripts/release.sh" "$REPO_ROOT/scripts/stamp-plugin-version.sh" scripts/
+  cp "$REPO_ROOT/scripts/release.sh" \
+     "$REPO_ROOT/scripts/stamp-nix-version.sh" \
+     "$REPO_ROOT/scripts/stamp-plugin-version.sh" scripts/
   cat > scripts/update-nix-flake.sh <<'STUB'
 #!/usr/bin/env bash
 echo "update-nix-flake $1" >> "$LOG"
-if grep -q "version = \"$1\"" nix/package.nix; then exit 2; fi
-printf '{\n  version = "%s";\n}\n' "$1" > nix/package.nix
+echo "release invoked the Docker-backed Nix updater" >&2
+exit 99
 STUB
   chmod +x scripts/update-nix-flake.sh
   printf '{\n  version = "0.1.0";\n}\n' > nix/package.nix
@@ -75,11 +79,22 @@ STUB
 }
 
 teardown() {
-  rm -rf "$WORK"
+  # Git authorship tooling may finish writing notes just after a fixture
+  # command returns. Retry rather than turning that unrelated write into a
+  # release-test failure on macOS.
+  for _ in 1 2 3; do
+    rm -rf "$WORK" 2>/dev/null && return 0
+    sleep 0.1
+  done
+  rm -rf "$WORK" 2>/dev/null || true
+  return 0
 }
 
 origin() { git --git-dir="$WORK/origin.git" "$@"; }
 plugin_version() { jq -r .version .claude-plugin/plugin.json; }
+# The fixture records every pushed ref, but authorship tooling may add its own
+# notes refs. Only main and release tags belong to the protocol under test.
+release_pushes() { grep -E '^refs/(heads/main|tags/v)' "$PUSH_LOG" || true; }
 
 @test "stable release commits and pushes the metadata before pushing the tag" {
   run scripts/release.sh 0.2.0
@@ -89,8 +104,9 @@ plugin_version() { jq -r .version .claude-plugin/plugin.json; }
   [ "$(origin rev-parse v0.2.0^{commit})" = "$(origin rev-parse main)" ]
   [ "$(origin show main:.claude-plugin/plugin.json | jq -r .version)" = "0.2.0" ]
   origin show main:nix/package.nix | grep -q 'version = "0.2.0"'
-  [ "$(cat "$PUSH_LOG")" = $'refs/heads/main\nrefs/tags/v0.2.0' ]
+  [ "$(release_pushes)" = $'refs/heads/main\nrefs/tags/v0.2.0' ]
   grep -q '^make release-check$' "$LOG"
+  ! grep -q update-nix-flake "$LOG"
 }
 
 @test "prerelease tags HEAD and leaves the stable metadata alone" {
@@ -100,7 +116,7 @@ plugin_version() { jq -r .version .claude-plugin/plugin.json; }
   [ "$(origin rev-parse main)" = "$BASE" ]
   [ "$(origin rev-parse v0.2.0-rc.1^{commit})" = "$BASE" ]
   [ "$(plugin_version)" = "0.1.0" ]
-  [ "$(cat "$PUSH_LOG")" = "refs/tags/v0.2.0-rc.1" ]
+  [ "$(release_pushes)" = "refs/tags/v0.2.0-rc.1" ]
   ! grep -q update-nix-flake "$LOG"
 }
 
@@ -113,7 +129,7 @@ plugin_version() { jq -r .version .claude-plugin/plugin.json; }
   [ "$(origin rev-parse main)" = "$BASE" ]
   ! origin rev-parse -q --verify refs/tags/v0.2.0 >/dev/null
   [ "$(plugin_version)" = "0.1.0" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
   grep -q '^make release-check$' "$LOG"
   ! grep -q update-nix-flake "$LOG"
 }
@@ -130,7 +146,7 @@ plugin_version() { jq -r .version .claude-plugin/plugin.json; }
   [ "$(origin rev-parse main)" = "$BASE" ]
   [ "$(git rev-parse HEAD)" = "$BASE" ]
   [ "$(plugin_version)" = "0.1.0" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
   [ ! -f "$LOG" ]
 }
 
@@ -144,7 +160,7 @@ plugin_version() { jq -r .version .claude-plugin/plugin.json; }
   [ "$status" -eq 1 ]
   [[ "$output" == *"Tag v0.2.0 already exists at"* ]]
   [ "$(origin rev-parse main)" = "$BASE" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
 }
 
 @test "refuses a stable version older than the latest stable tag" {
@@ -158,7 +174,7 @@ plugin_version() { jq -r .version .claude-plugin/plugin.json; }
 
   [ "$(origin rev-parse main)" = "$BASE" ]
   [ "$(plugin_version)" = "0.1.0" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
   [ ! -f "$LOG" ]
 }
 
@@ -171,28 +187,28 @@ plugin_version() { jq -r .version .claude-plugin/plugin.json; }
   [ "$(origin rev-parse v0.10.0^{commit})" = "$(origin rev-parse main)" ]
 }
 
-@test "a failed nix update restores the metadata and leaves the tree clean" {
-  cat > scripts/update-nix-flake.sh <<'STUB'
+@test "a failed nix version stamp restores the metadata and leaves the tree clean" {
+  cat > scripts/stamp-nix-version.sh <<'STUB'
 #!/usr/bin/env bash
 printf '{\n  version = "%s";\n}\n' "$1" > nix/package.nix
-echo "ERROR: nix build failed, and not because of the vendorHash"
+echo "ERROR: nix version stamp failed"
 exit 1
 STUB
-  git add scripts/update-nix-flake.sh
-  git commit -qm "Break the nix update"
+  git add scripts/stamp-nix-version.sh
+  git commit -qm "Break the nix version stamp"
   git push -q origin main
   : > "$PUSH_LOG"
   BASE=$(git rev-parse HEAD)
 
   run scripts/release.sh 0.2.0
   [ "$status" -eq 1 ]
-  [[ "$output" == *"update-nix-flake.sh failed (exit 1)"* ]]
+  [[ "$output" == *"nix version stamp failed"* ]]
 
   [ -z "$(git status --porcelain)" ]
   grep -q 'version = "0.1.0"' nix/package.nix
   [ "$(git rev-parse HEAD)" = "$BASE" ]
   [ "$(origin rev-parse main)" = "$BASE" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
 }
 
 @test "a failed plugin stamp restores the metadata and leaves the tree clean" {
@@ -210,13 +226,14 @@ STUB
   run scripts/release.sh 0.2.0
   [ "$status" -eq 1 ]
 
-  # The nix update succeeded before the stamp failed; both files come back.
+  # The Nix version stamp succeeded before the plugin stamp failed; both files
+  # come back.
   [ -z "$(git status --porcelain)" ]
   grep -q 'version = "0.1.0"' nix/package.nix
   [ "$(plugin_version)" = "0.1.0" ]
   [ "$(git rev-parse HEAD)" = "$BASE" ]
   [ "$(origin rev-parse main)" = "$BASE" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
 }
 
 @test "prerelease below the latest stable is not a downgrade of any channel" {
@@ -239,7 +256,7 @@ STUB
   [ "$(git rev-parse HEAD)" = "$PREPPED" ]
   [ "$(origin rev-parse main)" = "$PREPPED" ]
   [ "$(origin rev-parse v0.2.0^{commit})" = "$PREPPED" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
 }
 
 @test "refuses a hand-pushed stable tag at an unstamped HEAD before touching main" {
@@ -259,7 +276,7 @@ STUB
   grep -q 'version = "0.1.0"' nix/package.nix
   [ "$(git rev-parse HEAD)" = "$BASE" ]
   [ "$(origin rev-parse main)" = "$BASE" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
 }
 
 @test "an existing tag elsewhere is refused without suggesting a tag move" {
@@ -282,7 +299,7 @@ STUB
   run scripts/release.sh 0.2.0
   [ "$status" -eq 1 ]
   [[ "$output" == *"Not on main"* ]]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
 }
 
 @test "rejects malformed versions" {
@@ -308,7 +325,7 @@ HOOK
   [ "$(plugin_version)" = "0.1.0" ]
   [ "$(git rev-parse HEAD)" = "$BASE" ]
   [ "$(origin rev-parse main)" = "$BASE" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
 
   rm .git/hooks/pre-commit
   run scripts/release.sh 0.2.0
@@ -329,7 +346,7 @@ HOOK
 
   [ "$(origin rev-parse main)" = "$BASE" ]
   [ "$(plugin_version)" = "0.1.0" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
   [ ! -f "$LOG" ]
 }
 
@@ -347,7 +364,7 @@ HOOK
 
   [ "$(origin rev-parse main)" = "$BASE" ]
   [ "$(plugin_version)" = "0.1.0" ]
-  [ ! -s "$PUSH_LOG" ]
+  [ -z "$(release_pushes)" ]
   [ ! -f "$LOG" ]
 }
 
@@ -373,7 +390,7 @@ STUB
 
   [ "$(origin rev-parse main)" = "$BASE" ]
   [ "$(origin rev-parse v0.2.0^{commit})" = "$OTHER" ]
-  [ "$(cat "$PUSH_LOG")" = "refs/tags/v0.2.0" ]
+  [ "$(release_pushes)" = "refs/tags/v0.2.0" ]
 
   # The local clone is left where a re-run (with a new version) can start:
   # no unpushed prep commit, no stray local tag, clean tree.
@@ -400,7 +417,7 @@ STUB
 
   [ "$(origin rev-parse main)" = "$(git -C "$WORK/other" rev-parse HEAD)" ]
   ! origin rev-parse -q --verify refs/tags/v0.2.0 >/dev/null
-  [ "$(cat "$PUSH_LOG")" = "refs/heads/main" ]
+  [ "$(release_pushes)" = "refs/heads/main" ]
   [ -z "$(git status --porcelain)" ]
   [ "$(git rev-parse HEAD)" = "$BASE" ]
   ! git rev-parse -q --verify refs/tags/v0.2.0 >/dev/null

--- a/tests/e2e/release_workflow.bats
+++ b/tests/e2e/release_workflow.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# release_workflow.bats - static contracts for the tag workflow's publication
+# ordering. actionlint validates syntax; these assertions validate intent.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+}
+
+job_body() {
+  local job="$1"
+  awk -v job="$job" '
+    $0 == "  " job ":" { inside = 1 }
+    inside && $0 ~ /^  [a-zA-Z0-9_-]+:$/ && $0 != "  " job ":" { exit }
+    inside { print }
+  ' "$WORKFLOW"
+}
+
+@test "release waits for exact-tag Nix verification" {
+  release=$(job_body release)
+  [[ "$release" == *"needs: [test, security, nix-verify]"* ]]
+
+  nix=$(job_body nix-verify)
+  [[ "$nix" != *"needs: [release]"* ]]
+  [[ "$nix" == *"nix build --no-link --print-out-paths"* ]]
+}
+
+@test "prereleases complete the Nix gate without building stable metadata" {
+  nix=$(job_body nix-verify)
+  [[ "$nix" == *"name: Skip prerelease"* ]]
+  [[ "$nix" == *"if: \${{ contains(github.ref_name, '-') }}"* ]]
+  [[ "$nix" == *"if: \${{ !contains(github.ref_name, '-') }}"* ]]
+}

--- a/tests/e2e/stamp_nix_version.bats
+++ b/tests/e2e/stamp_nix_version.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# stamp_nix_version.bats - scripts/stamp-nix-version.sh updates only the Nix
+# package version. The exact tagged flake is built by the release workflow.
+
+setup() {
+  STAMP="${BATS_TEST_DIRNAME}/../../scripts/stamp-nix-version.sh"
+  WORK="$(mktemp -d)"
+  mkdir -p "$WORK/nix"
+  cat > "$WORK/nix/package.nix" <<'NIX'
+{ lib, buildGoModule }:
+buildGoModule (finalAttrs: {
+  pname = "hey";
+  version = "0.1.0";
+  vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+})
+NIX
+  cd "$WORK"
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+@test "stamps the version and leaves the vendorHash alone" {
+  run "$STAMP" 0.2.0
+  [ "$status" -eq 0 ]
+  grep -q 'version = "0.2.0";' nix/package.nix
+  grep -q 'vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";' nix/package.nix
+}
+
+@test "is idempotent" {
+  "$STAMP" 0.2.0
+  before=$(cat nix/package.nix)
+  "$STAMP" 0.2.0
+  [ "$(cat nix/package.nix)" = "$before" ]
+}
+
+@test "requires a version argument" {
+  run "$STAMP"
+  [ "$status" -ne 0 ]
+  grep -q 'version = "0.1.0";' nix/package.nix
+}
+
+@test "--check passes when the file already carries the version" {
+  run "$STAMP" --check 0.1.0
+  [ "$status" -eq 0 ]
+}
+
+@test "--check fails on a stale version and does not rewrite the file" {
+  run "$STAMP" --check 0.2.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"is at version 0.1.0, expected 0.2.0"* ]]
+  grep -q 'version = "0.1.0";' nix/package.nix
+}
+
+@test "fails without leaving a temporary file when no version literal exists" {
+  printf '{ vendorHash = "sha256-AAA="; }\n' > nix/package.nix
+  run "$STAMP" 0.2.0
+  [ "$status" -eq 1 ]
+  [ "$(ls -A nix)" = "package.nix" ]
+  [ "$(cat nix/package.nix)" = '{ vendorHash = "sha256-AAA="; }' ]
+}


### PR DESCRIPTION
## What changed

- Stamp the Nix package version during local release preparation without invoking Docker or building the flake.
- Run the existing exact-tag Nix build before GoReleaser, in parallel with tests and security.
- Keep prereleases on the latest stable Nix metadata and make their Nix gate an explicit no-op.
- Keep `make update-nix-hash` unchanged for dependency and vendorHash maintenance.
- Add release-script and workflow-ordering contracts.

## Why

The release command should only do the cheap metadata work needed to create the atomic prep commit and tag. PR-time Nix CI catches source and vendorHash drift where it is introduced; the exact tagged flake is still built before anything is published.

## Verification

- `make test-e2e` — 186 tests passed
- `shellcheck scripts/stamp-nix-version.sh scripts/check-stable-metadata.sh scripts/release.sh`
- `actionlint .github/workflows/release.yml .github/workflows/sensitive-change-gate.yml`
- `make check-release-lockstep`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Nix flake verification before publication and stamps the Nix package version during release prep to avoid Docker and pre-release rebuilds. Previously we verified the flake after publishing; now we build the exact tag first and block release if versions disagree.

- Workflow: adds a pre-publication nix-verify job that builds the exact tag and checks hey --version against the tag; release now needs test, security, and nix-verify. Prereleases skip this build and keep the latest stable Nix metadata. PR CI path filters now run the Nix flake build when .github/workflows/release.yml or scripts/stamp-nix-version.sh change.
- Release path: scripts/release.sh uses scripts/stamp-nix-version.sh to commit the Nix version stamp; it no longer calls the Docker-backed updater. scripts/check-stable-metadata.sh now delegates the Nix version check to the stamper.
- Maintenance: make update-nix-hash remains the way to update dependencies and vendorHash; releases only stamp the version. .github/workflows/sensitive-change-gate.yml treats scripts/stamp-nix-version.sh as sensitive.
- Tests: new E2E suites enforce the workflow ordering and the version-stamp behavior without invoking a flake build during release prep, including a static check that release waits on nix-verify and that prereleases skip the build.

<sup>Written for commit d1dedf3943fd6d9047181ccb946b11289e796718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

