### PR TITLE
Write in Markdown wherever text goes in

### DIFF
--- a/.surface
+++ b/.surface
@@ -50,6 +50,7 @@ hey bulk-reply preview
 hey bulk-reply send
 hey bulk-reply send --attach
 hey bulk-reply send --message
+hey bulk-reply send --message-html
 hey bulk-reply undo
 hey calendars
 hey clip
@@ -88,6 +89,7 @@ hey compose --attach
 hey compose --bcc
 hey compose --cc
 hey compose --message
+hey compose --message-html
 hey compose --subject
 hey compose --thread-id
 hey compose --to
@@ -112,6 +114,7 @@ hey contacts note
 hey contacts note delete
 hey contacts note set
 hey contacts note set --note
+hey contacts note set --note-html
 hey contacts note show
 hey contacts show
 hey contacts show-again
@@ -128,6 +131,7 @@ hey forward
 hey forward --bcc
 hey forward --cc
 hey forward --message
+hey forward --message-html
 hey forward --to
 hey habit
 hey habit complete
@@ -153,6 +157,7 @@ hey journal list --limit
 hey journal read
 hey journal write
 hey journal write --content
+hey journal write --content-html
 hey label
 hey label --all
 hey label --limit
@@ -187,6 +192,7 @@ hey recordings --starts-on
 hey reply
 hey reply --attach
 hey reply --message
+hey reply --message-html
 hey screener
 hey screener approve
 hey screener approve --box
@@ -230,11 +236,13 @@ hey skill install
 hey snippet
 hey snippet create
 hey snippet create --content
+hey snippet create --content-html
 hey snippet create --name
 hey snippet delete
 hey snippet list
 hey snippet update
 hey snippet update --content
+hey snippet update --content-html
 hey snippet update --name
 hey snippets
 hey spam

--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ hey forward 123 --to alice@example.com -m "For your review"  # forward the lates
 hey compose --to alice@example.com --subject "Lunch plans"  # body from $EDITOR
 hey compose --to alice@example.com --subject "Q3 revenue report" -m "The numbers are attached." --attach ./report.pdf
 hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Kitchen remodel timeline"  # with CC/BCC
+hey compose --to alice@example.com --subject "Sprint recap" -m "We **shipped** the pagination fix."
+hey compose --to alice@example.com --subject "Newsletter draft" --message-html "<h1>March</h1><p>What we shipped.</p>"
 hey drafts                         # list drafts
 hey seen 12345                     # mark a thread as seen
 hey unseen 12345 67890             # mark threads as unseen
@@ -411,6 +413,8 @@ hey stop-ignoring 12345            # resume attention for a thread
 `hey threads` reads a whole thread, oldest entry first, however many pages HEY serves it in — within limits it states: a hundred pages past the first, two thousand entries, as many bodies, 64 MiB of content and two minutes in all. A thread that could only be read in part — a body HEY would not serve, a limit reached — is refused rather than passed off as whole; `--allow-partial` takes what was read, with a `notice` saying what is missing and each entry's `body_state` saying whether its body was `hydrated`, `bodyless` (HEY served none), `over_limit` or `failed`. `--count` and `--ids-only` read the entry index and no bodies, so only a truncated index can make them partial. `--markdown` writes the thread as one Markdown document — a heading per entry naming the sender, date and ID, then the body — which is the shape to hand an agent or a notes app. `hey attachments` reads the bodies in every format, since that is where attachment metadata lives, and answers a partial thread the same way. `hey reply` answers the thread's latest entry and addresses the reply the way HEY does: everyone that entry was addressed to, plus whoever wrote it.
 
 Email bodies come back as Markdown. `hey threads` and the TUI render that Markdown for the terminal — headings, emphasis, lists, quotes, tables and code survive, and links keep their URLs and stay clickable where the terminal supports it. `--json` carries the same Markdown in `body`, so an agent reading a thread sees the structure a human sees rather than a flattened wall of text. `--html` still returns HEY's original HTML.
+
+Writing is Markdown too, everywhere text goes in: `-m`, `--content`, `--note`, positional content, stdin, and `$EDITOR` (which opens prefilled with the existing entry or note as Markdown). Every such flag has a raw-HTML twin — `--message-html`, `--content-html`, `--note-html` — for sending markup verbatim; each pair is mutually exclusive. The TUI's compose and bulk-reply forms convert Markdown the same way (`ctrl+p` previews the message as it will read). A fenced code block's language (` ```ruby `) is carried the way HEY's own editor stores it, so the web app syntax-highlights it.
 
 `hey share <thread_id>` gets a sharing link for a thread. Anyone with the link can see the entire thread and future emails or replies sent to it. `hey unshare <thread_id>` turns off the sharing link.
 

--- a/internal/cmd/attachments_test.go
+++ b/internal/cmd/attachments_test.go
@@ -346,7 +346,7 @@ func TestComposeUploadsAttachmentsBeforeSending(t *testing.T) {
 		t.Errorf("events = %v", state.events)
 	}
 	content := state.sentContents[0]
-	if !strings.Contains(content, "Attached.<br>") || !strings.Contains(content, `action-text-attachment sgid="sgid-upload"`) || !strings.Contains(content, `filename="quarterly-report.pdf"`) {
+	if !strings.Contains(content, "<p>Attached.</p><br>") || !strings.Contains(content, `action-text-attachment sgid="sgid-upload"`) || !strings.Contains(content, `filename="quarterly-report.pdf"`) {
 		t.Errorf("sent content = %q", content)
 	}
 }
@@ -365,7 +365,7 @@ func TestComposeReadsPipedBodyWithAttachments(t *testing.T) {
 
 	state.mu.Lock()
 	defer state.mu.Unlock()
-	if len(state.sentContents) != 1 || !strings.HasPrefix(state.sentContents[0], "Piped compose body<br>") {
+	if len(state.sentContents) != 1 || !strings.HasPrefix(state.sentContents[0], "<p>Piped compose body</p><br>") {
 		t.Errorf("sent content = %q", state.sentContents)
 	}
 }
@@ -440,7 +440,7 @@ func TestReplyReadsPipedBodyWithAttachments(t *testing.T) {
 
 	state.mu.Lock()
 	defer state.mu.Unlock()
-	if len(state.sentContents) != 1 || !strings.HasPrefix(state.sentContents[0], "Piped reply body<br>") {
+	if len(state.sentContents) != 1 || !strings.HasPrefix(state.sentContents[0], "<p>Piped reply body</p><br>") {
 		t.Errorf("sent content = %q", state.sentContents)
 	}
 }

--- a/internal/cmd/bulk_reply.go
+++ b/internal/cmd/bulk_reply.go
@@ -28,6 +28,7 @@ type bulkReplyPreviewCommand struct {
 type bulkReplySendCommand struct {
 	cmd         *cobra.Command
 	message     string
+	messageHTML string
 	attachments []string
 }
 
@@ -145,8 +146,10 @@ func newBulkReplySendCommand() *bulkReplySendCommand {
 		RunE: sendCommand.run,
 		Args: usageMinOneArg(),
 	}
-	sendCommand.cmd.Flags().StringVarP(&sendCommand.message, "message", "m", "", "Reply message (or opens $EDITOR)")
+	sendCommand.cmd.Flags().StringVarP(&sendCommand.message, "message", "m", "", "Reply message as Markdown (or opens $EDITOR)")
+	sendCommand.cmd.Flags().StringVar(&sendCommand.messageHTML, "message-html", "", "Reply message as raw HTML instead of Markdown")
 	sendCommand.cmd.Flags().StringArrayVar(&sendCommand.attachments, "attach", nil, "File to attach (repeatable)")
+	sendCommand.cmd.MarkFlagsMutuallyExclusive("message", "message-html")
 	return sendCommand
 }
 
@@ -158,9 +161,13 @@ func (c *bulkReplySendCommand) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	message, err := c.readMessage()
-	if err != nil {
-		return err
+	message := c.messageHTML
+	if message == "" {
+		markdownMessage, readErr := c.readMessage()
+		if readErr != nil {
+			return readErr
+		}
+		message = htmlutil.FromMarkdown(markdownMessage)
 	}
 	attachments, err := prepareAttachments(c.attachments)
 	if err != nil {
@@ -185,7 +192,7 @@ func (c *bulkReplySendCommand) run(cmd *cobra.Command, args []string) error {
 		entryIDs[i] = entry.ID
 	}
 
-	content := htmlutil.PrependText(draftContent(draft), message)
+	content := htmlutil.PrependHTML(draftContent(draft), message)
 	content, err = attachPreparedFiles(ctx, content, attachments)
 	if err != nil {
 		return err

--- a/internal/cmd/bulk_reply_test.go
+++ b/internal/cmd/bulk_reply_test.go
@@ -219,7 +219,29 @@ func TestBulkReplySendPreservesDraftAndReportsDelayedDelivery(t *testing.T) {
 	if fmt.Sprint(request.EntryIDs) != "[11 12]" {
 		t.Errorf("entry_ids = %v", request.EntryIDs)
 	}
-	want := "<div>Thanks everyone</div><br><div>Signing off with a tag!</div>"
+	want := "<p>Thanks everyone</p><br><div>Signing off with a tag!</div>"
+	if request.Message.Content != want {
+		t.Errorf("content = %q, want %q", request.Message.Content, want)
+	}
+}
+
+func TestBulkReplySendConvertsMarkdownMessage(t *testing.T) {
+	server, state := bulkReplyServer(t)
+	_, err := runBulkReply(t, server, []string{"--json"}, []string{"send", "101", "202", "-m", "Thanks **everyone**"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requests := state.snapshot()
+	var request struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(requests[len(requests)-1].Body, &request); err != nil {
+		t.Fatal(err)
+	}
+	want := "<p>Thanks <strong>everyone</strong></p><br><div>Signing off with a tag!</div>"
 	if request.Message.Content != want {
 		t.Errorf("content = %q, want %q", request.Message.Content, want)
 	}

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/editor"
+	"github.com/basecamp/hey-cli/internal/htmlutil"
 )
 
 type composeCommand struct {
@@ -18,6 +19,7 @@ type composeCommand struct {
 	bcc         string
 	subject     string
 	message     string
+	messageHTML string
 	threadID    string
 	attachments []string
 }
@@ -28,12 +30,14 @@ func newComposeCommand() *composeCommand {
 		Use:   "compose",
 		Short: "Write and send a new email",
 		Annotations: map[string]string{
-			"agent_notes": "Starts a new thread with --to (optionally --cc/--bcc), which requires --subject, or replies to an existing one with --thread-id, which does not. Repeatable --attach files are uploaded before sending and can be sent without body text.",
+			"agent_notes": "Starts a new thread with --to (optionally --cc/--bcc), which requires --subject, or replies to an existing one with --thread-id, which does not. Repeatable --attach files are uploaded before sending and can be sent without body text. The body is Markdown; use --message-html to send raw HTML instead.",
 		},
 		Example: `  hey compose --to alice@example.com --subject "Lunch plans" -m "Are you free Friday?"
   hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Kitchen remodel timeline" -m "Cabinets land the week of the 14th."
   hey compose --to alice@example.com --subject "Q3 revenue report" -m "The numbers are attached." --attach ./report.pdf
   hey compose --thread-id 12345 -m "Confirmed — see you then." --attach ./diagram.png
+  hey compose --to alice@example.com --subject "Sprint recap" -m "We **shipped** the pagination fix."
+  hey compose --to alice@example.com --subject "Newsletter draft" --message-html "<h1>March</h1><p>What we shipped.</p>"
   echo "Notes from the offsite" | hey compose --to bob@example.com --subject "Offsite recap"`,
 		RunE: composeCommand.run,
 	}
@@ -42,9 +46,11 @@ func newComposeCommand() *composeCommand {
 	composeCommand.cmd.Flags().StringVar(&composeCommand.cc, "cc", "", "CC recipient email address(es)")
 	composeCommand.cmd.Flags().StringVar(&composeCommand.bcc, "bcc", "", "BCC recipient email address(es)")
 	composeCommand.cmd.Flags().StringVar(&composeCommand.subject, "subject", "", "Message subject (required for a new message)")
-	composeCommand.cmd.Flags().StringVarP(&composeCommand.message, "message", "m", "", "Message body (or opens $EDITOR)")
+	composeCommand.cmd.Flags().StringVarP(&composeCommand.message, "message", "m", "", "Message body as Markdown (or opens $EDITOR)")
+	composeCommand.cmd.Flags().StringVar(&composeCommand.messageHTML, "message-html", "", "Message body as raw HTML instead of Markdown")
 	composeCommand.cmd.Flags().StringVar(&composeCommand.threadID, "thread-id", "", "Reply to this thread instead of starting a new one")
 	composeCommand.cmd.Flags().StringArrayVar(&composeCommand.attachments, "attach", nil, "File to attach (repeatable)")
+	composeCommand.cmd.MarkFlagsMutuallyExclusive("message", "message-html")
 
 	return composeCommand
 }
@@ -59,25 +65,29 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		return apierr.ErrUsageHint("--subject is required", "hey compose --to <email> --subject <subject> -m <message>")
 	}
 
-	message := c.message
-	if message == "" && !stdinIsTerminal() {
-		var err error
-		message, err = readStdin()
-		if err != nil {
-			return err
+	message := c.messageHTML
+	if message == "" {
+		markdownMessage := c.message
+		if markdownMessage == "" && !stdinIsTerminal() {
+			var err error
+			markdownMessage, err = readStdin()
+			if err != nil {
+				return err
+			}
+			if markdownMessage == "" && len(c.attachments) == 0 {
+				return apierr.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
+			}
+		} else if markdownMessage == "" && len(c.attachments) == 0 {
+			var err error
+			markdownMessage, err = editor.Open("")
+			if err != nil {
+				return apierr.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
+			}
+			if markdownMessage == "" {
+				return apierr.ErrUsage("empty message, aborting")
+			}
 		}
-		if message == "" && len(c.attachments) == 0 {
-			return apierr.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
-		}
-	} else if message == "" && len(c.attachments) == 0 {
-		var err error
-		message, err = editor.Open("")
-		if err != nil {
-			return apierr.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
-		}
-		if message == "" {
-			return apierr.ErrUsage("empty message, aborting")
-		}
+		message = htmlutil.FromMarkdown(markdownMessage)
 	}
 
 	ctx := cmd.Context()

--- a/internal/cmd/compose_test.go
+++ b/internal/cmd/compose_test.go
@@ -101,3 +101,44 @@ func TestComposeSubjectRequiredOnlyForANewMessage(t *testing.T) {
 		t.Errorf("cc = %v", sent.CC)
 	}
 }
+
+func TestComposeSendsTheMessageAsMarkdown(t *testing.T) {
+	server, sent := threadReplyServer(t, messageAddressedToJane, 11, 12)
+
+	err := runCLI(t, server, "--account", "8", "compose", "--thread-id", "7",
+		"-m", "The plan:\n\n- **ship** it\n- announce it")
+	if err != nil {
+		t.Fatalf("compose failed: %v", err)
+	}
+
+	want := "<p>The plan:</p>\n<ul>\n<li><strong>ship</strong> it</li>\n<li>announce it</li>\n</ul>"
+	if sent.Content != want {
+		t.Errorf("content = %q, want %q", sent.Content, want)
+	}
+}
+
+func TestComposeSendsRawHTMLVerbatim(t *testing.T) {
+	server, sent := threadReplyServer(t, messageAddressedToJane, 11, 12)
+
+	err := runCLI(t, server, "--account", "8", "compose", "--thread-id", "7",
+		"--message-html", "<h1>March</h1><p>What we shipped.</p>")
+	if err != nil {
+		t.Fatalf("compose failed: %v", err)
+	}
+	if want := "<h1>March</h1><p>What we shipped.</p>"; sent.Content != want {
+		t.Errorf("content = %q, want %q", sent.Content, want)
+	}
+}
+
+func TestComposeRefusesMessageAndMessageHTMLTogether(t *testing.T) {
+	server, sent := threadReplyServer(t, messageAddressedToJane, 11, 12)
+
+	err := runCLI(t, server, "compose", "--thread-id", "7",
+		"-m", "Hello", "--message-html", "<p>Hello</p>")
+	if err == nil || !strings.Contains(err.Error(), "none of the others can be") {
+		t.Fatalf("error = %v, want the flags refused as mutually exclusive", err)
+	}
+	if sent.Content != "" {
+		t.Errorf("nothing should have been sent, got %q", sent.Content)
+	}
+}

--- a/internal/cmd/contact_note_set.go
+++ b/internal/cmd/contact_note_set.go
@@ -11,12 +11,14 @@ import (
 
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/editor"
+	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
 type contactNoteSetCommand struct {
-	cmd  *cobra.Command
-	note string
+	cmd      *cobra.Command
+	note     string
+	noteHTML string
 }
 
 func newContactNoteSetCommand() *contactNoteSetCommand {
@@ -25,7 +27,7 @@ func newContactNoteSetCommand() *contactNoteSetCommand {
 		Use:   "set <id> [note]",
 		Short: "Write or edit a private contact note",
 		Annotations: map[string]string{
-			"agent_notes": "Accepts --note, positional content, stdin, or opens $EDITOR with the existing note. Use the delete subcommand to clear a note.",
+			"agent_notes": "Accepts --note, positional content, stdin, or opens $EDITOR with the existing note. The note is Markdown, or raw HTML via --note-html. Use the delete subcommand to clear a note.",
 		},
 		Example: `  hey contacts note set 12345 "Prefers email"
   hey contacts note set 12345 --note "Prefers email"
@@ -33,7 +35,9 @@ func newContactNoteSetCommand() *contactNoteSetCommand {
 		RunE: setCommand.run,
 		Args: cobra.MatchAll(usageMinOneArg(), cobra.MaximumNArgs(2)),
 	}
-	setCommand.cmd.Flags().StringVarP(&setCommand.note, "note", "n", "", "Private note content (or opens $EDITOR)")
+	setCommand.cmd.Flags().StringVarP(&setCommand.note, "note", "n", "", "Private note as Markdown (or opens $EDITOR)")
+	setCommand.cmd.Flags().StringVar(&setCommand.noteHTML, "note-html", "", "Private note as raw HTML instead of Markdown")
+	setCommand.cmd.MarkFlagsMutuallyExclusive("note", "note-html")
 	return setCommand
 }
 
@@ -46,28 +50,36 @@ func (c *contactNoteSetCommand) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	content, inputProvided, err := contactNoteInput(cmd.Flags().Changed("note"), c.note, args)
-	if err != nil {
-		return err
+	if c.noteHTML != "" && len(args) == 2 {
+		return apierr.ErrUsage("--note-html and positional note are mutually exclusive")
 	}
-	if !inputProvided {
-		if !stdinIsTerminal() {
-			content, err = readStdin()
-			if err != nil {
-				return err
-			}
-		} else {
-			existing, getErr := contactNoteForEditor(cmd.Context(), contactID, sdk.Contacts().Note)
-			if getErr != nil {
-				return apierr.FromSDK(getErr)
-			}
-			content, err = editor.Open(existing)
-			if err != nil {
-				return apierr.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
+	content := c.noteHTML
+	if content == "" {
+		markdownNote, inputProvided, inputErr := contactNoteInput(cmd.Flags().Changed("note"), c.note, args)
+		if inputErr != nil {
+			return inputErr
+		}
+		if !inputProvided {
+			if !stdinIsTerminal() {
+				markdownNote, inputErr = readStdin()
+				if inputErr != nil {
+					return inputErr
+				}
+			} else {
+				existing, getErr := contactNoteForEditor(cmd.Context(), contactID, sdk.Contacts().Note)
+				if getErr != nil {
+					return apierr.FromSDK(getErr)
+				}
+				markdownNote, inputErr = editor.Open(existing)
+				if inputErr != nil {
+					return apierr.ErrAPI(0, fmt.Sprintf("could not open editor: %v", inputErr))
+				}
 			}
 		}
+		content = htmlutil.FromMarkdown(strings.TrimSpace(markdownNote))
+	} else {
+		content = strings.TrimSpace(content)
 	}
-	content = strings.TrimSpace(content)
 	if content == "" {
 		return apierr.ErrUsage("note cannot be empty; use `hey contacts note delete <id>` to clear it")
 	}
@@ -102,6 +114,8 @@ func contactNoteInput(flagChanged bool, flagValue string, args []string) (string
 
 type contactNoteFetcher func(context.Context, int64) (*generated.ContactNote, error)
 
+// contactNoteForEditor prefills $EDITOR with the existing note as Markdown — the same
+// form the edited result is saved in.
 func contactNoteForEditor(ctx context.Context, contactID int64, fetch contactNoteFetcher) (string, error) {
 	note, err := fetch(ctx, contactID)
 	if err != nil {
@@ -109,6 +123,9 @@ func contactNoteForEditor(ctx context.Context, contactID int64, fetch contactNot
 	}
 	if note == nil {
 		return "", nil
+	}
+	if note.NoteHtml != "" {
+		return htmlutil.ToMarkdown(note.NoteHtml).String(), nil
 	}
 	return note.Note, nil
 }

--- a/internal/cmd/contacts_test.go
+++ b/internal/cmd/contacts_test.go
@@ -360,23 +360,33 @@ func TestContactNotesShowSetAndDelete(t *testing.T) {
 	if note := decodeContactData[generated.ContactNote](t, set.Data); note.Note != "Prefers a call" {
 		t.Errorf("set note = %+v", note)
 	}
+	if _, err := runContacts(t, server, "note", "set", "7", "--note-html", "<div>Prefers <strong>email</strong></div>"); err != nil {
+		t.Fatal(err)
+	}
 	if deleted, err := runContacts(t, server, "note", "delete", "7"); err != nil || deleted.Summary != "Private contact note deleted" {
 		t.Fatalf("delete: response=%+v error=%v", deleted, err)
 	}
 	requests := recorded.snapshot()
-	if len(requests) != 3 {
+	if len(requests) != 4 {
 		t.Fatalf("requests = %+v", requests)
 	}
 	var body generated.ContactNoteRequestContent
 	if err := json.Unmarshal(requests[1].Body, &body); err != nil {
 		t.Fatal(err)
 	}
-	if body.Contact.Note != "Prefers a call" {
-		t.Errorf("note body = %+v", body)
+	if want := "<p>Prefers a call</p>"; body.Contact.Note != want {
+		t.Errorf("note body = %q, want the Markdown converted to %q", body.Contact.Note, want)
+	}
+	var rawHTML generated.ContactNoteRequestContent
+	if err := json.Unmarshal(requests[2].Body, &rawHTML); err != nil {
+		t.Fatal(err)
+	}
+	if want := "<div>Prefers <strong>email</strong></div>"; rawHTML.Contact.Note != want {
+		t.Errorf("raw HTML note body = %q, want %q", rawHTML.Contact.Note, want)
 	}
 }
 
-func TestContactNoteSetPreservesMultilineContent(t *testing.T) {
+func TestContactNoteSetKeepsLineBreaks(t *testing.T) {
 	server, recorded := contactsServer(t)
 	content := "First line\nSecond line"
 	if _, err := runContacts(t, server, "note", "set", "7", content); err != nil {
@@ -390,8 +400,8 @@ func TestContactNoteSetPreservesMultilineContent(t *testing.T) {
 	if err := json.Unmarshal(requests[0].Body, &body); err != nil {
 		t.Fatal(err)
 	}
-	if body.Contact.Note != content {
-		t.Errorf("note = %q, want %q", body.Contact.Note, content)
+	if want := "<p>First line<br>\nSecond line</p>"; body.Contact.Note != want {
+		t.Errorf("note = %q, want %q", body.Contact.Note, want)
 	}
 }
 

--- a/internal/cmd/forward.go
+++ b/internal/cmd/forward.go
@@ -11,11 +11,12 @@ import (
 )
 
 type forwardCommand struct {
-	cmd     *cobra.Command
-	to      string
-	cc      string
-	bcc     string
-	message string
+	cmd         *cobra.Command
+	to          string
+	cc          string
+	bcc         string
+	message     string
+	messageHTML string
 }
 
 func newForwardCommand() *forwardCommand {
@@ -35,7 +36,9 @@ func newForwardCommand() *forwardCommand {
 	forwardCommand.cmd.Flags().StringVar(&forwardCommand.to, "to", "", "Recipient email address(es)")
 	forwardCommand.cmd.Flags().StringVar(&forwardCommand.cc, "cc", "", "CC recipient email address(es)")
 	forwardCommand.cmd.Flags().StringVar(&forwardCommand.bcc, "bcc", "", "BCC recipient email address(es)")
-	forwardCommand.cmd.Flags().StringVarP(&forwardCommand.message, "message", "m", "", "Optional note above the forwarded message")
+	forwardCommand.cmd.Flags().StringVarP(&forwardCommand.message, "message", "m", "", "Optional Markdown note above the forwarded message")
+	forwardCommand.cmd.Flags().StringVar(&forwardCommand.messageHTML, "message-html", "", "The note as raw HTML instead of Markdown")
+	forwardCommand.cmd.MarkFlagsMutuallyExclusive("message", "message-html")
 
 	return forwardCommand
 }
@@ -79,7 +82,11 @@ func (c *forwardCommand) run(cmd *cobra.Command, args []string) error {
 		return apierr.ErrNotFound("forward draft for thread", args[0])
 	}
 
-	content := htmlutil.PrependText(draft.Content, c.message)
+	note := c.messageHTML
+	if note == "" {
+		note = htmlutil.FromMarkdown(c.message)
+	}
+	content := htmlutil.PrependHTML(draft.Content, note)
 	if err := forwardSDK.Messages().Create(ctx, draft.Subject, content, to, cc, bcc); err != nil {
 		return apierr.FromSDK(err)
 	}

--- a/internal/cmd/forward_test.go
+++ b/internal/cmd/forward_test.go
@@ -108,7 +108,7 @@ func TestForwardSendsLatestEntryDraft(t *testing.T) {
 	if sent.Subject != "Fwd: Quarterly planning" {
 		t.Errorf("subject = %q", sent.Subject)
 	}
-	wantContent := `<div>For your review<br>Thanks &amp; take care</div><br><div>Quoted message</div>`
+	wantContent := "<p>For your review<br>\nThanks &amp; take care</p><br><div>Quoted message</div>"
 	if sent.Content != wantContent {
 		t.Errorf("content = %q, want %q", sent.Content, wantContent)
 	}
@@ -120,6 +120,40 @@ func TestForwardSendsLatestEntryDraft(t *testing.T) {
 	}
 	if len(sent.BCC) != 1 || sent.BCC[0] != "carol@example.com" {
 		t.Errorf("bcc = %v", sent.BCC)
+	}
+}
+
+func TestForwardSendsTheNoteAsMarkdown(t *testing.T) {
+	server, sent := forwardServer(t, `[{"id":12}]`)
+
+	err := runCLI(t, server, "--account", "8", "forward", "7",
+		"--to", "alice@example.com",
+		"-m", "For **your** review",
+	)
+	if err != nil {
+		t.Fatalf("forward failed: %v", err)
+	}
+
+	wantContent := `<p>For <strong>your</strong> review</p><br><div>Quoted message</div>`
+	if sent.Content != wantContent {
+		t.Errorf("content = %q, want %q", sent.Content, wantContent)
+	}
+}
+
+func TestForwardSendsARawHTMLNoteVerbatim(t *testing.T) {
+	server, sent := forwardServer(t, `[{"id":12}]`)
+
+	err := runCLI(t, server, "--account", "8", "forward", "7",
+		"--to", "alice@example.com",
+		"--message-html", "<div>For <strong>your</strong> review</div>",
+	)
+	if err != nil {
+		t.Fatalf("forward failed: %v", err)
+	}
+
+	wantContent := `<div>For <strong>your</strong> review</div><br><div>Quoted message</div>`
+	if sent.Content != wantContent {
+		t.Errorf("content = %q, want %q", sent.Content, wantContent)
 	}
 }
 

--- a/internal/cmd/journal.go
+++ b/internal/cmd/journal.go
@@ -25,7 +25,7 @@ func newJournalCommand() *journalCommand {
 		Use:   "journal",
 		Short: "Read and write journal entries",
 		Annotations: map[string]string{
-			"agent_notes": "Subcommands: list, read, write. Read defaults to today. Write accepts --content, stdin, or opens $EDITOR.",
+			"agent_notes": "Subcommands: list, read, write. Read defaults to today. Write accepts --content, stdin, or opens $EDITOR; content is Markdown, or raw HTML via --content-html.",
 		},
 	}
 
@@ -194,8 +194,9 @@ func (c *journalReadCommand) run(cmd *cobra.Command, args []string) error {
 // write
 
 type journalWriteCommand struct {
-	cmd     *cobra.Command
-	content string
+	cmd         *cobra.Command
+	content     string
+	contentHTML string
 }
 
 func newJournalWriteCommand() *journalWriteCommand {
@@ -216,7 +217,9 @@ be read the command stops rather than opening a blank buffer over it.`,
 		Args: cobra.MaximumNArgs(2),
 	}
 
-	journalWriteCommand.cmd.Flags().StringVarP(&journalWriteCommand.content, "content", "c", "", "Journal content (or opens $EDITOR)")
+	journalWriteCommand.cmd.Flags().StringVarP(&journalWriteCommand.content, "content", "c", "", "Journal content as Markdown (or opens $EDITOR)")
+	journalWriteCommand.cmd.Flags().StringVar(&journalWriteCommand.contentHTML, "content-html", "", "Journal content as raw HTML instead of Markdown")
+	journalWriteCommand.cmd.MarkFlagsMutuallyExclusive("content", "content-html")
 
 	return journalWriteCommand
 }
@@ -234,6 +237,9 @@ func (c *journalWriteCommand) run(cmd *cobra.Command, args []string) error {
 		if content != "" {
 			return apierr.ErrUsage("--content and positional content are mutually exclusive")
 		}
+		if c.contentHTML != "" {
+			return apierr.ErrUsage("--content-html and positional content are mutually exclusive")
+		}
 		if !isDateArg(args[0]) {
 			return apierr.ErrUsageHint(
 				"first argument must be a date (YYYY-MM-DD) when two positional arguments are given",
@@ -248,34 +254,43 @@ func (c *journalWriteCommand) run(cmd *cobra.Command, args []string) error {
 			if content != "" {
 				return apierr.ErrUsage("--content and positional content are mutually exclusive")
 			}
+			if c.contentHTML != "" {
+				return apierr.ErrUsage("--content-html and positional content are mutually exclusive")
+			}
 			content = args[0]
 		}
 	}
 	ctx := cmd.Context()
-	if content == "" && !stdinIsTerminal() {
-		piped, err := readStdin()
-		if err != nil {
-			return err
-		}
-		if piped == "" {
-			return apierr.ErrUsage("no content provided (use --content to provide inline, or pipe to stdin)")
-		}
-		content = piped
-	}
 
 	if date == "" {
 		date = time.Now().Format(dateLayout)
 	}
 
-	if content == "" {
-		var err error
-		content, err = journalEntryFromEditor(ctx, date, sdk.Journal().GetContent, editor.Open)
-		if err != nil {
-			return err
+	if c.contentHTML != "" {
+		content = strings.TrimSpace(c.contentHTML)
+	} else {
+		if content == "" && !stdinIsTerminal() {
+			piped, err := readStdin()
+			if err != nil {
+				return err
+			}
+			if piped == "" {
+				return apierr.ErrUsage("no content provided (use --content to provide inline, or pipe to stdin)")
+			}
+			content = piped
+		}
+		if content == "" {
+			var err error
+			content, err = journalEntryFromEditor(ctx, date, sdk.Journal().GetContent, editor.Open)
+			if err != nil {
+				return err
+			}
+		}
+		content = strings.TrimSpace(content)
+		if content != "" {
+			content = htmlutil.FromMarkdown(content)
 		}
 	}
-
-	content = strings.TrimSpace(content)
 
 	if _, err := sdk.Journal().Update(ctx, date, content); err != nil {
 		return apierr.FromSDK(err)
@@ -300,12 +315,14 @@ type journalContentFetcher func(context.Context, string) (string, error)
 // journalEntryFromEditor opens $EDITOR on the day's entry. A read that fails is fatal:
 // an empty day answers 204 as an empty string, so anything else means we do not know
 // what the day holds -- and saving an empty editor over it would replace the entry.
+// journalEntryFromEditor prefills $EDITOR with the day's entry as Markdown — the same
+// form the edited result is saved in.
 func journalEntryFromEditor(ctx context.Context, date string, fetch journalContentFetcher, open func(string) (string, error)) (string, error) {
 	existing, err := fetch(ctx, date)
 	if err != nil {
 		return "", apierr.FromSDK(err)
 	}
-	edited, err := open(existing)
+	edited, err := open(htmlutil.ToMarkdown(existing).String())
 	if err != nil {
 		return "", apierr.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
 	}

--- a/internal/cmd/journal_test.go
+++ b/internal/cmd/journal_test.go
@@ -143,6 +143,41 @@ func TestJournalWriteShortFlag(t *testing.T) {
 	}
 }
 
+func TestJournalWriteMarkdownContent(t *testing.T) {
+	var sent struct {
+		CalendarJournalEntry struct {
+			Content string `json:"content"`
+		} `json:"calendar_journal_entry"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			_ = json.NewDecoder(r.Body).Decode(&sent)
+			w.WriteHeader(204)
+			return
+		}
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	_, err := runJournalWrite(t, server, "2026-03-15", "**Bold** start to the week")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	want := "<p><strong>Bold</strong> start to the week</p>"
+	if sent.CalendarJournalEntry.Content != want {
+		t.Errorf("content = %q, want %q", sent.CalendarJournalEntry.Content, want)
+	}
+
+	_, err = runJournalWrite(t, server, "2026-03-15", "--content-html", "<div>Raw <strong>HTML</strong> entry</div>")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if want := "<div>Raw <strong>HTML</strong> entry</div>"; sent.CalendarJournalEntry.Content != want {
+		t.Errorf("content = %q, want %q", sent.CalendarJournalEntry.Content, want)
+	}
+}
+
 func TestJournalWriteConflictFlagAndPositional(t *testing.T) {
 	server := journalServer(t)
 	defer server.Close()
@@ -204,11 +239,11 @@ func TestJournalEntryFromEditorRefusesAFailedPrefillRead(t *testing.T) {
 	}
 }
 
-func TestJournalEntryFromEditorPrefillsTheDaysEntry(t *testing.T) {
+func TestJournalEntryFromEditorPrefillsTheDaysEntryAsMarkdown(t *testing.T) {
 	prefilled := ""
 	content, err := journalEntryFromEditor(t.Context(), "2026-01-31",
 		func(context.Context, string) (string, error) {
-			return "<div>Ran six miles</div>", nil
+			return "<div>Ran <strong>six</strong> miles</div>", nil
 		},
 		func(existing string) (string, error) {
 			prefilled = existing
@@ -217,10 +252,10 @@ func TestJournalEntryFromEditorPrefillsTheDaysEntry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if prefilled != "<div>Ran six miles</div>" {
+	if prefilled != "Ran **six** miles" {
 		t.Errorf("editor was pre-filled with %q", prefilled)
 	}
-	if content != "<div>Ran six miles</div> and swam" {
+	if content != "Ran **six** miles and swam" {
 		t.Errorf("content = %q", content)
 	}
 }

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/editor"
+	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
 type replyCommand struct {
 	cmd         *cobra.Command
 	message     string
+	messageHTML string
 	attachments []string
 }
 
@@ -28,7 +30,7 @@ The reply is addressed the way HEY's own web app addresses one: everyone that en
 addressed to, with whoever wrote it on the To line. HEY saves an unaddressed reply as a
 draft rather than sending it, so the command fails when it cannot work the recipients out.`,
 		Annotations: map[string]string{
-			"agent_notes": "Replies to the latest entry in a thread, addressed the way HEY addresses a reply: everyone that entry was addressed to, plus its sender on the To line. Accepts message via -m, stdin, or $EDITOR, plus repeatable --attach files; an attachment can be sent without body text.",
+			"agent_notes": "Replies to the latest entry in a thread, addressed the way HEY addresses a reply: everyone that entry was addressed to, plus its sender on the To line. Accepts message via -m, stdin, or $EDITOR, plus repeatable --attach files; an attachment can be sent without body text. The message is Markdown; use --message-html to send raw HTML instead.",
 		},
 		Example: `  hey reply 12345 -m "Friday works for me — I'll send an agenda."
   hey reply 12345 -m "Attached is the report." --attach ./report.pdf
@@ -37,8 +39,10 @@ draft rather than sending it, so the command fails when it cannot work the recip
 		Args: usageExactOneArg(),
 	}
 
-	replyCommand.cmd.Flags().StringVarP(&replyCommand.message, "message", "m", "", "Reply message (or opens $EDITOR)")
+	replyCommand.cmd.Flags().StringVarP(&replyCommand.message, "message", "m", "", "Reply message as Markdown (or opens $EDITOR)")
+	replyCommand.cmd.Flags().StringVar(&replyCommand.messageHTML, "message-html", "", "Reply message as raw HTML instead of Markdown")
 	replyCommand.cmd.Flags().StringArrayVar(&replyCommand.attachments, "attach", nil, "File to attach (repeatable)")
+	replyCommand.cmd.MarkFlagsMutuallyExclusive("message", "message-html")
 
 	return replyCommand
 }
@@ -61,23 +65,27 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 	}
 	replySDK := target.client
 
-	message := c.message
-	if message == "" && !stdinIsTerminal() {
-		message, err = readStdin()
-		if err != nil {
-			return err
+	message := c.messageHTML
+	if message == "" {
+		markdownMessage := c.message
+		if markdownMessage == "" && !stdinIsTerminal() {
+			markdownMessage, err = readStdin()
+			if err != nil {
+				return err
+			}
+			if markdownMessage == "" && len(c.attachments) == 0 {
+				return apierr.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
+			}
+		} else if markdownMessage == "" && len(c.attachments) == 0 {
+			markdownMessage, err = editor.Open("")
+			if err != nil {
+				return apierr.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
+			}
+			if markdownMessage == "" {
+				return apierr.ErrUsage("empty message, aborting")
+			}
 		}
-		if message == "" && len(c.attachments) == 0 {
-			return apierr.ErrUsage("no message provided (use -m or --message to provide inline, or pipe to stdin)")
-		}
-	} else if message == "" && len(c.attachments) == 0 {
-		message, err = editor.Open("")
-		if err != nil {
-			return apierr.ErrAPI(0, fmt.Sprintf("could not open editor: %v", err))
-		}
-		if message == "" {
-			return apierr.ErrUsage("empty message, aborting")
-		}
+		message = htmlutil.FromMarkdown(markdownMessage)
 	}
 
 	message, err = attachFilesWithClient(ctx, replySDK, message, c.attachments)

--- a/internal/cmd/snippet.go
+++ b/internal/cmd/snippet.go
@@ -9,6 +9,7 @@ import (
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/htmlutil"
 	"github.com/basecamp/hey-cli/internal/output"
 	"github.com/basecamp/hey-cli/internal/terminal"
 )
@@ -135,9 +136,10 @@ func newSnippetCommand() *snippetCommand {
 }
 
 type snippetCreateCommand struct {
-	cmd     *cobra.Command
-	name    string
-	content string
+	cmd         *cobra.Command
+	name        string
+	content     string
+	contentHTML string
 }
 
 func newSnippetCreateCommand() *snippetCreateCommand {
@@ -152,7 +154,9 @@ func newSnippetCreateCommand() *snippetCreateCommand {
 		Args: cobra.NoArgs,
 	}
 	createCommand.cmd.Flags().StringVar(&createCommand.name, "name", "", "Snippet name (required)")
-	createCommand.cmd.Flags().StringVar(&createCommand.content, "content", "", "Snippet content as text or HTML (required)")
+	createCommand.cmd.Flags().StringVar(&createCommand.content, "content", "", "Snippet content as Markdown")
+	createCommand.cmd.Flags().StringVar(&createCommand.contentHTML, "content-html", "", "Snippet content as raw HTML instead of Markdown")
+	createCommand.cmd.MarkFlagsMutuallyExclusive("content", "content-html")
 	return createCommand
 }
 
@@ -164,10 +168,14 @@ func (c *snippetCreateCommand) run(cmd *cobra.Command, _ []string) error {
 	if name == "" {
 		return apierr.ErrUsage("--name is required")
 	}
-	if strings.TrimSpace(c.content) == "" {
+	content := c.contentHTML
+	if content == "" {
+		content = htmlutil.FromMarkdown(c.content)
+	}
+	if strings.TrimSpace(content) == "" {
 		return apierr.ErrUsage("--content is required")
 	}
-	if err := sdk.Snippets().Create(cmd.Context(), name, c.content); err != nil {
+	if err := sdk.Snippets().Create(cmd.Context(), name, content); err != nil {
 		return apierr.FromSDK(err)
 	}
 	return writeMutation(cmd, fmt.Sprintf("Snippet %q created", name), map[string]any{"name": name},
@@ -176,9 +184,10 @@ func (c *snippetCreateCommand) run(cmd *cobra.Command, _ []string) error {
 }
 
 type snippetUpdateCommand struct {
-	cmd     *cobra.Command
-	name    string
-	content string
+	cmd         *cobra.Command
+	name        string
+	content     string
+	contentHTML string
 }
 
 func newSnippetUpdateCommand() *snippetUpdateCommand {
@@ -193,7 +202,9 @@ func newSnippetUpdateCommand() *snippetUpdateCommand {
 		Args: usageExactOneArg(),
 	}
 	updateCommand.cmd.Flags().StringVar(&updateCommand.name, "name", "", "New snippet name")
-	updateCommand.cmd.Flags().StringVar(&updateCommand.content, "content", "", "New snippet content as text or HTML")
+	updateCommand.cmd.Flags().StringVar(&updateCommand.content, "content", "", "New snippet content as Markdown")
+	updateCommand.cmd.Flags().StringVar(&updateCommand.contentHTML, "content-html", "", "New snippet content as raw HTML instead of Markdown")
+	updateCommand.cmd.MarkFlagsMutuallyExclusive("content", "content-html")
 	return updateCommand
 }
 
@@ -206,9 +217,9 @@ func (c *snippetUpdateCommand) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	nameChanged := cmd.Flags().Changed("name")
-	contentChanged := cmd.Flags().Changed("content")
+	contentChanged := cmd.Flags().Changed("content") || cmd.Flags().Changed("content-html")
 	if !nameChanged && !contentChanged {
-		return apierr.ErrUsage("provide --name or --content")
+		return apierr.ErrUsage("provide --name, --content or --content-html")
 	}
 	name := c.name
 	if nameChanged {
@@ -217,10 +228,14 @@ func (c *snippetUpdateCommand) run(cmd *cobra.Command, args []string) error {
 			return apierr.ErrUsage("--name cannot be empty")
 		}
 	}
-	if contentChanged && strings.TrimSpace(c.content) == "" {
+	content := c.contentHTML
+	if content == "" {
+		content = htmlutil.FromMarkdown(c.content)
+	}
+	if contentChanged && strings.TrimSpace(content) == "" {
 		return apierr.ErrUsage("--content cannot be empty")
 	}
-	if err := sdk.Snippets().Update(cmd.Context(), snippetID, name, c.content); err != nil {
+	if err := sdk.Snippets().Update(cmd.Context(), snippetID, name, content); err != nil {
 		return apierr.FromSDK(err)
 	}
 	return writeMutation(cmd, fmt.Sprintf("Snippet %d updated", snippetID), map[string]any{"id": snippetID})

--- a/internal/cmd/snippet_test.go
+++ b/internal/cmd/snippet_test.go
@@ -102,7 +102,7 @@ func TestSnippetCreateSendsNameAndContent(t *testing.T) {
 		if got := r.PostForm.Get("snippet[name]"); got != "Scheduling reply" {
 			t.Errorf("name = %q", got)
 		}
-		if got := r.PostForm.Get("snippet[content]"); got != "Does Tuesday work?" {
+		if got := r.PostForm.Get("snippet[content]"); got != "<p>Does Tuesday work?</p>" {
 			t.Errorf("content = %q", got)
 		}
 	}), "snippet", "create", "--name", "Scheduling reply", "--content", "Does Tuesday work?")
@@ -111,6 +111,39 @@ func TestSnippetCreateSendsNameAndContent(t *testing.T) {
 	}
 	if response.Summary != `Snippet "Scheduling reply" created` || response.Data.(map[string]any)["name"] != "Scheduling reply" {
 		t.Errorf("response = %#v", response)
+	}
+}
+
+func TestSnippetCreateConvertsMarkdownContent(t *testing.T) {
+	_, err := runJSONCommand(t, snippetMutationHandler(t, http.MethodPost, "/snippets", func(r *http.Request) {
+		if got := r.PostForm.Get("snippet[content]"); got != "<p>Does <strong>Tuesday</strong> work?</p>" {
+			t.Errorf("content = %q", got)
+		}
+	}), "snippet", "create", "--name", "Scheduling reply", "--content", "Does **Tuesday** work?")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSnippetCreateSendsRawHTMLVerbatim(t *testing.T) {
+	_, err := runJSONCommand(t, snippetMutationHandler(t, http.MethodPost, "/snippets", func(r *http.Request) {
+		if got := r.PostForm.Get("snippet[content]"); got != "<div>Office hours are <strong>Monday through Thursday</strong>.</div>" {
+			t.Errorf("content = %q", got)
+		}
+	}), "snippet", "create", "--name", "Office hours", "--content-html", "<div>Office hours are <strong>Monday through Thursday</strong>.</div>")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSnippetUpdateConvertsMarkdownContent(t *testing.T) {
+	_, err := runJSONCommand(t, snippetMutationHandler(t, http.MethodPatch, "/snippets/44", func(r *http.Request) {
+		if got := r.PostForm.Get("snippet[content]"); got != "<p><em>Wednesday</em> works for me.</p>" {
+			t.Errorf("content = %q", got)
+		}
+	}), "snippet", "update", "44", "--content", "*Wednesday* works for me.")
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -152,7 +185,8 @@ func TestSnippetCommandsValidateInput(t *testing.T) {
 	}{
 		{name: "create name", args: []string{"snippet", "create", "--content", "Hello"}, want: "--name is required"},
 		{name: "create content", args: []string{"snippet", "create", "--name", "Greeting"}, want: "--content is required"},
-		{name: "update fields", args: []string{"snippet", "update", "44"}, want: "provide --name or --content"},
+		{name: "update fields", args: []string{"snippet", "update", "44"}, want: "provide --name, --content or --content-html"},
+		{name: "exclusive content", args: []string{"snippet", "create", "--name", "Greeting", "--content", "Hello", "--content-html", "<p>Hello</p>"}, want: "none of the others can be"},
 		{name: "empty update", args: []string{"snippet", "update", "44", "--content", "  "}, want: "--content cannot be empty"},
 		{name: "invalid id", args: []string{"snippet", "delete", "zero"}, want: "invalid snippet ID: zero"},
 	}

--- a/internal/cmd/thread_reply_test.go
+++ b/internal/cmd/thread_reply_test.go
@@ -286,6 +286,34 @@ func TestRecipientsForReplyTo(t *testing.T) {
 	}
 }
 
+func TestReplySendsTheMessageAsMarkdown(t *testing.T) {
+	server, sent := threadReplyServer(t, messageAddressedToJane, 11, 12)
+
+	err := runCLI(t, server, "--account", "8", "reply", "7",
+		"-m", "Sounds **great** — Tuesday it is")
+	if err != nil {
+		t.Fatalf("reply failed: %v", err)
+	}
+
+	want := "<p>Sounds <strong>great</strong> — Tuesday it is</p>"
+	if sent.Content != want {
+		t.Errorf("content = %q, want %q", sent.Content, want)
+	}
+}
+
+func TestReplySendsRawHTMLVerbatim(t *testing.T) {
+	server, sent := threadReplyServer(t, messageAddressedToJane, 11, 12)
+
+	err := runCLI(t, server, "--account", "8", "reply", "7",
+		"--message-html", "<p>Confirmed — <strong>Tuesday</strong>.</p>")
+	if err != nil {
+		t.Fatalf("reply failed: %v", err)
+	}
+	if want := "<p>Confirmed — <strong>Tuesday</strong>.</p>"; sent.Content != want {
+		t.Errorf("content = %q, want %q", sent.Content, want)
+	}
+}
+
 // runCLI drives a command the way the binary does — through the root command, so the
 // output writer and auth are set up — against a test server.
 func runCLI(t *testing.T, server *httptest.Server, args ...string) error {

--- a/internal/htmlutil/from_markdown.go
+++ b/internal/htmlutil/from_markdown.go
@@ -1,0 +1,88 @@
+package htmlutil
+
+import (
+	"bytes"
+	stdhtml "html"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/renderer"
+	htmlrenderer "github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+// fromMarkdown converts what the author typed for one of HEY's rich-text fields.
+// Hard wraps keep a message breaking where it was typed, and raw HTML passes
+// through because the author could send it verbatim without this conversion.
+var fromMarkdown = goldmark.New(
+	goldmark.WithExtensions(extension.Strikethrough),
+	goldmark.WithRendererOptions(
+		htmlrenderer.WithHardWraps(),
+		htmlrenderer.WithUnsafe(),
+		renderer.WithNodeRenderers(util.Prioritized(&trixCodeBlockRenderer{}, 100)),
+	),
+)
+
+// trixLanguages maps a fence's info string to the language names HEY's own code
+// blocks carry, which is the set its server-side highlighter accepts.
+var trixLanguages = map[string]string{
+	"html": "html", "css": "css",
+	"javascript": "javascript", "js": "javascript",
+	"typescript": "typescript", "ts": "typescript",
+	"python": "python", "py": "python",
+	"ruby": "ruby", "rb": "ruby",
+	"java": "java", "php": "php", "swift": "swift",
+	"csharp": "csharp", "c#": "csharp", "cs": "csharp",
+	"go": "go", "golang": "go",
+	"rust": "rust", "rs": "rust",
+	"cpp": "cpp", "c++": "cpp",
+}
+
+// trixCodeBlockRenderer writes a fenced code block the way HEY's editor stores one:
+// a <pre> carrying the language as its own attribute, which is what the web app's
+// syntax highlighting reads.
+type trixCodeBlockRenderer struct{}
+
+func (r *trixCodeBlockRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ast.KindFencedCodeBlock, r.renderFencedCodeBlock)
+}
+
+func (r *trixCodeBlockRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		_, _ = w.WriteString("</code></pre>\n")
+		return ast.WalkContinue, nil
+	}
+	block, ok := node.(*ast.FencedCodeBlock)
+	if !ok {
+		return ast.WalkContinue, nil
+	}
+	_, _ = w.WriteString("<pre")
+	if language, ok := trixLanguages[strings.ToLower(string(block.Language(source)))]; ok {
+		_, _ = w.WriteString(` language="` + language + `"`)
+	}
+	_, _ = w.WriteString("><code>")
+	lines := block.Lines()
+	for i := range lines.Len() {
+		line := lines.At(i)
+		_, _ = w.Write(util.EscapeHTML(line.Value(source)))
+	}
+	return ast.WalkContinue, nil
+}
+
+// FromMarkdown converts Markdown the user wrote into HTML for one of HEY's
+// rich-text fields: a message body, a journal entry, a contact note, a snippet.
+func FromMarkdown(md string) string {
+	var buf bytes.Buffer
+	if err := fromMarkdown.Convert([]byte(md), &buf); err != nil {
+		return textAsHTML(md)
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func textAsHTML(text string) string {
+	text = strings.TrimSpace(strings.ReplaceAll(text, "\r\n", "\n"))
+	escaped := stdhtml.EscapeString(text)
+	return strings.ReplaceAll(escaped, "\n", "<br>")
+}

--- a/internal/htmlutil/from_markdown_test.go
+++ b/internal/htmlutil/from_markdown_test.go
@@ -1,0 +1,110 @@
+package htmlutil
+
+import "testing"
+
+func TestFromMarkdown(t *testing.T) {
+	tests := []struct {
+		name string
+		md   string
+		want string
+	}{
+		{
+			name: "plain paragraph",
+			md:   "Hello there",
+			want: "<p>Hello there</p>",
+		},
+		{
+			name: "single newline becomes a hard break",
+			md:   "Line one\nLine two",
+			want: "<p>Line one<br>\nLine two</p>",
+		},
+		{
+			name: "CRLF newline becomes a hard break",
+			md:   "Line one\r\nLine two",
+			want: "<p>Line one<br>\nLine two</p>",
+		},
+		{
+			name: "blank line splits paragraphs",
+			md:   "Para one\n\nPara two",
+			want: "<p>Para one</p>\n<p>Para two</p>",
+		},
+		{
+			name: "inline emphasis and strikethrough",
+			md:   "**bold** and *italic* and ~~gone~~",
+			want: "<p><strong>bold</strong> and <em>italic</em> and <del>gone</del></p>",
+		},
+		{
+			name: "heading and list",
+			md:   "# Agenda\n\n- budget\n- hiring",
+			want: "<h1>Agenda</h1>\n<ul>\n<li>budget</li>\n<li>hiring</li>\n</ul>",
+		},
+		{
+			name: "links keep their destinations",
+			md:   "[HEY](https://hey.com) and <https://example.com>",
+			want: `<p><a href="https://hey.com">HEY</a> and <a href="https://example.com">https://example.com</a></p>`,
+		},
+		{
+			name: "metacharacters are escaped",
+			md:   "a & b < c",
+			want: "<p>a &amp; b &lt; c</p>",
+		},
+		{
+			name: "raw HTML passes through",
+			md:   "<div>raw <strong>html</strong></div>",
+			want: "<div>raw <strong>html</strong></div>",
+		},
+		{
+			name: "code span and fence stay verbatim",
+			md:   "`hey box list`\n\n```\nmake test\n```",
+			want: "<p><code>hey box list</code></p>\n<pre><code>make test\n</code></pre>",
+		},
+		{
+			name: "fence language becomes HEY's pre attribute",
+			md:   "```ruby\nputs \"hey\"\n```",
+			want: "<pre language=\"ruby\"><code>puts &quot;hey&quot;\n</code></pre>",
+		},
+		{
+			name: "fence language aliases map to HEY's names",
+			md:   "```js\nconsole.log(1 < 2)\n```",
+			want: "<pre language=\"javascript\"><code>console.log(1 &lt; 2)\n</code></pre>",
+		},
+		{
+			name: "unknown fence language carries no attribute",
+			md:   "```brainfuck\n+++\n```",
+			want: "<pre><code>+++\n</code></pre>",
+		},
+		{
+			name: "blockquote",
+			md:   "> quoted reply",
+			want: "<blockquote>\n<p>quoted reply</p>\n</blockquote>",
+		},
+		{
+			name: "empty input stays empty",
+			md:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FromMarkdown(tt.md); got != tt.want {
+				t.Errorf("FromMarkdown(%q) = %q, want %q", tt.md, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrependHTML(t *testing.T) {
+	got := PrependHTML("<div>Forwarded message</div>", "<p>For <strong>your</strong> review</p>")
+	want := "<p>For <strong>your</strong> review</p><br><div>Forwarded message</div>"
+	if got != want {
+		t.Errorf("PrependHTML() = %q, want %q", got, want)
+	}
+}
+
+func TestPrependHTMLWithoutNote(t *testing.T) {
+	content := "<div>Forwarded message</div>"
+	if got := PrependHTML(content, "  "); got != content {
+		t.Errorf("PrependHTML() = %q, want the content untouched", got)
+	}
+}

--- a/internal/htmlutil/htmlutil.go
+++ b/internal/htmlutil/htmlutil.go
@@ -3,7 +3,6 @@ package htmlutil
 import (
 	"encoding/json"
 	"fmt"
-	stdhtml "html"
 	"strconv"
 	"strings"
 
@@ -37,15 +36,13 @@ func MessageSourceText(s string) string {
 	return strings.TrimSpace(b.String())
 }
 
-// PrependText adds a plain-text note before existing HTML content.
-func PrependText(content, note string) string {
-	note = strings.TrimSpace(strings.ReplaceAll(note, "\r\n", "\n"))
+// PrependHTML adds an HTML note before existing HTML content.
+func PrependHTML(content, note string) string {
+	note = strings.TrimSpace(note)
 	if note == "" {
 		return content
 	}
-	escaped := stdhtml.EscapeString(note)
-	escaped = strings.ReplaceAll(escaped, "\n", "<br>")
-	return "<div>" + escaped + "</div><br>" + content
+	return note + "<br>" + content
 }
 
 // ExtractImageURLs finds image URLs from <img src> tags and

--- a/internal/htmlutil/htmlutil_test.go
+++ b/internal/htmlutil/htmlutil_test.go
@@ -194,21 +194,6 @@ func TestExtractAttachmentsSkipsEmbeddedHTMLAttachment(t *testing.T) {
 	}
 }
 
-func TestPrependText(t *testing.T) {
-	got := PrependText(`<div>Forwarded message</div>`, "For your review\nThanks & take care")
-	want := `<div>For your review<br>Thanks &amp; take care</div><br><div>Forwarded message</div>`
-	if got != want {
-		t.Errorf("PrependText() = %q, want %q", got, want)
-	}
-}
-
-func TestPrependTextWithoutNote(t *testing.T) {
-	content := `<div>Forwarded message</div>`
-	if got := PrependText(content, "  "); got != content {
-		t.Errorf("PrependText() = %q, want unchanged content", got)
-	}
-}
-
 func TestExtractAttachments(t *testing.T) {
 	h := `<action-text-attachment sgid="sgid-1" url="/rails/blobs/report.pdf" filename="quarterly-report.pdf" content-type="application/pdf" filesize="128"></action-text-attachment>
 <figure data-trix-attachment='{"sgid":"sgid-2","url":"/rails/blobs/photo.png","filename":"photo.png","contentType":"image/png","filesize":256}'></figure>`

--- a/internal/tui/bulk_reply.go
+++ b/internal/tui/bulk_reply.go
@@ -309,7 +309,7 @@ func (v *mailView) sendBulkReply(form *bulkReplyForm) tea.Cmd {
 	for i, entry := range form.draft.Entries {
 		entryIDs[i] = entry.Id
 	}
-	content := htmlutil.PrependText(form.draft.Content, form.body.Value())
+	content := htmlutil.PrependHTML(form.draft.Content, htmlutil.FromMarkdown(strings.TrimSpace(form.body.Value())))
 	skipped := len(form.postingIDs) - len(entryIDs)
 	return func() tea.Msg {
 		delivery, err := v.vc.sdk.BulkReplies().Send(v.vc.ctx, entryIDs, content)

--- a/internal/tui/bulk_reply_test.go
+++ b/internal/tui/bulk_reply_test.go
@@ -268,7 +268,7 @@ func TestTUIBulkReplyReviewsThenSendsAndOffersUndo(t *testing.T) {
 	if len(request.EntryIDs) != 2 || request.EntryIDs[0] != 501 || request.EntryIDs[1] != 502 {
 		t.Errorf("entry IDs = %v", request.EntryIDs)
 	}
-	want := "<div>Thanks everyone</div><br><div>Signing off with a tag!</div>"
+	want := "<p>Thanks everyone</p><br><div>Signing off with a tag!</div>"
 	if request.Message.Content != want {
 		t.Errorf("content = %q, want %q", request.Message.Content, want)
 	}

--- a/internal/tui/compose.go
+++ b/internal/tui/compose.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -14,6 +15,7 @@ import (
 	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/markdown"
 )
 
 // --- Messages ---
@@ -86,6 +88,9 @@ type composeForm struct {
 	body   textarea.Model
 	focus  int // index into inputs, or len(inputs) for body
 
+	previewing bool
+	preview    viewport.Model
+
 	status  string
 	isError bool
 	sending bool
@@ -115,7 +120,8 @@ func newComposeForm(mode composeMode, s styles) *composeForm {
 	f.body = textarea.New()
 	f.body.Prompt = ""
 	f.body.ShowLineNumbers = false
-	f.body.Placeholder = "Write your message…"
+	f.body.Placeholder = "Write your message… Markdown works here"
+	f.preview = viewport.New(viewport.WithWidth(0), viewport.WithHeight(0))
 	return f
 }
 
@@ -149,7 +155,7 @@ func newForwardForm(ctxMsg forwardContextLoadedMsg, s styles) *composeForm {
 	f.sendSDK = ctxMsg.sdk
 	f.forwardedContent = ctxMsg.content
 	f.inputs[fieldSubject].SetValue(ctxMsg.subject)
-	f.body.Placeholder = "Add a note…"
+	f.body.Placeholder = "Add a note… Markdown works here"
 	return f
 }
 
@@ -184,6 +190,11 @@ func (f *composeForm) resize(width, height int) {
 	// title + fields + blank + status + blank
 	bodyH := height - len(f.inputs) - 5
 	f.body.SetHeight(max(bodyH, 3))
+	f.preview.SetWidth(inner)
+	f.preview.SetHeight(max(bodyH, 3))
+	if f.previewing {
+		f.renderPreview()
+	}
 }
 
 func (f *composeForm) values() (to, cc, bcc []string, subject, body string) {
@@ -195,7 +206,9 @@ func (f *composeForm) values() (to, cc, bcc []string, subject, body string) {
 	}
 	body = strings.TrimSpace(f.body.Value())
 	if f.mode == composeForward {
-		body = htmlutil.PrependText(f.forwardedContent, body)
+		body = htmlutil.PrependHTML(f.forwardedContent, htmlutil.FromMarkdown(body))
+	} else if body != "" {
+		body = htmlutil.FromMarkdown(body)
 	}
 	return
 }
@@ -225,6 +238,19 @@ func (f *composeForm) setStatus(s string, isErr bool) {
 func (f *composeForm) handleKey(view *mailView, msg tea.KeyPressMsg) (tea.Cmd, bool) {
 	if f.sending {
 		return nil, true
+	}
+	if f.previewing {
+		switch {
+		case msg.String() == "ctrl+p", msg.Key().Code == tea.KeyEscape:
+			f.previewing = false
+			return f.focusCurrent(), true
+		case msg.String() == "ctrl+s":
+			return f.submit(view), true
+		default:
+			var cmd tea.Cmd
+			f.preview, cmd = f.preview.Update(msg)
+			return cmd, true
+		}
 	}
 	if f.snippetPicker != nil {
 		picker := f.snippetPicker
@@ -257,16 +283,43 @@ func (f *composeForm) handleKey(view *mailView, msg tea.KeyPressMsg) (tea.Cmd, b
 		// Enter on a header field moves on, like tab.
 		f.focus++
 		return f.focusCurrent(), true
+	case msg.String() == "ctrl+p":
+		f.showPreview()
+		return nil, true
 	case msg.String() == "ctrl+s":
-		if problem := f.validate(); problem != "" {
-			f.setStatus(problem, true)
-			return nil, true
-		}
-		f.sending = true
-		f.setStatus("Sending…", false)
-		return view.send(f), true
+		return f.submit(view), true
 	}
 	return f.update(msg), true
+}
+
+func (f *composeForm) submit(view *mailView) tea.Cmd {
+	if problem := f.validate(); problem != "" {
+		f.setStatus(problem, true)
+		return nil
+	}
+	f.sending = true
+	f.setStatus("Sending…", false)
+	return view.send(f)
+}
+
+// showPreview renders the message the way it will read on arrival: the body the form
+// would send, back through the same HTML-to-Markdown edge every received email crosses.
+func (f *composeForm) showPreview() {
+	f.body.Blur()
+	f.previewing = true
+	f.renderPreview()
+}
+
+func (f *composeForm) renderPreview() {
+	_, _, _, _, body := f.values()
+	var content string
+	if body == "" {
+		content = styleMuted.Render("Nothing to preview yet")
+	} else {
+		content = markdown.Render(htmlutil.ToMarkdown(body), max(f.width-4, 10))
+	}
+	f.preview.SetContent(content)
+	f.preview.GotoTop()
 }
 
 func (f *composeForm) handleMsg(msg tea.Msg) (tea.Cmd, bool) {
@@ -303,9 +356,18 @@ func (f *composeForm) helpBindings() []helpBinding {
 	if f.snippetPicker != nil {
 		return f.snippetPicker.helpBindings()
 	}
+	if f.previewing {
+		return []helpBinding{
+			{"↑/↓", "scroll"},
+			{"ctrl+p", "edit"},
+			{"ctrl+s", "send"},
+			{"esc", "edit"},
+		}
+	}
 	return []helpBinding{
 		{"tab", "next field"},
 		{"ctrl+t", "snippets"},
+		{"ctrl+p", "preview"},
 		{"ctrl+s", "send"},
 		{"esc", "cancel"},
 	}
@@ -346,9 +408,16 @@ func (f *composeForm) view() string {
 		b.WriteString("\n")
 	}
 	b.WriteString("\n")
-	b.WriteString(f.body.View())
+	if f.previewing {
+		b.WriteString(f.preview.View())
+	} else {
+		b.WriteString(f.body.View())
+	}
 	b.WriteString("\n")
-	if f.mode == composeForward {
+	if f.previewing {
+		b.WriteString(labelStyle.Render("Previewing how the message will read."))
+		b.WriteString("\n")
+	} else if f.mode == composeForward {
 		b.WriteString(labelStyle.Render("The original message will be included."))
 		b.WriteString("\n")
 	}

--- a/internal/tui/compose_test.go
+++ b/internal/tui/compose_test.go
@@ -180,7 +180,7 @@ func TestComposeSendsMessage(t *testing.T) {
 		t.Errorf("sent %s %s, want POST /messages.json", rec.method, rec.path)
 	}
 	m := rec.body["message"].(map[string]any)
-	if m["subject"] != "Hello" || m["content"] != "Body text" {
+	if m["subject"] != "Hello" || m["content"] != "<p>Body text</p>" {
 		t.Errorf("message payload = %v", m)
 	}
 	addressed := rec.body["entry"].(map[string]any)["addressed"].(map[string]any)
@@ -242,7 +242,7 @@ func TestReplyFormPrefillsAndSends(t *testing.T) {
 	if rec.method != "POST" || rec.path != "/entries/99/replies.json" {
 		t.Errorf("sent %s %s, want POST /entries/99/replies.json", rec.method, rec.path)
 	}
-	if rec.body["message"].(map[string]any)["content"] != "Thanks!" {
+	if rec.body["message"].(map[string]any)["content"] != "<p>Thanks!</p>" {
 		t.Errorf("body = %v", rec.body)
 	}
 	addressed := rec.body["entry"].(map[string]any)["addressed"].(map[string]any)
@@ -388,7 +388,7 @@ func TestForwardFormLoadsLatestEntryAndSends(t *testing.T) {
 	if message["subject"] != "Fwd: Quarterly planning" {
 		t.Errorf("message subject = %v", message["subject"])
 	}
-	wantContent := `<div>For your review</div><br><div>Quoted message</div>`
+	wantContent := `<p>For your review</p><br><div>Quoted message</div>`
 	if message["content"] != wantContent {
 		t.Errorf("message content = %q, want %q", message["content"], wantContent)
 	}
@@ -481,5 +481,61 @@ func TestModelRoutesAllKeysToOpenForm(t *testing.T) {
 	m = updated.(model)
 	if m.mailView.CapturingInput() {
 		t.Error("esc should close the form through the model")
+	}
+}
+
+func TestComposePreviewTogglesWithoutClosingTheForm(t *testing.T) {
+	v, _ := composeTestServer(t)
+	v.Resize(80, 30)
+	v.HandleContentKey(keyPress("c"))
+	f := composeModal(v)
+	f.focus = f.bodyIndex()
+	f.focusCurrent()
+	typeText(v, "A **bold** plan")
+
+	v.HandleContentKey(tea.KeyPressMsg(tea.Key{Code: 'p', Mod: tea.ModCtrl}))
+	if !f.previewing {
+		t.Fatal("ctrl+p should open the preview")
+	}
+	view := v.View()
+	if !strings.Contains(view, "bold") || strings.Contains(view, "**bold**") {
+		t.Errorf("preview should render the Markdown, got %q", view)
+	}
+
+	// Typing must not reach the body while previewing, and esc goes back to
+	// editing instead of closing the form.
+	v.HandleContentKey(keyPress("x"))
+	if got := f.body.Value(); got != "A **bold** plan" {
+		t.Errorf("body changed while previewing: %q", got)
+	}
+	v.HandleContentKey(keyPress("esc"))
+	if f.previewing {
+		t.Error("esc should return to editing")
+	}
+	if composeModal(v) == nil {
+		t.Fatal("esc in the preview must not close the form")
+	}
+}
+
+func TestComposeBodyIsMarkdown(t *testing.T) {
+	f := newComposeForm(composeNew, styles{})
+	f.body.SetValue("**Bold** move\nsee the list:\n\n- budget\n- hiring")
+
+	_, _, _, _, body := f.values()
+	want := "<p><strong>Bold</strong> move<br>\nsee the list:</p>\n<ul>\n<li>budget</li>\n<li>hiring</li>\n</ul>"
+	if body != want {
+		t.Errorf("body = %q, want %q", body, want)
+	}
+}
+
+func TestForwardNoteIsMarkdown(t *testing.T) {
+	f := newComposeForm(composeForward, styles{})
+	f.forwardedContent = "<div>Quoted message</div>"
+	f.body.SetValue("For **your** review")
+
+	_, _, _, _, body := f.values()
+	want := "<p>For <strong>your</strong> review</p><br><div>Quoted message</div>"
+	if body != want {
+		t.Errorf("body = %q, want %q", body, want)
 	}
 }

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -422,12 +422,22 @@ hey compose --to alice@example.com --subject "Q3 revenue report" --attach ./repo
 hey compose --to alice@example.com --subject "Q3 revenue report" -m "The numbers are attached." --attach ./report.pdf --attach ./chart.png
 hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Kitchen remodel timeline" -m "Cabinets land the week of the 14th."
 hey compose --thread-id 12345 -m "Confirmed — see you then."  # Reply into an existing thread (no subject: it carries the thread's)
+hey compose --to alice@example.com --subject "Sprint recap" -m "We **shipped** the pagination fix."
+hey compose --to alice@example.com --subject "Newsletter draft" --message-html "<h1>March</h1><p>What we shipped.</p>"
 ```
 
 `hey reply` answers the thread's **latest** entry. HEY addresses the reply the way its own
 web app does: everyone that entry was addressed to, plus whoever wrote it, on the To line.
 A reply HEY cannot address is saved as a draft rather than sent, so the command fails
 rather than guessing when it cannot work out the recipients.
+
+Everything you send is Markdown by default — `-m`, `--content`, `--note`, positional
+content, stdin, and `$EDITOR` alike — and is converted to rich text on the way out. To
+send raw HTML instead, use the flag's HTML twin: `--message-html` on `compose`, `reply`,
+`forward`, and `bulk-reply send`; `--content-html` on `journal write` and
+`snippet create`/`update`; `--note-html` on `contacts note set`. Each pair is mutually
+exclusive. A fenced code block's language (` ```ruby `) survives the conversion, and
+HEY's web app syntax-highlights it.
 
 ### Email - The Screener
 


### PR DESCRIPTION
Sending anything through the CLI or TUI used to pass the text to HEY verbatim as rich text: Markdown showed up as literal asterisks, and typed newlines collapsed on rendering. Now every text input that lands in a rich-text field is Markdown, converted once at the edge.

## What changed

**Markdown in, rich text out — on every input path.** `compose`, `reply`, `forward`, `bulk-reply send`, `journal write`, `contacts note set`, and `snippet create`/`update` convert their content with the new `htmlutil.FromMarkdown` (goldmark: hard wraps so typed newlines survive, strikethrough, raw-HTML passthrough). This covers flags, positional content, stdin, and `$EDITOR` alike — and the editor now opens prefilled with the existing journal entry or contact note as Markdown, so you edit in the language you save in.

**Raw HTML stays available through a twin flag.** `--message-html`, `--content-html`, and `--note-html` send markup verbatim; each pair is mutually exclusive with its Markdown sibling (and with positional content where that exists).

**Code blocks keep their language.** A ` ```ruby ` fence is emitted as the `language` attribute on the `<pre>`, the same shape HEY's own editor stores, so the web app syntax-highlights it. Fence aliases map to HEY's names (`js`→`javascript`, `py`→`python`, `golang`→`go`, …); languages HEY doesn't highlight carry no attribute. The read side already understood that attribute, so the fence language round-trips.

**The TUI converts too, and can preview.** The compose form (new, reply, forward note) and the bulk-reply form send Markdown the same way. `ctrl+p` in compose previews the message as it will read — the outgoing body rendered back through the same HTML→Markdown edge every received email crosses, which also keeps the sealed `htmlutil.Markdown` type as the only road to the terminal renderer. Arrows scroll, `ctrl+s` still sends, `esc` returns to editing.

With plain-text prepending gone from every caller, `htmlutil.PrependText` is deleted; forwarded and bulk-reply drafts are joined with the new `PrependHTML`.

## Evidence

- Converter table tests: paragraphs, hard breaks, CRLF, emphasis/strikethrough, headings, lists, links, escaping, raw-HTML passthrough, fences with/without/unknown languages
- Payload tests per command assert the exact HTML the server received, for the Markdown default and the `-html` twin; exclusivity is tested for the flag pairs
- TUI tests: compose body and forward-note conversion, bulk-reply conversion, preview toggle (renders, isolates keys, esc keeps the form open)
- `make lint` — 0 issues; `htmlutil`, `cmd`, `tui` suites green; `.surface` updated (additive: the eight `-html` flags)