### PR TITLE
Suppress G115 in the dialect gosec reads

### DIFF
--- a/internal/tui/width_probe_unix.go
+++ b/internal/tui/width_probe_unix.go
@@ -49,7 +49,7 @@ func readCursorReports(in *os.File, count int, budget time.Duration) []int {
 		if remaining <= 0 {
 			return columns
 		}
-		fds := []unix.PollFd{{Fd: int32(in.Fd()), Events: unix.POLLIN}} //nolint:gosec // G115: fd fits in int32
+		fds := []unix.PollFd{{Fd: int32(in.Fd()), Events: unix.POLLIN}} // #nosec G115 -- a poll fd fits in int32
 		ready, err := unix.Poll(fds, int(remaining.Milliseconds())+1)
 		if errors.Is(err, unix.EINTR) {
 			continue


### PR DESCRIPTION
The security workflow's Go security analysis job has failed on every main push since 4a7c78f, most recently on [the #301 merge run](https://github.com/basecamp/hey-cli/actions/runs/32738338495/job/97466499959). The one finding:

```
internal/tui/width_probe_unix.go:52 - G115 (CWE-190): integer overflow conversion uintptr -> int32
```

The line already tried to suppress it — but with `//nolint:gosec`, which is golangci-lint's syntax. Standalone gosec, which the security workflow, `make gosec`, and `make release-check` run, only honors its own `#nosec` directive, so `make lint` stayed green while the workflow went red. Left alone this would also trip the next release's preflight.

The finding is a false positive: `unix.PollFd.Fd` is an `int32` because a poll fd fits in one. This rewrites the suppression as `// #nosec G115 -- a poll fd fits in int32`, matching the repo's other thirty-six. golangci-lint's gosec integration honors `#nosec` as well, so one directive serves both runners: `make lint` and `make gosec` both pass locally (gosec's Nosec count goes 36 → 37, Issues 1 → 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the suppression on the `unix.PollFd.Fd` cast from `//nolint:gosec` to `#nosec G115` so standalone `gosec` honors it. This turns the security workflow green without changing runtime behavior.

- The G115 finding is a false positive: a poll fd fits in `int32`; the conversion is safe.
- Aligns with existing `#nosec` usage so one directive serves both `gosec` and `golangci-lint`.
- Unblocks the security workflow and `make release-check`; `make lint` and `make gosec` both pass.

<sup>Written for commit 4387502ea5280c2a03b87c9f84c927a29b012ea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

