### PR TITLE
Reuse Nix store during vendor hash repair

### DIFF
--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -18,6 +18,7 @@ fi
 
 NIX_PKG="nix/package.nix"
 CHANGED=false
+NIX_STORE_VOLUME=""
 
 # The build source below is staged from tracked files only, so an untracked
 # .go file never reaches the verification build — but once committed it does
@@ -45,14 +46,31 @@ fi
 ORIG_PKG="$(mktemp)"
 cp "$NIX_PKG" "$ORIG_PKG"
 # shellcheck disable=SC2329  # invoked via the EXIT trap below
-restore_on_failure() {
+cleanup() {
   local status=$?
+
+  # Each invocation gets its own Docker volume, but the two builds needed for
+  # a stale vendorHash share it. Remove it on every exit so this optimization
+  # cannot become a persistent repo- or user-level cache. A cleanup failure is
+  # a failed run: otherwise the script would silently leave a large Nix store
+  # behind while claiming success.
+  if [[ -n "$NIX_STORE_VOLUME" ]] && \
+     ! docker volume rm "$NIX_STORE_VOLUME" >/dev/null 2>&1; then
+    echo "ERROR: could not remove temporary Nix store volume: $NIX_STORE_VOLUME" >&2
+    status=1
+  fi
+
   if [[ $status -ne 0 && $status -ne 2 ]]; then
     cp "$ORIG_PKG" "$NIX_PKG"
   fi
   rm -f "$ORIG_PKG"
+
+  # Preserve the triggering status across cleanup commands, including the
+  # script's documented exit 2 for an already-current package.
+  trap - EXIT
+  exit "$status"
 }
-trap restore_on_failure EXIT
+trap cleanup EXIT
 
 # --- Update version ---
 CURRENT_VERSION=$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' "$NIX_PKG" | head -1)
@@ -95,6 +113,21 @@ fi
 #   docker pull nixos/nix && docker inspect nixos/nix:latest --format '{{index .RepoDigests 0}}'
 NIX_IMAGE="${NIX_IMAGE:-nixos/nix@sha256:b9c9611c8530fa8049a1215b20638536e1e71dcaf85212e47845112caf3adeea}"
 
+# A Docker volume is much faster than a macOS bind mount for a Nix store.
+# Docker chooses a collision-free name, so separate updater runs remain cold
+# and isolated; cleanup removes it whether the run succeeds or fails. Create
+# it explicitly so a daemon failure cannot be mistaken for a volume that then
+# also fails cleanup.
+if ! NIX_STORE_VOLUME=$(docker volume create \
+  --label com.37signals.hey-cli.temporary=update-nix-flake); then
+  echo "ERROR: could not create a temporary Nix store volume"
+  exit 1
+fi
+if [[ -z "$NIX_STORE_VOLUME" ]]; then
+  echo "ERROR: Docker returned no name for the temporary Nix store volume"
+  exit 1
+fi
+
 # Runs `nix build` and echoes a trailing NIX_BUILD_EXIT= line so the real exit
 # status survives command substitution. Nothing here may swallow a failure: a
 # `|| true` plus a "did it print 'building hey'" heuristic is what let
@@ -122,7 +155,10 @@ run_nix_build() {
     echo "ERROR: staging tracked files for the build failed" >&2
     return 1
   fi
-  out=$(docker run --rm -v "$stage:/src:ro" "$NIX_IMAGE" bash -c '
+  out=$(docker run --rm \
+    -v "$stage:/src:ro" \
+    -v "$NIX_STORE_VOLUME:/nix" \
+    "$NIX_IMAGE" bash -c '
     cp -a /src /build && cd /build
     git config --global --add safe.directory /build
     git init -q && git add -A && \

--- a/tests/e2e/update_nix_flake.bats
+++ b/tests/e2e/update_nix_flake.bats
@@ -61,6 +61,13 @@ teardown() {
 stub_docker() {
   cat > "$STUB_DIR/docker" <<STUB
 #!/usr/bin/env bash
+if [ "\${1:-}" = volume ] && [ "\${2:-}" = create ]; then
+  echo test-nix-store
+  exit 0
+fi
+if [ "\${1:-}" = volume ] && [ "\${2:-}" = rm ]; then
+  exit 0
+fi
 cat <<'OUT'
 $1
 OUT
@@ -141,16 +148,40 @@ NIX_BUILD_EXIT=1"
 }
 
 @test "records a corrected hash only after a rebuild proves it" {
-  # First call reports the mismatch, second call succeeds.
+  # First call reports the mismatch, second call succeeds. Both must mount the
+  # same ephemeral Nix store so the verification build can reuse everything
+  # the discovery build already downloaded and compiled.
   cat > "$STUB_DIR/docker" <<'STUB'
 #!/usr/bin/env bash
 STATE="${NIX_STUB_STATE:?}"
+LOG="${NIX_STUB_LOG:?}"
+
+if [ "${1:-}" = volume ] && [ "${2:-}" = create ]; then
+  echo test-nix-store
+  exit 0
+fi
+if [ "${1:-}" = volume ] && [ "${2:-}" = rm ]; then
+  echo "rm $3" >> "$LOG"
+  exit 0
+fi
+
 # The staged source is mounted at SRC:/src:ro — find it.
 SRC=""
+STORE=""
 for a in "$@"; do
-  case "$a" in *:/src:ro) SRC="${a%%:*}";; esac
+  case "$a" in
+    *:/src:ro) SRC="${a%%:*}";;
+    *:/nix) STORE="${a%:/nix}";;
+  esac
 done
+echo "run $STORE" >> "$LOG"
+
 if [ -f "$STATE" ]; then
+  if [ "$(cat "$STATE")" != "$STORE" ]; then
+    echo "error: verification rebuild used a different Nix store"
+    echo "NIX_BUILD_EXIT=1"
+    exit 0
+  fi
   # The verification rebuild must see the corrected hash: the source is
   # restaged per call, so a stale first-call stage would silently verify the
   # old hash instead.
@@ -161,7 +192,7 @@ if [ -f "$STATE" ]; then
   fi
   echo "NIX_BUILD_EXIT=0"
 else
-  touch "$STATE"
+  printf '%s\n' "$STORE" > "$STATE"
   echo "error: hash mismatch in fixed-output derivation '/nix/store/abc-hey-0.1.1-go-modules.drv':"
   echo "         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA="
   echo "            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB="
@@ -170,11 +201,137 @@ fi
 STUB
   chmod +x "$STUB_DIR/docker"
 
-  NIX_STUB_STATE="$WORK/called" run scripts/update-nix-flake.sh 0.1.1
+  NIX_STUB_STATE="$WORK/store" NIX_STUB_LOG="$WORK/docker.log" \
+    run scripts/update-nix-flake.sh 0.1.1
   [ "$status" -eq 0 ]   # 0 = changes written
   [[ "$output" == *"vendorHash: updated"* ]]
   [[ "$output" == *"verified (build succeeded)"* ]]
   grep -q 'sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=' nix/package.nix
+
+  STORE="$(cat "$WORK/store")"
+  [ "$STORE" = test-nix-store ]
+  [ "$(grep -c "^run $STORE$" "$WORK/docker.log")" -eq 2 ]
+  [ "$(grep -c "^rm $STORE$" "$WORK/docker.log")" -eq 1 ]
+}
+
+@test "uses a fresh temporary Nix store for each invocation and removes it" {
+  # The speedup is intentionally intra-run only. It must not leave a cache in
+  # the checkout or the user's home, and a later updater invocation must begin
+  # with a different named volume.
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+LOG="${NIX_STUB_LOG:?}"
+COUNTER="${NIX_STUB_COUNTER:?}"
+if [ "${1:-}" = volume ] && [ "${2:-}" = create ]; then
+  N=0
+  [ ! -f "$COUNTER" ] || N="$(cat "$COUNTER")"
+  N=$((N + 1))
+  printf '%s\n' "$N" > "$COUNTER"
+  echo "test-nix-store-$N"
+  exit 0
+fi
+if [ "${1:-}" = volume ] && [ "${2:-}" = rm ]; then
+  echo "rm $3" >> "$LOG"
+  exit 0
+fi
+
+STORE=""
+for a in "$@"; do
+  case "$a" in *:/nix) STORE="${a%:/nix}";; esac
+done
+echo "run $STORE" >> "$LOG"
+echo "NIX_BUILD_EXIT=0"
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  NIX_STUB_LOG="$WORK/docker.log" NIX_STUB_COUNTER="$WORK/counter" \
+    run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 2 ]
+  NIX_STUB_LOG="$WORK/docker.log" NIX_STUB_COUNTER="$WORK/counter" \
+    run scripts/update-nix-flake.sh 0.1.1
+  [ "$status" -eq 2 ]
+
+  FIRST_STORE="$(sed -n '1s/^run //p' "$WORK/docker.log")"
+  SECOND_STORE="$(sed -n '3s/^run //p' "$WORK/docker.log")"
+  [ "$FIRST_STORE" = test-nix-store-1 ]
+  [ "$SECOND_STORE" = test-nix-store-2 ]
+  [[ "$FIRST_STORE" != */* ]]
+  [[ "$SECOND_STORE" != */* ]]
+  [ "$FIRST_STORE" != "$SECOND_STORE" ]
+  grep -qx "rm $FIRST_STORE" "$WORK/docker.log"
+  grep -qx "rm $SECOND_STORE" "$WORK/docker.log"
+}
+
+@test "removes the temporary Nix store when the build fails" {
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+LOG="${NIX_STUB_LOG:?}"
+if [ "${1:-}" = volume ] && [ "${2:-}" = create ]; then
+  echo test-nix-store
+  exit 0
+fi
+if [ "${1:-}" = volume ] && [ "${2:-}" = rm ]; then
+  echo "rm $3" >> "$LOG"
+  exit 0
+fi
+
+for a in "$@"; do
+  case "$a" in *:/nix) echo "run ${a%:/nix}" >> "$LOG";; esac
+done
+echo "error: builder failed with exit code 1"
+echo "NIX_BUILD_EXIT=1"
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  NIX_STUB_LOG="$WORK/docker.log" run scripts/update-nix-flake.sh 0.2.0
+  [ "$status" -eq 1 ]
+  STORE="$(sed -n '1s/^run //p' "$WORK/docker.log")"
+  grep -qx "rm $STORE" "$WORK/docker.log"
+  grep -q 'version = "0.1.1";' nix/package.nix
+}
+
+@test "fails closed and restores edits when temporary store cleanup fails" {
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = volume ] && [ "${2:-}" = create ]; then
+  echo test-nix-store
+  exit 0
+fi
+if [ "${1:-}" = volume ] && [ "${2:-}" = rm ]; then
+  exit 1
+fi
+echo "NIX_BUILD_EXIT=0"
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  run scripts/update-nix-flake.sh 0.2.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not remove temporary Nix store volume"* ]]
+  grep -q 'version = "0.1.1";' nix/package.nix
+  ! grep -q 'version = "0.2.0";' nix/package.nix
+}
+
+@test "does not attempt cleanup when temporary store creation fails" {
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+LOG="${NIX_STUB_LOG:?}"
+printf '%s\n' "$*" >> "$LOG"
+if [ "${1:-}" = volume ] && [ "${2:-}" = create ]; then
+  echo "Cannot connect to the Docker daemon" >&2
+  exit 1
+fi
+echo "unexpected Docker command" >&2
+exit 1
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  NIX_STUB_LOG="$WORK/docker.log" run scripts/update-nix-flake.sh 0.2.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not create a temporary Nix store volume"* ]]
+  [ "$(wc -l < "$WORK/docker.log")" -eq 1 ]
+  grep -q '^volume create ' "$WORK/docker.log"
+  grep -q 'version = "0.1.1";' nix/package.nix
+  ! grep -q 'version = "0.2.0";' nix/package.nix
 }
 
 @test "fails when the corrected hash still does not build" {
@@ -271,6 +428,13 @@ STUB
 
   cat > "$STUB_DIR/docker" <<'STUB'
 #!/usr/bin/env bash
+if [ "${1:-}" = volume ] && [ "${2:-}" = create ]; then
+  echo test-nix-store
+  exit 0
+fi
+if [ "${1:-}" = volume ] && [ "${2:-}" = rm ]; then
+  exit 0
+fi
 SRC=""
 for a in "$@"; do
   case "$a" in *:/src:ro) SRC="${a%%:*}";; esac
@@ -319,9 +483,16 @@ STUB
   echo 'tracked' > notes.md
   git add notes.md && git commit -qm notes
   rm notes.md
-  # Any docker invocation is itself a failure: staging must abort first.
+  # Volume lifecycle calls are expected, but the build itself must not run.
   cat > "$STUB_DIR/docker" <<'STUB'
 #!/usr/bin/env bash
+if [ "${1:-}" = volume ] && [ "${2:-}" = create ]; then
+  echo test-nix-store
+  exit 0
+fi
+if [ "${1:-}" = volume ] && [ "${2:-}" = rm ]; then
+  exit 0
+fi
 echo "error: build ran despite a failed staging pipeline"
 echo "NIX_BUILD_EXIT=0"
 STUB


### PR DESCRIPTION
## Why

A stale `vendorHash` makes the updater build twice: once to discover the corrected hash and once to verify it. Each build previously started with a separate empty `/nix`, repeating the cold download and compilation work.

## What changed

- create one Docker-managed temporary Nix-store volume per updater invocation
- mount it into both the discovery and verification containers
- remove it on success and failure, without adding a repo- or user-level cache
- fail closed and restore `nix/package.nix` if volume cleanup fails
- distinguish volume-creation failure from cleanup failure

## Verification

- real stale-hash Docker run on an M1 Mac: **140.61s total** for discovery plus successful verification
- the deliberately wrong hash was repaired back to the committed value; the probe worktree was clean afterward
- no labeled temporary Docker volume remained after success
- `bats tests/e2e/update_nix_flake.bats` (18/18)
- `shellcheck scripts/update-nix-flake.sh`
- `bash -n scripts/update-nix-flake.sh`
- `git diff --check`

The full local Bats run reached 185/190; its only failures were the existing macOS incompatibility in `install_ssh_key.bats` (`stat -c`). The updater tests all passed, and Linux CI covers the full suite.
