### PR TITLE
Stream Nix updater build progress

### DIFF
--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -19,6 +19,7 @@ fi
 NIX_PKG="nix/package.nix"
 CHANGED=false
 NIX_STORE_VOLUME=""
+NIX_BUILD_LOG=""
 
 # The build source below is staged from tracked files only, so an untracked
 # .go file never reaches the verification build — but once committed it does
@@ -57,6 +58,11 @@ cleanup() {
   if [[ -n "$NIX_STORE_VOLUME" ]] && \
      ! docker volume rm "$NIX_STORE_VOLUME" >/dev/null 2>&1; then
     echo "ERROR: could not remove temporary Nix store volume: $NIX_STORE_VOLUME" >&2
+    status=1
+  fi
+
+  if [[ -n "$NIX_BUILD_LOG" ]] && ! rm -f "$NIX_BUILD_LOG"; then
+    echo "ERROR: could not remove temporary Nix build log: $NIX_BUILD_LOG" >&2
     status=1
   fi
 
@@ -127,10 +133,13 @@ if [[ -z "$NIX_STORE_VOLUME" ]]; then
   echo "ERROR: Docker returned no name for the temporary Nix store volume"
   exit 1
 fi
+NIX_BUILD_LOG=$(mktemp)
 
-# Runs `nix build` and echoes a trailing NIX_BUILD_EXIT= line so the real exit
-# status survives command substitution. Nothing here may swallow a failure: a
-# `|| true` plus a "did it print 'building hey'" heuristic is what let
+# Runs `nix build`, streams its combined output, and records the same bytes in
+# the file passed as $1. The trailing NIX_BUILD_EXIT= line keeps the Nix status
+# available for fail-closed validation after the live stream finishes. Nothing
+# here may swallow a failure: a `|| true` plus a "did it print 'building hey'"
+# heuristic is what let
 # v0.8.0 ship a flake that could not build at all — nix logs
 # `building '...hey-0.8.0-go-modules.drv'` when it *starts* the build it
 # then fails, so the heuristic reported success on a hard failure.
@@ -142,10 +151,16 @@ fi
 # supposedly verified update. Staged fresh per call so the verification
 # rebuild sees the vendorHash written between calls.
 run_nix_build() {
-  local stage rc=0 out
+  local output_file="$1" stage rc=0
+  local -a pipeline_status
+
+  if ! : > "$output_file"; then
+    echo "ERROR: preparing the Nix build log failed" >&2
+    return 1
+  fi
+
   stage=$(mktemp -d)
-  # Errexit does not survive into this $()-invoked function (bash strips it in
-  # command substitution), so the staging pipeline must be checked by hand.
+  # The staging pipeline must be checked by hand.
   # tar still emits a partial archive — alongside a nonzero status — when a
   # tracked file is missing or unreadable (a plain `rm` without `git rm`, a
   # sparse checkout), and building that partial tree would verify source CI
@@ -155,21 +170,36 @@ run_nix_build() {
     echo "ERROR: staging tracked files for the build failed" >&2
     return 1
   fi
-  out=$(docker run --rm \
-    -v "$stage:/src:ro" \
-    -v "$NIX_STORE_VOLUME:/nix" \
-    "$NIX_IMAGE" bash -c '
-    cp -a /src /build && cd /build
-    git config --global --add safe.directory /build
-    git init -q && git add -A && \
-      GIT_COMMITTER_NAME=ci GIT_COMMITTER_EMAIL=ci@ci \
-      GIT_AUTHOR_NAME=ci GIT_AUTHOR_EMAIL=ci@ci \
-      git commit -q -m init
-    nix --extra-experimental-features "nix-command flakes" build --no-link 2>&1
-    echo "NIX_BUILD_EXIT=$?"
-  ' 2>&1) || rc=$?
+  # The pipeline is an if-condition so errexit cannot abort before PIPESTATUS
+  # is captured. Docker's status remains authoritative; a tee failure also
+  # fails the run when Docker itself succeeded because the complete log is a
+  # correctness input for the sentinel and vendorHash classifier.
+  if docker run --rm \
+      -v "$stage:/src:ro" \
+      -v "$NIX_STORE_VOLUME:/nix" \
+      "$NIX_IMAGE" bash -c '
+      cp -a /src /build && cd /build
+      git config --global --add safe.directory /build
+      git init -q && git add -A && \
+        GIT_COMMITTER_NAME=ci GIT_COMMITTER_EMAIL=ci@ci \
+        GIT_AUTHOR_NAME=ci GIT_AUTHOR_EMAIL=ci@ci \
+        git commit -q -m init
+      nix --extra-experimental-features "nix-command flakes" build \
+        --no-link --print-build-logs 2>&1
+      echo "NIX_BUILD_EXIT=$?"
+    ' 2>&1 | tee "$output_file"; then
+    pipeline_status=("${PIPESTATUS[@]}")
+  else
+    pipeline_status=("${PIPESTATUS[@]}")
+  fi
+
+  if [[ ${pipeline_status[0]} -ne 0 ]]; then
+    rc=${pipeline_status[0]}
+  elif [[ ${pipeline_status[1]} -ne 0 ]]; then
+    echo "ERROR: recording the Nix build output failed" >&2
+    rc=${pipeline_status[1]}
+  fi
   rm -rf "$stage"
-  printf '%s\n' "$out"
   return "$rc"
 }
 
@@ -179,15 +209,16 @@ nix_build_failed() {
   [[ "$(tail -n1 <<<"$1")" != "NIX_BUILD_EXIT=0" ]]
 }
 
-# The || is load-bearing twice over: it makes the abort explicit rather than
-# leaning on errexit-through-assignment, and it surfaces the captured output
-# when docker itself fails (daemon down, image pull) — previously that path
-# died via errexit with the diagnostic swallowed by the substitution.
-BUILD_OUTPUT=$(run_nix_build) || {
+# The explicit failure branch surfaces the captured output when Docker itself
+# fails (daemon down, image pull) while leaving the pipeline's Docker status
+# authoritative.
+run_nix_build "$NIX_BUILD_LOG" || {
+  BUILD_OUTPUT=$(<"$NIX_BUILD_LOG")
   echo "ERROR: could not run the Nix build"
   tail -25 <<<"$BUILD_OUTPUT"
   exit 1
 }
+BUILD_OUTPUT=$(<"$NIX_BUILD_LOG")
 
 if nix_build_failed "$BUILD_OUTPUT"; then
   # Classification lives in extract-nix-vendor-hash.sh, shared with CI's
@@ -214,11 +245,13 @@ if nix_build_failed "$BUILD_OUTPUT"; then
   # Prove the corrected hash actually builds. The old code trusted the hash it
   # had just written without ever rebuilding.
   echo "  verifying the updated vendorHash builds..."
-  BUILD_OUTPUT=$(run_nix_build) || {
+  run_nix_build "$NIX_BUILD_LOG" || {
+    BUILD_OUTPUT=$(<"$NIX_BUILD_LOG")
     echo "ERROR: could not run the Nix build"
     tail -25 <<<"$BUILD_OUTPUT"
     exit 1
   }
+  BUILD_OUTPUT=$(<"$NIX_BUILD_LOG")
   if nix_build_failed "$BUILD_OUTPUT"; then
     echo "ERROR: nix build still fails after updating the vendorHash"
     tail -25 <<<"$BUILD_OUTPUT"

--- a/tests/e2e/update_nix_flake.bats
+++ b/tests/e2e/update_nix_flake.bats
@@ -84,6 +84,132 @@ NIX_BUILD_EXIT=0"
   [[ "$output" == *"verified (build succeeded)"* ]]
 }
 
+@test "streams Nix progress before the build completes" {
+  # A command substitution used to hold every byte until Docker exited. Keep
+  # the stub blocked after its first line and prove that line has already
+  # reached the caller before allowing the build to finish.
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = volume ] && [ "${2:-}" = create ]; then
+  echo test-nix-store
+  exit 0
+fi
+if [ "${1:-}" = volume ] && [ "${2:-}" = rm ]; then
+  exit 0
+fi
+
+case "$*" in
+  *--print-build-logs*) ;;
+  *) echo "error: Nix builder logs were not enabled"; echo "NIX_BUILD_EXIT=1"; exit 0;;
+esac
+
+echo "visible build progress"
+touch "${NIX_STUB_READY:?}"
+for _ in {1..100}; do
+  [ ! -f "${NIX_STUB_CONTINUE:?}" ] || break
+  sleep 0.05
+done
+if [ ! -f "$NIX_STUB_CONTINUE" ]; then
+  echo "error: timed out waiting for the streaming assertion"
+  echo "NIX_BUILD_EXIT=1"
+  exit 0
+fi
+echo "NIX_BUILD_EXIT=0"
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  NIX_STUB_READY="$WORK/ready" NIX_STUB_CONTINUE="$WORK/continue" \
+    scripts/update-nix-flake.sh 0.1.1 > "$WORK/output" 2>&1 &
+  SCRIPT_PID=$!
+
+  for _ in {1..20}; do
+    [ ! -f "$WORK/ready" ] || break
+    sleep 0.05
+  done
+  [ -f "$WORK/ready" ]
+
+  STREAMED=false
+  for _ in {1..20}; do
+    if grep -q '^visible build progress$' "$WORK/output"; then
+      STREAMED=true
+      break
+    fi
+    sleep 0.05
+  done
+  if [ "$STREAMED" != true ]; then
+    # Let the child leave its bounded wait before failing the assertion.
+    touch "$WORK/continue"
+    wait "$SCRIPT_PID" || true
+  fi
+  [ "$STREAMED" = true ]
+  SENTINEL_ARRIVED_EARLY=false
+  if grep -q '^NIX_BUILD_EXIT=0$' "$WORK/output"; then
+    SENTINEL_ARRIVED_EARLY=true
+  fi
+
+  touch "$WORK/continue"
+  if wait "$SCRIPT_PID"; then
+    SCRIPT_STATUS=0
+  else
+    SCRIPT_STATUS=$?
+  fi
+  [ "$SCRIPT_STATUS" -eq 2 ]
+  [ "$SENTINEL_ARRIVED_EARLY" = false ]
+  [ "$(grep -c '^visible build progress$' "$WORK/output")" -eq 1 ]
+  grep -q '^NIX_BUILD_EXIT=0$' "$WORK/output"
+  grep -q 'vendorHash: verified (build succeeded)' "$WORK/output"
+}
+
+@test "does not let tee mask a Docker invocation failure" {
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = volume ] && [ "${2:-}" = create ]; then
+  echo test-nix-store
+  exit 0
+fi
+if [ "${1:-}" = volume ] && [ "${2:-}" = rm ]; then
+  exit 0
+fi
+echo "Cannot connect to the Docker daemon"
+exit 42
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  run scripts/update-nix-flake.sh 0.2.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Cannot connect to the Docker daemon"* ]]
+  [[ "$output" == *"could not run the Nix build"* ]]
+  [[ "$output" != *"verified (build succeeded)"* ]]
+  grep -q 'version = "0.1.1";' nix/package.nix
+  if grep -q 'version = "0.2.0";' nix/package.nix; then
+    echo "unverified version edit survived Docker failure"
+    return 1
+  fi
+}
+
+@test "fails closed when the streamed output cannot be recorded" {
+  stub_docker "NIX_BUILD_EXIT=0"
+  cat > "$STUB_DIR/tee" <<'STUB'
+#!/usr/bin/env bash
+# Consume the complete stream so Docker itself exits successfully, then make
+# only the recording side fail.
+while IFS= read -r _; do :; done
+exit 23
+STUB
+  chmod +x "$STUB_DIR/tee"
+
+  run scripts/update-nix-flake.sh 0.2.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"recording the Nix build output failed"* ]]
+  [[ "$output" == *"could not run the Nix build"* ]]
+  [[ "$output" != *"verified (build succeeded)"* ]]
+  grep -q 'version = "0.1.1";' nix/package.nix
+  if grep -q 'version = "0.2.0";' nix/package.nix; then
+    echo "unverified version edit survived log-recording failure"
+    return 1
+  fi
+}
+
 @test "rewrites the version literal when a new version is requested" {
   # The script's other responsibility. Without this case a regression in the
   # version rewrite passes CI, because every other test asks for the version
@@ -175,6 +301,11 @@ for a in "$@"; do
   esac
 done
 echo "run $STORE" >> "$LOG"
+
+case "$*" in
+  *--print-build-logs*) ;;
+  *) echo "error: Nix builder logs were not enabled"; echo "NIX_BUILD_EXIT=1"; exit 0;;
+esac
 
 if [ -f "$STATE" ]; then
   if [ "$(cat "$STATE")" != "$STORE" ]; then


### PR DESCRIPTION
## Why

A cold `make update-nix-hash` can spend minutes downloading and compiling with no visible detail because the updater captured all Docker output until the build finished. PR #295 is already merged; this is its independent follow-up on current `main`.

## What changed

- stream Docker/Nix output to the invoking terminal through `tee` while retaining the complete log for classification
- enable Nix builder output with `--print-build-logs`
- preserve Docker as the authoritative pipeline status and fail closed if log recording fails
- keep the last-line `NIX_BUILD_EXIT` sentinel, vendorHash extraction, tracked-only staging, rollback, shared temporary store, and cleanup contracts intact

## Verification

- `bats tests/e2e/update_nix_flake.bats` (21/21)
- `bash -n scripts/update-nix-flake.sh`
- `shellcheck scripts/update-nix-flake.sh`
- `git diff --check`
- full local Bats: 188/193; only the existing macOS `stat -c` failures in `install_ssh_key.bats`
- all non-`install_ssh_key.bats` tests sequentially: 183/183
- real disposable Docker probe: progress appeared in the caller log at 15s while the updater was still running; final exit was the expected 2, exactly one success sentinel was captured, and the probe volume was removed

The probe shared the machine with unrelated Nix review builds, so its 232s elapsed time is not presented as a performance benchmark.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams Docker/Nix build output during `update-nix-flake.sh` runs so progress appears live. Previously the script buffered all output until Docker exited; now it streams to the terminal while retaining the full log for classification.

- Streams combined Docker/Nix output via `tee` to the caller and a temp log file; preserves the trailing `NIX_BUILD_EXIT=` sentinel and vendorHash classification from the complete log.
- Enables Nix `--print-build-logs` to surface builder details.
- Keeps Docker’s exit status authoritative; surfaces Docker errors even when `tee` runs; fails closed if log recording (`tee`) fails.
- Leaves tracked-only staging, rollback behavior, shared temporary Nix store volume, and cleanup contracts unchanged.
- Adds e2e tests covering live progress, Docker failure surfacing, fail-closed on log recording errors, and version rewrite verification.

<sup>Written for commit 9496754bb8d08c524f8efd79299e454e42de06ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

