### PR TITLE
Resolve a bundle's thread out of app_bundle_url

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,11 +446,15 @@ cursor rather than declined for pointing elsewhere.
 because `hey box view --json` publishes those fields verbatim; `mail.Postings` describes them as
 the rows a reader acts on, and everything the TUI never reads — `bundled`, `entry_kind`,
 `kind`, `updated_at` — is left in the SDK type where the CLI can still reach it. `TopicID`
-is resolved once, out of `app_url`: HEY's `_posting.jbuilder` serves neither `topic` nor
-`topic_id`, so the URL is the only place a thread is named, and a bundle's URL names a
-contact instead and answers zero. `mail.TopicIDIn` is that parse, and it is exported
-because `internal/cmd` needs the same answer — `resolvePostingTopicID` in `sdk.go` is a
-call to it, not a second copy.
+is resolved once, out of the posting's URLs: HEY's `_posting.jbuilder` serves neither
+`topic` nor `topic_id`, so a URL is the only place a thread is named. `app_url` names it
+for a plain posting; a bundle's `app_url` names a contact, so `mail.TopicIDOf` falls back
+to `app_bundle_url`, which haystack's `bundle_posting` route points at a topic exactly
+when the bundle holds one unseen thread — the thread the row opens in the web app. A
+bundle with several unseen threads (or none) names no topic and answers zero.
+`mail.TopicIDOf` and the `mail.TopicIDIn` parse under it are exported because
+`internal/cmd` needs the same answer — `resolvePostingTopicID` in `sdk.go` is a call to
+them, not a second copy.
 
 **`mail.Entry` is one message in a thread**, described by `mail.NewEntry` against the
 message HEY served for it, because a topic's entry list and a message read on its own

--- a/internal/cmd/sdk.go
+++ b/internal/cmd/sdk.go
@@ -151,10 +151,10 @@ func formatDate(ts time.Time) string {
 // --- Posting topic ID helper ---
 
 // resolvePostingTopicID extracts the topic ID from an SDK Posting. The SDK Posting has
-// no TopicID field, so the thread is read out of app_url — the one parse of it lives in
-// internal/mail, which is where a posting is described.
+// no TopicID field, so the thread is read out of its URLs — the one parse of them lives
+// in internal/mail, which is where a posting is described.
 func resolvePostingTopicID(p generated.Posting) int64 {
-	return mail.TopicIDIn(p.AppUrl)
+	return mail.TopicIDOf(p)
 }
 
 // --- Calendar helpers ---

--- a/internal/mail/posting.go
+++ b/internal/mail/posting.go
@@ -70,7 +70,7 @@ func Postings(postings []generated.Posting) []Posting {
 func NewPosting(posting generated.Posting) Posting {
 	return Posting{
 		ID:                    posting.Id,
-		TopicID:               TopicIDIn(posting.AppUrl),
+		TopicID:               TopicIDOf(posting),
 		CreatedAt:             posting.CreatedAt,
 		Name:                  terminal.SanitizeLine(posting.Name),
 		Summary:               terminal.SanitizeLine(posting.Summary),
@@ -127,10 +127,23 @@ func collectionsOf(collections []generated.Collection) []Collection {
 	return described
 }
 
-// TopicIDIn reads the thread out of a posting's app_url, which is the only place HEY's
+// TopicIDOf resolves the thread a posting opens: its own app_url, or — for a bundle,
+// whose app_url is its sender's contact page — its app_bundle_url. HEY points that at a
+// topic exactly when the bundle holds one unseen thread (haystack's `bundle_posting`
+// route), which is the thread the bundle row opens in the web app. A bundle with several
+// unseen threads opens a bundle view of its own, and one with none opens the contact, so
+// neither names a topic and both answer zero.
+func TopicIDOf(posting generated.Posting) int64 {
+	if id := TopicIDIn(posting.AppUrl); id != 0 {
+		return id
+	}
+	return TopicIDIn(posting.AppBundleUrl)
+}
+
+// TopicIDIn reads the thread out of a posting's URL, which is the only place HEY's
 // posting JSON says which topic a posting is: `_posting.jbuilder` serves no topic and no
-// topic_id, and the web app follows the URL. A posting that addresses something else has
-// no topic — a bundle's app_url is its sender's contact page — and answers zero.
+// topic_id, and the web app follows the URL. A URL that addresses something else — a
+// contact page, a bundle view — has no topic and answers zero.
 func TopicIDIn(appURL string) int64 {
 	marker := strings.LastIndex(appURL, "/topics/")
 	if marker < 0 {

--- a/internal/mail/posting_test.go
+++ b/internal/mail/posting_test.go
@@ -90,6 +90,54 @@ func TestNewPostingReadsTheThreadOutOfTheAppURL(t *testing.T) {
 	}
 }
 
+// A bundle's app_url is its sender's contact page, but HEY points app_bundle_url at a
+// topic when the bundle holds one unseen thread — the thread the row opens in the web
+// app. That is the only URL such a posting names its thread in.
+func TestTopicIDOfFallsBackToTheBundleURL(t *testing.T) {
+	tests := map[string]struct {
+		posting generated.Posting
+		want    int64
+	}{
+		"app_url wins when both name a topic": {
+			posting: generated.Posting{
+				AppUrl:       "https://app.hey.com/topics/501",
+				AppBundleUrl: "https://app.hey.com/topics/700",
+			},
+			want: 501,
+		},
+		"a bundle around one unseen thread names it in app_bundle_url": {
+			posting: generated.Posting{
+				AppUrl:       "https://app.hey.com/contacts/88",
+				AppBundleUrl: "https://app.hey.com/topics/700#entry_1_9",
+			},
+			want: 700,
+		},
+		"a bundle of several unseen threads names no topic": {
+			posting: generated.Posting{
+				AppUrl:       "https://app.hey.com/contacts/88",
+				AppBundleUrl: "https://app.hey.com/postings/bundles/12/unseen",
+			},
+			want: 0,
+		},
+		"a fully seen bundle names its contact twice": {
+			posting: generated.Posting{
+				AppUrl:       "https://app.hey.com/contacts/88",
+				AppBundleUrl: "https://app.hey.com/contacts/88",
+			},
+			want: 0,
+		},
+	}
+
+	for name, test := range tests {
+		if got := TopicIDOf(test.posting); got != test.want {
+			t.Errorf("%s: topic ID = %d, want %d", name, got, test.want)
+		}
+		if described := NewPosting(test.posting); described.TopicID != test.want {
+			t.Errorf("%s: NewPosting topic ID = %d, want %d", name, described.TopicID, test.want)
+		}
+	}
+}
+
 func TestPostingsDescribesAPage(t *testing.T) {
 	described := Postings([]generated.Posting{{Id: 100}, {Id: 101, AppUrl: "https://app.hey.com/topics/9"}})
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -307,6 +307,8 @@ Box names: `imbox`, `feedbox`, `trailbox`, `asidebox`, `laterbox`, `bubblebox`
 
 **Response format:** `hey box view --json` returns the box itself — `id`, `kind`, `name`, `app_url`, `next_history_url`, `next_page` — with a `postings` array of the email threads in it. Each posting has: `id` (box item ID), `topic_id` (thread ID), `name` (subject), `seen` (read status), `created_at`, `contacts`, `summary`, `app_url`, `visible_entry_count`. Use `id` for `hey seen`, `hey unseen`, `hey move`, `hey label add`, `hey label remove`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring`, and `topic_id` for `hey threads`, `hey reply`, `hey forward`, `hey share` and `hey attachments`. A box item `id` passed to `hey threads` answers `not_found`, and so does a `topic_id` passed to `hey move`.
 
+A posting that bundles a contact's mail into one row can **omit `topic_id`**: a bundle names its sender rather than a thread, and its `name` joins the bundled subjects with `•`. A bundle that does carry a `topic_id` opens as that thread — its one unseen thread — and `hey threads` reads it as usual. For a bundle without one, never substitute the box item `id` (`hey threads <id>` answers `not_found`); there is no command that lists the threads inside a bundle, so run `hey contacts unbundle <contact_id>` — the contact is in the posting's `contacts` — to list that sender's mail as separate rows, or direct the user to open the bundle in HEY.
+
 `next_page` is the cursor `--page` takes, and it is the cursor inside `next_history_url` — `--page` accepts either. `--all` reads to the end instead.
 
 `--ids-only` and `--count` work here too, and answer for the postings: one box item ID per line, or how many threads were read.
@@ -395,7 +397,7 @@ on an entry; use `hey reply`, which works the addressing out itself.
 
 **ID note:** Every email thread has two IDs: an `id` (its box item ID) and a `topic_id` (its thread ID). `hey seen`, `hey unseen`, `hey move`, `hey label add`, `hey label remove`, `hey trash`, `hey spam`, `hey ignore`, and `hey stop-ignoring` expect `id`. `hey threads`, `hey share`, `hey unshare`, `hey attachments`, `hey reply`, `hey forward`, `hey collection add`, and `hey collection remove` expect `topic_id`. Passing the wrong one answers `not_found`, not a redirect.
 
-`hey box view --json`, `hey label view --json`, `hey collection view --json` and `hey search --json` all carry both.
+`hey box view --json`, `hey label view --json`, `hey collection view --json` and `hey search --json` all carry both — except a bundle posting, which can omit `topic_id` (see the Boxes section).
 
 ### Email - Attachments
 


### PR DESCRIPTION
A bundle posting's `app_url` names its sender's contact page, so `resolvePostingTopicID` always answered zero for one: `hey box view --json` served bundle rows with no `topic_id`, and nothing said how to reach the thread such a row opens. The skill meanwhile documented `topic_id` on every posting, so an agent following it into a bundle either got a missing field with no guidance or substituted the box item `id` — which `hey threads` answers with `not_found`.

haystack's `bundle_posting` route (`config/routes.rb`) points `app_bundle_url` at a topic exactly when the bundle holds **one unseen thread** — the thread the row opens in the web app. Several unseen threads get a bundle view of their own; none gets the contact page. So the URL fallback is faithful to what clicking the row does.

**Code:** `mail.TopicIDOf` resolves a posting's thread out of `app_url`, falling back to `app_bundle_url`. `mail.NewPosting` (the TUI's path) and `resolvePostingTopicID` in `internal/cmd` (every `--json`/styled/markdown listing) both use it, so a one-unseen-thread bundle now carries a usable `topic_id` everywhere. A bundle with several unseen threads, or none, still answers zero.

**Skill:** the Boxes section now says what a bundle row is (`name` is the `•`-joined subjects), that `topic_id` can be absent on one, that a present one opens as that thread, and that the remedy for an absent one is `hey contacts unbundle <contact_id>` (contact in the posting's `contacts`) or the HEY app — never the box item `id`. The Threads ID note points at it.

**AGENTS.md:** the "a bundle's URL names a contact instead and answers zero" sentence now describes the fallback.

Supersedes the guidance half of #157, which documented this as a manual workaround for agents; resolving it in the CLI keeps the skill's contract true instead. Related: #156 remains the gap for bundles of several unseen threads — there is still no command that lists the topics inside one.

The two `internal/tui` calendar test failures (`TestDayLabelsCoverTodosAndHabits`, `TestWeekDrawsTheHabitsKeptEachDay`) pre-exist on main and are unrelated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve a bundle posting’s thread from `app_bundle_url` when `app_url` points to a contact, so bundle rows expose a usable `topic_id` where one exists. Previously we parsed only `app_url`, so bundles always returned `topic_id = 0` and `hey box view --json` offered no way to reach the thread the row opens.

- Add `mail.TopicIDOf`: returns `TopicIDIn(app_url)` or falls back to `TopicIDIn(app_bundle_url)`. A bundle with one unseen thread now emits its thread ID; bundles with several unseen threads or none still return 0.
- Use `TopicIDOf` in `mail.NewPosting` and `internal/cmd`’s `resolvePostingTopicID`, so CLI listings (`--json`/styled/markdown) and the TUI agree.
- Tests cover URL precedence and bundle cases.
- Update `skills/hey/SKILL.md` and `AGENTS.md` to explain bundle rows, that `topic_id` can be absent, and to use `hey contacts unbundle <contact_id>` rather than passing a box item `id` to `hey threads`.

<sup>Written for commit cf5936dddb93fa957db0605da9f2951c56fd69da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

