### PR TITLE
Follow the calendars live, in the TUI and in hey watch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -699,8 +699,8 @@ where The Screener announces itself. When The Screener is what's on screen the q
 re-read too, through `screenerPane.refreshHead` — the same keep-your-place trick as the
 mail list — and held while a decision is in flight or the clear-everything question is up.
 On the history tab nothing is read; the pending pane is just marked unloaded, which is
-what `switchTab` already looks at. Both watches share one websocket
-(`tuiCableClient` in `internal/cmd/tui_watch.go`): two subscriptions, one authorization.
+what `switchTab` already looks at. All the watches share one websocket
+(`tuiCableClient` in `internal/cmd/tui_watch.go`): many subscriptions, one authorization.
 A client that stopped itself preserves its terminal failure and never dials again.
 `tuiSubscribe` detects that state after any failed subscription, drops the stopped client,
 and dials a fresh one; a replacement that also stops is dropped and its failure is
@@ -708,6 +708,48 @@ classified as authentication or network so the TUI can respond consistently. Mai
 doorbells are coalesced when their bounded queue
 is full, while a connection transition drains those stale doorbells and takes priority;
 the reconnect catch-up reads the current state once.
+
+The calendars are told the way The Screener is, one Turbo stream per calendar rather than
+one channel: `Calendar` broadcasts a refresh on its own stream whenever a recording on it
+is written, and `calendars.json` serves each calendar's `signed_stream_name` next to its
+`recording_changes_url` — the box shape, on the calendar. Nothing is parsed out of the
+frame; the arrival is the whole message. What nobody broadcasts is the calendar *list*
+changing, and the web app has the same blind spot (a calendar shared mid-session appears
+on its next navigation), so a slow poll of the calendar-level changes feed
+(`calendar_changes_url`, `Calendars().AllCalendarChanges` — one page, usually empty) is
+how both followers learn of a calendar arriving or leaving. Its `added` bucket carries the
+same wrapper as the list, stream name included, so a calendar learned of either way is
+immediately subscribable.
+
+The TUI's side is `tui.CalendarWatcher` (`internal/tui/live.go`), implemented by
+`watchCalendarChanges` in `internal/cmd/tui_watch.go`: every calendar's stream folded into
+one doorbell channel, the poll resubscribing arrivals and dropping leavers, and any
+subscription closing on its own tearing the whole watch down — reopening resubscribes
+everything, which is cheaper to reason about than limping on with some calendars quiet.
+The model follows it only while the Calendar or Journal section is on screen
+(`watchingCalendars` in `tui.go`): every other section re-reads on entry, so a doorbell
+rung for a section nobody is looking at would be answered by nothing. A ring is debounced
+through the same `liveRefreshDelay`, and the re-read is `calendarView.refreshLive` — the
+ordinary span read, which never shows the spinner once a day has been drawn and keeps the
+selection by `Recording.key()` — or `journalView.refreshLive`, which splices the fresh top
+page in front of what the list had grown past it, the `refreshHead` trick with dates for
+ids. Both hold the re-read while a form, a picker or a pending delete is up
+(`liveRetryDelay`), and a failed start or closed stream retries quietly on
+`mailWatchRetryDelay`'s curve: the calendar re-reads on every step the reader takes, so a
+watch that is down costs staleness, not a notice.
+
+`hey watch` follows the same streams on its own connection and reports the changes
+themselves (`internal/cmd/watch_calendar.go`). Rings are coalesced per calendar for
+`calendarCoalesceDelay`, then the calendar's recording feed is read from its cursor
+(`Calendars().AllRecordingChanges`, cursors capped at the watch's start like the boxes' —
+`calendarCursorNoLaterThan`) and each recording is a `recording_added`, `recording_updated`
+or `recording_deleted` line naming its calendar where a mail line names its box. The poll
+reports `calendar_added`, `calendar_updated` and `calendar_deleted`, and a recording feed's
+409 is `calendar_resync` after skipping ahead to a fresh cursor from the list. The
+email-specific flags switch all of it off — `--box`, or an `--events` list naming only
+mail changes (`watchingCalendars` in watch_calendar.go) — and `ready` waits for the
+calendars' catch-up exactly as it waits for the boxes', on the same retry backoff and the
+same `readyOnceCaughtUp` critical section.
 
 ### API documentation
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ appears in every section while the network is offline or live updates are reconn
 The TUI retries the connection, clears the status when it returns, and catches up the box
 on screen; Ctrl+R remains available whenever you want to read it yourself.
 
+The Calendar and Journal sections keep up the same way while they are on screen: HEY
+rings each calendar's own update stream when something on it is written, and the span or
+list you are looking at is read again a moment later, keeping your selection. A change
+that arrives while a form or a picker is open waits for it to close, and a calendar
+shared with you after the section opened is picked up by a slow background check.
+
 The Screener keeps up too. When a first-time sender writes, the count above the threads
 changes on its own, and if you have The Screener open the new sender appears in the queue
 without moving your place in it.
@@ -448,8 +454,9 @@ Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. B
 ### Watching for changes
 
 ```bash
-hey watch                               # follow every box, a line of JSON per change
-hey watch --box imbox --events added    # only new postings in the Imbox
+hey watch                               # follow every box and calendar, a line of JSON per change
+hey watch --box imbox --events added    # only new postings in the Imbox (calendars off)
+hey watch --events recording_added,recording_updated,recording_deleted   # calendar changes only
 hey watch --box imbox --exit-on-first   # block until something lands, then exit
 hey watch --since 2026-08-18T09:00:00Z  # catch up from a time first, then follow
 hey watch --box imbox --events new      # new mail only: unseen, unmuted, active since the watch began
@@ -475,6 +482,16 @@ is judged across all of them — a reply in The Feed and then a move into the Im
 one-liner above is what any desktop does with it; on Omarchy the bar plugin reads the same
 lines and sends one batched, replacing toast instead.
 
+The calendars are followed too, by default. A changed event, todo, habit or journal entry
+is a `recording_added`, `recording_updated` or `recording_deleted` line naming its
+calendar — `{"change":"recording_added","calendar":{"id":512,"name":"Household"},
+"recording_id":88001,"recording_type":"Calendar::Event","recording":{}}` — and a calendar
+arriving, changing or leaving is `calendar_added`, `calendar_updated` or
+`calendar_deleted`. A calendar whose feed fell too far behind is skipped ahead and says so
+with `calendar_resync`, the way a box says `resync`. The email-specific flags switch the
+calendars off: `--box` scopes the watch to mail, and an `--events` list naming only mail
+changes does the same.
+
 A change can drive a command instead of being printed, and there's a choice to make
 between two behaviours — pass one or the other, not both. `--run-async` spawns the
 command per change and moves on, so a slow one never holds up the watch and two can
@@ -483,7 +500,9 @@ slow one delays the next.
 
 Both hand the JSON to the command on its stdin, and the same fields as `HEY_CHANGE`,
 `HEY_AT`, `HEY_BOX_ID`, `HEY_BOX_KIND`, `HEY_BOX_NAME`, `HEY_POSTING_ID` and
-`HEY_THREAD_ID`, with `HEY_NEW=1` for new mail and `HEY_NEW=0` otherwise. Both also take over
+`HEY_THREAD_ID`, with `HEY_NEW=1` for new mail and `HEY_NEW=0` otherwise — and on a
+calendar line `HEY_CALENDAR_ID`, `HEY_CALENDAR_NAME`, `HEY_RECORDING_ID` and
+`HEY_RECORDING_TYPE` instead of the box and posting fields. Both also take over
 stdout, so the JSON isn't printed as well.
 
 ### Calendars

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/actioncable-go v0.0.0-20260821132720-3f7811951537
-	github.com/basecamp/hey-sdk/go v0.20.0
+	github.com/basecamp/hey-sdk/go v0.21.0
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/actioncable-go v0.0.0-20260821132720-3f7811951537 h1:OE1VMvKkpI+Vo7aP5IDRG6PNXW2IVMlLUWLgBcybGNc=
 github.com/basecamp/actioncable-go v0.0.0-20260821132720-3f7811951537/go.mod h1:9+DEydJMniIKraEsd4fDJpFEnqlLUJ6XhAswxRBaITk=
-github.com/basecamp/hey-sdk/go v0.20.0 h1:8mXqdpz0cMOuP75gcpVvfj4uhX6w8I31pnjGgy9eJxE=
-github.com/basecamp/hey-sdk/go v0.20.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
+github.com/basecamp/hey-sdk/go v0.21.0 h1:/CpoFDkD8uh0U5n/AjObF3GqPOTIprAxP79l1TuTL34=
+github.com/basecamp/hey-sdk/go v0.21.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -119,7 +119,7 @@ MAIL
   screener    Decide who gets to email you
   attachment  List and save files from a thread
   draft       Browse unsent drafts
-  watch       Follow email threads as they change
+  watch       Follow email threads and calendars as they change
 
 WRITE & SHARE
   bulk-reply  Reply to multiple email threads

--- a/internal/cmd/tui_watch.go
+++ b/internal/cmd/tui_watch.go
@@ -8,6 +8,9 @@ import (
 
 	actioncable "github.com/basecamp/actioncable-go"
 
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/cable"
 	"github.com/basecamp/hey-cli/internal/tui"
 )
@@ -68,7 +71,7 @@ const (
 
 // tuiWatchers are the streams `hey tui` follows to stay live.
 func tuiWatchers() tui.Watchers {
-	return tui.Watchers{Mail: watchMailChanges, Screener: watchScreenerChanges}
+	return tui.Watchers{Mail: watchMailChanges, Screener: watchScreenerChanges, Calendar: watchCalendarChanges}
 }
 
 // watchMailChanges opens the stream of changed boxes the TUI follows, over the same
@@ -175,6 +178,175 @@ func relayScreenerChanges(ctx context.Context, messages <-chan actioncable.Messa
 			}
 			ring(changes, struct{}{})
 		}
+	}
+}
+
+// calendarListPollInterval is how often a calendar watch reads the calendar-level changes
+// feed, which is the only way it can learn of a calendar added or removed while it runs:
+// a stream can only be subscribed once the calendar is known, and HEY broadcasts nothing
+// a JSON client can follow for the list itself. The read is one page and usually empty.
+const calendarListPollInterval = 5 * time.Minute
+
+// watchCalendarChanges opens the stream that says a calendar changed. HEY broadcasts a
+// refresh frame on each calendar's own stream whenever a recording on it is written —
+// the calendars list serves the signed name next to each calendar — so this subscribes
+// them all over the TUI's shared connection and folds them into one doorbell. What HEY
+// broadcasts is markup for the web app: nothing is read out of it, the arrival is the
+// whole message, and the TUI re-reads the span on screen behind it.
+func watchCalendarChanges(ctx, connectionCtx context.Context) (<-chan struct{}, error) {
+	list, err := sdk.Calendars().ListWithChanges(ctx)
+	if err != nil {
+		return nil, apierr.FromSDK(err)
+	}
+	if list == nil {
+		return nil, apierr.ErrAPI(0, "could not list calendars")
+	}
+	cursor, err := hey.CalendarChangesCursorFrom(list.CalendarChangesURL)
+	if err != nil {
+		return nil, apierr.FromSDK(err)
+	}
+
+	watch := newCalendarStreamWatch()
+	for _, calendar := range list.Calendars {
+		if err := watch.subscribe(ctx, connectionCtx, calendar); err != nil {
+			watch.stopAll()
+			return nil, err
+		}
+	}
+	go watch.run(ctx, connectionCtx, cursor)
+
+	return watch.changes, nil
+}
+
+// calendarStreamWatch is one doorbell over many subscriptions: every calendar's stream
+// rings the same channel, and a subscription that closes without being given up rings
+// dead instead, which tears the whole watch down — the TUI reopens it, resubscribing
+// everything, rather than limping on with some calendars gone quiet.
+type calendarStreamWatch struct {
+	changes chan struct{}
+	dead    chan struct{}
+	stops   map[int64]context.CancelFunc
+}
+
+func newCalendarStreamWatch() *calendarStreamWatch {
+	return &calendarStreamWatch{
+		changes: make(chan struct{}, 1),
+		dead:    make(chan struct{}, 1),
+		stops:   map[int64]context.CancelFunc{},
+	}
+}
+
+// subscribe follows one calendar's stream. A calendar HEY served without a stream name
+// cannot be followed and is skipped: its writes still reach the reader on every step they
+// take, just not between them.
+func (w *calendarStreamWatch) subscribe(ctx, connectionCtx context.Context, calendar hey.ListedCalendar) error {
+	if calendar.SignedStreamName == "" {
+		return nil
+	}
+
+	subCtx, stop := context.WithCancel(ctx) //nolint:gosec // G118: cancel stored in stops, called by drop or stopAll
+	subscription, err := tuiSubscribe(subCtx, connectionCtx, actioncable.Identifier{
+		Channel: turboStreamsChannel,
+		Params:  actioncable.Params{"signed_stream_name": calendar.SignedStreamName},
+	}, actioncable.OnConnected(func(reconnected bool) {
+		if reconnected {
+			ring(w.changes, struct{}{})
+		}
+	}))
+	if err != nil {
+		stop()
+		return err
+	}
+	w.stops[calendar.Calendar.Id] = stop
+
+	go func() {
+		defer unsubscribe(subCtx, subscription)
+		for {
+			select {
+			case <-subCtx.Done():
+				return
+			case _, open := <-subscription.Messages():
+				if !open {
+					if subCtx.Err() == nil {
+						ring(w.dead, struct{}{})
+					}
+					return
+				}
+				ring(w.changes, struct{}{})
+			}
+		}
+	}()
+
+	return nil
+}
+
+// run keeps the watch's calendar set current: the poll reads the calendar-level changes
+// feed, subscribes the streams of calendars that arrived, gives up those of calendars
+// that left, and rings for either — a new calendar's events are on the span already on
+// screen. A poll that fails is skipped; the cursor has not moved, so the next one reads
+// the same changes.
+func (w *calendarStreamWatch) run(ctx, connectionCtx context.Context, cursor hey.CalendarChangesCursor) {
+	defer close(w.changes)
+	defer w.stopAll()
+
+	poll := time.NewTicker(calendarListPollInterval)
+	defer poll.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.dead:
+			return
+		case <-poll.C:
+			next, alive := w.pollOnce(ctx, connectionCtx, cursor)
+			if !alive {
+				return
+			}
+			cursor = next
+		}
+	}
+}
+
+// pollOnce reads the calendar-level feed once. A read that fails is skipped — the cursor
+// has not moved, so the next poll reads the same changes — but a stream that cannot be
+// subscribed ends the watch: the connection is the likely reason, and reopening the whole
+// watch resubscribes everything.
+func (w *calendarStreamWatch) pollOnce(ctx, connectionCtx context.Context, cursor hey.CalendarChangesCursor) (hey.CalendarChangesCursor, bool) {
+	changes, err := sdk.Calendars().AllCalendarChanges(ctx, cursor)
+	if err != nil {
+		return cursor, true
+	}
+
+	for _, added := range changes.Added {
+		if err := w.subscribe(ctx, connectionCtx, added); err != nil {
+			return cursor, false
+		}
+	}
+	for _, deleted := range changes.Deleted {
+		w.drop(deleted.ID)
+	}
+	if len(changes.Added)+len(changes.Updated)+len(changes.Deleted) > 0 {
+		ring(w.changes, struct{}{})
+	}
+	if changes.NextCursor != nil {
+		cursor = *changes.NextCursor
+	}
+
+	return cursor, true
+}
+
+func (w *calendarStreamWatch) drop(calendarID int64) {
+	if stop, subscribed := w.stops[calendarID]; subscribed {
+		stop()
+		delete(w.stops, calendarID)
+	}
+}
+
+func (w *calendarStreamWatch) stopAll() {
+	for id, stop := range w.stops {
+		stop()
+		delete(w.stops, id)
 	}
 }
 

--- a/internal/cmd/tui_watch_test.go
+++ b/internal/cmd/tui_watch_test.go
@@ -5,11 +5,14 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
 
 	actioncable "github.com/basecamp/actioncable-go"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/auth"
@@ -272,5 +275,72 @@ func TestRingDropsWhatWouldBlock(t *testing.T) {
 	case <-notifications:
 	case <-time.After(time.Second):
 		t.Fatal("the first notification should be waiting")
+	}
+}
+
+func TestCalendarStreamWatchPollFollowsTheCalendarSet(t *testing.T) {
+	t.Setenv("HEY_TOKEN", "test-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A20%3A00.000Z>; rel="next"`)
+		_, _ = w.Write([]byte(`{
+			"added": [{"calendar": {"id": 514, "name": "Book Club"},
+			           "recording_changes_url": "/calendars/514/recording/changes.json?since=2026-08-18T09%3A14%3A00.000Z&v=1"}],
+			"deleted": [{"id": 513, "deleted_at": "2026-08-18T09:16:00.000Z"}]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+	initSDK(auth.NewManager(server.URL, server.Client(), t.TempDir()), server.URL)
+
+	watch := newCalendarStreamWatch()
+	dropped := false
+	watch.stops[513] = func() { dropped = true }
+	cursor, err := hey.CalendarChangesCursorFrom(server.URL + "/calendar/changes.json?since=2026-08-18T09%3A00%3A00.000Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	next, alive := watch.pollOnce(context.Background(), context.Background(), cursor)
+	if !alive {
+		t.Fatal("a poll that read cleanly should keep the watch alive")
+	}
+	if next.Since != "2026-08-18T09:20:00.000Z" {
+		t.Errorf("cursor = %+v, want it moved to where the feed left off", next)
+	}
+	if !dropped {
+		t.Error("a calendar that left should have its stream given up")
+	}
+	if _, still := watch.stops[513]; still {
+		t.Error("a dropped stream should leave the map")
+	}
+	select {
+	case <-watch.changes:
+	default:
+		t.Error("a changed calendar set should ring the doorbell")
+	}
+}
+
+func TestCalendarStreamWatchPollSkipsAFailedRead(t *testing.T) {
+	t.Setenv("HEY_TOKEN", "test-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	initSDK(auth.NewManager(server.URL, server.Client(), t.TempDir()), server.URL)
+
+	watch := newCalendarStreamWatch()
+	cursor, err := hey.CalendarChangesCursorFrom(server.URL + "/calendar/changes.json?since=2026-08-18T09%3A00%3A00.000Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	next, alive := watch.pollOnce(context.Background(), context.Background(), cursor)
+	if !alive {
+		t.Error("a read that failed should be retried by the next poll, not end the watch")
+	}
+	if next.Since != cursor.Since {
+		t.Errorf("cursor = %+v, want it left where it was", next)
 	}
 }

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -48,11 +48,13 @@ const (
 // here (watch_new.go) rather than by every reader; and resync, the watch's word
 // that a box changed more than it could follow. All but new are reported by
 // default; new is asked for, and asking for new alone leaves a resync out, so a
-// script for new mail never runs on one.
+// script for new mail never runs on one. The calendar's changes are named in
+// watch_calendar.go, reported by default, and switched off entirely by the
+// email-specific flags: --box, or an --events list that names only mail changes.
 var (
 	postingChanges   = []string{"added", "updated", "deleted"}
-	defaultChanges   = []string{"added", "updated", "deleted", "resync"}
-	watchableChanges = []string{"added", "updated", "deleted", "new", "resync"}
+	defaultChanges   = append([]string{"added", "updated", "deleted", "resync"}, calendarWatchChanges...)
+	watchableChanges = append([]string{"added", "updated", "deleted", "new", "resync"}, calendarWatchChanges...)
 )
 
 type watchCommand struct {
@@ -70,8 +72,9 @@ func newWatchCommand() *watchCommand {
 	watchCommand := &watchCommand{}
 	watchCommand.cmd = &cobra.Command{
 		Use:   "watch",
-		Short: "Follow email threads as they change",
-		Long: `Print email threads as they change, one JSON object per line. Runs until interrupted.
+		Short: "Follow email threads and calendars as they change",
+		Long: `Print email threads and calendar changes as they happen, one JSON object per line.
+Runs until interrupted.
 
 Changes can drive a command instead of being printed, and that is a choice between two
 behaviours: --run-async spawns the command per change and moves on, so a slow one never
@@ -84,13 +87,21 @@ seen, so the backlog a box's first read carries is not new. Reading a thread, mu
 moving it is not new activity; a reply on a known thread is. --events new selects the new
 ones, alone or alongside added, updated and deleted, and a script sees HEY_NEW=1 for them.
 
+The calendars are followed too, by default: recording_added, recording_updated and
+recording_deleted are the events, todos, habits and journal entries the calendars hold,
+each line naming its calendar; calendar_added, calendar_updated and calendar_deleted are
+the calendars themselves coming and going. The email-specific flags switch the calendars
+off: --box scopes the watch to mail, and an --events list naming only mail changes
+(added, updated, deleted, new, resync) does the same.
+
 Besides the thread changes, three lines describe the watch itself: "ready" once every box
-is caught up and the subscription is live (again after every reconnect's catch-up),
-"disconnected" when the connection drops, and "resync" when a box changed more than the
-feed can list one change at a time and the watch skipped ahead — re-read that box. A resync
-is an event of its own: reported by default, scripts run for it and --exit-on-first counts
-it, and --events can leave it out, as --events new does. Ready and disconnected are written
-to stdout only.`,
+and calendar is caught up and the subscription is live (again after every reconnect's
+catch-up), "disconnected" when the connection drops, and "resync" when a box changed more
+than the feed can list one change at a time and the watch skipped ahead — re-read that
+box. A resync is an event of its own: reported by default, scripts run for it and
+--exit-on-first counts it, and --events can leave it out, as --events new does. A
+calendar's feed falls behind the same way, and calendar_resync is the same word for it.
+Ready and disconnected are written to stdout only.`,
 		Annotations: map[string]string{
 			"agent_notes": "Long-running. Writes one JSON object per changed thread to stdout (NDJSON), not the usual envelope. Use --exit-on-first to block until one change lands and then exit.",
 		},
@@ -106,7 +117,7 @@ to stdout only.`,
 
 	flags := watchCommand.cmd.Flags()
 	flags.StringArrayVar(&watchCommand.boxes, "box", nil, "Box whose changes to report, by name or ID (repeatable, defaults to all; every box is followed either way, so new mail is judged across all of them)")
-	flags.StringSliceVar(&watchCommand.events, "events", defaultChanges, "Changes to report: added, updated, deleted, resync, and new for the added and updated threads that are new mail")
+	flags.StringSliceVar(&watchCommand.events, "events", defaultChanges, "Changes to report: added, updated, deleted, resync and new for mail; recording_added, recording_updated, recording_deleted, calendar_added, calendar_updated, calendar_deleted and calendar_resync for the calendars")
 	flags.StringVar(&watchCommand.since, "since", "", "Report changes since this time first (RFC 3339 or YYYY-MM-DD)")
 	flags.StringVar(&watchCommand.asyncScript, "run-async", "", "Shell command to spawn per change, without waiting for it")
 	flags.StringVar(&watchCommand.syncScript, "run-sync", "", "Shell command to run per change, one at a time, waiting for each")
@@ -164,11 +175,25 @@ func (c *watchCommand) run(cmd *cobra.Command, args []string) error {
 		running:     make(chan struct{}, asyncScriptLimit),
 	}
 
+	if c.watchingCalendars(changes) {
+		calendars, calendarsErr := c.watchedCalendars(ctx, started)
+		if calendarsErr != nil {
+			return calendarsErr
+		}
+		defer calendars.poll.Stop()
+		watch.calendar = calendars
+	}
+
 	client, err := cable.Dial(ctx, cfg.BaseURL, authMgr)
 	if err != nil {
 		return watchDialError(err)
 	}
 	defer func() { _ = client.Close() }()
+	watch.cable = client
+
+	if watch.calendar != nil {
+		watch.subscribeCalendars(ctx)
+	}
 
 	subscription, err := client.Subscribe(ctx, actioncable.Identifier{Channel: changesChannel},
 		actioncable.OnConnected(func(reconnected bool) {
@@ -337,18 +362,28 @@ type watchedBox struct {
 	reported bool // --box named it, or named nothing
 }
 
-// watchEvent is one changed posting, as a line of NDJSON or as a script's stdin —
-// or a word about the watch itself, which has no posting and, for ready and
-// disconnected, no box either. New is set on every added and updated posting,
-// true or false, and on nothing else.
+// watchEvent is one changed posting or calendar recording, as a line of NDJSON or as a
+// script's stdin — or a word about the watch itself, which has neither. A mail line
+// carries the box and the posting; a calendar line carries the calendar and the
+// recording instead, and an existing mail reader never sees the new fields. New is set
+// on every added and updated posting, true or false, and on nothing else.
 type watchEvent struct {
-	Change    string             `json:"change"`
-	At        string             `json:"at"`
-	Box       *watchEventBox     `json:"box,omitempty"`
-	PostingID int64              `json:"posting_id,omitempty"`
-	ThreadID  int64              `json:"thread_id,omitempty"`
-	New       *bool              `json:"new,omitempty"`
-	Posting   *generated.Posting `json:"posting,omitempty"`
+	Change        string               `json:"change"`
+	At            string               `json:"at"`
+	Box           *watchEventBox       `json:"box,omitempty"`
+	PostingID     int64                `json:"posting_id,omitempty"`
+	ThreadID      int64                `json:"thread_id,omitempty"`
+	New           *bool                `json:"new,omitempty"`
+	Posting       *generated.Posting   `json:"posting,omitempty"`
+	Calendar      *watchEventCalendar  `json:"calendar,omitempty"`
+	RecordingID   int64                `json:"recording_id,omitempty"`
+	RecordingType string               `json:"recording_type,omitempty"`
+	Recording     *generated.Recording `json:"recording,omitempty"`
+}
+
+type watchEventCalendar struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
 }
 
 func (e watchEvent) isNew() bool {
@@ -375,6 +410,8 @@ type watchEventBox struct {
 // one has been read, and what to do with a change once it arrives.
 type postingsWatch struct {
 	boxes          map[int64]*watchedBox
+	calendar       *calendarsWatch
+	cable          *actioncable.Client
 	changes        map[string]bool
 	asyncScript    string
 	syncScript     string
@@ -413,6 +450,16 @@ func (w *postingsWatch) listen(ctx context.Context, subscription *actioncable.Su
 		case <-w.retry:
 			w.retry = nil
 			if err := w.retryUnread(ctx); err != nil {
+				return err
+			}
+		case <-w.calendarWake():
+			w.coalesceCalendarRing()
+		case <-w.calendarDue():
+			if err := w.readRungCalendars(ctx); err != nil {
+				return err
+			}
+		case <-w.calendarPoll():
+			if err := w.pollCalendarList(ctx); err != nil {
 				return err
 			}
 		case message, open := <-subscription.Messages():
@@ -483,8 +530,8 @@ func (w *postingsWatch) followConnection(ctx context.Context) error {
 	}
 }
 
-// catchUp reads every box and announces ready — but only once every box has
-// been read. A read that failed is retried on the backoff with the box's cursor
+// catchUp reads every box and calendar and announces ready — but only once every one has
+// been read. A read that failed is retried on the backoff with its cursor
 // where it was, and ready waits for it: a reader told ready while a box is
 // still behind would take the gap for a clean picture. From ready on, anything
 // after the cursors is reported: a reader that wants a gap-free picture reads
@@ -493,16 +540,22 @@ func (w *postingsWatch) catchUp(ctx context.Context) error {
 	if err := w.readEveryBox(ctx); err != nil {
 		return err
 	}
+	if err := w.readEveryCalendar(ctx); err != nil {
+		return err
+	}
 	w.catchingUp = true
 	w.readyOnceCaughtUp(ctx)
 
 	return nil
 }
 
-// retryUnread reads the boxes whose last read failed, and announces the ready a
-// catch-up left owing once the last of them is read.
+// retryUnread reads the boxes and calendars whose last read failed, and announces the
+// ready a catch-up left owing once the last of them is read.
 func (w *postingsWatch) retryUnread(ctx context.Context) error {
 	if err := w.readUnreadBoxes(ctx); err != nil {
+		return err
+	}
+	if err := w.readUnreadCalendars(ctx); err != nil {
 		return err
 	}
 	w.readyOnceCaughtUp(ctx)
@@ -524,7 +577,7 @@ func (w *postingsWatch) retryUnread(ctx context.Context) error {
 // is the order things happened. The cable's goroutine waits on one line of
 // output at most.
 func (w *postingsWatch) readyOnceCaughtUp(ctx context.Context) {
-	if !w.catchingUp || len(w.unread) > 0 || w.finished() || ctx.Err() != nil {
+	if !w.catchingUp || len(w.unread) > 0 || w.calendarsBehind() || w.finished() || ctx.Err() != nil {
 		return
 	}
 
@@ -668,7 +721,12 @@ func permanentReadError(err error) bool {
 // and the change stays invisible until the next email happens along.
 func (w *postingsWatch) readAgainLater(box *watchedBox) {
 	w.unread[box.id] = true
+	w.armRetry()
+}
 
+// armRetry starts the shared backoff timer, once: the boxes and the calendars retry on
+// the same clock, and whichever read fails first sets it running.
+func (w *postingsWatch) armRetry() {
 	if w.retry == nil {
 		w.backoff = min(max(2*w.backoff, firstWatchRetry), longestWatchRetry)
 		w.retry = time.After(w.backoff)
@@ -677,8 +735,12 @@ func (w *postingsWatch) readAgainLater(box *watchedBox) {
 
 func (w *postingsWatch) wasRead(box *watchedBox) {
 	delete(w.unread, box.id)
+	w.settleBackoff()
+}
 
-	if len(w.unread) == 0 {
+// settleBackoff lets the retry delay start over once nothing is behind any more.
+func (w *postingsWatch) settleBackoff() {
+	if len(w.unread) == 0 && !w.calendarsBehind() {
 		w.backoff = 0
 	}
 }
@@ -736,16 +798,21 @@ func (w *postingsWatch) stopWatching(box *watchedBox) error {
 }
 
 // report hands one change on — printed, or run through the script — and says
-// whether it did.
+// whether it did. A calendar change carries its calendar instead of a box, so
+// box and posting are nil for it.
 func (w *postingsWatch) report(ctx context.Context, event watchEvent, box *watchedBox, posting *generated.Posting) bool {
-	if !box.reported || w.finished() || !w.reporting(event) {
+	if w.finished() || !w.reporting(event) {
 		return false
 	}
-
-	event.Box = &watchEventBox{ID: box.id, Kind: box.kind, Name: box.name}
-	if posting != nil {
-		event.Posting = posting
-		event.ThreadID = resolvePostingTopicID(*posting)
+	if box != nil {
+		if !box.reported {
+			return false
+		}
+		event.Box = &watchEventBox{ID: box.id, Kind: box.kind, Name: box.name}
+		if posting != nil {
+			event.Posting = posting
+			event.ThreadID = resolvePostingTopicID(*posting)
+		}
 	}
 	w.reported++
 
@@ -869,7 +936,10 @@ func (w *postingsWatch) scriptCommand(ctx context.Context, script string, event 
 // environment — a watch started by another watch's script, say — would reach
 // the script for an event that does not set it: HEY_NEW=1 on an update that is
 // not new, a thread id on a deletion. They are the event's to set or leave unset.
-var watchVariables = []string{"HEY_CHANGE", "HEY_AT", "HEY_BOX_ID", "HEY_BOX_KIND", "HEY_BOX_NAME", "HEY_POSTING_ID", "HEY_THREAD_ID", "HEY_NEW"}
+var watchVariables = []string{
+	"HEY_CHANGE", "HEY_AT", "HEY_BOX_ID", "HEY_BOX_KIND", "HEY_BOX_NAME", "HEY_POSTING_ID", "HEY_THREAD_ID", "HEY_NEW",
+	"HEY_CALENDAR_ID", "HEY_CALENDAR_NAME", "HEY_RECORDING_ID", "HEY_RECORDING_TYPE",
+}
 
 func withoutWatchVariables(environment []string) []string {
 	return slices.DeleteFunc(slices.Clone(environment), func(variable string) bool {
@@ -913,6 +983,17 @@ func (e watchEvent) environment() []string {
 	if e.ThreadID != 0 {
 		environment = append(environment, "HEY_THREAD_ID="+strconv.FormatInt(e.ThreadID, 10))
 	}
+	if e.Calendar != nil {
+		environment = append(environment,
+			"HEY_CALENDAR_ID="+strconv.FormatInt(e.Calendar.ID, 10),
+			"HEY_CALENDAR_NAME="+e.Calendar.Name)
+	}
+	if e.RecordingID != 0 {
+		environment = append(environment, "HEY_RECORDING_ID="+strconv.FormatInt(e.RecordingID, 10))
+	}
+	if e.RecordingType != "" {
+		environment = append(environment, "HEY_RECORDING_TYPE="+e.RecordingType)
+	}
 	if e.isNew() {
 		environment = append(environment, "HEY_NEW=1")
 	} else {
@@ -923,9 +1004,12 @@ func (e watchEvent) environment() []string {
 }
 
 func watchLine(event watchEvent) string {
-	var boxName, description string
+	var sourceName, description string
 	if event.Box != nil {
-		boxName = event.Box.Name
+		sourceName = event.Box.Name
+	}
+	if event.Calendar != nil {
+		sourceName = event.Calendar.Name
 	}
 	change := event.Change
 	if event.isNew() {
@@ -936,15 +1020,21 @@ func watchLine(event watchEvent) string {
 		description = "watching for changes"
 	case event.Change == watchDisconnected:
 		description = "connection lost — reconnecting"
-	case event.Change == watchResync:
+	case event.Change == watchResync || event.Change == watchCalendarResync:
 		description = "too much changed to follow one change at a time — skipped ahead"
 	case event.Posting != nil:
 		description = fmt.Sprintf("%s — %s (thread %d)", terminal.SanitizeLine(event.Posting.Creator.Name), truncate(terminal.SanitizeLine(event.Posting.Summary), 50), event.ThreadID)
+	case event.Recording != nil:
+		description = fmt.Sprintf("%s (%s %d)", truncate(terminal.SanitizeLine(event.Recording.Title), 50), event.RecordingType, event.RecordingID)
+	case event.RecordingID != 0:
+		description = fmt.Sprintf("%s %d", event.RecordingType, event.RecordingID)
+	case event.Calendar != nil:
+		description = fmt.Sprintf("calendar %d", event.Calendar.ID)
 	default:
 		description = fmt.Sprintf("posting %d", event.PostingID)
 	}
 
-	return fmt.Sprintf("%s  %-13s %-24s %s", event.At, change, terminal.SanitizeLine(boxName), description)
+	return fmt.Sprintf("%s  %-13s %-24s %s", event.At, change, terminal.SanitizeLine(sourceName), description)
 }
 
 func watchTime(at time.Time) string {

--- a/internal/cmd/watch_calendar.go
+++ b/internal/cmd/watch_calendar.go
@@ -1,0 +1,501 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	actioncable "github.com/basecamp/actioncable-go"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+)
+
+// The calendar's changes. Recordings — events, todos, habits, journal entries — are what
+// the calendars hold; the calendar_* three are the calendars themselves coming and going,
+// and calendar_resync is the watch's word that one of them changed more than its feed
+// could list.
+var calendarWatchChanges = []string{
+	"recording_added", "recording_updated", "recording_deleted",
+	"calendar_added", "calendar_updated", "calendar_deleted", "calendar_resync",
+}
+
+const (
+	// calendarCoalesceDelay collects one write's doorbells into a single read: HEY rings a
+	// calendar's stream once per recording it touches, and the feed answers them all at once.
+	calendarCoalesceDelay = 500 * time.Millisecond
+
+	// watchCalendarPollInterval is how often the calendar-level feed is read, which is the
+	// only way the watch learns of a calendar added or removed while it runs: there is no
+	// stream to follow until a calendar's name is known. The read is usually one empty page.
+	watchCalendarPollInterval = 5 * time.Minute
+)
+
+const (
+	watchCalendarAdded   = "calendar_added"
+	watchCalendarUpdated = "calendar_updated"
+	watchCalendarDeleted = "calendar_deleted"
+	watchCalendarResync  = "calendar_resync"
+)
+
+// watchedCalendar is one calendar the watch follows: how far its recording feed has been
+// read, and the stream that rings when it changes.
+type watchedCalendar struct {
+	id     int64
+	name   string
+	cursor hey.CalendarChangesCursor
+	stream string
+	stop   context.CancelFunc
+}
+
+// calendarsWatch is the calendar half of a watch: the calendars and their cursors, the
+// doorbell their streams ring, the coalescing timer behind it, and the poll that keeps
+// the set current.
+type calendarsWatch struct {
+	calendars  map[int64]*watchedCalendar
+	listCursor hey.CalendarChangesCursor
+	unread     map[int64]bool
+
+	pendingMu sync.Mutex
+	pending   map[int64]bool
+	wake      chan struct{}
+	due       <-chan time.Time
+	poll      *time.Ticker
+}
+
+// watchingCalendars is whether this invocation follows the calendars at all. Email-specific
+// flags switch them off: --box scopes the watch to mail, and an --events list that names
+// only mail changes has not asked for the calendar.
+func (c *watchCommand) watchingCalendars(changes map[string]bool) bool {
+	if len(c.boxes) > 0 {
+		return false
+	}
+	return slices.ContainsFunc(calendarWatchChanges, func(change string) bool { return changes[change] })
+}
+
+// watchedCalendars reads the calendars and where each one's feed should be read from. The
+// cursors are capped at the watch's start the way the boxes' are — the server bakes each
+// calendar's last activity into its URL, so a write that lands between reading the clock
+// and reading the list would otherwise sit behind the cursor, read by nothing.
+func (c *watchCommand) watchedCalendars(ctx context.Context, started time.Time) (*calendarsWatch, error) {
+	list, err := sdk.Calendars().ListWithChanges(ctx)
+	if err != nil {
+		return nil, apierr.FromSDK(err)
+	}
+	if list == nil {
+		return nil, apierr.ErrAPI(0, "could not list calendars")
+	}
+
+	listCursor, err := c.calendarCursor(list.CalendarChangesURL, started)
+	if err != nil {
+		return nil, err
+	}
+
+	watch := &calendarsWatch{
+		calendars:  map[int64]*watchedCalendar{},
+		listCursor: listCursor,
+		unread:     map[int64]bool{},
+		pending:    map[int64]bool{},
+		wake:       make(chan struct{}, 1),
+		poll:       time.NewTicker(watchCalendarPollInterval),
+	}
+	for _, listed := range list.Calendars {
+		calendar, err := c.followedCalendar(listed, started)
+		if err != nil {
+			return nil, err
+		}
+		watch.calendars[calendar.id] = calendar
+	}
+
+	return watch, nil
+}
+
+func (c *watchCommand) followedCalendar(listed hey.ListedCalendar, started time.Time) (*watchedCalendar, error) {
+	cursor, err := c.calendarCursor(listed.RecordingChangesURL, started)
+	if err != nil {
+		return nil, err
+	}
+
+	return &watchedCalendar{
+		id:     listed.Calendar.Id,
+		name:   calendarDisplayName(listed.Calendar),
+		cursor: cursor,
+		stream: listed.SignedStreamName,
+	}, nil
+}
+
+// calendarCursor is where a feed should be read from: the URL HEY served, moved by
+// --since, and otherwise capped at the watch's start.
+func (c *watchCommand) calendarCursor(changesURL string, started time.Time) (hey.CalendarChangesCursor, error) {
+	cursor, err := hey.CalendarChangesCursorFrom(changesURL)
+	if err != nil {
+		return hey.CalendarChangesCursor{}, apierr.FromSDK(err)
+	}
+	if c.since == "" {
+		return calendarCursorNoLaterThan(cursor, started), nil
+	}
+
+	at, err := parseWatchSince(c.since)
+	if err != nil {
+		return hey.CalendarChangesCursor{}, err
+	}
+	cursor.Since = at.UTC().Format(watchCursorTimeLayout)
+
+	return cursor, nil
+}
+
+// calendarCursorNoLaterThan is noLaterThan for a calendar feed's cursor, and exists for
+// the same race. A cursor that cannot be read is left as it is.
+func calendarCursorNoLaterThan(cursor hey.CalendarChangesCursor, started time.Time) hey.CalendarChangesCursor {
+	at, err := time.Parse(watchCursorTimeLayout, cursor.Since)
+	if err == nil && at.After(started) {
+		cursor.Since = started.UTC().Format(watchCursorTimeLayout)
+	}
+
+	return cursor
+}
+
+// calendarDisplayName is what a calendar is called on a watch line. The personal calendar
+// has no name of its own — HEY leaves the field empty and the web app labels it from the
+// identity — so the watch says what it is rather than nothing.
+func calendarDisplayName(calendar generated.Calendar) string {
+	if calendar.Name != "" {
+		return calendar.Name
+	}
+	if calendar.Personal {
+		return "Personal"
+	}
+	return fmt.Sprintf("Calendar %d", calendar.Id)
+}
+
+// ring notes which calendar rang and wakes the watch without blocking the cable's
+// dispatcher. The pending set coalesces a burst into one read per calendar.
+func (cw *calendarsWatch) ring(calendarID int64) {
+	cw.pendingMu.Lock()
+	cw.pending[calendarID] = true
+	cw.pendingMu.Unlock()
+	ring(cw.wake, struct{}{})
+}
+
+// take empties the pending set, in a stable order.
+func (cw *calendarsWatch) take() []int64 {
+	cw.pendingMu.Lock()
+	defer cw.pendingMu.Unlock()
+
+	rung := slices.Sorted(maps.Keys(cw.pending))
+	clear(cw.pending)
+
+	return rung
+}
+
+// --- The watch's calendar half, on the same loop as the boxes ---
+
+// calendarWake, calendarDue and calendarPoll are the loop's view of a calendar half that
+// may not exist: a receive on a nil channel blocks forever, which is exactly what a watch
+// without calendars wants from these arms.
+func (w *postingsWatch) calendarWake() <-chan struct{} {
+	if w.calendar == nil {
+		return nil
+	}
+	return w.calendar.wake
+}
+
+func (w *postingsWatch) calendarDue() <-chan time.Time {
+	if w.calendar == nil {
+		return nil
+	}
+	return w.calendar.due
+}
+
+func (w *postingsWatch) calendarPoll() <-chan time.Time {
+	if w.calendar == nil {
+		return nil
+	}
+	return w.calendar.poll.C
+}
+
+func (w *postingsWatch) calendarsBehind() bool {
+	return w.calendar != nil && len(w.calendar.unread) > 0
+}
+
+// subscribeCalendars follows every calendar's stream over the watch's own connection. A
+// calendar whose stream cannot be subscribed is still read at every catch-up; the warning
+// says its changes will not ring between them.
+func (w *postingsWatch) subscribeCalendars(ctx context.Context) {
+	for _, id := range slices.Sorted(maps.Keys(w.calendar.calendars)) {
+		w.subscribeCalendar(ctx, w.calendar.calendars[id])
+	}
+}
+
+func (w *postingsWatch) subscribeCalendar(ctx context.Context, calendar *watchedCalendar) {
+	if calendar.stream == "" || w.cable == nil {
+		return
+	}
+
+	subCtx, stop := context.WithCancel(ctx) //nolint:gosec // G118: cancel stored on the calendar, called when it stops being watched
+	subscription, err := w.cable.Subscribe(subCtx, actioncable.Identifier{
+		Channel: turboStreamsChannel,
+		Params:  actioncable.Params{"signed_stream_name": calendar.stream},
+	})
+	if err != nil {
+		stop()
+		fmt.Fprintf(w.errOut, "warning: could not follow %s's stream — its changes surface on reconnects only: %v\n", calendar.name, err)
+		return
+	}
+	calendar.stop = stop
+
+	id := calendar.id
+	go func() {
+		defer unsubscribe(subCtx, subscription)
+		for {
+			select {
+			case <-subCtx.Done():
+				return
+			case _, open := <-subscription.Messages():
+				if !open {
+					return
+				}
+				w.calendar.ring(id)
+			}
+		}
+	}()
+}
+
+// coalesceCalendarRing arms the read behind a doorbell, once: the timer collects the rest
+// of the burst, and readRungCalendars empties the pending set whole.
+func (w *postingsWatch) coalesceCalendarRing() {
+	if w.calendar.due == nil {
+		w.calendar.due = time.After(calendarCoalesceDelay)
+	}
+}
+
+func (w *postingsWatch) readRungCalendars(ctx context.Context) error {
+	w.calendar.due = nil
+	for _, id := range w.calendar.take() {
+		if calendar, watching := w.calendar.calendars[id]; watching {
+			if err := w.readCalendar(ctx, calendar); err != nil {
+				return err
+			}
+		}
+	}
+	w.readyOnceCaughtUp(ctx)
+
+	return nil
+}
+
+func (w *postingsWatch) readEveryCalendar(ctx context.Context) error {
+	if w.calendar == nil {
+		return nil
+	}
+	for _, id := range slices.Sorted(maps.Keys(w.calendar.calendars)) {
+		if err := w.readCalendar(ctx, w.calendar.calendars[id]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w *postingsWatch) readUnreadCalendars(ctx context.Context) error {
+	if w.calendar == nil {
+		return nil
+	}
+	for _, id := range slices.Sorted(maps.Keys(w.calendar.unread)) {
+		if calendar, watching := w.calendar.calendars[id]; watching {
+			if err := w.readCalendar(ctx, calendar); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (w *postingsWatch) readCalendar(ctx context.Context, calendar *watchedCalendar) error {
+	changes, err := sdk.Calendars().AllRecordingChanges(ctx, calendar.id, calendar.cursor)
+	if err != nil {
+		switch {
+		case ctx.Err() != nil:
+			return nil //nolint:nilerr // an interrupt or a --timeout is how a watch is meant to end
+		case permanentReadError(err):
+			return apierr.FromSDK(err)
+		default:
+			fmt.Fprintf(w.errOut, "warning: could not read changes in %s: %v\n", calendar.name, err)
+			w.calendar.unread[calendar.id] = true
+			w.armRetry()
+			return nil
+		}
+	}
+	delete(w.calendar.unread, calendar.id)
+	w.settleBackoff()
+
+	if changes.FullSyncRequired {
+		fmt.Fprintf(w.errOut, "notice: too much changed in %s to follow one change at a time — skipping ahead, re-read the calendar\n", calendar.name)
+		skipped, err := w.skipCalendarAhead(ctx, calendar)
+		if err != nil {
+			return err
+		}
+		if skipped {
+			w.reportCalendar(ctx, watchEvent{Change: watchCalendarResync, At: watchTime(time.Now())}, calendar.id, calendar.name)
+		}
+		return nil
+	}
+
+	if changes.NextCursor != nil {
+		calendar.cursor = *changes.NextCursor
+	}
+
+	w.reportRecordings(ctx, calendar, "recording_added", changes.Added, func(recording generated.Recording) time.Time { return recording.CreatedAt })
+	w.reportRecordings(ctx, calendar, "recording_updated", changes.Updated, func(recording generated.Recording) time.Time { return recording.UpdatedAt })
+	for _, deleted := range changes.Deleted {
+		w.reportCalendar(ctx, watchEvent{
+			Change:        "recording_deleted",
+			At:            watchTime(deleted.DeletedAt),
+			RecordingID:   deleted.ID,
+			RecordingType: deleted.Type,
+		}, calendar.id, calendar.name)
+	}
+
+	return nil
+}
+
+// reportRecordings walks one bucket in type order, so a read reports the same changes in
+// the same order every time.
+func (w *postingsWatch) reportRecordings(ctx context.Context, calendar *watchedCalendar, change string, bucket map[string][]generated.Recording, at func(generated.Recording) time.Time) {
+	for _, recordingType := range slices.Sorted(maps.Keys(bucket)) {
+		for _, recording := range bucket[recordingType] {
+			w.reportCalendar(ctx, watchEvent{
+				Change:        change,
+				At:            watchTime(at(recording)),
+				RecordingID:   recording.Id,
+				RecordingType: recordingType,
+				Recording:     &recording,
+			}, calendar.id, calendar.name)
+		}
+	}
+}
+
+// skipCalendarAhead moves a calendar's cursor to the server's current one, which is the
+// only way back once its feed has fallen too far behind, and says whether it did. A
+// calendar the server no longer lists cannot be followed any more and stops being watched
+// — the calendar-level feed reports its deletion in its own time.
+func (w *postingsWatch) skipCalendarAhead(ctx context.Context, calendar *watchedCalendar) (bool, error) {
+	list, err := sdk.Calendars().ListWithChanges(ctx)
+	if err != nil {
+		return false, apierr.FromSDK(err)
+	}
+	if list == nil {
+		return false, apierr.ErrAPI(0, "could not list calendars")
+	}
+
+	for _, listed := range list.Calendars {
+		if listed.Calendar.Id == calendar.id {
+			cursor, err := hey.CalendarChangesCursorFrom(listed.RecordingChangesURL)
+			if err != nil {
+				return false, apierr.FromSDK(err)
+			}
+			calendar.cursor = cursor
+			return true, nil
+		}
+	}
+
+	w.stopWatchingCalendar(calendar.id)
+	return false, nil
+}
+
+// pollCalendarList reads the calendar-level feed: calendars that arrived are followed
+// from here on and read once, calendars that left stop being watched, and every one of
+// them is a change to report. A read that fails is skipped — the cursor has not moved, so
+// the next poll reads the same changes.
+func (w *postingsWatch) pollCalendarList(ctx context.Context) error {
+	changes, err := sdk.Calendars().AllCalendarChanges(ctx, w.calendar.listCursor)
+	if err != nil {
+		switch {
+		case ctx.Err() != nil:
+			return nil //nolint:nilerr // an interrupt or a --timeout is how a watch is meant to end
+		case permanentReadError(err):
+			return apierr.FromSDK(err)
+		default:
+			fmt.Fprintf(w.errOut, "warning: could not read the calendar changes: %v\n", err)
+			return nil
+		}
+	}
+
+	for _, added := range changes.Added {
+		calendar, err := w.startWatchingCalendar(ctx, added)
+		if err != nil {
+			return err
+		}
+		w.reportCalendar(ctx, watchEvent{Change: watchCalendarAdded, At: watchTime(added.Calendar.UpdatedAt)}, calendar.id, calendar.name)
+		if err := w.readCalendar(ctx, calendar); err != nil {
+			return err
+		}
+	}
+	for _, updated := range changes.Updated {
+		name := calendarDisplayName(updated)
+		if calendar, watching := w.calendar.calendars[updated.Id]; watching {
+			calendar.name = name
+		}
+		w.reportCalendar(ctx, watchEvent{Change: watchCalendarUpdated, At: watchTime(updated.UpdatedAt)}, updated.Id, name)
+	}
+	for _, deleted := range changes.Deleted {
+		name := fmt.Sprintf("Calendar %d", deleted.ID)
+		if calendar, watching := w.calendar.calendars[deleted.ID]; watching {
+			name = calendar.name
+		}
+		w.stopWatchingCalendar(deleted.ID)
+		w.reportCalendar(ctx, watchEvent{Change: watchCalendarDeleted, At: watchTime(deleted.DeletedAt)}, deleted.ID, name)
+	}
+
+	if changes.NextCursor != nil {
+		w.calendar.listCursor = *changes.NextCursor
+	}
+
+	return nil
+}
+
+func (w *postingsWatch) startWatchingCalendar(ctx context.Context, listed hey.ListedCalendar) (*watchedCalendar, error) {
+	cursor, err := hey.CalendarChangesCursorFrom(listed.RecordingChangesURL)
+	if err != nil {
+		return nil, apierr.FromSDK(err)
+	}
+
+	calendar := &watchedCalendar{
+		id:     listed.Calendar.Id,
+		name:   calendarDisplayName(listed.Calendar),
+		cursor: cursor,
+		stream: listed.SignedStreamName,
+	}
+	w.calendar.calendars[calendar.id] = calendar
+	w.subscribeCalendar(ctx, calendar)
+
+	return calendar, nil
+}
+
+func (w *postingsWatch) stopWatchingCalendar(calendarID int64) {
+	calendar, watching := w.calendar.calendars[calendarID]
+	if !watching {
+		return
+	}
+	if calendar.stop != nil {
+		calendar.stop()
+	}
+	delete(w.calendar.calendars, calendarID)
+	delete(w.calendar.unread, calendarID)
+
+	w.calendar.pendingMu.Lock()
+	delete(w.calendar.pending, calendarID)
+	w.calendar.pendingMu.Unlock()
+}
+
+// reportCalendar stamps the calendar onto the event and hands it on the way a box change
+// is handed on.
+func (w *postingsWatch) reportCalendar(ctx context.Context, event watchEvent, calendarID int64, name string) {
+	event.Calendar = &watchEventCalendar{ID: calendarID, Name: name}
+	w.report(ctx, event, nil, nil)
+}

--- a/internal/cmd/watch_calendar_test.go
+++ b/internal/cmd/watch_calendar_test.go
@@ -1,0 +1,395 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/auth"
+)
+
+func TestWatchingCalendars(t *testing.T) {
+	command := newWatchCommand()
+	changes, err := command.watchedChanges()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !command.watchingCalendars(changes) {
+		t.Error("the calendars should be watched by default")
+	}
+
+	command.boxes = []string{"imbox"}
+	if command.watchingCalendars(changes) {
+		t.Error("--box scopes the watch to mail, so the calendars should be off")
+	}
+
+	command = newWatchCommand()
+	command.events = []string{"added", "new"}
+	changes, err = command.watchedChanges()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if command.watchingCalendars(changes) {
+		t.Error("an --events list naming only mail changes should leave the calendars off")
+	}
+
+	command.events = []string{"recording_added"}
+	changes, err = command.watchedChanges()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !command.watchingCalendars(changes) {
+		t.Error("asking for a calendar change should watch the calendars")
+	}
+}
+
+func TestCalendarCursor(t *testing.T) {
+	changesURL := "https://app.hey.com/calendars/512/recording/changes.json?since=2026-08-18T09%3A00%3A00.000Z&v=1"
+	started := time.Date(2026, 8, 18, 10, 0, 0, 0, time.UTC)
+
+	command := newWatchCommand()
+	cursor, err := command.calendarCursor(changesURL, started)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cursor.Since != "2026-08-18T09:00:00.000Z" || cursor.Version != "1" {
+		t.Errorf("cursor = %+v, want the server's own since and version", cursor)
+	}
+
+	command.since = "2026-08-17T08:30:00Z"
+	cursor, err = command.calendarCursor(changesURL, started)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cursor.Since != "2026-08-17T08:30:00.000Z" {
+		t.Errorf("since = %q, want --since to move it back", cursor.Since)
+	}
+	if cursor.Version != "1" {
+		t.Errorf("version = %q, want it to survive --since", cursor.Version)
+	}
+
+	command.since = "last tuesday"
+	if _, err := command.calendarCursor(changesURL, started); err == nil {
+		t.Error("expected an error for a --since we can't read")
+	}
+}
+
+func TestCalendarCursorNoLaterThan(t *testing.T) {
+	started := time.Date(2026, 8, 18, 9, 0, 0, 0, time.UTC)
+
+	late := hey.CalendarChangesCursor{Since: "2026-08-18T09:30:00.000Z", Version: "1"}
+	if capped := calendarCursorNoLaterThan(late, started); capped.Since != "2026-08-18T09:00:00.000Z" {
+		t.Errorf("since = %q, want a cursor later than the start moved back to it", capped.Since)
+	}
+
+	early := hey.CalendarChangesCursor{Since: "2026-08-18T08:00:00.000Z"}
+	if kept := calendarCursorNoLaterThan(early, started); kept.Since != "2026-08-18T08:00:00.000Z" {
+		t.Errorf("since = %q, want a cursor before the start left alone", kept.Since)
+	}
+
+	unreadable := hey.CalendarChangesCursor{Since: "whenever"}
+	if kept := calendarCursorNoLaterThan(unreadable, started); kept.Since != "whenever" {
+		t.Errorf("since = %q, want a cursor we can't read left as it is", kept.Since)
+	}
+}
+
+func newTestCalendarsWatch(t *testing.T, calendars ...*watchedCalendar) *calendarsWatch {
+	t.Helper()
+	watch := &calendarsWatch{
+		calendars: map[int64]*watchedCalendar{},
+		unread:    map[int64]bool{},
+		pending:   map[int64]bool{},
+		wake:      make(chan struct{}, 1),
+		poll:      time.NewTicker(time.Hour),
+	}
+	t.Cleanup(watch.poll.Stop)
+	for _, calendar := range calendars {
+		watch.calendars[calendar.id] = calendar
+	}
+	return watch
+}
+
+func recordingChangesCursor(t *testing.T, serverURL string, calendarID string) hey.CalendarChangesCursor {
+	t.Helper()
+	cursor, err := hey.CalendarChangesCursorFrom(serverURL + "/calendars/" + calendarID + "/recording/changes.json?since=2026-08-18T09%3A00%3A00.000Z&v=1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return cursor
+}
+
+func TestWatchReadsRungCalendars(t *testing.T) {
+	t.Setenv("HEY_TOKEN", "test-token")
+
+	var requested []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A14%3A22.031Z&v=1>; rel="next"`)
+		_, _ = w.Write([]byte(`{
+			"added": {"Calendar::Event": [{"id": 88001, "title": "Dentist appointment", "created_at": "2026-08-18T09:10:00.000Z"}]},
+			"updated": {"Calendar::JournalEntry": [{"id": 88002, "updated_at": "2026-08-18T09:12:00.000Z"}]},
+			"deleted": {"Calendar::Todo": [{"id": 88003, "deleted_at": "2026-08-18T09:14:00.000Z", "type": "Calendar::Todo"}]}
+		}`))
+	}))
+	defer server.Close()
+	initSDK(auth.NewManager(server.URL, server.Client(), t.TempDir()), server.URL)
+
+	watch, out := newTestWatch("recording_added", "recording_updated", "recording_deleted")
+	watch.calendar = newTestCalendarsWatch(t, &watchedCalendar{id: 512, name: "Household", cursor: recordingChangesCursor(t, server.URL, "512")})
+
+	watch.calendar.ring(512)
+	<-watch.calendar.wake
+	if err := watch.readRungCalendars(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(requested) != 1 || !strings.Contains(requested[0], "/calendars/512/recording/changes.json") {
+		t.Fatalf("requests = %v, want one read of the calendar's own feed", requested)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("wrote %d lines, want one per change: %q", len(lines), out.String())
+	}
+
+	var added watchEvent
+	if err := json.Unmarshal([]byte(lines[0]), &added); err != nil {
+		t.Fatalf("first line isn't JSON: %v", err)
+	}
+	if added.Change != "recording_added" || added.RecordingID != 88001 || added.RecordingType != "Calendar::Event" {
+		t.Errorf("added = %+v, want event 88001", added)
+	}
+	if added.Calendar == nil || added.Calendar.ID != 512 || added.Calendar.Name != "Household" {
+		t.Errorf("calendar = %+v, want the calendar the change is on", added.Calendar)
+	}
+	if added.Box != nil || added.New != nil {
+		t.Errorf("event = %+v, want no box and no new on a calendar line", added)
+	}
+	if added.Recording == nil || added.Recording.Title != "Dentist appointment" {
+		t.Error("an added recording should carry the recording itself")
+	}
+
+	var deleted watchEvent
+	if err := json.Unmarshal([]byte(lines[2]), &deleted); err != nil {
+		t.Fatalf("third line isn't JSON: %v", err)
+	}
+	if deleted.Change != "recording_deleted" || deleted.RecordingID != 88003 || deleted.RecordingType != "Calendar::Todo" {
+		t.Errorf("deleted = %+v, want todo 88003 with its type", deleted)
+	}
+	if deleted.Recording != nil {
+		t.Error("a deleted recording is gone, so there's nothing to carry")
+	}
+
+	if watch.calendar.calendars[512].cursor.Since != "2026-08-18T09:14:22.031Z" {
+		t.Errorf("cursor = %+v, want it moved to where the feed left off", watch.calendar.calendars[512].cursor)
+	}
+}
+
+func TestWatchCalendarSkipsAheadOnAFullSync(t *testing.T) {
+	t.Setenv("HEY_TOKEN", "test-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/calendars.json" {
+			_, _ = w.Write([]byte(`{
+				"calendars": [{"calendar": {"id": 512, "name": "Household"},
+				               "recording_changes_url": "/calendars/512/recording/changes.json?since=2026-08-18T11%3A00%3A00.000Z&v=1",
+				               "signed_stream_name": "signed-household"}],
+				"calendar_changes_url": "/calendar/changes.json?since=2026-08-18T11%3A00%3A00.000Z"
+			}`))
+			return
+		}
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer server.Close()
+	initSDK(auth.NewManager(server.URL, server.Client(), t.TempDir()), server.URL)
+
+	watch, out := newTestWatch("recording_added", "calendar_resync")
+	watch.calendar = newTestCalendarsWatch(t, &watchedCalendar{id: 512, name: "Household", cursor: recordingChangesCursor(t, server.URL, "512")})
+
+	if err := watch.readCalendar(context.Background(), watch.calendar.calendars[512]); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var event watchEvent
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &event); err != nil {
+		t.Fatalf("output isn't JSON: %q", out.String())
+	}
+	if event.Change != watchCalendarResync || event.Calendar == nil || event.Calendar.ID != 512 {
+		t.Errorf("event = %+v, want a calendar_resync naming the calendar", event)
+	}
+	if watch.calendar.calendars[512].cursor.Since != "2026-08-18T11:00:00.000Z" {
+		t.Errorf("cursor = %+v, want the server's own fresh cursor", watch.calendar.calendars[512].cursor)
+	}
+}
+
+func TestWatchCalendarStopsWatchingAGoneCalendar(t *testing.T) {
+	t.Setenv("HEY_TOKEN", "test-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/calendars.json" {
+			_, _ = w.Write([]byte(`{"calendars": [], "calendar_changes_url": "/calendar/changes.json?since=2026-08-18T11%3A00%3A00.000Z"}`))
+			return
+		}
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer server.Close()
+	initSDK(auth.NewManager(server.URL, server.Client(), t.TempDir()), server.URL)
+
+	watch, out := newTestWatch("recording_added", "calendar_resync")
+	watch.calendar = newTestCalendarsWatch(t, &watchedCalendar{id: 512, name: "Household", cursor: recordingChangesCursor(t, server.URL, "512")})
+
+	if err := watch.readCalendar(context.Background(), watch.calendar.calendars[512]); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("wrote %q, want no resync for a calendar that is gone", out.String())
+	}
+	if _, watching := watch.calendar.calendars[512]; watching {
+		t.Error("a calendar the server no longer lists should stop being watched")
+	}
+}
+
+func TestWatchPollReportsCalendarChanges(t *testing.T) {
+	t.Setenv("HEY_TOKEN", "test-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/calendars/") {
+			w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A20%3A00.000Z&v=1>; rel="next"`)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A20%3A00.000Z>; rel="next"`)
+		_, _ = w.Write([]byte(`{
+			"added": [{"calendar": {"id": 514, "name": "Book Club", "updated_at": "2026-08-18T09:14:00.000Z"},
+			           "recording_changes_url": "/calendars/514/recording/changes.json?since=2026-08-18T09%3A14%3A00.000Z&v=1",
+			           "signed_stream_name": "signed-bookclub"}],
+			"updated": [{"id": 512, "name": "Home", "updated_at": "2026-08-18T09:15:00.000Z"}],
+			"deleted": [{"id": 513, "deleted_at": "2026-08-18T09:16:00.000Z"}]
+		}`))
+	}))
+	defer server.Close()
+	initSDK(auth.NewManager(server.URL, server.Client(), t.TempDir()), server.URL)
+
+	watch, out := newTestWatch("calendar_added", "calendar_updated", "calendar_deleted")
+	listCursor, err := hey.CalendarChangesCursorFrom(server.URL + "/calendar/changes.json?since=2026-08-18T09%3A00%3A00.000Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	watch.calendar = newTestCalendarsWatch(t,
+		&watchedCalendar{id: 512, name: "Household"},
+		&watchedCalendar{id: 513, name: "Old Projects"})
+	watch.calendar.listCursor = listCursor
+
+	if err := watch.pollCalendarList(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("wrote %d lines, want added, updated and deleted: %q", len(lines), out.String())
+	}
+
+	var added watchEvent
+	if err := json.Unmarshal([]byte(lines[0]), &added); err != nil {
+		t.Fatalf("first line isn't JSON: %v", err)
+	}
+	if added.Change != watchCalendarAdded || added.Calendar.ID != 514 || added.Calendar.Name != "Book Club" {
+		t.Errorf("added = %+v, want the new calendar", added)
+	}
+	if _, watching := watch.calendar.calendars[514]; !watching {
+		t.Error("a calendar that arrived should be watched from here on")
+	}
+
+	var updated watchEvent
+	if err := json.Unmarshal([]byte(lines[1]), &updated); err != nil {
+		t.Fatalf("second line isn't JSON: %v", err)
+	}
+	if updated.Change != watchCalendarUpdated || updated.Calendar.Name != "Home" {
+		t.Errorf("updated = %+v, want the calendar's new name", updated)
+	}
+	if watch.calendar.calendars[512].name != "Home" {
+		t.Errorf("name = %q, want the watch to carry the rename", watch.calendar.calendars[512].name)
+	}
+
+	var deleted watchEvent
+	if err := json.Unmarshal([]byte(lines[2]), &deleted); err != nil {
+		t.Fatalf("third line isn't JSON: %v", err)
+	}
+	if deleted.Change != watchCalendarDeleted || deleted.Calendar.ID != 513 || deleted.Calendar.Name != "Old Projects" {
+		t.Errorf("deleted = %+v, want the calendar under the name the watch knew it by", deleted)
+	}
+	if _, watching := watch.calendar.calendars[513]; watching {
+		t.Error("a calendar that left should stop being watched")
+	}
+
+	if watch.calendar.listCursor.Since != "2026-08-18T09:20:00.000Z" {
+		t.Errorf("cursor = %+v, want it moved to where the feed left off", watch.calendar.listCursor)
+	}
+}
+
+func TestWatchReadyWaitsForACalendarBehind(t *testing.T) {
+	watch, out := newTestWatch("recording_added")
+	watch.calendar = newTestCalendarsWatch(t, &watchedCalendar{id: 512, name: "Household"})
+	watch.calendar.unread[512] = true
+	watch.catchingUp = true
+
+	watch.readyOnceCaughtUp(context.Background())
+	if out.Len() != 0 {
+		t.Errorf("wrote %q, want no ready while a calendar is behind", out.String())
+	}
+
+	delete(watch.calendar.unread, 512)
+	watch.readyOnceCaughtUp(context.Background())
+	if !strings.Contains(out.String(), `"change":"ready"`) {
+		t.Errorf("wrote %q, want the ready once the calendar is read", out.String())
+	}
+}
+
+func TestCalendarEventEnvironment(t *testing.T) {
+	event := watchEvent{
+		Change:        "recording_added",
+		At:            "2026-08-18T09:14:22.031Z",
+		Calendar:      &watchEventCalendar{ID: 512, Name: "Household"},
+		RecordingID:   88001,
+		RecordingType: "Calendar::Event",
+	}
+
+	environment := strings.Join(event.environment(), "\n")
+	for _, want := range []string{"HEY_CHANGE=recording_added", "HEY_CALENDAR_ID=512", "HEY_CALENDAR_NAME=Household", "HEY_RECORDING_ID=88001", "HEY_RECORDING_TYPE=Calendar::Event"} {
+		if !strings.Contains(environment, want) {
+			t.Errorf("environment = %q, want %s", environment, want)
+		}
+	}
+	if strings.Contains(environment, "HEY_BOX_ID") {
+		t.Errorf("environment = %q, want no box on a calendar event", environment)
+	}
+}
+
+func TestCalendarWatchLine(t *testing.T) {
+	line := watchLine(watchEvent{
+		Change:        "recording_added",
+		At:            "2026-08-18T09:14:22.031Z",
+		Calendar:      &watchEventCalendar{ID: 512, Name: "House\x1b[31mhold"},
+		RecordingID:   88001,
+		RecordingType: "Calendar::Event",
+		Recording:     &generated.Recording{Title: "Dentist \x1b[31mappointment"},
+	})
+
+	if !strings.Contains(line, "Household") || strings.Contains(line, "\x1b[31m") {
+		t.Errorf("line = %q, want the calendar named and every escape stripped", line)
+	}
+	if !strings.Contains(line, "Dentist appointment") {
+		t.Errorf("line = %q, want the recording's title", line)
+	}
+}

--- a/internal/tui/calendar.go
+++ b/internal/tui/calendar.go
@@ -1545,6 +1545,22 @@ func (v *calendarView) AccountSwitchBlocked() bool {
 	return v.requests.kind == calendarRequestMutation || v.requests.kind == calendarRequestTimeTrack
 }
 
+// refreshLive re-reads the span on screen for a change that arrived over the watch, and
+// says it is held when the view cannot take one right now: a form or a picker is the
+// reader's focus, a read they asked for is in flight and must not be superseded, and a
+// delete waiting on its second x must not have the list change under it. The re-read
+// rides the ordinary request lane — once a day has been drawn it never shows the spinner,
+// and the selection is kept by key, so nothing moves under the reader but the facts.
+func (v *calendarView) refreshLive() (tea.Cmd, bool) {
+	if v.CapturingInput() || v.requests.loading || v.confirmDelete != "" {
+		return nil, true
+	}
+	if len(v.calendars) == 0 {
+		return nil, false
+	}
+	return v.requestRecordings(), false
+}
+
 // Restyle re-renders the day/week/year grid, which caches styled output in its
 // viewport. The recording detail is plain text and needs nothing.
 func (v *calendarView) Restyle() {

--- a/internal/tui/journal.go
+++ b/internal/tui/journal.go
@@ -44,6 +44,17 @@ type journalPageAppendedMsg struct {
 	err       error
 }
 
+// journalPageRefreshedMsg is the top of the list read again for a change that arrived
+// over the watch. It carries a bare counter of its own rather than riding the request
+// lane, for the reason the appended page does: a live re-read must never cancel — or be
+// cancelled by — the read the reader asked for, and it never shows the spinner.
+type journalPageRefreshedMsg struct {
+	requestID uint64
+	entries   []journalSummary
+	nextPage  string
+	err       error
+}
+
 type journalDetailMsg struct {
 	requestResult
 	date    string
@@ -122,6 +133,7 @@ type journalView struct {
 	nextPage    string
 	loadingMore bool
 	moreID      uint64
+	liveID      uint64
 
 	detailDate    string
 	detailContent string
@@ -177,6 +189,18 @@ func (v *journalView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		v.list.growEntries(msg.entries)
 		v.nextPage = msg.nextPage
 		return v.loadMoreEntries(), true
+
+	case journalPageRefreshedMsg:
+		if msg.requestID != v.liveID {
+			return nil, true
+		}
+		if msg.err != nil {
+			// A live re-read that failed costs staleness, not a notice: nothing the
+			// reader did is waiting on it, and the next change rings again.
+			return nil, true
+		}
+		v.spliceRefreshedEntries(msg.entries, msg.nextPage)
+		return nil, true
 
 	case journalDetailMsg:
 		if cmd, ok := v.requests.settle(msg.requestResult); !ok {
@@ -519,6 +543,73 @@ func (v *journalView) loadMoreEntries() tea.Cmd {
 	v.loadingMore = true
 	v.moreID++
 	return v.fetchMoreJournalPage(v.vc.ctx, v.moreID, v.nextPage)
+}
+
+// refreshLive re-reads the top of the list for a change that arrived over the watch, and
+// says it is held when the view cannot take one right now: a form or a prompt is the
+// reader's focus, a removal is waiting on its second x, or a read they asked for is in
+// flight. A search is left alone — its results are a snapshot of a question already
+// answered — and an open entry is too: the list under it is spliced, but what the reader
+// is reading does not change under them.
+func (v *journalView) refreshLive() (tea.Cmd, bool) {
+	if v.form != nil || v.prompt != nil || v.confirmRemove || v.requests.loading {
+		return nil, true
+	}
+	if !v.loaded || v.query != "" {
+		return nil, false
+	}
+	v.liveID++
+	return v.fetchRefreshedJournalPage(v.vc.ctx, v.liveID), false
+}
+
+func (v *journalView) fetchRefreshedJournalPage(ctx context.Context, requestID uint64) tea.Cmd {
+	return func() tea.Msg {
+		result, err := v.vc.sdk.Journal().ListPage(ctx, "", "")
+		if err != nil {
+			return journalPageRefreshedMsg{requestID: requestID, err: err}
+		}
+		if result == nil {
+			return journalPageRefreshedMsg{requestID: requestID}
+		}
+		return journalPageRefreshedMsg{
+			requestID: requestID,
+			entries:   journalSummaries(result.Entries),
+			nextPage:  result.NextPage,
+		}
+	}
+}
+
+// spliceRefreshedEntries puts the fresh top page in front of whatever the list had grown
+// past it, the way the mail list's refreshHead does. The journal is one entry per day,
+// newest first, so the fresh page covers every date down to its last entry and the old
+// tail keeps the rest until a full re-read. The cursor stays on its day, and the cursor
+// for what comes next only moves while the top page is the whole list.
+func (v *journalView) spliceRefreshedEntries(fresh []journalSummary, nextPage string) {
+	var selectedDate string
+	if entry := v.list.selected(); entry != nil {
+		selectedDate = entry.Date
+	}
+
+	if len(fresh) == 0 {
+		v.list.setEntries(nil)
+		v.nextPage = ""
+		return
+	}
+
+	cutoff := fresh[len(fresh)-1].Date
+	var tail []journalSummary
+	for _, entry := range v.list.entries {
+		if entry.Date < cutoff {
+			tail = append(tail, entry)
+		}
+	}
+	if len(tail) == 0 {
+		v.nextPage = nextPage
+	}
+	v.list.setEntries(append(fresh, tail...))
+	if selectedDate != "" {
+		v.list.selectDate(selectedDate)
+	}
 }
 
 func (v *journalView) fetchJournalPage(ctx context.Context, requestID uint64, page, query string) tea.Cmd {

--- a/internal/tui/live.go
+++ b/internal/tui/live.go
@@ -10,11 +10,12 @@ import (
 	"github.com/basecamp/hey-cli/internal/apierr"
 )
 
-// Watchers are the streams the TUI follows to stay live. Both are optional: without them
+// Watchers are the streams the TUI follows to stay live. All are optional: without them
 // a list is the snapshot it was read as.
 type Watchers struct {
 	Mail     MailWatcher
 	Screener ScreenerWatcher
+	Calendar CalendarWatcher
 }
 
 // MailWatcher opens the stream of mail and connection events that keeps the TUI live.
@@ -46,6 +47,13 @@ type MailWatchEvent struct {
 // signed stream is replaced. HEY serves the signed name alongside the pending count, so
 // a watcher opens after that name has been read.
 type ScreenerWatcher func(ctx, connectionCtx context.Context, signedStreamName string) (<-chan struct{}, error)
+
+// CalendarWatcher opens the stream that says a calendar changed. It subscribes every
+// calendar the account can see and folds them into one doorbell: which calendar rang does
+// not matter, because the TUI re-reads whatever span is on screen either way. A watcher
+// discovers calendars added or removed while it runs on its own and rings for those too.
+// The stream closes when ctx is done, or when whatever is behind it has given up for good.
+type CalendarWatcher func(ctx, connectionCtx context.Context) (<-chan struct{}, error)
 
 // AnyBoxChanged stands for "something changed, we don't know what" — a watcher sends it
 // after a reconnect, where the changes broadcast while it was away were missed.
@@ -250,4 +258,60 @@ func waitForScreenerChangeCmd(stream string, changes <-chan struct{}) tea.Cmd {
 
 func refreshScreenerLaterCmd(delay time.Duration) tea.Cmd {
 	return tea.Tick(delay, func(time.Time) tea.Msg { return screenerRefreshDueMsg{} })
+}
+
+// --- The calendar ---
+
+// calendarWatchStartedMsg carries the stream a watcher opened, or the reason there isn't
+// one. The attempt identifies the watch that asked, so a start that lost its race with a
+// section switch — the watch was dropped and another opened — cannot install its stream
+// over the current one.
+type calendarWatchStartedMsg struct {
+	attempt uint64
+	changes <-chan struct{}
+	err     error
+}
+
+// calendarChangedMsg reports that a calendar changed, or that the stream has closed. The
+// frame HEY broadcasts carries nothing the TUI can use: it is a doorbell, and the span on
+// screen is read again behind it.
+type calendarChangedMsg struct {
+	attempt uint64
+	closed  bool
+}
+
+// calendarRefreshDueMsg is the re-read a calendar change asked for, once its delay has passed.
+type calendarRefreshDueMsg struct{}
+
+// calendarWatchRetryMsg asks the model to open a new calendar watch after a failed start
+// or a stream that closed. The attempt identifies the state that scheduled it, the way
+// mailWatchRetryMsg's does.
+type calendarWatchRetryMsg struct{ attempt uint64 }
+
+func startCalendarWatchCmd(ctx, connectionCtx context.Context, watch CalendarWatcher, attempt uint64) tea.Cmd {
+	if watch == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		changes, err := watch(ctx, connectionCtx)
+		return calendarWatchStartedMsg{attempt: attempt, changes: changes, err: err}
+	}
+}
+
+func waitForCalendarChangeCmd(attempt uint64, changes <-chan struct{}) tea.Cmd {
+	if changes == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		_, open := <-changes
+		return calendarChangedMsg{attempt: attempt, closed: !open}
+	}
+}
+
+func refreshCalendarLaterCmd(delay time.Duration) tea.Cmd {
+	return tea.Tick(delay, func(time.Time) tea.Msg { return calendarRefreshDueMsg{} })
+}
+
+func retryCalendarWatchLaterCmd(attempt uint64, delay time.Duration) tea.Cmd {
+	return tea.Tick(delay, func(time.Time) tea.Msg { return calendarWatchRetryMsg{attempt: attempt} })
 }

--- a/internal/tui/live_test.go
+++ b/internal/tui/live_test.go
@@ -706,3 +706,252 @@ func mailWithBoxServer(t *testing.T, postingsJSON string) (*mailView, *recordedR
 	v.Update(currentPostingsLoaded(v, testPostings()))
 	return v, recorded
 }
+
+// --- The calendar's streams ---
+
+func TestWaitForCalendarChangeReportsTheRingAndTheClose(t *testing.T) {
+	changes := make(chan struct{}, 1)
+	changes <- struct{}{}
+
+	if rung := waitForCalendarChangeCmd(3, changes)().(calendarChangedMsg); rung.closed || rung.attempt != 3 {
+		t.Errorf("rung = %+v, want an open stream on attempt 3", rung)
+	}
+
+	close(changes)
+	if rung := waitForCalendarChangeCmd(3, changes)().(calendarChangedMsg); !rung.closed {
+		t.Errorf("rung = %+v, want a closed stream", rung)
+	}
+
+	if cmd := waitForCalendarChangeCmd(1, nil); cmd != nil {
+		t.Error("nothing to wait on should be no command")
+	}
+}
+
+func TestStartCalendarWatchCarriesTheStreamAttemptOrReason(t *testing.T) {
+	changes := make(chan struct{})
+	opened := startCalendarWatchCmd(context.Background(), context.Background(), func(_, _ context.Context) (<-chan struct{}, error) {
+		return changes, nil
+	}, 4)().(calendarWatchStartedMsg)
+	if opened.changes == nil || opened.err != nil || opened.attempt != 4 {
+		t.Errorf("opened = %+v, want attempt 4 and its stream", opened)
+	}
+
+	refused := startCalendarWatchCmd(context.Background(), context.Background(), func(_, _ context.Context) (<-chan struct{}, error) {
+		return nil, errors.New("cable server said no")
+	}, 5)().(calendarWatchStartedMsg)
+	if refused.err == nil || refused.attempt != 5 {
+		t.Errorf("refused = %+v, want attempt 5 and the reason it failed", refused)
+	}
+
+	if cmd := startCalendarWatchCmd(context.Background(), context.Background(), nil, 1); cmd != nil {
+		t.Error("no watcher should be no command")
+	}
+}
+
+func TestModelFollowsTheCalendarOnlyWhileItIsOnScreen(t *testing.T) {
+	m := newModel()
+	m.watchCalendar = func(_, _ context.Context) (<-chan struct{}, error) { return make(chan struct{}), nil }
+
+	updated, cmd := m.switchSection(sectionCalendar)
+	m = updated.(model)
+	if m.stopCalendarWatch == nil || cmd == nil {
+		t.Fatal("entering the calendar should open the watch")
+	}
+	attempt := m.calendarWatchAttempt
+
+	changes := make(chan struct{}, 1)
+	updated, _ = m.Update(calendarWatchStartedMsg{attempt: attempt, changes: changes})
+	m = updated.(model)
+	if m.calendarChanges == nil {
+		t.Fatal("the model should hold on to the stream")
+	}
+
+	updated, _ = m.switchSection(sectionJournal)
+	m = updated.(model)
+	if m.stopCalendarWatch == nil {
+		t.Fatal("the journal draws from the same streams, so the watch should stay open")
+	}
+
+	updated, _ = m.switchSection(sectionMail)
+	m = updated.(model)
+	if m.stopCalendarWatch != nil || m.calendarChanges != nil {
+		t.Error("leaving for mail should give the streams up")
+	}
+}
+
+func TestModelIgnoresAStaleCalendarStream(t *testing.T) {
+	m := newModel()
+	m.watchCalendar = func(_, _ context.Context) (<-chan struct{}, error) { return make(chan struct{}), nil }
+	updated, _ := m.switchSection(sectionCalendar)
+	m = updated.(model)
+
+	stale := make(chan struct{}, 1)
+	updated, cmd := m.Update(calendarWatchStartedMsg{attempt: m.calendarWatchAttempt - 1, changes: stale})
+	m = updated.(model)
+	if m.calendarChanges != nil || cmd != nil {
+		t.Error("a stream opened for a watch already given up should be ignored")
+	}
+}
+
+func TestModelArmsOneCalendarReReadPerRing(t *testing.T) {
+	m := newModel()
+	m.section = sectionCalendar
+	m.activeView = m.calendarView
+	m.calendarWatchAttempt = 2
+	m.calendarChanges = make(chan struct{})
+
+	updated, cmd := m.Update(calendarChangedMsg{attempt: 2})
+	m = updated.(model)
+	if !m.calendarRefreshDue || cmd == nil {
+		t.Fatal("a ring should arm the delayed re-read")
+	}
+
+	updated, _ = m.Update(calendarChangedMsg{attempt: 2})
+	m = updated.(model)
+	if !m.calendarRefreshDue {
+		t.Error("a second ring inside the delay should be folded into the first")
+	}
+}
+
+func TestModelRetriesAClosedCalendarStreamWhileWatching(t *testing.T) {
+	m := newModel()
+	m.watchCalendar = func(_, _ context.Context) (<-chan struct{}, error) { return make(chan struct{}), nil }
+	updated, _ := m.switchSection(sectionCalendar)
+	m = updated.(model)
+	attempt := m.calendarWatchAttempt
+
+	updated, cmd := m.Update(calendarChangedMsg{attempt: attempt, closed: true})
+	m = updated.(model)
+	if cmd == nil || m.stopCalendarWatch != nil || m.calendarWatchFailures != 1 {
+		t.Errorf("failures = %d, want the watch dropped and a retry armed", m.calendarWatchFailures)
+	}
+
+	updated, retry := m.Update(calendarWatchRetryMsg{attempt: m.calendarWatchAttempt})
+	m = updated.(model)
+	if retry == nil || m.stopCalendarWatch == nil {
+		t.Error("the retry should open a new watch while the calendar is on screen")
+	}
+}
+
+func TestModelDropsACalendarRetryAfterLeaving(t *testing.T) {
+	m := newModel()
+	m.watchCalendar = func(_, _ context.Context) (<-chan struct{}, error) { return make(chan struct{}), nil }
+	updated, _ := m.switchSection(sectionCalendar)
+	m = updated.(model)
+	attempt := m.calendarWatchAttempt
+
+	updated, _ = m.Update(calendarChangedMsg{attempt: attempt, closed: true})
+	m = updated.(model)
+	updated, _ = m.switchSection(sectionMail)
+	m = updated.(model)
+
+	updated, retry := m.Update(calendarWatchRetryMsg{attempt: m.calendarWatchAttempt})
+	m = updated.(model)
+	if retry != nil || m.stopCalendarWatch != nil {
+		t.Error("a retry that fires after leaving the section should open nothing")
+	}
+}
+
+func TestCalendarViewHoldsAReReadWhileBusy(t *testing.T) {
+	vc := testVC()
+	v := newCalendarView(vc)
+	v.calendars = []Calendar{{ID: 512, Name: "Household"}}
+
+	v.eventForm = &eventForm{}
+	if _, held := v.refreshLive(); !held {
+		t.Error("a re-read should be held while a form is open")
+	}
+	v.eventForm = nil
+
+	v.requests.loading = true
+	if _, held := v.refreshLive(); !held {
+		t.Error("a re-read should be held while a read the reader asked for is in flight")
+	}
+	v.requests.loading = false
+
+	v.confirmDelete = "88001"
+	if _, held := v.refreshLive(); !held {
+		t.Error("a re-read should be held while a delete waits on its second x")
+	}
+	v.confirmDelete = ""
+
+	v.calendars = nil
+	if cmd, held := v.refreshLive(); held || cmd != nil {
+		t.Error("a view that has read nothing yet has nothing to re-read")
+	}
+}
+
+func TestModelHoldsTheCalendarReReadAndComesBack(t *testing.T) {
+	m := newModel()
+	m.section = sectionCalendar
+	m.activeView = m.calendarView
+	m.calendarView.calendars = []Calendar{{ID: 512, Name: "Household"}}
+	m.calendarView.eventForm = &eventForm{}
+
+	cmd := m.refreshCalendarSection()
+	if cmd == nil || !m.calendarRefreshDue {
+		t.Error("a held re-read should stay owed and come back later")
+	}
+}
+
+func TestJournalViewRefreshGates(t *testing.T) {
+	vc := testVC()
+	v := newJournalView(vc)
+
+	if cmd, held := v.refreshLive(); held || cmd != nil {
+		t.Error("a list never read has nothing to re-read")
+	}
+
+	v.loaded = true
+	v.form = newJournalForm("2026-08-18", "", vc.styles)
+	if _, held := v.refreshLive(); !held {
+		t.Error("a re-read should be held while the editor is open")
+	}
+	v.form = nil
+
+	v.query = "dentist"
+	if cmd, held := v.refreshLive(); held || cmd != nil {
+		t.Error("search results are a snapshot and should be left alone")
+	}
+}
+
+func TestJournalSpliceKeepsTheTailAndTheSelection(t *testing.T) {
+	vc := testVC()
+	v := newJournalView(vc)
+	v.loaded = true
+	v.nextPage = "3"
+	v.list.setEntries([]journalSummary{
+		{Date: "2026-08-20", Preview: "Went for a run"},
+		{Date: "2026-08-19", Preview: "Dinner with Maria"},
+		{Date: "2026-08-18", Preview: "Quiet day"},
+	})
+	v.list.selectDate("2026-08-19")
+
+	v.spliceRefreshedEntries([]journalSummary{
+		{Date: "2026-08-21", Preview: "New entry"},
+		{Date: "2026-08-20", Preview: "Went for a longer run"},
+	}, "2")
+
+	dates := make([]string, 0, len(v.list.entries))
+	for _, entry := range v.list.entries {
+		dates = append(dates, entry.Date)
+	}
+	want := []string{"2026-08-21", "2026-08-20", "2026-08-19", "2026-08-18"}
+	if strings.Join(dates, " ") != strings.Join(want, " ") {
+		t.Errorf("dates = %v, want the fresh page in front of the old tail: %v", dates, want)
+	}
+	if v.list.entries[1].Preview != "Went for a longer run" {
+		t.Error("the fresh page should replace what it covers")
+	}
+	if selected := v.list.selected(); selected == nil || selected.Date != "2026-08-19" {
+		t.Errorf("selected = %+v, want the cursor kept on its day", selected)
+	}
+	if v.nextPage != "3" {
+		t.Errorf("nextPage = %q, want the deepest page's cursor kept while the list has grown past the top", v.nextPage)
+	}
+
+	v.spliceRefreshedEntries(nil, "")
+	if len(v.list.entries) != 0 || v.nextPage != "" {
+		t.Error("an empty journal should empty the list")
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -96,6 +96,16 @@ type model struct {
 	stopScreenerWatch  context.CancelFunc
 	screenerRefreshDue bool
 
+	// The calendar's streams, followed only while the calendar or the journal is on
+	// screen: every other section re-reads its data on entry, so a doorbell rung for a
+	// section nobody is looking at would be paid for and answered by nothing.
+	watchCalendar         CalendarWatcher
+	calendarChanges       <-chan struct{}
+	calendarWatchAttempt  uint64
+	calendarWatchFailures int
+	stopCalendarWatch     context.CancelFunc
+	calendarRefreshDue    bool
+
 	// Linked mail accounts
 	mailAccounts            []mailAccountChoice
 	mailAccountsLoaded      bool
@@ -161,6 +171,7 @@ func newModelWithMailAccounts(rootSDK, sdk *hey.Client, selected string, watcher
 		screenerView:        sv,
 		watchMail:           watchers.Mail,
 		watchScreener:       watchers.Screener,
+		watchCalendar:       watchers.Calendar,
 		mailWatchAttempt:    1,
 		watchCtx:            watchCtx,
 		stopWatching:        stopWatching,
@@ -429,6 +440,38 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case screenerRefreshDueMsg:
 		return m, m.refreshScreener()
+
+	case calendarWatchStartedMsg:
+		if msg.attempt != m.calendarWatchAttempt {
+			return m, nil
+		}
+		if msg.err != nil {
+			return m, m.retryCalendarWatch()
+		}
+		m.calendarChanges = msg.changes
+		m.calendarWatchFailures = 0
+		return m, waitForCalendarChangeCmd(msg.attempt, msg.changes)
+
+	case calendarChangedMsg:
+		if msg.attempt != m.calendarWatchAttempt {
+			return m, nil
+		}
+		if msg.closed {
+			return m, m.retryCalendarWatch()
+		}
+		return m, tea.Batch(m.calendarChanged(), waitForCalendarChangeCmd(msg.attempt, m.calendarChanges))
+
+	case calendarRefreshDueMsg:
+		return m, m.refreshCalendarSection()
+
+	case calendarWatchRetryMsg:
+		if msg.attempt != m.calendarWatchAttempt || m.calendarChanges != nil || m.stopCalendarWatch != nil {
+			return m, nil
+		}
+		if !m.watchingCalendars() {
+			return m, nil
+		}
+		return m, m.startCalendarWatch()
 
 	case screenerPendingRefreshedMsg:
 		cmd, _ := m.screenerView.Update(msg)
@@ -1020,6 +1063,85 @@ func (m *model) refreshScreener() tea.Cmd {
 	return tea.Batch(m.stampViewCmd(m.mailView.refreshScreenerCount()), m.stampViewCmd(queue))
 }
 
+// watchingCalendars is whether the calendar's streams are worth following: the calendar
+// and the journal draw from them, and every other section re-reads on entry anyway.
+func (m model) watchingCalendars() bool {
+	return m.section == sectionCalendar || m.section == sectionJournal
+}
+
+// startCalendarWatch opens the calendar's streams, unless a watch is already open or on
+// its way. The watch gets a context of its own under the TUI-wide one, so leaving the
+// section can give the streams up without touching the connection they share.
+func (m *model) startCalendarWatch() tea.Cmd {
+	if m.watchCalendar == nil || m.stopCalendarWatch != nil {
+		return nil
+	}
+	watchCtx, stop := context.WithCancel(m.watchCtx) //nolint:gosec // G118: cancel stored, called on section switch, retry or ctrl+c
+	m.stopCalendarWatch = stop
+	m.calendarWatchAttempt++
+	return startCalendarWatchCmd(watchCtx, m.watchCtx, m.watchCalendar, m.calendarWatchAttempt)
+}
+
+// dropCalendarWatch gives up the calendar's streams. Left open they would go on ringing
+// for a section nobody is looking at, and hold their subscriptions for as long as the
+// TUI runs.
+func (m *model) dropCalendarWatch() {
+	if m.stopCalendarWatch != nil {
+		m.stopCalendarWatch()
+	}
+	m.stopCalendarWatch = nil
+	m.calendarChanges = nil
+	m.calendarWatchFailures = 0
+	m.calendarRefreshDue = false
+}
+
+// retryCalendarWatch comes back from a failed start or a closed stream, on the same
+// doubling delay the mail watch retries on — but quietly: the calendar re-reads on every
+// step the reader takes, so a watch that is down costs staleness, not a broken screen,
+// and the mail watch already announces a connection that is gone.
+func (m *model) retryCalendarWatch() tea.Cmd {
+	m.dropCalendarWatch()
+	if !m.watchingCalendars() {
+		return nil
+	}
+	m.calendarWatchFailures++
+	return retryCalendarWatchLaterCmd(m.calendarWatchAttempt, mailWatchRetryDelay(m.calendarWatchFailures))
+}
+
+// calendarChanged is the calendar's doorbell. One write lands as several broadcasts —
+// HEY touches the calendar per recording — so the re-read is delayed and one is armed at
+// a time.
+func (m *model) calendarChanged() tea.Cmd {
+	if m.calendarRefreshDue {
+		return nil
+	}
+	m.calendarRefreshDue = true
+	return refreshCalendarLaterCmd(liveRefreshDelay)
+}
+
+// refreshCalendarSection re-reads what the doorbell was rung about: the span the calendar
+// is on, or the journal's list. A view that cannot take a re-read right now — a form or a
+// picker is open, or a read is already in flight — holds the change rather than dropping
+// it. A section switched away from needs nothing: it re-reads on entry.
+func (m *model) refreshCalendarSection() tea.Cmd {
+	m.calendarRefreshDue = false
+	var cmd tea.Cmd
+	var held bool
+	switch m.activeView {
+	case sectionView(m.calendarView):
+		cmd, held = m.calendarView.refreshLive()
+	case sectionView(m.journalView):
+		cmd, held = m.journalView.refreshLive()
+	default:
+		return nil
+	}
+	if held {
+		m.calendarRefreshDue = true
+		return refreshCalendarLaterCmd(liveRetryDelay)
+	}
+	return m.stampViewCmd(cmd)
+}
+
 func (m model) switchSection(sec section) (tea.Model, tea.Cmd) {
 	if sec == m.section || m.hasPendingMutation() {
 		return m, nil
@@ -1035,11 +1157,17 @@ func (m model) switchSection(sec section) (tea.Model, tea.Cmd) {
 	case sectionJournal:
 		m.activeView = m.journalView
 	}
+	var watch tea.Cmd
+	if m.watchingCalendars() {
+		watch = m.startCalendarWatch()
+	} else {
+		m.dropCalendarWatch()
+	}
 	m.activeView.Resize(m.vc.width, m.vc.height)
 	cmd := m.activeView.Init()
 	cmd = m.syncLoading(cmd)
 	m.updateHelpBindings()
-	return m, cmd
+	return m, tea.Batch(cmd, watch)
 }
 
 func (m model) openRequest(request OpenRequest) (tea.Model, tea.Cmd) {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-DXiAVd2WnmbrjF3Fkwv7OHr5W7qgILdcUw/FaRpp45Q=";
+  vendorHash = "sha256-lLydS6Petq+Mkq6ehH/ZKk8wjm0Lu1NFCqkJ/Hvejic=";
 
   subPackages = [ "cmd/hey" ];
 


### PR DESCRIPTION
The TUI's Calendar and Journal sections now stay current, and `hey watch` reports calendar changes alongside mail. Built on hey-sdk v0.21.0 (basecamp/hey-sdk#120) and HEY serving each calendar's `signed_stream_name` in `calendars.json` (deployed alongside this).

## How it follows

**Doorbell over cable, then pull.** HEY rings a calendar's own update stream whenever something on it is written; the frame carries nothing, so arrival is the whole message — the same model as The Screener's stream. The TUI subscribes every calendar's stream over its shared websocket, but only while the Calendar or Journal section is on screen: every other section re-reads on entry, so a doorbell rung elsewhere would be answered by nothing. Rings are debounced through the existing `liveRefreshDelay`; the calendar re-read rides the ordinary span read (never shows the spinner once drawn, keeps the selection by key), and the journal splices the fresh top page in front of what the list had grown past — `refreshHead` with dates for ids. Forms, pickers and pending deletes hold a re-read; a dead watch retries quietly on the mail watch's backoff, costing staleness rather than a notice.

**A slow poll catches new calendars.** Nothing announces the calendar *list* changing (the web app has the same blind spot — a calendar shared mid-session appears on its next navigation), so a five-minute read of the calendar-level changes feed — one page, usually empty — is how arrivals are subscribed and leavers dropped.

## hey watch

Calendar changes are reported by default: `recording_added` / `recording_updated` / `recording_deleted` lines carry a `calendar` object where mail lines carry `box`, plus a `recording_id`, `recording_type` and the recording itself; `calendar_added` / `calendar_updated` / `calendar_deleted` come from the poll, and `calendar_resync` is the calendar's word for a feed that fell too far behind and skipped ahead. Rings coalesce per calendar for 500ms before the feed is read; cursors start at the watch's start, capped the way box cursors are; `--since` maps straight onto the feeds; scripts get `HEY_CALENDAR_ID`, `HEY_CALENDAR_NAME`, `HEY_RECORDING_ID` and `HEY_RECORDING_TYPE`; `ready` waits for the calendar catch-up on the same retry backoff and critical section as the boxes'.

**Email-specific flags disable it entirely**: `--box`, or an `--events` list naming only mail changes (`added`, `updated`, `deleted`, `new`, `resync`), means no calendar subscriptions and no polling — and existing mail lines are byte-identical, so nothing scripted against today's output changes.

## Housekeeping

- SDK pinned to v0.21.0, Nix `vendorHash` recomputed via `make update-nix-hash`.
- AGENTS.md's watching section and the README cover the new behavior.
- ~600 lines of new tests: coalesce/read, resync skip-ahead, gone calendars, poll add/rename/delete, ready gating, env vars, sanitized styled lines, model watch lifecycle, debounce and hold, journal splice.