### PR TITLE
Use cached Go 1.26.6 from nixpkgs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -157,9 +157,9 @@ make update-nix-hash
 The PR-time `nix-build` job fails on every dependency bump by design — dependabot
 does not update `vendorHash` — and prints the correct hash with that command.
 
-`nix/package.nix` rebuilds Go from the upstream source tarball while
-nixpkgs-unstable lags `go.mod`'s toolchain (`minGo`). After a `nix flake update`
-that brings nixpkgs level, delete that block.
+`nix/go.nix` selects the Go toolchain from the locked nixpkgs snapshot for both
+the package and development shell. When `go.mod` moves beyond that snapshot,
+run `nix flake update nixpkgs` and commit `flake.lock` with the toolchain bump.
 
 ## CLI surface compatibility
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787172299,
-        "narHash": "sha256-PShzS87awOlE5XWkxUGBd/58/F+AtE2ZMgFffKj4r8s=",
+        "lastModified": 1787414105,
+        "narHash": "sha256-WncT27+3BOkgTaJZLnCsf3LcYf9RXMuR9ONSN4rzQ7s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "07e1d92cdc0ed416cfa11ff3ca40d17e61cfba7a",
+        "rev": "a9e6d84f9c2f9012f5fe7d964a7851352300e61a",
         "type": "github"
       },
       "original": {

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -1,28 +1,10 @@
-{ lib, fetchurl, go_1_26 }:
+{ go_1_26 }:
 
 # The Go toolchain shared by the package build and the dev shell.
 #
-# go.mod's `go` directive is the floor; nixpkgs-unstable lagged it at 1.26.5
-# when this flake was written, so the toolchain is rebuilt from the upstream
-# source tarball until nixpkgs catches up. The override is conditional and
-# drops itself once go_1_26 reaches 1.26.6 — delete this file's override and
-# return go_1_26 directly after a `nix flake update` that makes
-# `lib.versionOlder` false. Keep minGo in step with go.mod: a toolchain bump
-# that outpaces flake.lock breaks the build without touching go.mod or go.sum,
-# which is why the nix-build CI job runs on every go.mod change and on tags.
-#
-# Both consumers must use this one derivation. The dev shell once listed
-# go_1_26 directly, which handed `nix develop` a Go older than go.mod's
-# directive — `make build` then failed under GOTOOLCHAIN=local or offline.
-let
-  minGo = "1.26.6";
-in
-if lib.versionOlder go_1_26.version minGo
-then go_1_26.overrideAttrs (_: {
-  version = minGo;
-  src = fetchurl {
-    url = "https://go.dev/dl/go${minGo}.src.tar.gz";
-    hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
-  };
-})
-else go_1_26
+# Both consumers use this one derivation so the package and `nix develop`
+# cannot drift. flake.lock temporarily selects a NixOS 26.05 snapshot because
+# nixpkgs-unstable still carried Go 1.26.5 when 1.26.6 landed; a normal lock
+# update can return to unstable once it catches up. The nix-build CI job covers
+# every go.mod change and every release tag, so a regression fails closed.
+go_1_26

--- a/scripts/extract-nix-vendor-hash.sh
+++ b/scripts/extract-nix-vendor-hash.sh
@@ -18,11 +18,11 @@
 # - Matching a bare `got:` is far too loose: any failing build whose log happens
 #   to contain one — a Go test assertion printing `got: 42`, say — would yield
 #   "42" as a vendorHash and misreport an unrelated failure as a hash problem.
-# - Accepting any fixed-output mismatch is also too loose. This flake has a
-#   second fixed-output derivation — the Go source tarball nix/go.nix fetches
-#   while nixpkgs lags go.mod — and a stale hash there must not be written
-#   into vendorHash, nor reported to a contributor as the vendorHash remedy.
-#   The rebuild would then fail with nix/package.nix already corrupted.
+# - Accepting any fixed-output mismatch is also too loose. This flake used to
+#   carry a second one — the Go source tarball needed while nixpkgs lagged
+#   go.mod — and its hash must not be written into vendorHash or reported as
+#   the vendorHash remedy. The rebuild would then fail with nix/package.nix
+#   already corrupted.
 #
 # Exit codes:
 #   0 — a go-modules fixed-output hash mismatch was reported; the SRI hash is

--- a/tests/e2e/extract_nix_vendor_hash.bats
+++ b/tests/e2e/extract_nix_vendor_hash.bats
@@ -89,10 +89,9 @@ LOG
 }
 
 @test "rejects a mismatch in a fixed-output derivation that is not go-modules" {
-  # This flake carries a second fixed-output derivation: the Go source tarball
-  # nix/go.nix fetches while nixpkgs lags go.mod. A stale hash there is a
-  # nix/go.nix problem; writing it into vendorHash corrupts the tracked file and
-  # then fails the verification rebuild anyway.
+  # A source-toolchain workaround used to add a second fixed-output derivation.
+  # Keep the classifier scoped to go-modules: writing any other derivation's
+  # hash into vendorHash corrupts the tracked file and fails the rebuild.
   run "$EXTRACT" <<'LOG'
 error: hash mismatch in fixed-output derivation '/nix/store/abc-go1.26.6.src.tar.gz.drv':
          specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=

--- a/tests/e2e/update_nix_flake.bats
+++ b/tests/e2e/update_nix_flake.bats
@@ -116,10 +116,10 @@ NIX_BUILD_EXIT=1"
 }
 
 @test "does not write the Go source tarball's hash into vendorHash" {
-  # nix/go.nix fetches the Go source with its own fixed-output hash. When that
-  # one is stale, the remedy is in go.nix; the classifier must not hand its
-  # `got:` to this script, which would corrupt package.nix and then fail the
-  # verification rebuild.
+  # nix/go.nix used to fetch Go from source while nixpkgs lagged go.mod. Keep
+  # proving that a non-vendor fixed-output failure cannot hand its `got:` to
+  # this script, which would corrupt package.nix and fail the verification
+  # rebuild.
   stub_docker "error: hash mismatch in fixed-output derivation '/nix/store/abc-go1.26.6.src.tar.gz.drv':
          specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
             got:    sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=


### PR DESCRIPTION
## Why

A fresh Nix store currently recompiles Go 1.26.6 because the locked `nixpkgs-unstable` snapshot only provides 1.26.5. That makes the cold diagnostic path much more expensive than it needs to be.

The latest unstable snapshot still has 1.26.5, and the staging commit that introduced 1.26.6 is not substitutable. This pins the immutable Aug 22 NixOS 26.05 snapshot (`a9e6d84f9c2f9012f5fe7d964a7851352300e61a`), where `go_1_26` is exactly 1.26.6 and cached on both supported Linux architectures. The original input remains `nixpkgs-unstable`; once unstable catches up, a normal lock update can return there.

## What changed

- regenerate `flake.lock` with Nix at the cached 1.26.6 snapshot
- select `go_1_26` directly for both the package and development shell
- remove the upstream Go source override
- update Nix maintenance guidance and mark the non-vendor source-hash fixtures as historical

## Verification

- fresh disposable aarch64-Linux Nix store: **71.34s**, full flake build passed
- exact evaluation: `go_1_26.version == 1.26.6`
- build plan scheduled only `hey-0.2.2-go-modules.drv` and `hey-0.2.2.drv`; Nix fetched `/nix/store/...-go-1.26.6` from `cache.nixos.org`
- x86_64-Linux dry-run likewise fetched Go 1.26.6 and scheduled no Go derivation
- built binary: `hey version 0.2.2`
- all-system `nix flake check --no-build`: passed
- focused Bats: **38/38**
- `bash -n`, ShellCheck, release lockstep, and `git diff --check`: passed
- independent xhigh Codex review: no actionable findings

## Stack order

This is an independently mergeable foundation against `main`. It should land before the Go 1.27 stack (#283 → #296); no history in that existing stack is rewritten by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use cached Go 1.26.6 from `nixpkgs` to avoid rebuilding the toolchain on fresh Nix stores. Previously we rebuilt 1.26.6 from source because `nixpkgs-unstable` had 1.26.5; now `flake.lock` pins an Aug 22 NixOS 26.05 snapshot where `go_1_26` is 1.26.6 and substitutable.

- Pin `flake.lock` to the snapshot with cached `go_1_26 == 1.26.6` on x86_64-linux and aarch64-linux.
- Use `go_1_26` directly for the package and `nix develop`; remove the source-tarball override in `nix/go.nix`.
- Update `RELEASING.md` to: when `go.mod` advances past the lock, run `nix flake update nixpkgs` and commit `flake.lock`.
- Keep vendor-hash extraction scoped to go-modules; update comments/tests and mark non-vendor fixtures as historical.
- Impact: cold builds fetch the toolchain, schedule no Go derivation, and complete faster.
- Order: merge before the Go 1.27 stack.

<sup>Written for commit df0fdc84fd2010f43b4a78f5c5a022f5b17af3b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

