### PR TITLE
Cut text between graphemes and measure it by what the terminal draws

### DIFF
--- a/internal/tui/calendar_test.go
+++ b/internal/tui/calendar_test.go
@@ -1793,6 +1793,61 @@ func TestDayViewKeepsEmojiTitlesAligned(t *testing.T) {
 	}
 }
 
+// A truncated title is cut between grapheme clusters, never inside one. Scripts that
+// stack marks on a base — Arabic harakat, Devanagari matras, Thai vowels and tones — and
+// joined emoji would otherwise lose their marks at the cut and shift every cell after it.
+func TestTruncateStrCutsBetweenGraphemes(t *testing.T) {
+	cases := []struct {
+		name  string
+		s     string
+		width int
+		want  string
+	}{
+		{"arabic keeps its harakat", "مُدير المشروع", 5, "مُدير…"},
+		{"hindi keeps its matra", "बैठक की योजना", 3, "बैठ…"},
+		{"thai keeps its vowel mark", "ประชุมทีม", 5, "ประชุ…"},
+		{"joined emoji is dropped whole", "Team 👨‍👩‍👧 sync", 6, "Team …"},
+		{"joined emoji fits whole", "Team 👨‍👩‍👧 sync", 8, "Team 👨‍👩‍👧…"},
+		{"a flag never loses half its pair", "Fly to 🇭🇷 soon", 8, "Fly to …"},
+		{"a variation selector stays on its base", "Vote ☑️ now", 7, "Vote …"},
+	}
+	for _, c := range cases {
+		got := truncateStr(c.s, c.width)
+		if got != c.want {
+			t.Errorf("%s: truncateStr(%q, %d) = %q, want %q", c.name, c.s, c.width, got, c.want)
+		}
+		if w := displayWidth(got); w > c.width {
+			t.Errorf("%s: result %q is %d cells wide, over %d", c.name, got, w, c.width)
+		}
+	}
+
+	if got := centerPad("Vote ☑️", 6); got != "Vote " {
+		t.Errorf("centerPad overflow = %q, want %q", got, "Vote ")
+	}
+}
+
+// A glyph the terminal draws wider than a width table guesses shears every row it sits
+// on, so the day grid budgets title glyphs by the calibrated widths: under a calibration
+// that draws spacing matras wide, every row still measures the grid's width by that same
+// calibration.
+func TestDayViewBudgetsCalibratedGlyphWidths(t *testing.T) {
+	withWidths(t, clusterWidths{spacingMark: 1, vs16: 2, flagPair: 2, skinTone: 2, zwjJoined: true})
+
+	placed := placedEvent{
+		rec:      Recording{ID: 1, Title: "बैठक की योजना", CalendarColor: "green"},
+		startCol: 8, endCol: 20,
+	}
+	grid := stripANSI(renderDayGrid([][]placedEvent{{placed}}, 40, 4, 18, -1, styleMuted, selection{}))
+	if !strings.Contains(grid, "की") {
+		t.Errorf("the matra was torn from its consonant:\n%s", grid)
+	}
+	for row, line := range strings.Split(strings.TrimSuffix(grid, "\n"), "\n") {
+		if width := displayWidth(line); width != 40 {
+			t.Errorf("grid row %d is %d columns wide, want 40: %q", row, width, line)
+		}
+	}
+}
+
 // An event is drawn in the color of the calendar it is filed on, so which calendar it
 // belongs to is answered by looking at it. HEY leaves the personal calendar's color out of
 // its JSON, and those fall back to the theme's own accent rather than to no fill.

--- a/internal/tui/calendar_views.go
+++ b/internal/tui/calendar_views.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
-	"github.com/charmbracelet/x/ansi"
 
 	habitvalues "github.com/basecamp/hey-cli/internal/habit"
 	"github.com/basecamp/hey-cli/internal/terminal"
@@ -977,7 +976,7 @@ type titleGlyph struct {
 func verticalTitleGlyphs(title string) []titleGlyph {
 	glyphs := make([]titleGlyph, 0, len(title))
 	for title != "" {
-		text, width := ansi.FirstGraphemeCluster(title, ansi.GraphemeWidth)
+		text, width := firstCluster(title)
 		if text == "" {
 			break
 		}
@@ -1337,7 +1336,7 @@ func weekAllDaySpans(days []weekDayInfo) []weekAllDaySpan {
 // cell for the one pill on screen that is selected, and nothing for any of the others.
 func eventPill(event Recording, width int, sel selection) string {
 	title := truncateStr(terminal.SanitizeLine(event.Title), width)
-	if pad := width - lipgloss.Width(title); pad > 0 {
+	if pad := width - displayWidth(title); pad > 0 {
 		title += strings.Repeat(" ", pad)
 	}
 
@@ -1626,13 +1625,13 @@ func renderRibbon(items []Recording, width int, describe func(Recording) (string
 		if i > 0 {
 			gap = "  "
 		}
-		if used+lipgloss.Width(gap+marker+" "+label) > width {
+		if used+displayWidth(gap+marker+" "+label) > width {
 			if used < width {
 				b.WriteString(styleMuted.Render("…"))
 			}
 			break
 		}
-		used += lipgloss.Width(gap + marker + " " + label)
+		used += displayWidth(gap + marker + " " + label)
 		b.WriteString(gap + markerStyle.Render(marker) + " " + labelStyle.Render(label))
 	}
 	return b.String()
@@ -1648,37 +1647,29 @@ func truncateStr(s string, maxLen int) string {
 	if maxLen <= 0 {
 		return ""
 	}
-	if lipgloss.Width(s) <= maxLen {
+	if displayWidth(s) <= maxLen {
 		return s
 	}
 	if maxLen <= 1 {
 		return "…"
 	}
-	runes := []rune(s)
-	for len(runes) > 0 && lipgloss.Width(string(runes))+lipgloss.Width("…") > maxLen {
-		runes = runes[:len(runes)-1]
-	}
-	return string(runes) + "…"
+	return fitGraphemes(s, maxLen-1) + "…"
 }
 
 // padTo fills a cell out to its column width, measuring what is visible so the styling a
 // cell already carries is not counted.
 func padTo(s string, width int) string {
-	if pad := width - lipgloss.Width(s); pad > 0 {
+	if pad := width - displayWidth(s); pad > 0 {
 		return s + strings.Repeat(" ", pad)
 	}
 	return s
 }
 
 func centerPad(s string, width int) string {
-	sw := lipgloss.Width(s)
+	sw := displayWidth(s)
 	pad := width - sw
 	if pad <= 0 {
-		runes := []rune(s)
-		for len(runes) > 0 && lipgloss.Width(string(runes)) > width {
-			runes = runes[:len(runes)-1]
-		}
-		return string(runes)
+		return fitGraphemes(s, width)
 	}
 	left := pad / 2
 	right := pad - left

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -612,7 +612,7 @@ func (c *contentList) view() string {
 		date := formatDisplayDate(p.CreatedAt)
 		subject = truncateToWidth(subject, textWidth)
 		// Pad through the gap and right-align the date within its column.
-		gap := max(textWidth-lipgloss.Width(subject)+2+dateCol-lipgloss.Width(date), 1)
+		gap := max(textWidth-displayWidth(subject)+2+dateCol-lipgloss.Width(date), 1)
 
 		line1.WriteString(emphasize(subjectBase).Render(subject))
 		line1.WriteString(gapStyle.Render(strings.Repeat(" ", gap)))
@@ -648,11 +648,11 @@ func (c *contentList) view() string {
 		}
 
 		detailWidth := max(textWidth-2, 1) // the indent narrows the second line
-		if lipgloss.Width(sender) > detailWidth {
+		if displayWidth(sender) > detailWidth {
 			sender = truncateToWidth(sender, detailWidth)
 			excerpt = ""
 		} else {
-			excerpt = truncateToWidth(excerpt, detailWidth-lipgloss.Width(sender))
+			excerpt = truncateToWidth(excerpt, detailWidth-displayWidth(sender))
 		}
 
 		line2.WriteString(emphasize(senderBase).Render(sender))
@@ -660,7 +660,7 @@ func (c *contentList) view() string {
 		if isCursor {
 			// Pad to the full row width so the selection background also
 			// covers the space under the date.
-			pad := prefixWidth + textWidth + 2 + dateCol - 6 - lipgloss.Width(sender) - lipgloss.Width(excerpt)
+			pad := prefixWidth + textWidth + 2 + dateCol - 6 - displayWidth(sender) - displayWidth(excerpt)
 			if pad > 0 {
 				line2.WriteString(gapStyle.Render(strings.Repeat(" ", pad)))
 			}
@@ -719,15 +719,28 @@ func hintedSectionHeader(label, hint string, width int) string {
 // truncateToWidth trims s so its rendered width fits in w cells, appending
 // "..." when anything was cut. Returns "" when w cannot hold the ellipsis.
 func truncateToWidth(s string, w int) string {
-	if lipgloss.Width(s) <= w {
+	if displayWidth(s) <= w {
 		return s
 	}
 	if w <= 3 {
 		return ""
 	}
-	runes := []rune(s)
-	for lipgloss.Width(string(runes)) > w-3 && len(runes) > 0 {
-		runes = runes[:len(runes)-1]
+	return fitGraphemes(s, w-3) + "..."
+}
+
+// fitGraphemes keeps whole grapheme clusters from the front of s until the next one
+// would not fit in width cells, so a cut never lands inside an emoji sequence or
+// between a base letter and its combining marks.
+func fitGraphemes(s string, width int) string {
+	var b strings.Builder
+	for s != "" {
+		cluster, clusterWidth := firstCluster(s)
+		if cluster == "" || clusterWidth > width {
+			break
+		}
+		b.WriteString(cluster)
+		width -= clusterWidth
+		s = s[len(cluster):]
 	}
-	return string(runes) + "..."
+	return b.String()
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1112,6 +1112,7 @@ func (m model) handleSubnavKey(msg tea.KeyPressMsg) tea.Cmd {
 // Run starts the TUI with the resolved mail account, the identity root client used for
 // interactive account switching, the live watchers, and an optional initial thread.
 func Run(rootSDK, sdk *hey.Client, selected string, watchers Watchers, options Options) error {
+	calibrateWidths(os.Stdin, os.Stdout)
 	m := newModelWithMailAccounts(rootSDK, sdk, selected, watchers)
 	if options.OpenTopic.TopicID > 0 {
 		request := options.OpenTopic

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1100,6 +1100,12 @@ func TestTruncateToWidth(t *testing.T) {
 	if got := truncateToWidth("abcdef", 3); got != "" {
 		t.Errorf("truncateToWidth narrow = %q, want empty", got)
 	}
+	if got := truncateToWidth("Family 👨‍👩‍👧 picnic", 11); got != "Family ..." {
+		t.Errorf("truncateToWidth kept a torn emoji sequence = %q, want %q", got, "Family ...")
+	}
+	if got := truncateToWidth("Vote ☑️ now please", 9); got != "Vote ..." {
+		t.Errorf("truncateToWidth stripped a variation selector = %q, want %q", got, "Vote ...")
+	}
 }
 
 // --- View rendering ---

--- a/internal/tui/width.go
+++ b/internal/tui/width.go
@@ -1,0 +1,116 @@
+package tui
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Terminals disagree about exactly the clusters the width rules leave undefined — a
+// spacing combining mark like a Devanagari matra, a text-default symbol forced to emoji
+// by a variation selector, a joined emoji on a terminal that does not join. The
+// disagreement is not cosmetic: the terminal advances the cursor by what it drew, so
+// every cell to the right of such a glyph shifts and every aligned row it sits on
+// shears. No width table is right everywhere, so these widths are asked of the terminal
+// itself at startup (probeWidths) and kept here. Without an answer the guess errs wide:
+// over-allocating shows as a one-cell gap beside the glyph, under-allocating shears the
+// row.
+type clusterWidths struct {
+	spacingMark int  // cells one spacing combining mark adds to its base
+	vs16        int  // cells for a text-default base forced to emoji presentation
+	flagPair    int  // cells for a regional-indicator pair
+	skinTone    int  // cells for an emoji carrying a skin-tone modifier
+	zwjJoined   bool // whether a ZWJ sequence draws as one glyph
+}
+
+var widths = clusterWidths{spacingMark: 1, vs16: 2, flagPair: 2, skinTone: 2, zwjJoined: true}
+
+const (
+	zwj  = '\u200d'
+	vs16 = '\ufe0f'
+)
+
+// displayWidth is the number of terminal cells s occupies, by the calibrated widths.
+// Styling is not counted, so a styled cell measures what is visible, as lipgloss.Width
+// does.
+func displayWidth(s string) int {
+	total := 0
+	for rest := ansi.Strip(s); rest != ""; {
+		cluster, _ := ansi.FirstGraphemeCluster(rest, ansi.GraphemeWidth)
+		if cluster == "" {
+			break
+		}
+		total += clusterCells(cluster)
+		rest = rest[len(cluster):]
+	}
+	return total
+}
+
+// firstCluster returns the leading grapheme cluster of s and the cells it occupies.
+func firstCluster(s string) (string, int) {
+	cluster, _ := ansi.FirstGraphemeCluster(s, ansi.GraphemeWidth)
+	return cluster, clusterCells(cluster)
+}
+
+func clusterCells(cluster string) int {
+	if strings.ContainsRune(cluster, zwj) {
+		width := 0
+		for part := range strings.SplitSeq(cluster, string(zwj)) {
+			if widths.zwjJoined {
+				width = max(width, clusterCells(part))
+			} else {
+				width += clusterCells(part)
+			}
+		}
+		return width
+	}
+	if isFlagPair(cluster) {
+		return widths.flagPair
+	}
+	if strings.ContainsFunc(cluster, isSkinToneModifier) {
+		return widths.skinTone
+	}
+	if strings.ContainsRune(cluster, vs16) {
+		base := strings.ReplaceAll(cluster, string(vs16), "")
+		if ansi.StringWidth(base) >= 2 {
+			return 2
+		}
+		return widths.vs16
+	}
+	if marks := countSpacingMarks(cluster); marks > 0 {
+		base := strings.Map(dropSpacingMark, cluster)
+		return ansi.StringWidth(base) + marks*widths.spacingMark
+	}
+	return ansi.StringWidth(cluster)
+}
+
+func isFlagPair(cluster string) bool {
+	runes := []rune(cluster)
+	return len(runes) == 2 && isRegionalIndicator(runes[0]) && isRegionalIndicator(runes[1])
+}
+
+func isRegionalIndicator(r rune) bool {
+	return r >= 0x1f1e6 && r <= 0x1f1ff
+}
+
+func isSkinToneModifier(r rune) bool {
+	return r >= 0x1f3fb && r <= 0x1f3ff
+}
+
+func countSpacingMarks(cluster string) int {
+	marks := 0
+	for _, r := range cluster {
+		if unicode.Is(unicode.Mc, r) {
+			marks++
+		}
+	}
+	return marks
+}
+
+func dropSpacingMark(r rune) rune {
+	if unicode.Is(unicode.Mc, r) {
+		return -1
+	}
+	return r
+}

--- a/internal/tui/width_probe.go
+++ b/internal/tui/width_probe.go
@@ -1,0 +1,99 @@
+package tui
+
+import (
+	"strings"
+)
+
+// The probe clusters, one per class whose width no rule pins down. Each is printed at
+// column one followed by a cursor position report, so the column the terminal answers is
+// the width it actually drew — the one measurement no table can contradict. Mode 2027 is
+// switched on for the probe because Bubble Tea runs the session with it wherever the
+// terminal supports it, and a terminal that ignores the mode probes the same either way.
+var widthProbes = []string{
+	"की",    // base plus a spacing combining mark
+	"✈️",    // text-default base forced to emoji presentation
+	"🇭🇷",    // regional-indicator pair
+	"👍🏽",    // emoji with a skin-tone modifier
+	"👨‍👩‍👧", // ZWJ sequence
+}
+
+const (
+	probeSetup    = "\x1b[?2026h\x1b[?25l\x1b[?2027h"
+	probeCleanup  = "\r\x1b[K\x1b[?2027l\x1b[?25h\x1b[?2026l"
+	cursorReport  = "\x1b[6n"
+	probeMaxWidth = 8
+)
+
+func probeRequest() string {
+	var b strings.Builder
+	b.WriteString(probeSetup)
+	for _, probe := range widthProbes {
+		b.WriteString("\r" + probe + cursorReport)
+	}
+	b.WriteString(probeCleanup)
+	return b.String()
+}
+
+// parseCursorReports pulls the column out of every ESC[row;colR in data, in order,
+// skipping anything else — a keystroke landing mid-probe must not derail the answers
+// behind it.
+func parseCursorReports(data []byte) []int {
+	columns := []int{}
+	for i := 0; i < len(data); i++ {
+		if col, length, ok := cursorReportAt(data[i:]); ok {
+			columns = append(columns, col)
+			i += length - 1
+		}
+	}
+	return columns
+}
+
+func cursorReportAt(data []byte) (col, length int, ok bool) {
+	if len(data) < 2 || data[0] != 0x1b || data[1] != '[' {
+		return 0, 0, false
+	}
+	i := 2
+	if _, i = digitsAt(data, i); i < 0 || i >= len(data) || data[i] != ';' {
+		return 0, 0, false
+	}
+	if col, i = digitsAt(data, i+1); i < 0 || i >= len(data) || data[i] != 'R' {
+		return 0, 0, false
+	}
+	return col, i + 1, true
+}
+
+func digitsAt(data []byte, i int) (value, next int) {
+	start := i
+	for i < len(data) && data[i] >= '0' && data[i] <= '9' {
+		value = value*10 + int(data[i]-'0')
+		i++
+	}
+	if i == start || i-start > 4 {
+		return 0, -1
+	}
+	return value, i
+}
+
+// deriveWidths turns the reported columns into a width table. A report outside the
+// plausible range means the probe was disturbed — a resize, a wrapped line — and the
+// whole calibration is discarded rather than half-trusted.
+func deriveWidths(columns []int) (clusterWidths, bool) {
+	if len(columns) != len(widthProbes) {
+		return clusterWidths{}, false
+	}
+	measured := make([]int, len(columns))
+	for i, column := range columns {
+		width := column - 1
+		if width < 1 || width > probeMaxWidth {
+			return clusterWidths{}, false
+		}
+		measured[i] = width
+	}
+	return clusterWidths{
+		spacingMark: measured[0] - 1,
+		vs16:        measured[1],
+		flagPair:    measured[2],
+		skinTone:    measured[3],
+		zwjJoined:   measured[4] <= 2,
+	}, true
+}

--- a/internal/tui/width_probe_test.go
+++ b/internal/tui/width_probe_test.go
@@ -1,0 +1,67 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProbeRequestCarriesEveryProbe(t *testing.T) {
+	request := probeRequest()
+	for _, probe := range widthProbes {
+		if !strings.Contains(request, "\r"+probe+cursorReport) {
+			t.Errorf("request is missing the probe for %q", probe)
+		}
+	}
+	if !strings.HasPrefix(request, probeSetup) || !strings.HasSuffix(request, probeCleanup) {
+		t.Error("request does not restore the terminal around the probes")
+	}
+}
+
+func TestParseCursorReports(t *testing.T) {
+	reports := []byte("\x1b[12;3R\x1b[12;2R\x1b[12;3R")
+	if got := parseCursorReports(reports); len(got) != 3 || got[0] != 3 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("parsed %v, want [3 2 3]", got)
+	}
+
+	// A keystroke or a stray escape landing mid-probe must not derail the reports behind it.
+	noisy := []byte("q\x1b[12;3Rw\x1b[A\x1b[5;17R\x1b[9999;99999R\x1b[;R")
+	if got := parseCursorReports(noisy); len(got) != 2 || got[0] != 3 || got[1] != 17 {
+		t.Errorf("parsed noisy %v, want [3 17]", got)
+	}
+
+	if got := parseCursorReports([]byte("no reports here")); len(got) != 0 {
+		t.Errorf("parsed %v from junk, want none", got)
+	}
+}
+
+func TestDeriveWidths(t *testing.T) {
+	// Columns are one past the width drawn: की=2, ✈️=2, 🇭🇷=2, 👍🏽=2, family=2.
+	probed, ok := deriveWidths([]int{3, 3, 3, 3, 3})
+	if !ok {
+		t.Fatal("plausible columns were rejected")
+	}
+	want := clusterWidths{spacingMark: 1, vs16: 2, flagPair: 2, skinTone: 2, zwjJoined: true}
+	if probed != want {
+		t.Errorf("derived %+v, want %+v", probed, want)
+	}
+
+	// A terminal that keeps matras narrow, draws VS16 in text width, and splits families.
+	probed, ok = deriveWidths([]int{2, 2, 3, 5, 7})
+	if !ok {
+		t.Fatal("plausible columns were rejected")
+	}
+	want = clusterWidths{spacingMark: 0, vs16: 1, flagPair: 2, skinTone: 4, zwjJoined: false}
+	if probed != want {
+		t.Errorf("derived %+v, want %+v", probed, want)
+	}
+
+	if _, ok := deriveWidths([]int{3, 3, 3}); ok {
+		t.Error("a short answer was trusted")
+	}
+	if _, ok := deriveWidths([]int{3, 3, 3, 3, 42}); ok {
+		t.Error("an implausible column was trusted")
+	}
+	if _, ok := deriveWidths([]int{1, 3, 3, 3, 3}); ok {
+		t.Error("a zero width was trusted")
+	}
+}

--- a/internal/tui/width_probe_unix.go
+++ b/internal/tui/width_probe_unix.go
@@ -1,0 +1,68 @@
+//go:build unix
+
+package tui
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+)
+
+// calibrateWidths asks the terminal how wide it draws the probe clusters and adopts its
+// answers. It runs before the Bubble Tea program owns the terminal, in raw mode so the
+// reports are readable, and gives up quietly — keeping the pessimistic defaults — when
+// either end is not a terminal or the answers do not arrive in time. The reads poll with
+// a deadline rather than blocking, so a terminal that never answers cannot stall the TUI
+// or leave a reader stealing its input.
+func calibrateWidths(in, out *os.File) {
+	inFd, outFd := int(in.Fd()), int(out.Fd()) //nolint:gosec // G115: fds fit in int
+	if !term.IsTerminal(inFd) || !term.IsTerminal(outFd) {
+		return
+	}
+	restore, err := term.MakeRaw(inFd)
+	if err != nil {
+		return
+	}
+	defer term.Restore(inFd, restore) //nolint:errcheck
+
+	if _, err := out.WriteString(probeRequest()); err != nil {
+		return
+	}
+	if probed, ok := deriveWidths(readCursorReports(in, len(widthProbes), 300*time.Millisecond)); ok {
+		widths = probed
+	}
+}
+
+func readCursorReports(in *os.File, count int, budget time.Duration) []int {
+	deadline := time.Now().Add(budget)
+	buf := make([]byte, 0, 256)
+	chunk := make([]byte, 64)
+	for {
+		columns := parseCursorReports(buf)
+		if len(columns) >= count {
+			return columns[:count]
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return columns
+		}
+		fds := []unix.PollFd{{Fd: int32(in.Fd()), Events: unix.POLLIN}} //nolint:gosec // G115: fd fits in int32
+		ready, err := unix.Poll(fds, int(remaining.Milliseconds())+1)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if err != nil || ready == 0 {
+			return columns
+		}
+		n, err := in.Read(chunk)
+		if n > 0 {
+			buf = append(buf, chunk[:n]...)
+		}
+		if err != nil {
+			return parseCursorReports(buf)
+		}
+	}
+}

--- a/internal/tui/width_probe_windows.go
+++ b/internal/tui/width_probe_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package tui
+
+import "os"
+
+// Windows has no pollable console read, so the probe is skipped and the pessimistic
+// defaults stand.
+func calibrateWidths(in, out *os.File) {}

--- a/internal/tui/width_test.go
+++ b/internal/tui/width_test.go
@@ -1,0 +1,65 @@
+package tui
+
+import "testing"
+
+func withWidths(t *testing.T, calibrated clusterWidths) {
+	t.Helper()
+	previous := widths
+	widths = calibrated
+	t.Cleanup(func() { widths = previous })
+}
+
+// The same text measures differently on terminals that answered the probe differently.
+// The table pins both worlds: one that draws spacing marks and forced-emoji wide, and one
+// that keeps them narrow.
+func TestDisplayWidthFollowsTheCalibration(t *testing.T) {
+	wide := clusterWidths{spacingMark: 1, vs16: 2, flagPair: 2, skinTone: 2, zwjJoined: true}
+	narrow := clusterWidths{spacingMark: 0, vs16: 1, flagPair: 2, skinTone: 4, zwjJoined: false}
+
+	cases := []struct {
+		s            string
+		wide, narrow int
+	}{
+		{"hello", 5, 5},
+		{"漢字", 4, 4},
+		{"café", 4, 4},        // combining marks are Mn and add nothing anywhere
+		{"की", 2, 1},          // spacing matra
+		{"बैठक", 3, 3},        // ै is Mn, no spacing marks here
+		{"✈️", 2, 1},          // text-default base + VS16
+		{"☑️", 2, 1},          // same
+		{"😀️", 2, 2},          // VS16 on an already-wide base changes nothing
+		{"🇭🇷", 2, 2},          // flag pair
+		{"👍🏽", 2, 4},          // skin tone
+		{"👨‍👩‍👧", 2, 6},       // ZWJ family: joined or sum of parts
+		{"a👨‍👩‍👧b की", 7, 10}, // mixed, including the space
+	}
+	for _, c := range cases {
+		withWidths(t, wide)
+		if got := displayWidth(c.s); got != c.wide {
+			t.Errorf("wide: displayWidth(%q) = %d, want %d", c.s, got, c.wide)
+		}
+		withWidths(t, narrow)
+		if got := displayWidth(c.s); got != c.narrow {
+			t.Errorf("narrow: displayWidth(%q) = %d, want %d", c.s, got, c.narrow)
+		}
+	}
+}
+
+func TestDisplayWidthIgnoresStyling(t *testing.T) {
+	if got := displayWidth("\x1b[31mकी\x1b[0m"); got != displayWidth("की") {
+		t.Errorf("styled width = %d, want %d", got, displayWidth("की"))
+	}
+}
+
+func TestFirstClusterMeasuresLikeDisplayWidth(t *testing.T) {
+	for s := "Fly to 🇭🇷 की ✈️!"; s != ""; {
+		cluster, width := firstCluster(s)
+		if cluster == "" {
+			t.Fatalf("firstCluster stalled on %q", s)
+		}
+		if width != displayWidth(cluster) {
+			t.Errorf("firstCluster(%q) width = %d, displayWidth = %d", cluster, width, displayWidth(cluster))
+		}
+		s = s[len(cluster):]
+	}
+}


### PR DESCRIPTION
## The bug

Event titles in the calendar's day view sheared their rows: a title containing a Devanagari matra (की, यो, ना) notched every event block on its screen row and broke the dashed hour rules behind them. The same mis-measurement could also strip a variation selector or a combining mark at a truncation cut anywhere user text is shortened.

## Why it happens

Two problems, one root:

1. **Truncation by runes.** The truncation helpers trimmed one rune at a time, so a cut could land inside a grapheme cluster — `Vote ☑️` truncated to `Vote ☑`, leaving a glyph whose width some terminals then render differently than measured.

2. **Widths by a fixed table.** Terminals disagree about exactly the clusters the width rules leave undefined — a spacing combining mark like a Devanagari matra (lipgloss counts की as 1 cell; some terminals draw 2), a text-default symbol forced to emoji by VS16 (✈️: 1 or 2), a ZWJ sequence on a terminal that doesn't join (👨‍👩‍👧: 2 or 6). The mode-2027 spec is explicit about emoji and variation selectors but silent on spacing marks, so the disagreement is permanent and no static table can be right everywhere. It isn't cosmetic: the terminal advances the cursor by what it actually drew, so every cell to the right of such a glyph shifts, and every aligned row it crosses shears.

## The fix

- **Cut between clusters.** `fitGraphemes` walks whole grapheme clusters; `truncateStr`, `truncateToWidth`, and `centerPad` build on it. A cut can no longer land inside an emoji sequence or between a base letter and its marks.

- **Ask the terminal, don't guess.** Before the Bubble Tea program starts, `calibrateWidths` prints one probe cluster per ambiguous class (matra, VS16, flag pair, skin tone, ZWJ) followed by a cursor position report, inside a synchronized update so nothing flickers, with mode 2027 switched on for the probe since Bubble Tea runs the session with it where supported. The column the terminal answers is the width it actually drew — the one measurement no table can contradict. Reads poll with a 300ms deadline instead of blocking, so a terminal that never answers can't stall the TUI or leave a reader stealing its input.

- **One ruler everywhere.** `displayWidth`/`firstCluster` read from the calibration, and everything that measures somebody else's text — the truncation helpers, mail list rows, the day view's vertical titles, `padTo`/`centerPad` — goes through them. Without a probe answer the defaults err wide: over-allocating shows as a one-cell gap beside the glyph, under-allocating shears the whole row.

Windows has no pollable console read, so the probe is skipped there and the pessimistic defaults stand.

## Why not lipgloss

Every helper in lipgloss/x/ansi measures with one of two baked-in tables and none of them accepts an override, so the cut point and the cell budget would come from a ruler that can't be corrected. Ultraviolet (under Bubble Tea v2's renderer) already defines `WidthMethod` as an interface with exactly the right shape, but every layer above narrows it to the two-value enum and Bubble Tea doesn't expose it — `displayWidth` is deliberately that same `StringWidth(string) int` shape, so if a `tea.WithWidthMethod(...)` ever lands, the calibration can drive the renderer's own cell buffer too.

## Tests

- Cluster and string widths under differing calibrations (wide and narrow terminals), styled input, and mixed scripts — Arabic harakat, Devanagari matras, Thai vowel marks, VS16, flags, skin tones, ZWJ.
- Probe request framing, cursor-report parsing with keystroke noise interleaved, and derivation that discards implausible answers rather than half-trusting them.
- Day-grid alignment: under a calibration that draws matras wide, every row still measures the grid's width by that same calibration, and the matra keeps its consonant.