### PR TITLE
The HEY bar panel appears when you sign in with hey

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,16 @@ prints help. The TUI lives at `hey tui` (plus the hidden `hey hey`). `config.jso
 disables every prompt regardless of TTY detection: the wizard skips OAuth and answers its
 own confirmations with their defaults.
 
+On Omarchy, an interactive OAuth sign-in — `hey auth login`/`hey login`, the wizard, or
+`requireAuth`'s prompt — offers to install the `37signals.hey` bar plugin
+(`internal/cmd/omarchy_plugin.go`): asked once, remembered in
+`StateDir()/omarchy/bar-plugin.json`, serialized by a flock next to it. The hook never
+runs for machine output, `HEY_NONINTERACTIVE`, a non-TTY, or `--token`/`--cookie` logins,
+and it never re-enables a plugin that is off the bar — only explicit `hey setup omarchy`
+does, which installs in every output format and fails loudly (`setup_failed`) on any
+incomplete outcome; `--remove` writes its tombstone first, disables, and keeps the
+checkout. Details and the state model are in docs/omarchy.md.
+
 Coding-agent integration lives in `internal/harness` (agent registry, Claude Code / Codex
 detection, plugin and skill health checks) and `internal/cmd/setup_agent*.go` (`hey setup
 claude|codex|agents`). Claude Code gets the `hey@37signals` plugin from `basecamp/claude-plugins`

--- a/README.md
+++ b/README.md
@@ -628,10 +628,10 @@ read from `~/.local/state/omarchy/current/theme/`, and restyles live when you ru
 
 ```bash
 omarchy pkg aur add hey-cli  # hey-cli is on the AUR
-omarchy plugin add https://github.com/basecamp/omarchy-hey-plugin.git --enable
-hey setup omarchy            # install into the desktop
+hey auth login               # signing in with hey puts HEY in your bar (asked once)
+hey setup omarchy            # the explicit path: installs in every output format, fails loudly
 hey setup omarchy --notify   # toast new mail from the bar plugin (--no-notify turns it off)
-hey setup omarchy --remove   # take it all out again
+hey setup omarchy --remove   # disable the bar plugin (checkout kept) and remove the desktop pieces
 ```
 
 The bar gets the [HEY plugin](https://github.com/basecamp/omarchy-hey-plugin): the HEY
@@ -639,6 +639,14 @@ logo lights when the Imbox has unseen mail and opens a panel of recent threads. 
 its engine — the plugin reads the Imbox with `hey box view imbox` and runs `hey watch` so the
 bar is live: a thread you archive in the TUI, on your phone or in the web app leaves the
 panel within a second, and after a disconnect the watch catches up from where it left off.
+
+Signing in interactively — `hey auth login`, the setup wizard, or any command's sign-in
+prompt — offers to install that plugin, asks once, and remembers your answer. The offer
+never fires in scripts: machine output (`--json` and friends), `HEY_NONINTERACTIVE`, a
+non-TTY, and `--token`/`--cookie` logins all skip it, and `hey setup omarchy` is how a
+script installs it — explicitly, in every output format, verified against the running
+shell, with a loud failure when it cannot. A plugin you disable stays disabled until you
+run `hey setup omarchy` again; `--remove` disables it and keeps the checkout.
 
 Setup installs a `HEY TUI` launcher entry, a `HEY` row in the SUPER+SPACE menu, and a
 `hey.toml.tpl` theme template so theme authors can tune the overlay. It prints the

--- a/docs/omarchy.md
+++ b/docs/omarchy.md
@@ -158,9 +158,12 @@ file, one lock:
   mutation; a held lock is a quiet skip at sign-in and a failure under force.
 - **Ensure never enables an off-bar checkout.** A plugin the user disabled stays disabled
   whatever the marker says — pending included, where the sign-in owes the one-line notice
-  "install incomplete — run hey setup omarchy" and nothing else. Ensure's only mutation is
-  `omarchy plugin add`, on fresh consent or a pending retry; re-enabling is force mode's
-  alone (`omarchy plugin enable`, the reversal of `omarchy plugin disable`).
+  "install incomplete — run hey setup omarchy" and nothing else. Ensure's only enabling
+  mutation is `omarchy plugin add`, on fresh consent or a pending retry; re-enabling is
+  force mode's alone (`omarchy plugin enable`, the reversal of `omarchy plugin disable`).
+  The one other thing a sign-in may write is the one-time legacy migration: once the
+  plugin is on the bar, the old inline `hey-unread` module leaves shell.json, its notify
+  choice carried along.
 - **The probe**, `omarchy plugin list --json`, distinguishes three failures: the omarchy
   CLI missing ("update Omarchy"), the shell not running (an ssh session — nothing is
   asked, cloned or throttled), and an answer that is not a plugin list (fail closed). Its

--- a/docs/omarchy.md
+++ b/docs/omarchy.md
@@ -129,9 +129,9 @@ toggle in the panel header, or `omarchy bar set 37signals.hey notify true --json
 
 ### Installed at sign-in
 
-Signing in with hey is what puts the plugin in the bar — DHH's ask was that the panel
-"magically appear when you're logged in", with no hand-copied commands. One idempotent
-routine (`internal/cmd/omarchy_plugin.go`), three entry points, one state file, one lock:
+Signing in with hey is what puts the plugin in the bar, with no hand-copied commands.
+One idempotent routine (`internal/cmd/omarchy_plugin.go`), three entry points, one state
+file, one lock:
 
 - **Entry points.** An interactive OAuth sign-in — `hey auth login` / `hey login`,
   `requireAuth`'s "Sign in now?" (how `hey tui` and every data command sign in), the lite

--- a/docs/omarchy.md
+++ b/docs/omarchy.md
@@ -151,7 +151,8 @@ file, one lock:
 - **The marker**, `StateDir()/omarchy/bar-plugin.json`: `accepted_at` is consent, asked
   once and never re-asked; `pending_enable` + `installing_at` an unfinished install;
   `installed_at` history; `declined_at`/`removed_at` the user's no; `last_clone_*` a 24 h
-  retry throttle for failed clones only — nothing else is throttled. A marker that cannot
+  retry throttle for failed clone attempts only (timeouts included) — nothing else is
+  throttled. A marker that cannot
   be read fails installation closed ("delete it, then run hey setup omarchy"); only
   `--remove` still disables then, since nothing can resurrect the plugin through a
   fail-closed install. The flock beside it (`bar-plugin.lock`) serializes every look and

--- a/docs/omarchy.md
+++ b/docs/omarchy.md
@@ -69,7 +69,7 @@ step does not stop the others.
 |---|---|---|
 | Desktop entry | `~/.local/share/applications/HEY TUI.desktop` | Distinct from Omarchy's shipped `HEY.desktop` web app. Launches under app-id `org.omarchy.hey` |
 | Menu row | marker block in `~/.config/omarchy/extensions/omarchy-menu.jsonc` | one root `HEY` row that focuses or launches the TUI; its guard is a PATH lookup, never network or `hey` itself. Becomes a submenu once there is more than one thing to open |
-| Bar plugin | the `37signals.hey` entry in `~/.config/omarchy/shell.json`'s bar layout | not installed by setup — `omarchy plugin add https://github.com/basecamp/omarchy-hey-plugin.git --enable` does that — but configured by it: `--notify` / `--no-notify` set or delete the entry's `notify` key, which the shell hot-reloads and the plugin reads to decide whether to toast. `--remove` leaves the key alone: it is set as readily from the panel or `omarchy bar set` as from here, so removal cannot tell a preference it wrote from one it didn't — `--no-notify` is the off switch. An earlier inline `hey-unread` module is removed on sight, its notify choice carried over |
+| Bar plugin | clone under `~/.config/omarchy/plugins/37signals.hey`, entry in `~/.config/omarchy/shell.json`'s bar layout | installed and enabled by **signing in with hey** (asked once — see below) or by this command, which also finishes an interrupted install and re-enables a plugin you disabled, verified against the running shell. `--notify` / `--no-notify` set or delete the entry's `notify` key, which the shell hot-reloads and the plugin reads to decide whether to toast. `--remove` disables the plugin and keeps its checkout. An earlier inline `hey-unread` module is removed on sight, its notify choice carried over |
 | Theme template | `~/.config/omarchy/themed/hey.toml.tpl` | renders `hey.toml` into every theme so theme authors can override the overlay; triggers `omarchy-theme-refresh` |
 | Keybinding | printed, never written | `o.bind("SUPER + SHIFT + ALT + H", "HEY TUI", "omarchy-launch-or-focus-tui --app-id=org.omarchy.hey hey tui")`; SUPER+SHIFT+E keeps opening the web app unless you `hl.unbind` it. Spelled out rather than `{ tui = "hey tui" }` because the lua helper quotes that into one word and the app-id derived from it would never match |
 
@@ -126,6 +126,54 @@ live as extra keys on the `{"id":"37signals.hey"}` entry in `shell.json`, hot-re
 the shell. Three ways to flip a key, all equivalent: `hey setup omarchy --notify`, the
 toggle in the panel header, or `omarchy bar set 37signals.hey notify true --json`. Flipping
 `notify` only gates the plugin's toasts; the watch runs on regardless, and nothing restarts.
+
+### Installed at sign-in
+
+Signing in with hey is what puts the plugin in the bar — DHH's ask was that the panel
+"magically appear when you're logged in", with no hand-copied commands. One idempotent
+routine (`internal/cmd/omarchy_plugin.go`), three entry points, one state file, one lock:
+
+- **Entry points.** An interactive OAuth sign-in — `hey auth login` / `hey login`,
+  `requireAuth`'s "Sign in now?" (how `hey tui` and every data command sign in), the lite
+  wizard — runs the routine in *ensure* mode and prints at most one stderr line; the full
+  wizard runs it as Step 3; `hey setup omarchy` runs it in *force* mode. The automatic
+  hooks never run for machine output, `HEY_NONINTERACTIVE`, a non-TTY, or
+  `--token`/`--cookie` logins: a script installs with `hey setup omarchy`, which works in
+  every output format and exits `setup_failed` on any incomplete outcome — an incomplete
+  forced install is a failure, never a quiet skip.
+- **Ordering, per mode.** Ensure: state gates → shell probe → consent → intent write →
+  `omarchy plugin add` → verify → final write. Nothing is asked where installation is
+  impossible, nothing is cloned before the shell is known up and the intent is on disk,
+  and every incomplete outcome is non-fatal to the login. Force: the intent write comes
+  first — recording acceptance, clearing a decline, a removal and the clone throttle,
+  since the command is the explicit ask — so a crash leaves a pending install the *next
+  explicit setup* finishes.
+- **The marker**, `StateDir()/omarchy/bar-plugin.json`: `accepted_at` is consent, asked
+  once and never re-asked; `pending_enable` + `installing_at` an unfinished install;
+  `installed_at` history; `declined_at`/`removed_at` the user's no; `last_clone_*` a 24 h
+  retry throttle for failed clones only — nothing else is throttled. A marker that cannot
+  be read fails installation closed ("delete it, then run hey setup omarchy"); only
+  `--remove` still disables then, since nothing can resurrect the plugin through a
+  fail-closed install. The flock beside it (`bar-plugin.lock`) serializes every look and
+  mutation; a held lock is a quiet skip at sign-in and a failure under force.
+- **Ensure never enables an off-bar checkout.** A plugin the user disabled stays disabled
+  whatever the marker says — pending included, where the sign-in owes the one-line notice
+  "install incomplete — run hey setup omarchy" and nothing else. Ensure's only mutation is
+  `omarchy plugin add`, on fresh consent or a pending retry; re-enabling is force mode's
+  alone (`omarchy plugin enable`, the reversal of `omarchy plugin disable`).
+- **The probe**, `omarchy plugin list --json`, distinguishes three failures: the omarchy
+  CLI missing ("update Omarchy"), the shell not running (an ssh session — nothing is
+  asked, cloned or throttled), and an answer that is not a plugin list (fail closed). Its
+  `{id, enabled}` refines what shell.json's layout says. Installed is decided by the
+  shell: the verify probe must list the plugin enabled, and the final write must land —
+  "enabled, but could not record" is a failure everywhere, never a success with a hidden
+  error; the next run's crash repair finishes the marker.
+- **`--remove`** writes its tombstone first — a removal that cannot be recorded runs
+  nothing — then `omarchy plugin disable 37signals.hey`. The checkout stays: `omarchy
+  plugin remove` deletes it, and hey never runs that, nor `rm`.
+- **The source is not configurable.** `omarchyBarPluginSource` is a package var only as a
+  test seam; there is no flag, env var, or build override, so nothing but the public
+  repository ever ships or installs.
 
 ### New mail is a watch event
 
@@ -199,6 +247,14 @@ new --run-async 'notify-send -a HEY "New mail in HEY"'` is the one-liner.
 
 ## Decisions
 
+- **Sign-in with hey installs the face.** hey-cli observes a sign-in only on its own
+  surfaces — the web app is not visible from the host, and there is no HEY desktop app —
+  so the promise is "signing in with hey puts HEY in your bar", not "wherever you log
+  in". Consent is interactive, asked once, and remembered; ensure never enables an
+  off-bar checkout, so a plugin you disable is never resurrected by a sign-in; the
+  automatic hooks never run for scripts, and `hey setup omarchy` is the explicit,
+  verified, fail-loud path. The location-independent version is Omarchy's to ship (see
+  Follow-ups).
 - **Indicator, not count.** Pending screener mail is not what people mean by "important",
   and a number is the attention treadmill HEY exists to end. The glyph lights or it does
   not.
@@ -259,6 +315,11 @@ completions for a binary that has not been fetched yet.
 
 ## Follow-ups, in rough order
 
+0. **The Omarchy-side counterpart**: ship `37signals.hey` with Omarchy itself, so the
+   panel is on the bar before hey-cli is installed — its own button already drives
+   "Install HEY CLI…" and "Sign in to HEY…", which is the only way "the panel appears
+   wherever you log in" becomes true (a web-app login is not observable from the host).
+   A recommendation for the Omarchy team, not built here.
 1. **mailto: handler** that opens a floating compose (`hey compose --mailto`), opt-in
    against the incumbent `omarchy-webapp-handler-hey`.
 2. **Agent-triage digests**: `hey --json` feeding a system agent that emits sparse

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -98,6 +98,7 @@ Use --token or --cookie for non-interactive login.`,
 					fmt.Fprintln(w, identityGreeting(identity))
 				}
 				printAgentNudge(w)
+				ensureOmarchyBarPluginAfterLogin(cmd.ErrOrStderr())
 				return nil
 			}
 			return writeOK(map[string]string{"method": "oauth"}, output.WithSummary("Logged in successfully"))

--- a/internal/cmd/auth_commands_test.go
+++ b/internal/cmd/auth_commands_test.go
@@ -21,6 +21,8 @@ func runAuthCommand(t *testing.T, configHome, baseURL, envToken string, jsonOutp
 	t.Setenv("HEY_TOKEN", envToken)
 	t.Setenv("HEY_NO_KEYRING", "1")
 	t.Setenv("HEY_BASE_URL", "")
+	// Never let a test detect the developer's Omarchy and talk to its shell.
+	t.Setenv("OMARCHY_PATH", "")
 	t.Setenv("HOME", configHome)
 	t.Setenv("XDG_CONFIG_HOME", configHome)
 	t.Setenv("XDG_STATE_HOME", configHome)

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -168,6 +168,11 @@ func runDoctorChecks(ctx context.Context, root *cobra.Command) []map[string]stri
 		}
 	}
 
+	// Omarchy bar plugin
+	if env := liveOmarchyEnv(); env.detected() {
+		checks = append(checks, checkOmarchyBarPlugin(env))
+	}
+
 	// Git
 	if _, err := exec.LookPath("git"); err == nil {
 		checks = append(checks, map[string]string{
@@ -242,6 +247,46 @@ func checkBaselineSkill() map[string]string {
 		check["status"] = "warning"
 		check["message"] = fmt.Sprintf("Stale (installed: %s, current: %s)", installed, version.Version)
 		check["hint"] = "hey skill install"
+	}
+	return check
+}
+
+// checkOmarchyBarPlugin reports the bar plugin's state on an Omarchy desktop:
+// the sign-in hook installs it, `hey setup omarchy` forces or removes it, and
+// this is where the in-between states get their remediation. Reads only —
+// files and the marker, never a subprocess.
+func checkOmarchyBarPlugin(env omarchyEnv) map[string]string {
+	check := map[string]string{"name": "Omarchy Bar Plugin"}
+	marker, _, err := readOmarchyPluginMarker(env.markerPath())
+	if err != nil {
+		check["status"] = "error"
+		check["message"] = "State unreadable at " + env.markerPath()
+		check["hint"] = "Delete it, then run: hey setup omarchy"
+		return check
+	}
+	onBar := omarchySetup{env: env}.pluginOnBar()
+	switch {
+	case marker.DeclinedAt != "":
+		check["status"] = "info"
+		check["message"] = "Declined — hey setup omarchy installs it"
+	case marker.RemovedAt != "":
+		check["status"] = "info"
+		check["message"] = "Removed — hey setup omarchy re-enables it"
+	case marker.PendingEnable:
+		check["status"] = "warning"
+		check["message"] = "Install pending"
+		check["hint"] = "hey setup omarchy"
+	case onBar:
+		check["status"] = "ok"
+		check["message"] = "Installed and enabled"
+	case env.pluginCloned():
+		check["status"] = "warning"
+		check["message"] = "Cloned but not on the bar"
+		check["hint"] = "hey setup omarchy re-enables it"
+	default:
+		check["status"] = "warning"
+		check["message"] = "Not installed"
+		check["hint"] = "hey setup omarchy"
 	}
 	return check
 }

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -282,9 +282,12 @@ func checkOmarchyBarPlugin(env omarchyEnv) map[string]string {
 		check["status"] = "info"
 		check["message"] = "Removed — hey setup omarchy re-enables it"
 	case env.pluginCloned():
+		// The files alone cannot prove the plugin disabled: an enabled
+		// plugin needs no spelled-out layout entry, and doctor never runs a
+		// subprocess to ask the shell — say what is known, no more.
 		check["status"] = "warning"
-		check["message"] = "Cloned but not on the bar"
-		check["hint"] = "hey setup omarchy re-enables it"
+		check["message"] = "Cloned; not in the configured bar layout (the shell may still have it enabled)"
+		check["hint"] = "hey setup omarchy verifies and enables it"
 	default:
 		check["status"] = "warning"
 		check["message"] = "Not installed"

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -266,19 +266,21 @@ func checkOmarchyBarPlugin(env omarchyEnv) map[string]string {
 	}
 	onBar := omarchySetup{env: env}.pluginOnBar()
 	switch {
+	case marker.PendingEnable:
+		check["status"] = "warning"
+		check["message"] = "Install pending"
+		check["hint"] = "hey setup omarchy"
+	case onBar:
+		// The bar is the present tense; a decline or removal recorded
+		// before a later manual enable is history, as in ensure mode.
+		check["status"] = "ok"
+		check["message"] = "Installed and enabled"
 	case marker.DeclinedAt != "":
 		check["status"] = "info"
 		check["message"] = "Declined — hey setup omarchy installs it"
 	case marker.RemovedAt != "":
 		check["status"] = "info"
 		check["message"] = "Removed — hey setup omarchy re-enables it"
-	case marker.PendingEnable:
-		check["status"] = "warning"
-		check["message"] = "Install pending"
-		check["hint"] = "hey setup omarchy"
-	case onBar:
-		check["status"] = "ok"
-		check["message"] = "Installed and enabled"
 	case env.pluginCloned():
 		check["status"] = "warning"
 		check["message"] = "Cloned but not on the bar"

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -271,10 +271,12 @@ func checkOmarchyBarPlugin(env omarchyEnv) map[string]string {
 		check["message"] = "Install pending"
 		check["hint"] = "hey setup omarchy"
 	case onBar:
-		// The bar is the present tense; a decline or removal recorded
-		// before a later manual enable is history, as in ensure mode.
+		// The layout entry is the shell's own config and outranks a decline
+		// or removal recorded before a later manual enable — but the files
+		// cannot prove the shell has it enabled right now, so claim only
+		// the layout.
 		check["status"] = "ok"
-		check["message"] = "Installed and enabled"
+		check["message"] = "Installed (in the configured bar layout)"
 	case marker.DeclinedAt != "":
 		check["status"] = "info"
 		check["message"] = "Declined — hey setup omarchy installs it"

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -16,7 +16,7 @@ func TestCuratedCommandHelpUsesUserFacingLanguage(t *testing.T) {
 	root := newRootCmd()
 	tests := map[string]string{
 		"auth":  "Sign in to HEY, sign out, or check your login status.",
-		"setup": "Sign in and connect your coding agents.",
+		"setup": "Sign in and connect your coding agents. On Omarchy, a styled interactive run also\ninstalls hey into the desktop and offers the HEY bar plugin (asked once); machine\nand non-interactive runs never touch the desktop — hey setup omarchy does that\nexplicitly.",
 	}
 
 	for name, expected := range tests {

--- a/internal/cmd/omarchy.go
+++ b/internal/cmd/omarchy.go
@@ -336,9 +336,16 @@ func notifyDetail(notify bool) string {
 }
 
 // configureBarPlugin reports one merged step for the plugin — its install
-// (installBarPlugin) folded together with its notify setting — and, only when
-// there was one to remove, a step for the legacy module before it.
+// folded together with its notify setting — and, only when there was one to
+// remove, a step for the legacy module before it. The whole sequence holds
+// the plugin lock: the legacy and notify rewrites of shell.json act on what
+// they read, so a concurrent remove cannot slip between the read and the
+// write and have its disable overwritten.
 func (s omarchySetup) configureBarPlugin() []omarchyStep {
+	return s.underBarPluginLock(s.configureBarPluginLocked)
+}
+
+func (s omarchySetup) configureBarPluginLocked() []omarchyStep {
 	path := s.env.shellPath()
 	shell, err := s.loadShellConfig()
 	if err != nil {
@@ -357,7 +364,7 @@ func (s omarchySetup) configureBarPlugin() []omarchyStep {
 		steps = s.writeBarSteps(steps, shell, true)
 	}
 
-	install := s.installBarPlugin()
+	install := s.installBarPluginLocked()
 	if install.Status == "skipped" || install.Status == "failed" {
 		return append(steps, install)
 	}
@@ -472,20 +479,25 @@ func barPluginNotifies(plugin map[string]any) bool {
 
 // removeBar takes out what setup wrote into the bar layout — a legacy
 // hey-unread module — and disables the plugin, tombstone first, keeping the
-// checkout (removeBarPlugin). The entry's notify setting rides with the
-// entry: `omarchy plugin disable` takes both off the bar together.
+// checkout (removeBarPluginLocked). The entry's notify setting rides with
+// the entry: `omarchy plugin disable` takes both off the bar together. One
+// lock spans the whole sequence, as in configureBarPlugin.
 func (s omarchySetup) removeBar() []omarchyStep {
+	return s.underBarPluginLock(s.removeBarLocked)
+}
+
+func (s omarchySetup) removeBarLocked() []omarchyStep {
 	path := s.env.shellPath()
 	shell, err := s.loadShellConfig()
 	if err != nil {
-		return []omarchyStep{stepResult("bar indicator", path, false, err, "", ""), s.removeBarPlugin(false)}
+		return []omarchyStep{stepResult("bar indicator", path, false, err, "", ""), s.removeBarPluginLocked(false)}
 	}
 	bar, _ := shell["bar"].(map[string]any)
 	layout, _ := bar["layout"].(map[string]any)
 	legacy, _ := s.removeLegacyBarModule(shell, layout)
 	onBar := barLayoutModule(layout, omarchyBarPluginID) != nil
 	steps := s.writeBarSteps([]omarchyStep{stepResult("bar indicator", path, legacy, nil, "removed", "absent")}, shell, legacy)
-	return append(steps, s.removeBarPlugin(onBar))
+	return append(steps, s.removeBarPluginLocked(onBar))
 }
 
 // removeLegacyBarModule drops the inline hey-unread module earlier releases

--- a/internal/cmd/omarchy.go
+++ b/internal/cmd/omarchy.go
@@ -396,20 +396,19 @@ func (s omarchySetup) applyNotify(legacyNotified bool) omarchyStep {
 		return stepResult("bar plugin", path, false, err, "", "")
 	}
 	plugin := barLayoutModule(layout, omarchyBarPluginID)
-	if plugin == nil {
-		// Enabled per the shell, but no spelled-out layout entry to hold a
-		// setting yet: nothing to configure.
-		return omarchyStep{Name: "bar plugin", Path: path, Status: "unchanged"}
-	}
 	want := s.notify
 	if want == nil && legacyNotified {
 		// The legacy module was toasting and the plugin has not been told
 		// either way: keep the user's choice rather than silently turning
 		// the toasts off with the module.
-		if _, has := plugin["notify"]; !has {
+		_, has := plugin["notify"]
+		if plugin == nil || !has {
 			on := true
 			want = &on
 		}
+	}
+	if plugin == nil {
+		return s.setNotifyWithoutEntry(want)
 	}
 	settingChanged := false
 	if want != nil {
@@ -428,6 +427,25 @@ func (s omarchySetup) applyNotify(legacyNotified bool) omarchyStep {
 		step.Status = "installed"
 	}
 	return s.writeBarSteps([]omarchyStep{step}, shell, settingChanged)[0]
+}
+
+// setNotifyWithoutEntry handles an enabled plugin with no spelled-out layout
+// entry to hold the key. Seeding a partial layout would override the shell's
+// whole default layout, so the omarchy CLI materializes the setting instead —
+// and with no entry there is no key, so "off" is already true.
+func (s omarchySetup) setNotifyWithoutEntry(want *bool) omarchyStep {
+	path := s.env.shellPath()
+	if want == nil {
+		return omarchyStep{Name: "bar plugin", Path: path, Status: "unchanged"}
+	}
+	if !*want {
+		return omarchyStep{Name: "bar plugin", Path: path, Status: "unchanged", Detail: notifyDetail(false)}
+	}
+	out, err := s.env.run("omarchy", "bar", "set", omarchyBarPluginID, "notify", "true", "--json")
+	if err != nil {
+		return stepResult("bar plugin", path, false, errors.New(firstOutputLine(out, err)), "", "")
+	}
+	return omarchyStep{Name: "bar plugin", Path: path, Status: "installed", Detail: notifyDetail(true)}
 }
 
 // writeBarSteps writes shell.json when anything changed and turns every

--- a/internal/cmd/omarchy.go
+++ b/internal/cmd/omarchy.go
@@ -398,7 +398,28 @@ func (s omarchySetup) removeLegacyIndicator(carryNotify bool) omarchyStep {
 	if err != nil {
 		return stepResult("bar indicator", path, false, err, "", "")
 	}
-	legacy, notified := s.removeLegacyBarModule(shell, layout)
+	present, notified := legacyIndicator(layout)
+	if !present {
+		return omarchyStep{Name: "bar indicator", Path: path, Status: "absent"}
+	}
+	if carryNotify && notified && barLayoutModule(layout, omarchyBarPluginID) == nil {
+		// No entry to hold the key (an enabled plugin needs none): the CLI
+		// materializes it — rewriting shell.json, so the removal below
+		// reloads rather than clobbering the new entry with this stale
+		// snapshot. If the choice cannot land, the toasting module stays
+		// for the next explicit setup rather than dying with the migration.
+		on := true
+		if carried := s.setNotifyWithoutEntry(&on); carried.failure != nil {
+			return carried
+		}
+		if shell, err = s.loadShellConfig(); err != nil {
+			return stepResult("bar indicator", path, false, err, "", "")
+		}
+		if layout, err = existingBarLayout(shell); err != nil {
+			return stepResult("bar indicator", path, false, err, "", "")
+		}
+	}
+	legacy, _ := s.removeLegacyBarModule(shell, layout)
 	if !legacy {
 		return omarchyStep{Name: "bar indicator", Path: path, Status: "absent"}
 	}
@@ -406,15 +427,6 @@ func (s omarchySetup) removeLegacyIndicator(carryNotify bool) omarchyStep {
 		if plugin := barLayoutModule(layout, omarchyBarPluginID); plugin != nil {
 			if _, has := plugin["notify"]; !has {
 				plugin["notify"] = true
-			}
-		} else {
-			// No entry to hold the key (an enabled plugin needs none): the
-			// CLI materializes it, and if that cannot land the toasting
-			// module stays — the next explicit setup migrates — rather
-			// than the choice dying with it.
-			on := true
-			if carried := s.setNotifyWithoutEntry(&on); carried.failure != nil {
-				return carried
 			}
 		}
 	}

--- a/internal/cmd/omarchy.go
+++ b/internal/cmd/omarchy.go
@@ -355,20 +355,63 @@ func (s omarchySetup) configureBarPluginLocked() []omarchyStep {
 	if err != nil {
 		return []omarchyStep{stepResult("bar plugin", path, false, err, "", "")}
 	}
-	legacy, legacyNotified := s.removeLegacyBarModule(shell, layout)
-	var steps []omarchyStep
-	if legacy {
-		steps = append(steps, omarchyStep{Name: "bar indicator", Path: path, Status: "removed",
-			Detail: "hey-unread module removed; the " + omarchyBarPluginID + " plugin replaces it"})
-		// On disk before the plugin install reads or rewrites shell.json.
-		steps = s.writeBarSteps(steps, shell, true)
-	}
+	// Peek only: the legacy indicator keeps working until its replacement
+	// is on the bar — a declined consent, a downed shell or a failed clone
+	// must not cost the user the panel they already have.
+	legacyPresent, legacyNotified := legacyIndicator(layout)
 
 	install := s.installBarPluginLocked()
 	if install.Status == "skipped" || install.Status == "failed" {
-		return append(steps, install)
+		return []omarchyStep{install}
+	}
+	var steps []omarchyStep
+	if legacyPresent {
+		// The carry is applyNotify's below, so the report says "installed".
+		steps = append(steps, s.removeLegacyIndicator(false))
 	}
 	return append(steps, s.mergeNotify(install, legacyNotified))
+}
+
+// legacyIndicator reports whether layout still carries the inline hey-unread
+// module earlier releases installed, and whether it was toasting.
+func legacyIndicator(layout map[string]any) (present, notified bool) {
+	module := barLayoutModule(layout, omarchyBarModuleID)
+	if module == nil {
+		return false, false
+	}
+	moduleExec, _ := module["exec"].(string)
+	return true, strings.HasSuffix(moduleExec, " --notify")
+}
+
+// removeLegacyIndicator drops the legacy module and writes shell.json. It
+// reloads the file first — the caller may have rewritten it since any
+// earlier look. carryNotify moves the module's toast choice onto the
+// plugin's entry when that entry exists and has not been told either way;
+// configureBarPlugin passes false and lets applyNotify do it instead.
+func (s omarchySetup) removeLegacyIndicator(carryNotify bool) omarchyStep {
+	path := s.env.shellPath()
+	shell, err := s.loadShellConfig()
+	if err != nil {
+		return stepResult("bar indicator", path, false, err, "", "")
+	}
+	layout, err := existingBarLayout(shell)
+	if err != nil {
+		return stepResult("bar indicator", path, false, err, "", "")
+	}
+	legacy, notified := s.removeLegacyBarModule(shell, layout)
+	if !legacy {
+		return omarchyStep{Name: "bar indicator", Path: path, Status: "absent"}
+	}
+	if carryNotify && notified {
+		if plugin := barLayoutModule(layout, omarchyBarPluginID); plugin != nil {
+			if _, has := plugin["notify"]; !has {
+				plugin["notify"] = true
+			}
+		}
+	}
+	step := omarchyStep{Name: "bar indicator", Path: path, Status: "removed",
+		Detail: "hey-unread module removed; the " + omarchyBarPluginID + " plugin replaces it"}
+	return s.writeBarSteps([]omarchyStep{step}, shell, true)[0]
 }
 
 // mergeNotify reloads shell.json — the install may have rewritten it — and
@@ -487,17 +530,11 @@ func (s omarchySetup) removeBar() []omarchyStep {
 }
 
 func (s omarchySetup) removeBarLocked() []omarchyStep {
-	path := s.env.shellPath()
-	shell, err := s.loadShellConfig()
-	if err != nil {
-		return []omarchyStep{stepResult("bar indicator", path, false, err, "", ""), s.removeBarPluginLocked(false)}
-	}
-	bar, _ := shell["bar"].(map[string]any)
-	layout, _ := bar["layout"].(map[string]any)
-	legacy, _ := s.removeLegacyBarModule(shell, layout)
-	onBar := barLayoutModule(layout, omarchyBarPluginID) != nil
-	steps := s.writeBarSteps([]omarchyStep{stepResult("bar indicator", path, legacy, nil, "removed", "absent")}, shell, legacy)
-	return append(steps, s.removeBarPluginLocked(onBar))
+	// The tombstone (and the disable behind it) land before any layout
+	// rewrite: a stop in between costs only the legacy cleanup, which the
+	// marker does not guard — never the record of the user's intent.
+	plugin := s.removeBarPluginLocked(s.pluginOnBar())
+	return []omarchyStep{s.removeLegacyIndicator(false), plugin}
 }
 
 // removeLegacyBarModule drops the inline hey-unread module earlier releases

--- a/internal/cmd/omarchy.go
+++ b/internal/cmd/omarchy.go
@@ -140,10 +140,6 @@ type omarchyStep struct {
 	// and the wizard say nothing about a step that neither did nor owes
 	// anything.
 	attempted bool
-	// finalized marks a run that recorded a verified enable — including the
-	// quiet crash repairs — which is the moment the legacy indicator
-	// migration is owed.
-	finalized bool
 }
 
 type omarchySetup struct {

--- a/internal/cmd/omarchy.go
+++ b/internal/cmd/omarchy.go
@@ -555,8 +555,13 @@ func (s omarchySetup) removeBar() []omarchyStep {
 func (s omarchySetup) removeBarLocked() []omarchyStep {
 	// The tombstone (and the disable behind it) land before any layout
 	// rewrite: a stop in between costs only the legacy cleanup, which the
-	// marker does not guard — never the record of the user's intent.
+	// marker does not guard — never the record of the user's intent. And a
+	// removal that could not be recorded or completed rewrites nothing
+	// else either — the rerun does the cleanup.
 	plugin := s.removeBarPluginLocked(s.pluginOnBar())
+	if plugin.Status == "failed" {
+		return []omarchyStep{plugin}
+	}
 	return []omarchyStep{s.removeLegacyIndicator(false), plugin}
 }
 

--- a/internal/cmd/omarchy.go
+++ b/internal/cmd/omarchy.go
@@ -407,6 +407,15 @@ func (s omarchySetup) removeLegacyIndicator(carryNotify bool) omarchyStep {
 			if _, has := plugin["notify"]; !has {
 				plugin["notify"] = true
 			}
+		} else {
+			// No entry to hold the key (an enabled plugin needs none): the
+			// CLI materializes it, and if that cannot land the toasting
+			// module stays — the next explicit setup migrates — rather
+			// than the choice dying with it.
+			on := true
+			if carried := s.setNotifyWithoutEntry(&on); carried.failure != nil {
+				return carried
+			}
 		}
 	}
 	step := omarchyStep{Name: "bar indicator", Path: path, Status: "removed",

--- a/internal/cmd/omarchy.go
+++ b/internal/cmd/omarchy.go
@@ -2,21 +2,19 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/config"
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
@@ -40,9 +38,6 @@ const (
 	omarchyMenuEnd      = "  // <<< hey-cli"
 	omarchyFocusCommand = "omarchy-launch-or-focus-tui --app-id=" + omarchyAppID + " hey tui"
 	omarchyBarGlyph     = "" // nf-fa-envelope; verified to render in the bar's JetBrainsMono Nerd Font
-	// omarchy-theme-refresh re-renders every template and retints every app; a
-	// minute is generous.
-	omarchyCommandTimeout = time.Minute
 	// The hint spells the focus command out rather than using `{ tui = "hey tui" }`:
 	// the lua helper shell-quotes that into one word and launch-or-focus-tui would
 	// derive the app-id from it, never matching the window every other surface opens.
@@ -61,27 +56,23 @@ SUPER+SHIFT+E still opens the HEY web app. To point it at the TUI instead:
 type omarchyEnv struct {
 	home        string
 	omarchyPath string
+	stateDir    string   // hey's own state dir, holding the bar plugin marker and lock
 	iconRoots   []string // icon theme roots searched for Omarchy's HEY icon
-	run         func(name string, args ...string) error
+	run         func(name string, args ...string) (string, error)
 }
 
 func liveOmarchyEnv() omarchyEnv {
 	home, _ := os.UserHomeDir()
-	return omarchyEnv{
+	env := omarchyEnv{
 		home:        home,
 		omarchyPath: os.Getenv("OMARCHY_PATH"),
+		stateDir:    config.StateDir(),
 		iconRoots:   []string{filepath.Join(home, ".local", "share", "icons"), "/usr/share/icons"},
-		run: func(name string, args ...string) error {
-			if _, err := exec.LookPath(name); err != nil {
-				return err
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), omarchyCommandTimeout)
-			defer cancel()
-			cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- fixed omarchy command names
-			cmd.Stdout, cmd.Stderr = io.Discard, io.Discard
-			return cmd.Run()
-		},
 	}
+	env.run = func(name string, args ...string) (string, error) {
+		return runOmarchyCommand(env.omarchyRoot(), name, args...)
+	}
+	return env
 }
 
 func (e omarchyEnv) detected() bool {
@@ -141,15 +132,23 @@ func (e omarchyEnv) iconName() string {
 
 type omarchyStep struct {
 	Name    string `json:"name"`
-	Status  string `json:"status"` // installed, unchanged, removed, absent, kept, failed
+	Status  string `json:"status"` // installed, unchanged, skipped, removed, absent, kept, failed
 	Detail  string `json:"detail,omitempty"`
 	Path    string `json:"path,omitempty"`
 	failure error
+	// attempted marks an outcome worth a line to a human — the sign-in hook
+	// and the wizard say nothing about a step that neither did nor owes
+	// anything.
+	attempted bool
 }
 
 type omarchySetup struct {
 	env    omarchyEnv
 	notify *bool // nil keeps the bar plugin's notify setting as it is
+	// forcePlugin is `hey setup omarchy`: install the bar plugin in every
+	// output format, finish a pending install, re-enable a disabled one, and
+	// carry a failure for every incomplete outcome.
+	forcePlugin bool
 }
 
 func (s omarchySetup) apply() []omarchyStep {
@@ -318,17 +317,16 @@ func stripMenuBlock(content string) string {
 }
 
 // Bar: the unread indicator is the 37signals.hey bar plugin
-// (github.com/basecamp/omarchy-hey-plugin), which runs `hey watch`. Setup
-// does not install it — a plugin is a git clone the user adds with `omarchy
-// plugin add` — but it finds the plugin's layout entry in shell.json and flips
-// its `notify` setting there, the way `omarchy bar set` would; the shell
-// hot-reloads the file. Earlier releases installed an inline `hey-unread`
-// command module instead, which setup now removes — two pollers in one slot —
-// carrying its notify choice over to the plugin when the plugin has none.
-// The toasts are the plugin's own, composed from the new-mail lines of `hey
-// watch`: no state file, so turning them on is nothing more than setting the key.
-
-const omarchyBarPluginInstall = "omarchy plugin add https://github.com/basecamp/omarchy-hey-plugin.git --enable"
+// (github.com/basecamp/omarchy-hey-plugin), which runs `hey watch`. Signing
+// in with hey offers to install it (omarchy_plugin.go), and `hey setup
+// omarchy` installs it explicitly; this file's part is the plugin's `notify`
+// setting on its layout entry in shell.json, the way `omarchy bar set` would
+// flip it; the shell hot-reloads the file. Earlier releases installed an
+// inline `hey-unread` command module instead, which setup still removes — two
+// pollers in one slot — carrying its notify choice over to the plugin when
+// the plugin has none. The toasts are the plugin's own, composed from the
+// new-mail lines of `hey watch`: no state file, so turning them on is nothing
+// more than setting the key.
 
 func notifyDetail(notify bool) string {
 	if notify {
@@ -337,8 +335,9 @@ func notifyDetail(notify bool) string {
 	return "notifications off"
 }
 
-// configureBarPlugin reports one step for the plugin and, only when there was
-// one to remove, a step for the legacy module before it.
+// configureBarPlugin reports one merged step for the plugin — its install
+// (installBarPlugin) folded together with its notify setting — and, only when
+// there was one to remove, a step for the legacy module before it.
 func (s omarchySetup) configureBarPlugin() []omarchyStep {
 	path := s.env.shellPath()
 	shell, err := s.loadShellConfig()
@@ -354,18 +353,54 @@ func (s omarchySetup) configureBarPlugin() []omarchyStep {
 	if legacy {
 		steps = append(steps, omarchyStep{Name: "bar indicator", Path: path, Status: "removed",
 			Detail: "hey-unread module removed; the " + omarchyBarPluginID + " plugin replaces it"})
+		// On disk before the plugin install reads or rewrites shell.json.
+		steps = s.writeBarSteps(steps, shell, true)
 	}
 
+	install := s.installBarPlugin()
+	if install.Status == "skipped" || install.Status == "failed" {
+		return append(steps, install)
+	}
+	return append(steps, s.mergeNotify(install, legacyNotified))
+}
+
+// mergeNotify reloads shell.json — the install may have rewritten it — and
+// folds the notify outcome into the plugin's one step.
+func (s omarchySetup) mergeNotify(install omarchyStep, legacyNotified bool) omarchyStep {
+	notify := s.applyNotify(legacyNotified)
+	if notify.Status == "failed" {
+		return notify
+	}
+	if install.Status == "installed" {
+		notify.Status = "installed"
+		notify.attempted = true
+		if notify.Detail != "" {
+			notify.Detail = install.Detail + "; " + notify.Detail
+		} else {
+			notify.Detail = install.Detail
+		}
+	}
+	return notify
+}
+
+// applyNotify sets or deletes the plugin entry's notify key, carrying a
+// removed legacy module's choice over when the plugin has none.
+func (s omarchySetup) applyNotify(legacyNotified bool) omarchyStep {
+	path := s.env.shellPath()
+	shell, err := s.loadShellConfig()
+	if err != nil {
+		return stepResult("bar plugin", path, false, err, "", "")
+	}
+	layout, err := existingBarLayout(shell)
+	if err != nil {
+		return stepResult("bar plugin", path, false, err, "", "")
+	}
 	plugin := barLayoutModule(layout, omarchyBarPluginID)
 	if plugin == nil {
-		detail := "install the bar plugin: " + omarchyBarPluginInstall
-		if legacyNotified {
-			detail += "; then hey setup omarchy --notify to keep the toasts"
-		}
-		steps = append(steps, omarchyStep{Name: "bar plugin", Path: path, Status: "skipped", Detail: detail})
-		return s.writeBarSteps(steps, shell, legacy)
+		// Enabled per the shell, but no spelled-out layout entry to hold a
+		// setting yet: nothing to configure.
+		return omarchyStep{Name: "bar plugin", Path: path, Status: "unchanged"}
 	}
-
 	want := s.notify
 	if want == nil && legacyNotified {
 		// The legacy module was toasting and the plugin has not been told
@@ -376,8 +411,6 @@ func (s omarchySetup) configureBarPlugin() []omarchyStep {
 			want = &on
 		}
 	}
-	// The plugin step reports its own setting only: a legacy removal in the
-	// same pass is the other step's news.
 	settingChanged := false
 	if want != nil {
 		current, has := plugin["notify"]
@@ -394,7 +427,7 @@ func (s omarchySetup) configureBarPlugin() []omarchyStep {
 	if settingChanged {
 		step.Status = "installed"
 	}
-	return s.writeBarSteps(append(steps, step), shell, legacy || settingChanged)
+	return s.writeBarSteps([]omarchyStep{step}, shell, settingChanged)[0]
 }
 
 // writeBarSteps writes shell.json when anything changed and turns every
@@ -419,31 +452,22 @@ func barPluginNotifies(plugin map[string]any) bool {
 	return notify
 }
 
-// removeBar takes out what setup wrote into the bar layout: a legacy hey-unread
-// module. The plugin entry and its notify setting stay — the entry is the
-// user's, added with omarchy plugin add, and the setting is the plugin's, set
-// as readily from its panel or `omarchy bar set` as from here, so removal
-// cannot tell a preference it wrote from one it didn't. --no-notify is the
-// explicit way to turn the toasts off.
+// removeBar takes out what setup wrote into the bar layout — a legacy
+// hey-unread module — and disables the plugin, tombstone first, keeping the
+// checkout (removeBarPlugin). The entry's notify setting rides with the
+// entry: `omarchy plugin disable` takes both off the bar together.
 func (s omarchySetup) removeBar() []omarchyStep {
 	path := s.env.shellPath()
 	shell, err := s.loadShellConfig()
 	if err != nil {
-		return []omarchyStep{stepResult("bar indicator", path, false, err, "", ""), stepResult("bar plugin", path, false, err, "", "")}
+		return []omarchyStep{stepResult("bar indicator", path, false, err, "", ""), s.removeBarPlugin(false)}
 	}
 	bar, _ := shell["bar"].(map[string]any)
 	layout, _ := bar["layout"].(map[string]any)
 	legacy, _ := s.removeLegacyBarModule(shell, layout)
-	plugin := omarchyStep{Name: "bar plugin", Path: path, Status: "absent"}
-	if entry := barLayoutModule(layout, omarchyBarPluginID); entry != nil {
-		plugin.Status = "kept"
-		plugin.Detail = "the plugin and its notify setting are yours; hey setup omarchy --no-notify turns the toasts off"
-		if !barPluginNotifies(entry) {
-			plugin.Detail = "the plugin is yours; notifications are off"
-		}
-	}
-	steps := []omarchyStep{stepResult("bar indicator", path, legacy, nil, "removed", "absent"), plugin}
-	return s.writeBarSteps(steps, shell, legacy)
+	onBar := barLayoutModule(layout, omarchyBarPluginID) != nil
+	steps := s.writeBarSteps([]omarchyStep{stepResult("bar indicator", path, legacy, nil, "removed", "absent")}, shell, legacy)
+	return append(steps, s.removeBarPlugin(onBar))
 }
 
 // removeLegacyBarModule drops the inline hey-unread module earlier releases
@@ -637,7 +661,7 @@ func (s omarchySetup) installTemplate() omarchyStep {
 	}
 	changed, err := writeFileIfChanged(path, []byte(omarchyThemeTemplate), 0o644)
 	if err == nil && changed {
-		if refreshErr := s.env.run("omarchy-theme-refresh"); refreshErr != nil {
+		if _, refreshErr := s.env.run("omarchy-theme-refresh"); refreshErr != nil {
 			return omarchyStep{Name: "theme template", Path: path, Status: "installed",
 				Detail: "rendered on the next theme switch (omarchy-theme-refresh unavailable)"}
 		}
@@ -657,7 +681,7 @@ func (s omarchySetup) removeTemplate() omarchyStep {
 	}
 	changed, err := removeFileIfPresent(path)
 	if err == nil && changed {
-		if refreshErr := s.env.run("omarchy-theme-refresh"); refreshErr != nil {
+		if _, refreshErr := s.env.run("omarchy-theme-refresh"); refreshErr != nil {
 			return omarchyStep{Name: "theme template", Path: path, Status: "removed",
 				Detail: "rendered hey.toml stays until the next theme switch (omarchy-theme-refresh unavailable)"}
 		}
@@ -743,13 +767,21 @@ func newSetupOmarchyCommand() *setupOmarchyCommand {
 		Use:   "omarchy",
 		Args:  cobra.NoArgs,
 		Short: "Install hey into the Omarchy desktop",
-		Long: `Install hey into the Omarchy desktop: a launcher entry, rows in the SUPER+SPACE
-menu, and a theme template so themes can tune the TUI's accent colors. Every piece
-is idempotent and --remove takes them all out again — all but the bar plugin's notify
-setting, which is the plugin's own; --no-notify is how to turn that off.
+		Long: `Install hey into the Omarchy desktop: the 37signals.hey bar plugin, a launcher
+entry, rows in the SUPER+SPACE menu, and a theme template so themes can tune the
+TUI's accent colors. Every piece is idempotent.
 
-The bar indicator is the 37signals.hey plugin, which runs hey watch; install it
-with omarchy plugin add https://github.com/basecamp/omarchy-hey-plugin.git --enable.
+Signing in with hey offers the bar plugin on its own, asked once; this command is
+the explicit path — it installs in every output format, finishes an interrupted
+install, re-enables a plugin you disabled, and never reports success unless the
+running shell verified the plugin enabled. The plugin runs hey watch: the HEY
+glyph lights when the Imbox has unseen mail.
+
+--remove disables the bar plugin and keeps its checkout (omarchy plugin remove
+37signals.hey deletes it), and takes the desktop pieces out. A removed or
+disabled plugin stays off the bar until you run hey setup omarchy again — a
+sign-in never re-enables it.
+
 --notify turns on the bar plugin's new-mail toasts (one per batch of changes at
 most, replaced rather than stacked, silenced by the notification DND toggle) by
 setting notify on the plugin's entry in shell.json. --no-notify turns them back
@@ -790,7 +822,7 @@ func (c *setupOmarchyCommand) run(cmd *cobra.Command, args []string) error {
 		return apierr.ErrUsageHint("Omarchy not detected", "hey setup omarchy needs ~/.local/state/omarchy or OMARCHY_PATH")
 	}
 
-	setup := omarchySetup{env: c.env}
+	setup := omarchySetup{env: c.env, forcePlugin: true}
 	if c.notify || c.noNotify {
 		setup.notify = &c.notify
 	}
@@ -822,7 +854,7 @@ func (c *setupOmarchyCommand) run(cmd *cobra.Command, args []string) error {
 			fmt.Fprint(w, omarchyKeybindHint)
 		}
 		if len(failures) > 0 {
-			return fmt.Errorf("%d step(s) failed", len(failures))
+			return setupOmarchyFailure(failures, steps)
 		}
 		return nil
 	}
@@ -836,15 +868,21 @@ func (c *setupOmarchyCommand) run(cmd *cobra.Command, args []string) error {
 		data["keybind_hint"] = omarchyKeybindHint
 	}
 	if len(failures) > 0 {
-		// An operational failure, not a usage error: some steps already changed
-		// files, and they ride along in the error meta so a scripting caller can
-		// see which pieces landed and which did not.
-		return &apierr.Error{
-			Code:    "setup_failed",
-			Message: strings.Join(failures, "; "),
-			Hint:    "fix the paths above and run hey setup omarchy again",
-			Meta:    map[string]any{"steps": steps},
-		}
+		return setupOmarchyFailure(failures, steps)
 	}
 	return writeOK(data, output.WithSummary(summary))
+}
+
+// setupOmarchyFailure is an operational failure, not a usage error: some
+// steps already changed files, and they ride along in the error meta so a
+// scripting caller can see which pieces landed and which did not. An
+// incomplete forced install is a failure in every output format — never a
+// quiet skip.
+func setupOmarchyFailure(failures []string, steps []omarchyStep) error {
+	return &apierr.Error{
+		Code:    "setup_failed",
+		Message: strings.Join(failures, "; "),
+		Hint:    "fix the failures above and run hey setup omarchy again",
+		Meta:    map[string]any{"steps": steps},
+	}
 }

--- a/internal/cmd/omarchy.go
+++ b/internal/cmd/omarchy.go
@@ -140,6 +140,10 @@ type omarchyStep struct {
 	// and the wizard say nothing about a step that neither did nor owes
 	// anything.
 	attempted bool
+	// finalized marks a run that recorded a verified enable — including the
+	// quiet crash repairs — which is the moment the legacy indicator
+	// migration is owed.
+	finalized bool
 }
 
 type omarchySetup struct {
@@ -364,12 +368,14 @@ func (s omarchySetup) configureBarPluginLocked() []omarchyStep {
 	if install.Status == "skipped" || install.Status == "failed" {
 		return []omarchyStep{install}
 	}
-	var steps []omarchyStep
-	if legacyPresent {
-		// The carry is applyNotify's below, so the report says "installed".
-		steps = append(steps, s.removeLegacyIndicator(false))
+	// The notify carry lands first; the legacy module — the only copy of
+	// that choice — leaves only once it has. A failed carry keeps the
+	// module for the rerun, so the preference cannot die with it.
+	merged := s.mergeNotify(install, legacyNotified)
+	if !legacyPresent || merged.Status == "failed" {
+		return []omarchyStep{merged}
 	}
-	return append(steps, s.mergeNotify(install, legacyNotified))
+	return []omarchyStep{s.removeLegacyIndicator(false), merged}
 }
 
 // legacyIndicator reports whether layout still carries the inline hey-unread

--- a/internal/cmd/omarchy_exec_other.go
+++ b/internal/cmd/omarchy_exec_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package cmd
+
+import "os/exec"
+
+// setOmarchyProcessGroup is a no-op where process groups are not a thing:
+// CommandContext's default kill takes the direct child, which is all these
+// platforms offer.
+func setOmarchyProcessGroup(*exec.Cmd) {}

--- a/internal/cmd/omarchy_exec_unix.go
+++ b/internal/cmd/omarchy_exec_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package cmd
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setOmarchyProcessGroup puts the child in its own process group and kills
+// the whole group on timeout, so a plugin add's git subprocess dies with it
+// instead of holding the pipes open.
+func setOmarchyProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/internal/cmd/omarchy_exec_unix_test.go
+++ b/internal/cmd/omarchy_exec_unix_test.go
@@ -1,0 +1,35 @@
+//go:build unix
+
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRunOmarchyCommandTimeoutKillsTheProcessGroup(t *testing.T) {
+	orig := omarchyCommandTimeout
+	omarchyCommandTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { omarchyCommandTimeout = orig })
+
+	start := time.Now()
+	_, err := runOmarchyCommand("", "sh", "-c", "sleep 60 & wait")
+	if err == nil {
+		t.Fatal("a timed-out command must error")
+	}
+	// A killed direct child whose grandchild survives would hold the pipes
+	// until WaitDelay; a leaked group would hold them for the full sleep.
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("the run took %v — the process group was not killed", elapsed)
+	}
+}
+
+func TestRunOmarchyCommandCapsAndDrainsOutput(t *testing.T) {
+	out, err := runOmarchyCommand("", "sh", "-c", "head -c 200000 /dev/zero | tr '\\0' 'a'")
+	if err != nil {
+		t.Fatalf("a chatty child must be drained, not blocked: %v", err)
+	}
+	if len(out) != omarchyOutputLimit {
+		t.Fatalf("output = %d bytes, want capped at %d", len(out), omarchyOutputLimit)
+	}
+}

--- a/internal/cmd/omarchy_exec_unix_test.go
+++ b/internal/cmd/omarchy_exec_unix_test.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"os"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -21,6 +23,28 @@ func TestRunOmarchyCommandTimeoutKillsTheProcessGroup(t *testing.T) {
 	// until WaitDelay; a leaked group would hold them for the full sleep.
 	if elapsed := time.Since(start); elapsed > 10*time.Second {
 		t.Fatalf("the run took %v — the process group was not killed", elapsed)
+	}
+}
+
+func TestRunOmarchyCommandInterruptCancelsTheRun(t *testing.T) {
+	// The child sits in its own process group, outside the terminal's
+	// foreground group — Ctrl-C must still stop a mutating install.
+	done := make(chan error, 1)
+	go func() {
+		_, err := runOmarchyCommand("", "sh", "-c", "sleep 60 & wait")
+		done <- err
+	}()
+	time.Sleep(500 * time.Millisecond)
+	if err := syscall.Kill(os.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("an interrupted command must error")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the interrupt did not cancel the run")
 	}
 }
 

--- a/internal/cmd/omarchy_plugin.go
+++ b/internal/cmd/omarchy_plugin.go
@@ -1,0 +1,625 @@
+package cmd
+
+// The HEY bar panel appears when you sign in with hey. omarchy.go installs hey
+// into the desktop; this file installs the 37signals.hey bar plugin itself —
+// the one piece that used to be a command the user copied.
+//
+// One idempotent routine, three entry points, one state file, one lock:
+//
+//   - Ensure mode (the sign-in hook, the wizard) asks once — "Put HEY in your
+//     Omarchy bar?" — records the answer, and never enables a checkout that is
+//     off the bar: a plugin the user disabled stays disabled, whatever the
+//     marker says. Its only mutation is `omarchy plugin add`, on fresh consent
+//     or a pending retry, and it never runs for machine output, HEY_NONINTERACTIVE,
+//     a non-TTY, or a --token/--cookie login.
+//   - Force mode (`hey setup omarchy`) records its intent before acting, so a
+//     crash leaves a pending install the next explicit setup finishes — never
+//     a quiet skip — and it never reports success unless the running shell
+//     verified the plugin enabled. Explicit --json still installs.
+//   - --remove writes its tombstone first — a removal that cannot be recorded
+//     does not run — then disables. The checkout stays.
+//
+// The marker lives at StateDir()/omarchy/bar-plugin.json. accepted_at is
+// consent, never re-asked; pending_enable + installing_at an unfinished
+// install; declined_at/removed_at the user's no; last_clone_* a 24h retry
+// throttle for failed clones only. Installation fails closed on a marker it
+// cannot read; only --remove still disables then, since nothing can resurrect
+// the plugin through a fail-closed install.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gofrs/flock"
+
+	"github.com/basecamp/hey-cli/internal/terminal"
+	"github.com/basecamp/hey-cli/internal/tui"
+	"github.com/basecamp/hey-cli/internal/version"
+)
+
+// omarchyBarPluginSource is what `omarchy plugin add` clones. A var only as a
+// test seam — tests assign it directly; nothing overrides it at build or run
+// time, so nothing but the public URL ever ships or installs.
+var omarchyBarPluginSource = "https://github.com/basecamp/omarchy-hey-plugin.git"
+
+// omarchyBarPluginInstallHint is the manual command, surviving only in the
+// clone-failure remediation.
+func omarchyBarPluginInstallHint() string {
+	return "omarchy plugin add " + omarchyBarPluginSource + " --enable"
+}
+
+// omarchyCloneRetryInterval is how long a failed clone suppresses the sign-in
+// hook's retry. Clone failures only: nothing else is throttled.
+const omarchyCloneRetryInterval = 24 * time.Hour
+
+// ensureOmarchyBarPluginAfterLogin puts HEY in the Omarchy bar after an
+// interactive OAuth sign-in — the "signing in with hey puts HEY in your bar"
+// promise. At most one stderr line, and never a failed login: every outcome
+// here is advisory.
+var ensureOmarchyBarPluginAfterLogin = func(w io.Writer) {
+	if writer == nil || !writer.IsStyled() || !interactiveStdio() {
+		return
+	}
+	env := liveOmarchyEnv()
+	if !env.detected() {
+		return
+	}
+	step := omarchySetup{env: env}.installBarPlugin()
+	switch {
+	case step.Status == "installed":
+		fmt.Fprintln(w, "HEY is in your Omarchy bar now.")
+	case step.Status == "failed":
+		fmt.Fprintln(w, "Omarchy bar plugin not installed: "+step.Detail)
+	case step.attempted:
+		fmt.Fprintln(w, "Omarchy bar plugin: "+step.Detail)
+	}
+}
+
+// confirmOmarchyPanel is the one question the sign-in hook may ask, once ever.
+// A seam so tests can answer it.
+var confirmOmarchyPanel = func() (bool, error) {
+	return tui.Confirm("Put HEY in your Omarchy bar?", true)
+}
+
+// installBarPlugin puts the 37signals.hey plugin in the bar, in ensure or
+// force mode per s.forcePlugin. Everything runs under the marker lock, and
+// nothing here prompts, clones or writes before its mode's gates say so.
+func (s omarchySetup) installBarPlugin() omarchyStep {
+	if !s.env.detected() || !filepath.IsAbs(s.env.home) {
+		return s.pluginSkip("Omarchy not detected")
+	}
+	if s.env.stateDir == "" || !filepath.IsAbs(s.env.stateDir) {
+		return s.pluginSkip("no state directory to record the install in — set XDG_STATE_HOME or HOME")
+	}
+	lock, err := acquireOmarchyPluginLock(s.env)
+	if err != nil {
+		return s.pluginSkip("another hey is setting up the bar")
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	marker, _, err := readOmarchyPluginMarker(s.env.markerPath())
+	if err != nil {
+		return s.pluginFailed(omarchyMarkerUnreadable(s.env))
+	}
+	if s.forcePlugin {
+		return s.forceInstall(marker)
+	}
+	return s.ensureInstall(marker)
+}
+
+// ensureInstall is the sign-in path: quiet wherever installation is
+// impossible or unwanted, and never a resurrection — an off-bar checkout is
+// not enabled here whatever the marker says, pending included. Only explicit
+// `hey setup omarchy` re-enables.
+func (s omarchySetup) ensureInstall(marker omarchyPluginMarker) omarchyStep {
+	onBar := s.pluginOnBar()
+	cloned := s.env.pluginCloned()
+	switch {
+	case onBar && marker.PendingEnable:
+		// A crash between enable and the final write: finish the
+		// bookkeeping — unless the shell says the plugin is off, which is
+		// the user's doing and stays.
+		probe, failStep, ok := s.probeShellPlugins()
+		if !ok {
+			return failStep
+		}
+		if !probe.present || !probe.enabled {
+			return s.pluginNotice("install incomplete — run hey setup omarchy")
+		}
+		step := s.finalize(marker)
+		if step.Status == "installed" {
+			step.Status, step.Detail, step.attempted = "unchanged", "", false
+		}
+		return step
+	case onBar:
+		// Whoever put it there — even after a decline or a removal, an
+		// enabled plugin is just there to configure.
+		return s.pluginStep("unchanged", "")
+	case marker.DeclinedAt != "" || marker.RemovedAt != "":
+		return s.pluginStep("skipped", "declined or removed — hey setup omarchy installs it")
+	case cloned && marker.PendingEnable:
+		// Never enabled automatically: the checkout may be off the bar
+		// because the user put it there.
+		return s.pluginNotice("install incomplete — run hey setup omarchy")
+	case cloned:
+		return s.pluginStep("skipped", "the checkout is disabled or was installed by someone else")
+	case marker.PendingEnable:
+		// Consent stands; retry the clone without asking again, throttled.
+		if marker.cloneThrottled() {
+			return s.pluginStep("skipped", "waiting to retry a failed clone")
+		}
+		probe, failStep, ok := s.probeShellPlugins()
+		if !ok {
+			return failStep
+		}
+		if probe.present && probe.enabled {
+			return s.finalize(marker) // a lost race: someone enabled it
+		}
+		if probe.present {
+			return s.pluginNotice("install incomplete — run hey setup omarchy")
+		}
+		return s.addAndVerify(marker)
+	case marker.InstalledAt != "":
+		return s.pluginStep("skipped", "removed outside hey")
+	default:
+		return s.ensureFreshInstall(marker)
+	}
+}
+
+// ensureFreshInstall is the first sign-in on a box with nothing recorded:
+// probe the shell, ask once, put the intent on disk, then clone.
+func (s omarchySetup) ensureFreshInstall(marker omarchyPluginMarker) omarchyStep {
+	probe, failStep, ok := s.probeShellPlugins()
+	if !ok {
+		return failStep
+	}
+	if probe.present {
+		// The shell knows the plugin but shell.json's layout does not spell
+		// it out: someone else's install. Enabled means the bar already has
+		// it; disabled means it is theirs to re-enable.
+		if probe.enabled {
+			return s.pluginStep("unchanged", "")
+		}
+		return s.pluginStep("skipped", "the checkout is disabled or was installed by someone else")
+	}
+	yes, err := confirmOmarchyPanel()
+	if err != nil {
+		// No answer (esc, no terminal): ask again another day.
+		return s.pluginStep("skipped", "not confirmed")
+	}
+	if !yes {
+		marker.DeclinedAt = omarchyNow()
+		if writeErr := s.env.writeMarker(marker); writeErr != nil {
+			return s.pluginFailed("could not record the bar plugin state in " + s.env.markerPath() + ": " + writeErr.Error())
+		}
+		return s.pluginStep("skipped", "declined — hey setup omarchy installs it")
+	}
+	now := omarchyNow()
+	if marker.AcceptedAt == "" {
+		marker.AcceptedAt = now
+	}
+	marker.PendingEnable = true
+	marker.InstallingAt = now
+	marker.CLIVersion = version.Version
+	if writeErr := s.env.writeMarker(marker); writeErr != nil {
+		return s.pluginFailed("could not record the bar plugin state in " + s.env.markerPath() + ": " + writeErr.Error())
+	}
+	return s.addAndVerify(marker)
+}
+
+// forceInstall is `hey setup omarchy`: intent on disk before anything runs —
+// clearing a decline, a removal and the clone throttle, since the command is
+// the explicit ask — so a crash leaves a pending install the next explicit
+// setup finishes. Every incomplete outcome carries a failure.
+func (s omarchySetup) forceInstall(marker omarchyPluginMarker) omarchyStep {
+	now := omarchyNow()
+	if marker.AcceptedAt == "" {
+		marker.AcceptedAt = now
+	}
+	marker.PendingEnable = true
+	marker.InstallingAt = now
+	marker.CLIVersion = version.Version
+	marker.DeclinedAt, marker.RemovedAt = "", ""
+	marker.LastCloneError, marker.LastCloneAt = "", ""
+	if err := s.env.writeMarker(marker); err != nil {
+		return s.pluginFailed("could not record the bar plugin state in " + s.env.markerPath() + ": " + err.Error())
+	}
+	probe, failStep, ok := s.probeShellPlugins()
+	if !ok {
+		return failStep
+	}
+	switch {
+	case probe.present && probe.enabled:
+		step := s.finalize(marker)
+		if step.Status == "installed" {
+			step.Status, step.Detail = "unchanged", "already enabled"
+		}
+		return step
+	case probe.present || s.env.pluginCloned():
+		// The reversal of `omarchy plugin disable`; the verify below is the
+		// guarantee either way.
+		out, err := s.env.run("omarchy", "plugin", "enable", omarchyBarPluginID)
+		if err != nil && !strings.Contains(strings.ToLower(out), "already") {
+			return s.pluginFailed(firstOutputLine(out, err))
+		}
+		return s.verifyAndFinalize(marker)
+	default:
+		return s.addAndVerify(marker)
+	}
+}
+
+// addAndVerify clones the plugin — the one mutation ensure mode is allowed —
+// and believes only the shell about the result.
+func (s omarchySetup) addAndVerify(marker omarchyPluginMarker) omarchyStep {
+	out, err := s.env.run("omarchy", "plugin", "add", omarchyBarPluginSource, "--enable", "--yes")
+	lower := strings.ToLower(out)
+	switch {
+	case strings.Contains(lower, "failed to clone"):
+		marker.LastCloneError = firstOutputLine(out, err)
+		marker.LastCloneAt = omarchyNow()
+		_ = s.env.writeMarker(marker) // best effort: the throttle is a convenience
+		return s.pluginFailed("could not clone " + omarchyBarPluginSource + " — check the network, or run: " + omarchyBarPluginInstallHint())
+	case err != nil && !strings.Contains(lower, "already installed") && !strings.Contains(lower, "already used"):
+		return s.pluginFailed(firstOutputLine(out, err))
+	default:
+		// Added — or a lost race already installed it; the verify decides.
+		return s.verifyAndFinalize(marker)
+	}
+}
+
+// verifyAndFinalize reports installed only when the running shell lists the
+// plugin enabled and the marker recorded it. Anything less keeps the pending
+// intent and fails.
+func (s omarchySetup) verifyAndFinalize(marker omarchyPluginMarker) omarchyStep {
+	probe, _, ok := s.probeShellPlugins()
+	if !ok || !probe.present || !probe.enabled {
+		return s.pluginFailed("the shell did not enable the plugin — run hey setup omarchy")
+	}
+	return s.finalize(marker)
+}
+
+// finalize records a verified enable. A failed write here is a failure
+// everywhere — never installed with a hidden error; the next run's
+// crash-repair row finishes the marker.
+func (s omarchySetup) finalize(marker omarchyPluginMarker) omarchyStep {
+	marker.PendingEnable = false
+	marker.InstallingAt = ""
+	marker.InstalledAt = omarchyNow()
+	marker.CLIVersion = version.Version
+	marker.LastCloneError, marker.LastCloneAt = "", ""
+	if err := s.env.writeMarker(marker); err != nil {
+		return s.pluginFailed("enabled, but could not record the bar plugin state in " + s.env.markerPath() + ": " + err.Error())
+	}
+	step := s.pluginStep("installed", "installed and enabled")
+	step.attempted = true
+	return step
+}
+
+// removeBarPlugin is --remove's half: tombstone first, then disable. The
+// checkout stays; deleting it is `omarchy plugin remove`, which hey never
+// runs.
+func (s omarchySetup) removeBarPlugin(onBar bool) omarchyStep {
+	if s.env.stateDir == "" || !filepath.IsAbs(s.env.stateDir) {
+		return s.pluginFailed("no state directory to record the removal in — set XDG_STATE_HOME or HOME")
+	}
+	lock, err := acquireOmarchyPluginLock(s.env)
+	if err != nil {
+		return s.pluginFailed("another hey is setting up the bar")
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	marker, _, err := readOmarchyPluginMarker(s.env.markerPath())
+	if err != nil {
+		// A marker we cannot read must not trap removal: installation is
+		// already fail-closed on it, so nothing can resurrect the plugin.
+		// Disable anyway, leave the marker as evidence, and exit nonzero
+		// with the repair hint.
+		step := s.disableBarPlugin(onBar)
+		detail := omarchyMarkerUnreadable(s.env)
+		if step.Status == "failed" {
+			detail = step.Detail + "; " + detail
+		}
+		return s.pluginFailed(detail)
+	}
+	marker.RemovedAt = omarchyNow()
+	marker.PendingEnable = false
+	marker.InstallingAt = ""
+	if writeErr := s.env.writeMarker(marker); writeErr != nil {
+		return s.pluginFailed("could not record the removal in " + s.env.markerPath() + ": " + writeErr.Error())
+	}
+	return s.disableBarPlugin(onBar)
+}
+
+func (s omarchySetup) disableBarPlugin(onBar bool) omarchyStep {
+	if !onBar {
+		return s.pluginStep("absent", "")
+	}
+	out, err := s.env.run("omarchy", "plugin", "disable", omarchyBarPluginID)
+	if err != nil {
+		return s.pluginFailed(firstOutputLine(out, err))
+	}
+	step := s.pluginStep("removed", "disabled; the checkout stays — omarchy plugin remove "+omarchyBarPluginID+" deletes it")
+	step.attempted = true
+	return step
+}
+
+// --- The shell probe ---
+
+type omarchyPluginProbe struct {
+	present bool
+	enabled bool
+}
+
+// omarchyShellDownPattern matches the omarchy CLI telling us there is no
+// shell to talk to — an ssh session, a fresh tty, a stopped shell.
+var omarchyShellDownPattern = regexp.MustCompile(`omarchy-shell is not running|not ready|OMARCHY_PATH is not set`)
+
+// probeShellPlugins asks the running shell for its plugin list. ok=false
+// comes with the step to report, in one of three distinct shapes: the omarchy
+// CLI missing (update Omarchy), the shell down (nothing to do here), and an
+// answer that is not a plugin list (fail closed).
+func (s omarchySetup) probeShellPlugins() (omarchyPluginProbe, omarchyStep, bool) {
+	out, err := s.env.run("omarchy", "plugin", "list", "--json")
+	if err != nil && errors.Is(err, exec.ErrNotFound) {
+		return omarchyPluginProbe{}, s.pluginSkip("Omarchy CLI not found — update Omarchy"), false
+	}
+	if omarchyShellDownPattern.MatchString(out) {
+		return omarchyPluginProbe{}, s.pluginSkip("the Omarchy shell is not running — sign in again from the desktop, or run hey setup omarchy there"), false
+	}
+	var plugins []struct {
+		ID      string `json:"id"`
+		Enabled bool   `json:"enabled"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &plugins); jsonErr != nil {
+		return omarchyPluginProbe{}, s.pluginFailed("unexpected answer from omarchy plugin list"), false
+	}
+	var probe omarchyPluginProbe
+	for _, plugin := range plugins {
+		if plugin.ID == omarchyBarPluginID {
+			probe.present, probe.enabled = true, plugin.Enabled
+		}
+	}
+	return probe, omarchyStep{}, true
+}
+
+// pluginOnBar reads shell.json's layout for the plugin's entry — the fact the
+// shell itself acts on. Unreadable means unknown, and the probe refines it.
+func (s omarchySetup) pluginOnBar() bool {
+	shell, err := s.loadShellConfig()
+	if err != nil {
+		return false
+	}
+	layout, err := existingBarLayout(shell)
+	if err != nil {
+		return false
+	}
+	return barLayoutModule(layout, omarchyBarPluginID) != nil
+}
+
+// --- Step shapes ---
+
+// pluginStep is a quiet outcome: no line at sign-in, no issue in the wizard.
+func (s omarchySetup) pluginStep(status, detail string) omarchyStep {
+	return omarchyStep{Name: "bar plugin", Path: s.env.markerPath(), Status: status, Detail: detail}
+}
+
+// pluginNotice is the one skip that owes the user a line: consent stands but
+// the install is unfinished, and only an explicit setup finishes it.
+func (s omarchySetup) pluginNotice(detail string) omarchyStep {
+	step := s.pluginStep("skipped", detail)
+	step.attempted = true
+	if s.forcePlugin {
+		step.failure = errors.New(detail)
+	}
+	return step
+}
+
+// pluginSkip cannot proceed here: quiet at sign-in, a failure under
+// `hey setup omarchy`, where an incomplete forced install is never a quiet
+// skip.
+func (s omarchySetup) pluginSkip(detail string) omarchyStep {
+	step := s.pluginStep("skipped", detail)
+	if s.forcePlugin {
+		step.failure = errors.New(detail)
+		step.attempted = true
+	}
+	return step
+}
+
+func (s omarchySetup) pluginFailed(detail string) omarchyStep {
+	step := s.pluginStep("failed", detail)
+	step.failure = errors.New(detail)
+	step.attempted = true
+	return step
+}
+
+func stepNamed(steps []omarchyStep, name string) omarchyStep {
+	for _, step := range steps {
+		if step.Name == name {
+			return step
+		}
+	}
+	return omarchyStep{}
+}
+
+// --- The marker and its lock ---
+
+// omarchyPluginMarker is the bar plugin's state file. Timestamps are RFC3339;
+// only what is set is written.
+type omarchyPluginMarker struct {
+	AcceptedAt     string `json:"accepted_at,omitempty"`
+	PendingEnable  bool   `json:"pending_enable,omitempty"`
+	InstallingAt   string `json:"installing_at,omitempty"`
+	InstalledAt    string `json:"installed_at,omitempty"`
+	CLIVersion     string `json:"cli_version,omitempty"`
+	DeclinedAt     string `json:"declined_at,omitempty"`
+	RemovedAt      string `json:"removed_at,omitempty"`
+	LastCloneError string `json:"last_clone_error,omitempty"`
+	LastCloneAt    string `json:"last_clone_at,omitempty"`
+}
+
+func (m omarchyPluginMarker) cloneThrottled() bool {
+	if m.LastCloneAt == "" {
+		return false
+	}
+	at, err := time.Parse(time.RFC3339, m.LastCloneAt)
+	return err == nil && time.Since(at) < omarchyCloneRetryInterval
+}
+
+func readOmarchyPluginMarker(path string) (omarchyPluginMarker, bool, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed path under hey's own state dir
+	if errors.Is(err, os.ErrNotExist) {
+		return omarchyPluginMarker{}, false, nil
+	}
+	if err != nil {
+		return omarchyPluginMarker{}, false, err
+	}
+	var marker omarchyPluginMarker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return omarchyPluginMarker{}, true, err
+	}
+	return marker, true, nil
+}
+
+func (e omarchyEnv) writeMarker(marker omarchyPluginMarker) error {
+	if err := os.MkdirAll(filepath.Dir(e.markerPath()), 0o700); err != nil {
+		return err
+	}
+	return writeJSONFile(e.markerPath(), marker)
+}
+
+func omarchyMarkerUnreadable(env omarchyEnv) string {
+	return "bar plugin state unreadable at " + env.markerPath() + " — delete it, then run hey setup omarchy"
+}
+
+// acquireOmarchyPluginLock serializes every look at the marker and every
+// mutation behind it. Non-blocking: a held lock is another hey's turn.
+func acquireOmarchyPluginLock(env omarchyEnv) (*flock.Flock, error) {
+	if err := os.MkdirAll(filepath.Dir(env.lockPath()), 0o700); err != nil {
+		return nil, err
+	}
+	lock := flock.New(env.lockPath())
+	locked, err := lock.TryLock()
+	if err != nil {
+		return nil, err
+	}
+	if !locked {
+		return nil, errors.New("lock held")
+	}
+	return lock, nil
+}
+
+func (e omarchyEnv) pluginDir() string {
+	return filepath.Join(e.configDir(), "plugins", omarchyBarPluginID)
+}
+
+// pluginCloned is the checkout fact, read without a subprocess: `omarchy
+// plugin add` clones under ~/.config/omarchy/plugins/<id> with a manifest.
+func (e omarchyEnv) pluginCloned() bool {
+	_, err := os.Stat(filepath.Join(e.pluginDir(), "manifest.json"))
+	return err == nil
+}
+
+func (e omarchyEnv) markerPath() string {
+	return filepath.Join(e.stateDir, "omarchy", "bar-plugin.json")
+}
+
+func (e omarchyEnv) lockPath() string {
+	return filepath.Join(e.stateDir, "omarchy", "bar-plugin.lock")
+}
+
+// omarchyRoot is the install root exported to a child as OMARCHY_PATH when
+// our own environment lacks it — the same walk defaultShellPath does.
+func (e omarchyEnv) omarchyRoot() string {
+	roots := []string{e.omarchyPath, filepath.Join(e.home, ".local", "share", "omarchy"), "/usr/share/omarchy"}
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		if info, err := os.Stat(root); err == nil && info.IsDir() {
+			return root
+		}
+	}
+	return ""
+}
+
+func omarchyNow() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func firstOutputLine(out string, err error) string {
+	for _, line := range strings.Split(out, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return terminal.SanitizeLine(line)
+		}
+	}
+	if err != nil {
+		return err.Error()
+	}
+	return "no output"
+}
+
+// --- The subprocess runner ---
+
+// omarchyOutputLimit caps what a subprocess can hand back; the rest is
+// drained so the child never blocks on a full pipe.
+const omarchyOutputLimit = 64 << 10
+
+// omarchyCommandTimeout bounds every omarchy subprocess. omarchy-theme-refresh
+// re-renders every template and retints every app, and a plugin add clones
+// over the network; a minute is generous. A var so tests can shorten it.
+var omarchyCommandTimeout = time.Minute
+
+// runOmarchyCommand runs an omarchy command and answers its combined output.
+// A package var so command-level tests can intercept every subprocess.
+var runOmarchyCommand = func(omarchyRoot, name string, args ...string) (string, error) {
+	if _, err := exec.LookPath(name); err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), omarchyCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- fixed omarchy command names
+	// The omarchy CLI needs OMARCHY_PATH to find the shell; non-login and
+	// agent environments lack it, so export the root we detected ourselves.
+	if omarchyRoot != "" && os.Getenv("OMARCHY_PATH") == "" {
+		cmd.Env = append(os.Environ(), "OMARCHY_PATH="+omarchyRoot)
+	}
+	output := &cappedOutput{limit: omarchyOutputLimit}
+	cmd.Stdout, cmd.Stderr = output, output
+	// A plugin add spawns git; on timeout the whole process group dies, and
+	// WaitDelay unblocks Wait if a grandchild still holds the pipes.
+	setOmarchyProcessGroup(cmd)
+	cmd.WaitDelay = 5 * time.Second
+	err := cmd.Run()
+	return output.String(), err
+}
+
+// cappedOutput keeps the first limit bytes and swallows the rest, so a chatty
+// child runs to EOF instead of blocking on a full pipe.
+type cappedOutput struct {
+	buf   bytes.Buffer
+	limit int
+}
+
+func (c *cappedOutput) Write(p []byte) (int, error) {
+	if remaining := c.limit - c.buf.Len(); remaining > 0 {
+		if len(p) > remaining {
+			c.buf.Write(p[:remaining])
+		} else {
+			c.buf.Write(p)
+		}
+	}
+	return len(p), nil
+}
+
+func (c *cappedOutput) String() string { return c.buf.String() }

--- a/internal/cmd/omarchy_plugin.go
+++ b/internal/cmd/omarchy_plugin.go
@@ -184,8 +184,21 @@ func (s omarchySetup) ensureInstall(marker omarchyPluginMarker) omarchyStep {
 	case marker.DeclinedAt != "" || marker.RemovedAt != "":
 		return s.pluginStep("skipped", "declined or removed — hey setup omarchy installs it")
 	case cloned && marker.PendingEnable:
-		// Never enabled automatically: the checkout may be off the bar
-		// because the user put it there.
+		// Never enabled automatically — but an enable that succeeded
+		// without a layout entry and crashed before the final write looks
+		// exactly like this, so the read-only probe self-repairs it. A
+		// checkout the shell reports disabled stays put.
+		probe, failStep, outcome := s.probeShellPlugins()
+		if outcome != probeAnswered {
+			return failStep
+		}
+		if probe.present && probe.enabled {
+			step := s.finalize(marker)
+			if step.Status == "installed" {
+				step.Status, step.Detail, step.attempted = "unchanged", "", false
+			}
+			return step
+		}
 		return s.pluginNotice("install incomplete — run hey setup omarchy")
 	case cloned:
 		return s.pluginStep("skipped", "the checkout is disabled or was installed by someone else")

--- a/internal/cmd/omarchy_plugin.go
+++ b/internal/cmd/omarchy_plugin.go
@@ -100,15 +100,30 @@ func (s omarchySetup) installBarPlugin() omarchyStep {
 	if !s.env.detected() || !filepath.IsAbs(s.env.home) {
 		return s.pluginSkip("Omarchy not detected")
 	}
+	return s.underBarPluginLock(func() []omarchyStep {
+		return []omarchyStep{s.installBarPluginLocked()}
+	})[0]
+}
+
+// underBarPluginLock runs fn with the plugin lock held — one acquisition
+// spanning every marker look and every shell.json write, so a concurrent
+// remove cannot interleave with an install's notify rewrite and restore a
+// disabled entry. The gates and contention become the one plugin step fn
+// never gets to produce.
+func (s omarchySetup) underBarPluginLock(fn func() []omarchyStep) []omarchyStep {
 	if s.env.stateDir == "" || !filepath.IsAbs(s.env.stateDir) {
-		return s.pluginSkip("no state directory to record the install in — set XDG_STATE_HOME or HOME")
+		return []omarchyStep{s.pluginSkip("no state directory to record the bar plugin state in — set XDG_STATE_HOME or HOME")}
 	}
 	lock, err := acquireOmarchyPluginLock(s.env)
 	if err != nil {
-		return s.pluginSkip(omarchyLockDetail(err))
+		return []omarchyStep{s.pluginSkip(omarchyLockDetail(err))}
 	}
 	defer func() { _ = lock.Unlock() }()
+	return fn()
+}
 
+// installBarPluginLocked is the mode dispatch, the lock already held.
+func (s omarchySetup) installBarPluginLocked() omarchyStep {
 	marker, _, err := readOmarchyPluginMarker(s.env.markerPath())
 	if err != nil {
 		return s.pluginFailed(omarchyMarkerUnreadable(s.env))
@@ -317,19 +332,10 @@ func (s omarchySetup) finalize(marker omarchyPluginMarker) omarchyStep {
 	return step
 }
 
-// removeBarPlugin is --remove's half: tombstone first, then disable. The
-// checkout stays; deleting it is `omarchy plugin remove`, which hey never
-// runs.
-func (s omarchySetup) removeBarPlugin(onBar bool) omarchyStep {
-	if s.env.stateDir == "" || !filepath.IsAbs(s.env.stateDir) {
-		return s.pluginFailed("no state directory to record the removal in — set XDG_STATE_HOME or HOME")
-	}
-	lock, err := acquireOmarchyPluginLock(s.env)
-	if err != nil {
-		return s.pluginFailed(omarchyLockDetail(err))
-	}
-	defer func() { _ = lock.Unlock() }()
-
+// removeBarPluginLocked is --remove's half, the lock already held: tombstone
+// first, then disable. The checkout stays; deleting it is `omarchy plugin
+// remove`, which hey never runs.
+func (s omarchySetup) removeBarPluginLocked(onBar bool) omarchyStep {
 	marker, _, err := readOmarchyPluginMarker(s.env.markerPath())
 	if err != nil {
 		// A marker we cannot read must not trap removal: installation is
@@ -370,6 +376,11 @@ func (s omarchySetup) disableBarPlugin(onBar bool) omarchyStep {
 	}
 	out, err := s.env.run("omarchy", "plugin", "disable", omarchyBarPluginID)
 	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			// Omarchy itself is gone: a stale layout entry is not a running
+			// plugin, and removal keeps working after uninstall.
+			return s.pluginStep("absent", "")
+		}
 		return s.pluginFailed(firstOutputLine(out, err))
 	}
 	step := s.pluginStep("removed", "disabled; the checkout stays — omarchy plugin remove "+omarchyBarPluginID+" deletes it")

--- a/internal/cmd/omarchy_plugin.go
+++ b/internal/cmd/omarchy_plugin.go
@@ -102,18 +102,43 @@ func (s omarchySetup) installBarPlugin() omarchyStep {
 	}
 	return s.underBarPluginLock(func() []omarchyStep {
 		step := s.installBarPluginLocked()
-		// In ensure mode, installed and unchanged both mean "the plugin is
-		// on the bar" — a fresh install, a quiet crash repair, or one that
-		// was already enabled. All of them owe the legacy migration: the
-		// plugin replaces the inline hey-unread indicator earlier releases
-		// installed, and a migrating user must not keep two icons and two
-		// pollers until an explicit setup. Quiet and best-effort — a
-		// failed cleanup costs nothing the next setup will not fix.
-		if step.Status == "installed" || step.Status == "unchanged" {
-			_ = s.removeLegacyIndicator(true)
+		// The plugin replaces the inline hey-unread indicator earlier
+		// releases installed, so a sign-in that finds the plugin live owes
+		// the migration — or a migrating user keeps two icons and two
+		// pollers until an explicit setup. "installed" was just verified;
+		// an "unchanged" may rest on a layout entry alone, so with a
+		// legacy module actually present the read-only probe confirms the
+		// replacement is enabled before its predecessor is removed. Quiet
+		// and best-effort — a failed cleanup costs nothing the next setup
+		// will not fix.
+		if (step.Status == "installed" || step.Status == "unchanged") && s.legacyIndicatorPresent() {
+			live := step.Status == "installed"
+			if !live {
+				probe, _, outcome := s.probeShellPlugins()
+				live = outcome == probeAnswered && probe.present && probe.enabled
+			}
+			if live {
+				_ = s.removeLegacyIndicator(true)
+			}
 		}
 		return []omarchyStep{step}
 	})[0]
+}
+
+// legacyIndicatorPresent reports whether shell.json still carries the old
+// inline hey-unread module — the cheap check that keeps every ordinary
+// sign-in from paying for a migration nobody needs.
+func (s omarchySetup) legacyIndicatorPresent() bool {
+	shell, err := s.loadShellConfig()
+	if err != nil {
+		return false
+	}
+	layout, err := existingBarLayout(shell)
+	if err != nil {
+		return false
+	}
+	present, _ := legacyIndicator(layout)
+	return present
 }
 
 // underBarPluginLock runs fn with the plugin lock held — one acquisition
@@ -314,18 +339,22 @@ func (s omarchySetup) forceInstall(marker omarchyPluginMarker) omarchyStep {
 func (s omarchySetup) addAndVerify(marker omarchyPluginMarker) omarchyStep {
 	out, err := s.env.run("omarchy", "plugin", "add", omarchyBarPluginSource, "--enable", "--yes")
 	lower := strings.ToLower(out)
-	switch {
-	case strings.Contains(lower, "failed to clone"):
+	cloneRefused := strings.Contains(lower, "failed to clone")
+	failed := cloneRefused || (err != nil && !strings.Contains(lower, "already installed") && !strings.Contains(lower, "already used"))
+	if failed {
+		// Every failed add arms the retry throttle — a hang killed at the
+		// timeout says no "failed to clone" but retrying it on every
+		// sign-in would block each one for another minute.
 		marker.LastCloneError = firstOutputLine(out, err)
 		marker.LastCloneAt = omarchyNow()
 		_ = s.env.writeMarker(marker) // best effort: the throttle is a convenience
-		return s.pluginFailed("could not clone " + omarchyBarPluginSource + " — check the network, or run: " + omarchyBarPluginInstallHint())
-	case err != nil && !strings.Contains(lower, "already installed") && !strings.Contains(lower, "already used"):
+		if cloneRefused {
+			return s.pluginFailed("could not clone " + omarchyBarPluginSource + " — check the network, or run: " + omarchyBarPluginInstallHint())
+		}
 		return s.pluginFailed(firstOutputLine(out, err))
-	default:
-		// Added — or a lost race already installed it; the verify decides.
-		return s.verifyAndFinalize(marker)
 	}
+	// Added — or a lost race already installed it; the verify decides.
+	return s.verifyAndFinalize(marker)
 }
 
 // verifyAndFinalize reports installed only when the running shell lists the

--- a/internal/cmd/omarchy_plugin.go
+++ b/internal/cmd/omarchy_plugin.go
@@ -102,12 +102,13 @@ func (s omarchySetup) installBarPlugin() omarchyStep {
 	}
 	return s.underBarPluginLock(func() []omarchyStep {
 		step := s.installBarPluginLocked()
-		if step.Status == "installed" {
+		if step.Status == "installed" || step.finalized {
 			// The plugin replaces the inline hey-unread indicator earlier
-			// releases installed: a sign-in that installs one takes the
-			// other out, or a migrating user keeps two icons and two
-			// pollers until an explicit setup. Quiet and best-effort — a
-			// failed cleanup costs nothing the next setup will not fix.
+			// releases installed: a sign-in that installs one — the quiet
+			// crash repairs included — takes the other out, or a migrating
+			// user keeps two icons and two pollers until an explicit
+			// setup. Quiet and best-effort — a failed cleanup costs
+			// nothing the next setup will not fix.
 			_ = s.removeLegacyIndicator(true)
 		}
 		return []omarchyStep{step}
@@ -135,7 +136,7 @@ func (s omarchySetup) underBarPluginLock(fn func() []omarchyStep) []omarchyStep 
 func (s omarchySetup) installBarPluginLocked() omarchyStep {
 	marker, _, err := readOmarchyPluginMarker(s.env.markerPath())
 	if err != nil {
-		return s.pluginFailed(omarchyMarkerUnreadable(s.env))
+		return s.pluginFailed(omarchyMarkerUnreadable(s.env, "hey setup omarchy"))
 	}
 	if s.forcePlugin {
 		return s.forceInstall(marker)
@@ -351,6 +352,7 @@ func (s omarchySetup) finalize(marker omarchyPluginMarker) omarchyStep {
 	}
 	step := s.pluginStep("installed", "installed and enabled")
 	step.attempted = true
+	step.finalized = true
 	return step
 }
 
@@ -363,9 +365,10 @@ func (s omarchySetup) removeBarPluginLocked(onBar bool) omarchyStep {
 		// A marker we cannot read must not trap removal: installation is
 		// already fail-closed on it, so nothing can resurrect the plugin.
 		// Disable anyway, leave the marker as evidence, and exit nonzero
-		// with the repair hint.
+		// with a removal-shaped repair hint — pointing at a plain setup
+		// here would re-enable what was just removed.
 		step := s.disableBarPlugin(onBar)
-		detail := omarchyMarkerUnreadable(s.env)
+		detail := omarchyMarkerUnreadable(s.env, "hey setup omarchy --remove")
 		if step.Status == "failed" {
 			detail = step.Detail + "; " + detail
 		}
@@ -570,8 +573,10 @@ func (e omarchyEnv) writeMarker(marker omarchyPluginMarker) error {
 	return writeJSONFile(e.markerPath(), marker)
 }
 
-func omarchyMarkerUnreadable(env omarchyEnv) string {
-	return "bar plugin state unreadable at " + env.markerPath() + " — delete it, then run hey setup omarchy"
+// omarchyMarkerUnreadable is the fail-closed remediation; command matches
+// the operation in flight, so following it never undoes what was asked.
+func omarchyMarkerUnreadable(env omarchyEnv, command string) string {
+	return "bar plugin state unreadable at " + env.markerPath() + " — delete it, then run " + command
 }
 
 // errOmarchyLockHeld is genuine contention — another hey holds the lock —

--- a/internal/cmd/omarchy_plugin.go
+++ b/internal/cmd/omarchy_plugin.go
@@ -103,15 +103,17 @@ func (s omarchySetup) installBarPlugin() omarchyStep {
 	return s.underBarPluginLock(func() []omarchyStep {
 		step := s.installBarPluginLocked()
 		// The plugin replaces the inline hey-unread indicator earlier
-		// releases installed, so a sign-in that finds the plugin live owes
-		// the migration — or a migrating user keeps two icons and two
-		// pollers until an explicit setup. "installed" was just verified;
-		// an "unchanged" may rest on a layout entry alone, so with a
-		// legacy module actually present the read-only probe confirms the
-		// replacement is enabled before its predecessor is removed. Quiet
-		// and best-effort — a failed cleanup costs nothing the next setup
-		// will not fix.
-		if (step.Status == "installed" || step.Status == "unchanged") && s.legacyIndicatorPresent() {
+		// releases installed, and one rule covers every path here: with
+		// the legacy module still present and the replacement verifiably
+		// live, a sign-in migrates — whatever else this run decided (a
+		// fresh install, a quiet repair, already enabled, or a checkout
+		// someone installed by hand). "installed" was just verified;
+		// anything else earns the read-only probe first, so a layout entry
+		// alone never costs a working panel; a failed run stays
+		// fail-closed with no cleanup at all. Quiet and best-effort — a
+		// failed cleanup costs nothing the next setup will not fix, and a
+		// sign-in with no legacy module pays nothing.
+		if step.Status != "failed" && s.legacyIndicatorPresent() {
 			live := step.Status == "installed"
 			if !live {
 				probe, _, outcome := s.probeShellPlugins()

--- a/internal/cmd/omarchy_plugin.go
+++ b/internal/cmd/omarchy_plugin.go
@@ -35,9 +35,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gofrs/flock"
@@ -103,7 +105,7 @@ func (s omarchySetup) installBarPlugin() omarchyStep {
 	}
 	lock, err := acquireOmarchyPluginLock(s.env)
 	if err != nil {
-		return s.pluginSkip("another hey is setting up the bar")
+		return s.pluginSkip(omarchyLockDetail(err))
 	}
 	defer func() { _ = lock.Unlock() }()
 
@@ -115,6 +117,16 @@ func (s omarchySetup) installBarPlugin() omarchyStep {
 		return s.forceInstall(marker)
 	}
 	return s.ensureInstall(marker)
+}
+
+// omarchyLockDetail keeps "wait for the other hey" for actual contention;
+// any other acquisition failure (an unwritable state dir, a filesystem
+// error) is its own problem and waiting will not fix it.
+func omarchyLockDetail(err error) string {
+	if errors.Is(err, errOmarchyLockHeld) {
+		return errOmarchyLockHeld.Error()
+	}
+	return "could not take the bar plugin lock: " + err.Error()
 }
 
 // ensureInstall is the sign-in path: quiet wherever installation is
@@ -129,8 +141,8 @@ func (s omarchySetup) ensureInstall(marker omarchyPluginMarker) omarchyStep {
 		// A crash between enable and the final write: finish the
 		// bookkeeping — unless the shell says the plugin is off, which is
 		// the user's doing and stays.
-		probe, failStep, ok := s.probeShellPlugins()
-		if !ok {
+		probe, failStep, outcome := s.probeShellPlugins()
+		if outcome != probeAnswered {
 			return failStep
 		}
 		if !probe.present || !probe.enabled {
@@ -158,8 +170,8 @@ func (s omarchySetup) ensureInstall(marker omarchyPluginMarker) omarchyStep {
 		if marker.cloneThrottled() {
 			return s.pluginStep("skipped", "waiting to retry a failed clone")
 		}
-		probe, failStep, ok := s.probeShellPlugins()
-		if !ok {
+		probe, failStep, outcome := s.probeShellPlugins()
+		if outcome != probeAnswered {
 			return failStep
 		}
 		if probe.present && probe.enabled {
@@ -179,8 +191,8 @@ func (s omarchySetup) ensureInstall(marker omarchyPluginMarker) omarchyStep {
 // ensureFreshInstall is the first sign-in on a box with nothing recorded:
 // probe the shell, ask once, put the intent on disk, then clone.
 func (s omarchySetup) ensureFreshInstall(marker omarchyPluginMarker) omarchyStep {
-	probe, failStep, ok := s.probeShellPlugins()
-	if !ok {
+	probe, failStep, outcome := s.probeShellPlugins()
+	if outcome != probeAnswered {
 		return failStep
 	}
 	if probe.present {
@@ -234,8 +246,8 @@ func (s omarchySetup) forceInstall(marker omarchyPluginMarker) omarchyStep {
 	if err := s.env.writeMarker(marker); err != nil {
 		return s.pluginFailed("could not record the bar plugin state in " + s.env.markerPath() + ": " + err.Error())
 	}
-	probe, failStep, ok := s.probeShellPlugins()
-	if !ok {
+	probe, failStep, outcome := s.probeShellPlugins()
+	if outcome != probeAnswered {
 		return failStep
 	}
 	switch {
@@ -281,8 +293,8 @@ func (s omarchySetup) addAndVerify(marker omarchyPluginMarker) omarchyStep {
 // plugin enabled and the marker recorded it. Anything less keeps the pending
 // intent and fails.
 func (s omarchySetup) verifyAndFinalize(marker omarchyPluginMarker) omarchyStep {
-	probe, _, ok := s.probeShellPlugins()
-	if !ok || !probe.present || !probe.enabled {
+	probe, _, outcome := s.probeShellPlugins()
+	if outcome != probeAnswered || !probe.present || !probe.enabled {
 		return s.pluginFailed("the shell did not enable the plugin — run hey setup omarchy")
 	}
 	return s.finalize(marker)
@@ -314,7 +326,7 @@ func (s omarchySetup) removeBarPlugin(onBar bool) omarchyStep {
 	}
 	lock, err := acquireOmarchyPluginLock(s.env)
 	if err != nil {
-		return s.pluginFailed("another hey is setting up the bar")
+		return s.pluginFailed(omarchyLockDetail(err))
 	}
 	defer func() { _ = lock.Unlock() }()
 
@@ -342,7 +354,19 @@ func (s omarchySetup) removeBarPlugin(onBar bool) omarchyStep {
 
 func (s omarchySetup) disableBarPlugin(onBar bool) omarchyStep {
 	if !onBar {
-		return s.pluginStep("absent", "")
+		// shell.json's layout is not the whole truth: an enabled plugin
+		// needs no spelled-out entry, and an unreadable shell.json says
+		// nothing — ask the shell before calling the plugin absent.
+		probe, failStep, outcome := s.probeShellPlugins()
+		switch {
+		case outcome == probeNoCLI:
+			// No omarchy CLI: nothing can be running, nothing to disable.
+			return s.pluginStep("absent", "")
+		case outcome != probeAnswered:
+			return s.pluginFailed(failStep.Detail)
+		case !probe.present || !probe.enabled:
+			return s.pluginStep("absent", "")
+		}
 	}
 	out, err := s.env.run("omarchy", "plugin", "disable", omarchyBarPluginID)
 	if err != nil {
@@ -364,24 +388,39 @@ type omarchyPluginProbe struct {
 // shell to talk to — an ssh session, a fresh tty, a stopped shell.
 var omarchyShellDownPattern = regexp.MustCompile(`omarchy-shell is not running|not ready|OMARCHY_PATH is not set`)
 
-// probeShellPlugins asks the running shell for its plugin list. ok=false
-// comes with the step to report, in one of three distinct shapes: the omarchy
-// CLI missing (update Omarchy), the shell down (nothing to do here), and an
-// answer that is not a plugin list (fail closed).
-func (s omarchySetup) probeShellPlugins() (omarchyPluginProbe, omarchyStep, bool) {
+// omarchyProbeOutcome distinguishes the ways a probe can not answer, because
+// they demand different reactions: no CLI means nothing can be running at
+// all, a down shell means try again from the desktop, and anything else
+// fails closed.
+type omarchyProbeOutcome int
+
+const (
+	probeAnswered omarchyProbeOutcome = iota
+	probeNoCLI
+	probeShellDown
+	probeUnexpected
+)
+
+// probeShellPlugins asks the running shell for its plugin list. Anything but
+// probeAnswered comes with the step to report.
+func (s omarchySetup) probeShellPlugins() (omarchyPluginProbe, omarchyStep, omarchyProbeOutcome) {
 	out, err := s.env.run("omarchy", "plugin", "list", "--json")
 	if err != nil && errors.Is(err, exec.ErrNotFound) {
-		return omarchyPluginProbe{}, s.pluginSkip("Omarchy CLI not found — update Omarchy"), false
+		return omarchyPluginProbe{}, s.pluginSkip("Omarchy CLI not found — update Omarchy"), probeNoCLI
 	}
 	if omarchyShellDownPattern.MatchString(out) {
-		return omarchyPluginProbe{}, s.pluginSkip("the Omarchy shell is not running — sign in again from the desktop, or run hey setup omarchy there"), false
+		return omarchyPluginProbe{}, s.pluginSkip("the Omarchy shell is not running — sign in again from the desktop, or run hey setup omarchy there"), probeShellDown
 	}
+	trimmed := strings.TrimSpace(out)
 	var plugins []struct {
 		ID      string `json:"id"`
 		Enabled bool   `json:"enabled"`
 	}
-	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &plugins); jsonErr != nil {
-		return omarchyPluginProbe{}, s.pluginFailed("unexpected answer from omarchy plugin list"), false
+	// Fail closed on anything but a clean array cleanly answered: a failing
+	// command whose output happens to parse, or a JSON null (which
+	// unmarshals into a nil slice without error), is not a plugin list.
+	if err != nil || !strings.HasPrefix(trimmed, "[") || json.Unmarshal([]byte(trimmed), &plugins) != nil {
+		return omarchyPluginProbe{}, s.pluginFailed("unexpected answer from omarchy plugin list"), probeUnexpected
 	}
 	var probe omarchyPluginProbe
 	for _, plugin := range plugins {
@@ -389,7 +428,7 @@ func (s omarchySetup) probeShellPlugins() (omarchyPluginProbe, omarchyStep, bool
 			probe.present, probe.enabled = true, plugin.Enabled
 		}
 	}
-	return probe, omarchyStep{}, true
+	return probe, omarchyStep{}, probeAnswered
 }
 
 // pluginOnBar reads shell.json's layout for the plugin's entry — the fact the
@@ -502,6 +541,10 @@ func omarchyMarkerUnreadable(env omarchyEnv) string {
 	return "bar plugin state unreadable at " + env.markerPath() + " — delete it, then run hey setup omarchy"
 }
 
+// errOmarchyLockHeld is genuine contention — another hey holds the lock —
+// as opposed to a failure to reach the lock at all.
+var errOmarchyLockHeld = errors.New("another hey is setting up the bar")
+
 // acquireOmarchyPluginLock serializes every look at the marker and every
 // mutation behind it. Non-blocking: a held lock is another hey's turn.
 func acquireOmarchyPluginLock(env omarchyEnv) (*flock.Flock, error) {
@@ -514,7 +557,7 @@ func acquireOmarchyPluginLock(env omarchyEnv) (*flock.Flock, error) {
 		return nil, err
 	}
 	if !locked {
-		return nil, errors.New("lock held")
+		return nil, errOmarchyLockHeld
 	}
 	return lock, nil
 }
@@ -588,6 +631,12 @@ var runOmarchyCommand = func(omarchyRoot, name string, args ...string) (string, 
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), omarchyCommandTimeout)
 	defer cancel()
+	// Ctrl-C must reach the isolated process group: the child sits outside
+	// the terminal's foreground group, so translate an interrupt into the
+	// same cancellation the timeout uses — Cancel kills the whole group and
+	// hey survives to report the aborted step.
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- fixed omarchy command names
 	// The omarchy CLI needs OMARCHY_PATH to find the shell; non-login and
 	// agent environments lack it, so export the root we detected ourselves.

--- a/internal/cmd/omarchy_plugin.go
+++ b/internal/cmd/omarchy_plugin.go
@@ -102,13 +102,14 @@ func (s omarchySetup) installBarPlugin() omarchyStep {
 	}
 	return s.underBarPluginLock(func() []omarchyStep {
 		step := s.installBarPluginLocked()
-		if step.Status == "installed" || step.finalized {
-			// The plugin replaces the inline hey-unread indicator earlier
-			// releases installed: a sign-in that installs one — the quiet
-			// crash repairs included — takes the other out, or a migrating
-			// user keeps two icons and two pollers until an explicit
-			// setup. Quiet and best-effort — a failed cleanup costs
-			// nothing the next setup will not fix.
+		// In ensure mode, installed and unchanged both mean "the plugin is
+		// on the bar" — a fresh install, a quiet crash repair, or one that
+		// was already enabled. All of them owe the legacy migration: the
+		// plugin replaces the inline hey-unread indicator earlier releases
+		// installed, and a migrating user must not keep two icons and two
+		// pollers until an explicit setup. Quiet and best-effort — a
+		// failed cleanup costs nothing the next setup will not fix.
+		if step.Status == "installed" || step.Status == "unchanged" {
 			_ = s.removeLegacyIndicator(true)
 		}
 		return []omarchyStep{step}
@@ -352,7 +353,6 @@ func (s omarchySetup) finalize(marker omarchyPluginMarker) omarchyStep {
 	}
 	step := s.pluginStep("installed", "installed and enabled")
 	step.attempted = true
-	step.finalized = true
 	return step
 }
 

--- a/internal/cmd/omarchy_plugin.go
+++ b/internal/cmd/omarchy_plugin.go
@@ -101,7 +101,16 @@ func (s omarchySetup) installBarPlugin() omarchyStep {
 		return s.pluginSkip("Omarchy not detected")
 	}
 	return s.underBarPluginLock(func() []omarchyStep {
-		return []omarchyStep{s.installBarPluginLocked()}
+		step := s.installBarPluginLocked()
+		if step.Status == "installed" {
+			// The plugin replaces the inline hey-unread indicator earlier
+			// releases installed: a sign-in that installs one takes the
+			// other out, or a migrating user keeps two icons and two
+			// pollers until an explicit setup. Quiet and best-effort — a
+			// failed cleanup costs nothing the next setup will not fix.
+			_ = s.removeLegacyIndicator(true)
+		}
+		return []omarchyStep{step}
 	})[0]
 }
 

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -596,6 +598,74 @@ func TestOmarchyPluginMalformedMarkerFailsClosed(t *testing.T) {
 	}
 	if markerBytes(t, env) != "{not json" {
 		t.Error("remove must leave the malformed marker untouched")
+	}
+}
+
+func TestOmarchyPluginSignInInstallMigratesTheLegacyIndicator(t *testing.T) {
+	// A migrating user signs in: the new plugin lands and the inline
+	// hey-unread module leaves with it — never two icons and two pollers.
+	env, _ := testOmarchyEnv(t)
+	stubConfirmOmarchyPanel(t, true, nil)
+	writeShell(t, env, legacyShellJSON)
+	enabled := false
+	env.run = func(name string, args ...string) (string, error) {
+		command := strings.Join(append([]string{name}, args...), " ")
+		switch {
+		case strings.HasPrefix(command, "omarchy plugin list"):
+			if enabled {
+				return pluginListEnabled, nil
+			}
+			return pluginListAbsent, nil
+		case strings.HasPrefix(command, "omarchy plugin add"):
+			enabled = true
+			return "Installed", nil
+		default:
+			return "", nil
+		}
+	}
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "installed" {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
+	}
+	if strings.Contains(readText(t, env.shellPath()), "hey-unread") {
+		t.Error("a sign-in install must take the legacy indicator out")
+	}
+}
+
+func TestSetupWizardSkipsOmarchyOnRejectedCredentials(t *testing.T) {
+	// Stored-but-rejected credentials are not a login: the desktop step
+	// must not prompt or install while the user is effectively signed out.
+	isolateAgents(t)
+	stubInteractive(t, true)
+	confirms := stubConfirmOmarchyPanel(t, true, nil)
+	ran := stubOmarchyRun(t, omarchyUnavailable)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+	configHome := t.TempDir()
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", true, "auth", "login", "--cookie", "stale-cookie"); err != nil {
+		t.Fatalf("auth login: %v", err)
+	}
+	origColor := colorDisabled
+	colorDisabled = true
+	t.Cleanup(func() { colorDisabled = origColor })
+	t.Setenv("OMARCHY_PATH", t.TempDir())
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	root.SetArgs([]string{"--base-url", server.URL, "setup", "--styled"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("setup: %v\n%s", err, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Stored sign-in rejected") {
+		t.Fatalf("expected the rejected-credentials warning:\n%s", stdout.String())
+	}
+	if *confirms != 0 || len(*ran) != 0 {
+		t.Errorf("the Omarchy step must wait for a working login: confirms=%d ran=%v", *confirms, *ran)
 	}
 }
 

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -307,12 +307,16 @@ func TestOmarchyPluginEnsurePendingClonedFinalizesWhenTheShellSaysEnabled(t *tes
 
 func TestOmarchyPluginEnsureOnBarMigratesTheLegacyIndicator(t *testing.T) {
 	// The plugin is already enabled (installed by hand, say) beside the old
-	// hey-unread module: a sign-in still migrates — the unchanged outcome
-	// means "on the bar", and the toast choice moves onto the entry.
-	env, ran, _ := testOmarchyEnvScripted(t, nil)
-	writeShell(t, env, `{"version":1,"bar":{"layout":{"left":[{"id":"omarchy.menu"}],"center":[],"right":[
+	// hey-unread module: a sign-in still migrates — after the read-only
+	// probe confirms the replacement is live — and the toast choice moves
+	// onto the entry.
+	legacyBesideEntry := `{"version":1,"bar":{"layout":{"left":[{"id":"omarchy.menu"}],"center":[],"right":[
   {"id":"hey-unread","type":"command","exec":"hey omarchy bar-status --notify","interval":180},
-  {"id":"37signals.hey"},{"id":"omarchy.tray"}]}}}`)
+  {"id":"37signals.hey"},{"id":"omarchy.tray"}]}}}`
+	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListEnabled},
+	})
+	writeShell(t, env, legacyBesideEntry)
 
 	step := omarchySetup{env: env}.installBarPlugin()
 	if step.Status != "unchanged" || step.attempted {
@@ -324,8 +328,79 @@ func TestOmarchyPluginEnsureOnBarMigratesTheLegacyIndicator(t *testing.T) {
 	if entry := pluginEntry(t, env); entry == nil || entry["notify"] != true {
 		t.Errorf("the toast choice must move onto the entry, got %v", entry)
 	}
-	if len(*ran) != 0 {
-		t.Errorf("the on-bar migration needs no subprocess: %v", *ran)
+	if got := mutationCommands(*ran); len(got) != 0 {
+		t.Errorf("the on-bar migration mutates nothing but shell.json: %v", got)
+	}
+
+	// A layout entry the shell reports disabled is not a live replacement:
+	// the still-working legacy module stays.
+	env2, ran2, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListDisabled},
+	})
+	writeShell(t, env2, legacyBesideEntry)
+	if step := (omarchySetup{env: env2}).installBarPlugin(); step.Status != "unchanged" {
+		t.Fatalf("second = %q %q", step.Status, step.Detail)
+	}
+	if !strings.Contains(readText(t, env2.shellPath()), "hey-unread") {
+		t.Error("a disabled replacement must not cost the working legacy panel")
+	}
+	if got := mutationCommands(*ran2); len(got) != 0 {
+		t.Errorf("nothing may be mutated: %v", got)
+	}
+}
+
+func TestOmarchyPluginTimedOutCloneIsThrottledToo(t *testing.T) {
+	// A hung add killed at the timeout says no "failed to clone" — it arms
+	// the retry throttle all the same, or every sign-in would block for
+	// another minute.
+	env, _, replies := testOmarchyEnvScripted(t, nil)
+	stubConfirmOmarchyPanel(t, true, nil)
+	replies["omarchy plugin add"] = omarchyReply{err: errors.New("signal: killed")}
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "failed" {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if !marker.PendingEnable || marker.LastCloneAt == "" {
+		t.Fatalf("a timed-out add must arm the throttle: %+v", marker)
+	}
+	if second := (omarchySetup{env: env}).installBarPlugin(); second.Status != "skipped" || second.attempted {
+		t.Errorf("throttled retry = %q attempted=%v", second.Status, second.attempted)
+	}
+}
+
+func TestOmarchyRemoveKeepsLegacyWhenTheTombstoneCannotLand(t *testing.T) {
+	// A removal that could not be recorded rewrites nothing else either.
+	if os.Geteuid() == 0 {
+		t.Skip("root can write anywhere")
+	}
+	env, ran, _ := testOmarchyEnvScripted(t, nil)
+	writeShell(t, env, legacyShellJSON)
+	if err := os.MkdirAll(filepath.Dir(env.lockPath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(env.lockPath(), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := filepath.Dir(env.markerPath())
+	if err := os.Chmod(stateDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o700) })
+
+	steps := omarchySetup{env: env, forcePlugin: true}.removeBar()
+	if bar := stepNamed(steps, "bar plugin"); bar.Status != "failed" {
+		t.Fatalf("bar = %q %q", bar.Status, bar.Detail)
+	}
+	if stepNamed(steps, "bar indicator").Name != "" {
+		t.Error("no legacy rewrite may ride on an unrecorded removal")
+	}
+	if !strings.Contains(readText(t, env.shellPath()), "hey-unread") {
+		t.Error("shell.json must be untouched")
+	}
+	if got := mutationCommands(*ran); len(got) != 0 {
+		t.Errorf("no mutation on an unrecorded removal: %v", got)
 	}
 }
 

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -1,0 +1,1195 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+const (
+	pluginListAbsent   = `[]`
+	pluginListEnabled  = `[{"id":"omarchy.clock","enabled":true},{"id":"37signals.hey","enabled":true}]`
+	pluginListDisabled = `[{"id":"omarchy.clock","enabled":true},{"id":"37signals.hey","enabled":false}]`
+)
+
+func stubConfirmOmarchyPanel(t *testing.T, answer bool, err error) *int {
+	t.Helper()
+	calls := 0
+	orig := confirmOmarchyPanel
+	confirmOmarchyPanel = func() (bool, error) {
+		calls++
+		return answer, err
+	}
+	t.Cleanup(func() { confirmOmarchyPanel = orig })
+	return &calls
+}
+
+// stubOmarchyRun intercepts every live omarchy subprocess (liveOmarchyEnv's
+// runner), recording each command and answering with fn.
+func stubOmarchyRun(t *testing.T, fn func(name string, args ...string) (string, error)) *[]string {
+	t.Helper()
+	var ran []string
+	orig := runOmarchyCommand
+	runOmarchyCommand = func(_, name string, args ...string) (string, error) {
+		ran = append(ran, strings.Join(append([]string{name}, args...), " "))
+		return fn(name, args...)
+	}
+	t.Cleanup(func() { runOmarchyCommand = orig })
+	return &ran
+}
+
+func omarchyUnavailable(string, ...string) (string, error) { return "", exec.ErrNotFound }
+
+func stubOmarchyAfterLogin(t *testing.T) *int {
+	t.Helper()
+	calls := 0
+	orig := ensureOmarchyBarPluginAfterLogin
+	ensureOmarchyBarPluginAfterLogin = func(io.Writer) { calls++ }
+	t.Cleanup(func() { ensureOmarchyBarPluginAfterLogin = orig })
+	return &calls
+}
+
+func stubLoginInteractively(t *testing.T, err error) *int {
+	t.Helper()
+	calls := 0
+	orig := loginInteractively
+	loginInteractively = func(io.Writer) error {
+		calls++
+		return err
+	}
+	t.Cleanup(func() { loginInteractively = orig })
+	return &calls
+}
+
+func clonePluginCheckout(t *testing.T, env omarchyEnv) {
+	t.Helper()
+	if err := os.MkdirAll(env.pluginDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(env.pluginDir(), "manifest.json"), []byte(`{"id":"37signals.hey","version":"0.4.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedMarker(t *testing.T, env omarchyEnv, marker omarchyPluginMarker) {
+	t.Helper()
+	if err := env.writeMarker(marker); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readMarkerFile(t *testing.T, env omarchyEnv) (omarchyPluginMarker, bool) {
+	t.Helper()
+	marker, exists, err := readOmarchyPluginMarker(env.markerPath())
+	if err != nil {
+		t.Fatalf("marker: %v", err)
+	}
+	return marker, exists
+}
+
+func markerBytes(t *testing.T, env omarchyEnv) string {
+	t.Helper()
+	data, err := os.ReadFile(env.markerPath())
+	if errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+// mutationCommands filters the recorder down to commands that change
+// anything: the plugin list probe and a theme refresh are reads or
+// unrelated.
+func mutationCommands(ran []string) []string {
+	var out []string
+	for _, command := range ran {
+		if !strings.HasPrefix(command, "omarchy plugin list") && command != "omarchy-theme-refresh" {
+			out = append(out, command)
+		}
+	}
+	return out
+}
+
+// --- Ensure mode: the transition table, row by row ---
+
+func TestOmarchyPluginFreshInstallAsksOnceThenAddsAndVerifies(t *testing.T) {
+	env, _ := testOmarchyEnv(t)
+	confirms := stubConfirmOmarchyPanel(t, true, nil)
+	var ran []string
+	enabled := false
+	env.run = func(name string, args ...string) (string, error) {
+		command := strings.Join(append([]string{name}, args...), " ")
+		ran = append(ran, command)
+		switch {
+		case strings.HasPrefix(command, "omarchy plugin list"):
+			if enabled {
+				return pluginListEnabled, nil
+			}
+			return pluginListAbsent, nil
+		case strings.HasPrefix(command, "omarchy plugin add"):
+			// The intent must be durable before anything is cloned.
+			marker, exists := readMarkerFile(t, env)
+			if !exists || !marker.PendingEnable || marker.AcceptedAt == "" {
+				t.Errorf("intent not on disk before the clone: %+v (exists=%v)", marker, exists)
+			}
+			enabled = true
+			clonePluginCheckout(t, env)
+			writeShell(t, env, pluginShellJSON)
+			return "Installed 37signals.hey", nil
+		default:
+			return "", nil
+		}
+	}
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "installed" || !step.attempted {
+		t.Fatalf("step = %q %q attempted=%v", step.Status, step.Detail, step.attempted)
+	}
+	if *confirms != 1 {
+		t.Errorf("consent asked %d times, want 1", *confirms)
+	}
+	if want := "omarchy plugin add " + omarchyBarPluginSource + " --enable --yes"; !contains(ran, want) {
+		t.Errorf("commands = %v, want %q", ran, want)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if marker.PendingEnable || marker.InstalledAt == "" || marker.AcceptedAt == "" || marker.InstallingAt != "" {
+		t.Errorf("marker after install = %+v", marker)
+	}
+
+	// The next sign-in finds it on the bar and does nothing at all.
+	countBefore := len(ran)
+	second := omarchySetup{env: env}.installBarPlugin()
+	if second.Status != "unchanged" || second.attempted || len(ran) != countBefore {
+		t.Errorf("second ensure = %q, ran %v", second.Status, ran[countBefore:])
+	}
+}
+
+func TestOmarchyPluginSourceSeam(t *testing.T) {
+	orig := omarchyBarPluginSource
+	omarchyBarPluginSource = "https://example.org/omarchy-hey-plugin-fork.git"
+	t.Cleanup(func() { omarchyBarPluginSource = orig })
+	env, ran, replies := testOmarchyEnvScripted(t, nil)
+	stubConfirmOmarchyPanel(t, true, nil)
+	replies["omarchy plugin add"] = omarchyReply{out: "failed to clone"}
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if !contains(*ran, "omarchy plugin add https://example.org/omarchy-hey-plugin-fork.git --enable --yes") {
+		t.Errorf("commands = %v", *ran)
+	}
+	if !strings.Contains(step.Detail, "https://example.org/omarchy-hey-plugin-fork.git") {
+		t.Errorf("the remediation must name the source actually used: %q", step.Detail)
+	}
+}
+
+func TestOmarchyPluginEnsureAsksOnceAndRemembersNo(t *testing.T) {
+	env, ran, _ := testOmarchyEnvScripted(t, nil)
+	confirms := stubConfirmOmarchyPanel(t, false, nil)
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "skipped" || step.attempted {
+		t.Fatalf("declined = %q attempted=%v", step.Status, step.attempted)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if marker.DeclinedAt == "" {
+		t.Fatalf("the decline must be recorded: %+v", marker)
+	}
+	countAfterFirst := len(*ran)
+
+	if second := (omarchySetup{env: env}).installBarPlugin(); second.Status != "skipped" || second.attempted {
+		t.Errorf("second = %q attempted=%v", second.Status, second.attempted)
+	}
+	if *confirms != 1 {
+		t.Errorf("asked %d times, want 1", *confirms)
+	}
+	if len(*ran) != countAfterFirst {
+		t.Errorf("a remembered no runs nothing, ran %v", (*ran)[countAfterFirst:])
+	}
+}
+
+func TestOmarchyPluginEnsureCanceledConsentAsksAgainNextTime(t *testing.T) {
+	// Esc is not a no: nothing is recorded, so the next sign-in asks again.
+	env, _, _ := testOmarchyEnvScripted(t, nil)
+	confirms := stubConfirmOmarchyPanel(t, false, errors.New("canceled"))
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "skipped" || step.attempted {
+		t.Fatalf("canceled = %q attempted=%v", step.Status, step.attempted)
+	}
+	if _, exists := readMarkerFile(t, env); exists {
+		t.Error("a canceled prompt must record nothing")
+	}
+	if second := (omarchySetup{env: env}).installBarPlugin(); second.Status != "skipped" {
+		t.Errorf("second = %q", second.Status)
+	}
+	if *confirms != 2 {
+		t.Errorf("asked %d times, want every time until answered", *confirms)
+	}
+}
+
+func TestOmarchyPluginEnsureNeverResurrectsADisabledPlugin(t *testing.T) {
+	// A verified install whose final write failed leaves pending_enable set;
+	// the user then disables the plugin. The next sign-in owes a notice and
+	// nothing else — only explicit hey setup omarchy re-enables.
+	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListDisabled},
+	})
+	clonePluginCheckout(t, env)
+	seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-24T00:00:00Z", PendingEnable: true, InstallingAt: "2026-08-24T00:00:00Z"})
+	confirms := stubConfirmOmarchyPanel(t, true, nil)
+
+	// Checkout present, off the bar (disable removed the layout entry).
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "skipped" || !step.attempted || !strings.Contains(step.Detail, "hey setup omarchy") {
+		t.Fatalf("step = %q %q attempted=%v", step.Status, step.Detail, step.attempted)
+	}
+	if got := mutationCommands(*ran); len(got) != 0 {
+		t.Errorf("ensure must not enable an off-bar checkout: %v", got)
+	}
+	if *confirms != 0 {
+		t.Error("nothing to ask: consent already stands")
+	}
+
+	// The same with the layout entry still present but the shell reporting
+	// the plugin disabled: the probe's answer wins and nothing is enabled.
+	writeShell(t, env, pluginShellJSON)
+	step = omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "skipped" || !step.attempted {
+		t.Fatalf("disabled per the shell = %q %q", step.Status, step.Detail)
+	}
+	if got := mutationCommands(*ran); len(got) != 0 {
+		t.Errorf("no mutation may run: %v", got)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if !marker.PendingEnable {
+		t.Error("the pending intent stays for hey setup omarchy to finish")
+	}
+}
+
+func TestOmarchyPluginEnsureFinishesTheMarkerAfterACrash(t *testing.T) {
+	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListEnabled},
+	})
+	clonePluginCheckout(t, env)
+	writeShell(t, env, pluginShellJSON)
+	seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-24T00:00:00Z", PendingEnable: true})
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "unchanged" || step.attempted {
+		t.Fatalf("crash repair should be quiet, got %q attempted=%v", step.Status, step.attempted)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if marker.PendingEnable || marker.InstalledAt == "" {
+		t.Errorf("marker = %+v", marker)
+	}
+	if got := mutationCommands(*ran); len(got) != 0 {
+		t.Errorf("verify and write only: %v", got)
+	}
+}
+
+func TestOmarchyPluginEnsureQuietRows(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, env omarchyEnv)
+	}{
+		{"declined", func(t *testing.T, env omarchyEnv) {
+			seedMarker(t, env, omarchyPluginMarker{DeclinedAt: "2026-08-01T00:00:00Z"})
+		}},
+		{"removed", func(t *testing.T, env omarchyEnv) {
+			seedMarker(t, env, omarchyPluginMarker{RemovedAt: "2026-08-01T00:00:00Z"})
+		}},
+		{"installed then deleted outside hey", func(t *testing.T, env omarchyEnv) {
+			seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-01T00:00:00Z", InstalledAt: "2026-08-01T00:00:00Z"})
+		}},
+		{"someone else's disabled clone", func(t *testing.T, env omarchyEnv) {
+			clonePluginCheckout(t, env)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, ran, _ := testOmarchyEnvScripted(t, nil)
+			confirms := stubConfirmOmarchyPanel(t, true, nil)
+			tc.setup(t, env)
+			before := markerBytes(t, env)
+
+			step := omarchySetup{env: env}.installBarPlugin()
+			if step.Status != "skipped" || step.attempted {
+				t.Errorf("step = %q %q attempted=%v", step.Status, step.Detail, step.attempted)
+			}
+			if *confirms != 0 {
+				t.Error("no prompt on a quiet row")
+			}
+			if len(*ran) != 0 {
+				t.Errorf("no subprocess on a quiet row: %v", *ran)
+			}
+			if after := markerBytes(t, env); after != before {
+				t.Errorf("no write on a quiet row:\nbefore: %s\nafter: %s", before, after)
+			}
+		})
+	}
+}
+
+func TestOmarchyPluginEnsureOnBarIsUnchanged(t *testing.T) {
+	env, ran, _ := testOmarchyEnvScripted(t, nil)
+	writeShell(t, env, pluginShellJSON)
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "unchanged" || step.attempted {
+		t.Fatalf("step = %q", step.Status)
+	}
+	if len(*ran) != 0 {
+		t.Errorf("an on-bar plugin needs no subprocess: %v", *ran)
+	}
+	if _, exists := readMarkerFile(t, env); exists {
+		t.Error("an on-bar plugin needs no write")
+	}
+}
+
+func TestOmarchyPluginEnsureRetryIsThrottledAfterACloneFailure(t *testing.T) {
+	env, ran, replies := testOmarchyEnvScripted(t, nil)
+	confirms := stubConfirmOmarchyPanel(t, true, nil)
+	replies["omarchy plugin add"] = omarchyReply{out: "failed to clone " + omarchyBarPluginSource, err: errors.New("exit status 1")}
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "failed" || !strings.Contains(step.Detail, "could not clone") || !strings.Contains(step.Detail, omarchyBarPluginInstallHint()) {
+		t.Fatalf("clone failure = %q %q", step.Status, step.Detail)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if !marker.PendingEnable || marker.LastCloneAt == "" {
+		t.Fatalf("marker = %+v", marker)
+	}
+
+	// Within the throttle: quiet, no prompt, no clone.
+	countBefore := len(*ran)
+	step = omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "skipped" || step.attempted || len(*ran) != countBefore {
+		t.Errorf("throttled retry = %q attempted=%v, ran %v", step.Status, step.attempted, (*ran)[countBefore:])
+	}
+
+	// Past it: the clone retries, and consent is not asked again.
+	marker.LastCloneAt = time.Now().UTC().Add(-25 * time.Hour).Format(time.RFC3339)
+	seedMarker(t, env, marker)
+	addRan := false
+	base := env.run
+	env.run = func(name string, args ...string) (string, error) {
+		if strings.HasPrefix(strings.Join(append([]string{name}, args...), " "), "omarchy plugin add") {
+			addRan = true
+			replies["omarchy plugin list"] = omarchyReply{out: pluginListEnabled}
+			return "Installed", nil
+		}
+		return base(name, args...)
+	}
+	step = omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "installed" || !addRan {
+		t.Fatalf("retry past the throttle = %q, addRan=%v", step.Status, addRan)
+	}
+	if *confirms != 1 {
+		t.Errorf("consent asked %d times, want once ever", *confirms)
+	}
+}
+
+func TestOmarchyPluginEnsureShellDownIsQuiet(t *testing.T) {
+	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: "omarchy-shell is not running (start it from the desktop)", err: errors.New("exit status 1")},
+	})
+	confirms := stubConfirmOmarchyPanel(t, true, nil)
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "skipped" || step.attempted || !strings.Contains(step.Detail, "shell is not running") {
+		t.Fatalf("step = %q %q attempted=%v", step.Status, step.Detail, step.attempted)
+	}
+	if *confirms != 0 {
+		t.Error("no prompt with no shell")
+	}
+	if got := mutationCommands(*ran); len(got) != 0 {
+		t.Errorf("no clone with no shell: %v", got)
+	}
+	if _, exists := readMarkerFile(t, env); exists {
+		t.Error("nothing may be recorded before consent")
+	}
+
+	// A pending install stays pending, untouched and unthrottled.
+	seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-24T00:00:00Z", PendingEnable: true})
+	before := markerBytes(t, env)
+	step = omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "skipped" || step.attempted {
+		t.Errorf("pending with the shell down = %q attempted=%v", step.Status, step.attempted)
+	}
+	if markerBytes(t, env) != before {
+		t.Error("the pending intent must be untouched")
+	}
+}
+
+func TestOmarchyPluginEnsureMissingCLISaysUpdateOmarchy(t *testing.T) {
+	env, _, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {err: exec.ErrNotFound},
+	})
+	stubConfirmOmarchyPanel(t, true, nil)
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "skipped" || !strings.Contains(step.Detail, "update Omarchy") {
+		t.Fatalf("a missing omarchy CLI must be distinct: %q %q", step.Status, step.Detail)
+	}
+}
+
+func TestOmarchyPluginProbeFailsClosedOnAnUnexpectedAnswer(t *testing.T) {
+	env, _, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: "I am not JSON"},
+	})
+	stubConfirmOmarchyPanel(t, true, nil)
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "failed" || !strings.Contains(step.Detail, "unexpected answer") {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
+	}
+}
+
+func TestOmarchyPluginVerifyFailureKeepsThePendingIntent(t *testing.T) {
+	env, _, replies := testOmarchyEnvScripted(t, nil)
+	stubConfirmOmarchyPanel(t, true, nil)
+	replies["omarchy plugin add"] = omarchyReply{out: "Installed"}
+	// The verify re-probes and still sees nothing enabled.
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "failed" || !strings.Contains(step.Detail, "did not enable") {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if !marker.PendingEnable {
+		t.Errorf("pending must be kept: %+v", marker)
+	}
+}
+
+func TestOmarchyPluginFinalWriteFailureIsAFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write anywhere")
+	}
+	env, _, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListEnabled},
+	})
+	clonePluginCheckout(t, env)
+	writeShell(t, env, pluginShellJSON)
+	seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-24T00:00:00Z", PendingEnable: true})
+	stateDir := filepath.Dir(env.markerPath())
+	if err := os.WriteFile(env.lockPath(), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(stateDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o700) })
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "failed" || !strings.Contains(step.Detail, "enabled, but could not record") {
+		t.Fatalf("a hidden write failure is never installed: %q %q", step.Status, step.Detail)
+	}
+}
+
+func TestOmarchyPluginLockContention(t *testing.T) {
+	env, ran, _ := testOmarchyEnvScripted(t, nil)
+	stubConfirmOmarchyPanel(t, true, nil)
+	if err := os.MkdirAll(filepath.Dir(env.lockPath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lock := flock.New(env.lockPath())
+	locked, err := lock.TryLock()
+	if err != nil || !locked {
+		t.Fatalf("take the lock: %v %v", locked, err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "skipped" || step.attempted || !strings.Contains(step.Detail, "another hey") {
+		t.Fatalf("ensure under contention = %q %q", step.Status, step.Detail)
+	}
+	force := omarchySetup{env: env, forcePlugin: true}.installBarPlugin()
+	if force.failure == nil {
+		t.Error("force under contention is a failure")
+	}
+	if len(*ran) != 0 {
+		t.Errorf("no subprocess under contention: %v", *ran)
+	}
+	if markerBytes(t, env) != "" {
+		t.Error("no state may be claimed under contention")
+	}
+}
+
+func TestOmarchyPluginRefusesABadStateDir(t *testing.T) {
+	for _, stateDir := range []string{"", "relative/state"} {
+		env, ran, _ := testOmarchyEnvScripted(t, nil)
+		stubConfirmOmarchyPanel(t, true, nil)
+		env.stateDir = stateDir
+
+		step := omarchySetup{env: env}.installBarPlugin()
+		if step.Status != "skipped" || step.attempted {
+			t.Errorf("stateDir %q: ensure = %q", stateDir, step.Status)
+		}
+		force := omarchySetup{env: env, forcePlugin: true}.installBarPlugin()
+		if force.failure == nil {
+			t.Errorf("stateDir %q: force must fail", stateDir)
+		}
+		if len(*ran) != 0 {
+			t.Errorf("stateDir %q: nothing may run: %v", stateDir, *ran)
+		}
+	}
+}
+
+func TestOmarchyPluginMalformedMarkerFailsClosed(t *testing.T) {
+	env, ran, _ := testOmarchyEnvScripted(t, nil)
+	confirms := stubConfirmOmarchyPanel(t, true, nil)
+	if err := os.MkdirAll(filepath.Dir(env.markerPath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(env.markerPath(), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, force := range []bool{false, true} {
+		step := omarchySetup{env: env, forcePlugin: force}.installBarPlugin()
+		if step.Status != "failed" || !strings.Contains(step.Detail, "state unreadable") || !strings.Contains(step.Detail, "hey setup omarchy") {
+			t.Errorf("force=%v: %q %q", force, step.Status, step.Detail)
+		}
+	}
+	if *confirms != 0 || len(*ran) != 0 {
+		t.Errorf("fail closed means no prompt and no command: %d %v", *confirms, *ran)
+	}
+	if markerBytes(t, env) != "{not json" {
+		t.Error("the marker must be left as evidence")
+	}
+
+	// --remove is the exception: it still disables, leaves the marker, and
+	// fails with the repair hint.
+	writeShell(t, env, pluginShellJSON)
+	step := omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(true)
+	if step.Status != "failed" || !strings.Contains(step.Detail, "state unreadable") {
+		t.Fatalf("remove with a bad marker = %q %q", step.Status, step.Detail)
+	}
+	if !contains(*ran, "omarchy plugin disable "+omarchyBarPluginID) {
+		t.Errorf("remove must still disable: %v", *ran)
+	}
+	if markerBytes(t, env) != "{not json" {
+		t.Error("remove must leave the malformed marker untouched")
+	}
+}
+
+// --- Force mode ---
+
+func TestOmarchyPluginForceClearsSuppressionsBeforeActing(t *testing.T) {
+	env, _ := testOmarchyEnv(t)
+	clonePluginCheckout(t, env)
+	seedMarker(t, env, omarchyPluginMarker{DeclinedAt: "2026-08-01T00:00:00Z", RemovedAt: "2026-08-02T00:00:00Z", LastCloneAt: "2026-08-03T00:00:00Z", LastCloneError: "boom"})
+	sawIntent := false
+	enabled := false
+	env.run = func(name string, args ...string) (string, error) {
+		command := strings.Join(append([]string{name}, args...), " ")
+		switch {
+		case strings.HasPrefix(command, "omarchy plugin list"):
+			if enabled {
+				return pluginListEnabled, nil
+			}
+			return pluginListDisabled, nil
+		case command == "omarchy plugin enable "+omarchyBarPluginID:
+			marker, _ := readMarkerFile(t, env)
+			sawIntent = marker.PendingEnable && marker.DeclinedAt == "" && marker.RemovedAt == "" && marker.LastCloneAt == ""
+			enabled = true
+			return "", nil
+		default:
+			return "", nil
+		}
+	}
+
+	step := omarchySetup{env: env, forcePlugin: true}.installBarPlugin()
+	if step.Status != "installed" {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
+	}
+	if !sawIntent {
+		t.Error("the intent write, suppressions cleared, must precede the enable")
+	}
+	marker, _ := readMarkerFile(t, env)
+	if marker.PendingEnable || marker.InstalledAt == "" || marker.DeclinedAt != "" || marker.RemovedAt != "" {
+		t.Errorf("marker = %+v", marker)
+	}
+}
+
+func TestOmarchyPluginForceWithThePluginAlreadyEnabled(t *testing.T) {
+	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListEnabled},
+	})
+	clonePluginCheckout(t, env)
+
+	step := omarchySetup{env: env, forcePlugin: true}.installBarPlugin()
+	if step.Status != "unchanged" || step.failure != nil {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
+	}
+	if got := mutationCommands(*ran); len(got) != 0 {
+		t.Errorf("no mutation for an enabled plugin: %v", got)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if marker.PendingEnable || marker.InstalledAt == "" {
+		t.Errorf("marker = %+v", marker)
+	}
+}
+
+// --- Removal ---
+
+func TestOmarchyPluginRemoveTombstoneFirst(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write anywhere")
+	}
+	env, ran, replies := testOmarchyEnvScripted(t, nil)
+	clonePluginCheckout(t, env)
+	seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-01T00:00:00Z", InstalledAt: "2026-08-01T00:00:00Z"})
+	stateDir := filepath.Dir(env.markerPath())
+	if err := os.WriteFile(env.lockPath(), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// An unrecordable removal runs nothing.
+	if err := os.Chmod(stateDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o700) })
+	step := omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(true)
+	if step.Status != "failed" || !strings.Contains(step.Detail, "could not record the removal") {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
+	}
+	if len(*ran) != 0 {
+		t.Errorf("tombstone first: %v", *ran)
+	}
+	if err := os.Chmod(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// A failed disable keeps the tombstone and fails.
+	replies["omarchy plugin disable"] = omarchyReply{out: "no shell", err: errors.New("exit status 1")}
+	step = omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(true)
+	if step.Status != "failed" {
+		t.Fatalf("failed disable = %q %q", step.Status, step.Detail)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if marker.RemovedAt == "" {
+		t.Errorf("the tombstone stands: %+v", marker)
+	}
+
+	// A clean disable reports removed and keeps the checkout.
+	replies["omarchy plugin disable"] = omarchyReply{}
+	step = omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(true)
+	if step.Status != "removed" || !strings.Contains(step.Detail, "checkout stays") {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
+	}
+	if _, err := os.Stat(filepath.Join(env.pluginDir(), "manifest.json")); err != nil {
+		t.Error("the checkout must survive removal")
+	}
+
+	// Off the bar: nothing to disable, tombstone still written.
+	countBefore := len(*ran)
+	step = omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(false)
+	if step.Status != "absent" || len(*ran) != countBefore {
+		t.Errorf("off-bar remove = %q, ran %v", step.Status, (*ran)[countBefore:])
+	}
+}
+
+// --- The sign-in hook ---
+
+func TestEnsureOmarchyBarPluginAfterLogin(t *testing.T) {
+	t.Setenv("OMARCHY_PATH", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	stubConfirmOmarchyPanel(t, true, nil)
+	enabled := false
+	ran := stubOmarchyRun(t, func(name string, args ...string) (string, error) {
+		command := strings.Join(append([]string{name}, args...), " ")
+		switch {
+		case strings.HasPrefix(command, "omarchy plugin list"):
+			if enabled {
+				return pluginListEnabled, nil
+			}
+			return pluginListAbsent, nil
+		case strings.HasPrefix(command, "omarchy plugin add"):
+			enabled = true
+			shellDir := filepath.Join(home, ".config", "omarchy")
+			if err := os.MkdirAll(shellDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(shellDir, "shell.json"), []byte(pluginShellJSON), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			return "Installed", nil
+		default:
+			return "", nil
+		}
+	})
+	prev := writer
+	t.Cleanup(func() { writer = prev })
+	var out bytes.Buffer
+
+	// Machine output never runs the hook's body.
+	writer = output.New(output.Options{Format: output.FormatJSON, Stdout: &out, Stderr: &out})
+	stubInteractive(t, true)
+	ensureOmarchyBarPluginAfterLogin(&out)
+	if len(*ran) != 0 || out.Len() != 0 {
+		t.Fatalf("machine output must be inert: %v %q", *ran, out.String())
+	}
+
+	// Non-interactive stdio never runs it either.
+	writer = output.New(output.Options{Format: output.FormatStyled, Stdout: &out, Stderr: &out})
+	stubInteractive(t, false)
+	ensureOmarchyBarPluginAfterLogin(&out)
+	if len(*ran) != 0 || out.Len() != 0 {
+		t.Fatalf("non-interactive must be inert: %v %q", *ran, out.String())
+	}
+
+	// Styled and interactive: installed and announced, one line.
+	stubInteractive(t, true)
+	ensureOmarchyBarPluginAfterLogin(&out)
+	if got := strings.TrimSpace(out.String()); got != "HEY is in your Omarchy bar now." {
+		t.Fatalf("hook output = %q", got)
+	}
+
+	// The next sign-in is silent — the work is done.
+	out.Reset()
+	countBefore := len(*ran)
+	ensureOmarchyBarPluginAfterLogin(&out)
+	if out.Len() != 0 {
+		t.Errorf("second login output = %q", out.String())
+	}
+	if got := mutationCommands((*ran)[countBefore:]); len(got) != 0 {
+		t.Errorf("second login mutations = %v", got)
+	}
+}
+
+func TestLoginTokenAndCookieNeverRunTheOmarchyHook(t *testing.T) {
+	hookCalls := stubOmarchyAfterLogin(t)
+	server := quietServer(t)
+	configHome := t.TempDir()
+
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", true, "auth", "login", "--cookie", "session-cookie"); err != nil {
+		t.Fatalf("cookie login: %v", err)
+	}
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", true, "auth", "login", "--token", "stored-token"); err != nil {
+		t.Fatalf("token login: %v", err)
+	}
+	if *hookCalls != 0 {
+		t.Errorf("hook ran %d times for token/cookie logins", *hookCalls)
+	}
+}
+
+func TestRequireAuthRunsTheOmarchyHookAfterSignIn(t *testing.T) {
+	isolateAgents(t)
+	server := quietServer(t)
+	t.Setenv("HEY_TOKEN", "")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home)
+
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"--base-url", server.URL, "auth", "status"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("prime globals: %v", err)
+	}
+
+	stubInteractive(t, true)
+	stubAskToSignIn(t, true)
+	logins := stubLoginInteractively(t, nil)
+	hookCalls := stubOmarchyAfterLogin(t)
+	prev := writer
+	writer = output.New(output.Options{Format: output.FormatStyled, Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
+	t.Cleanup(func() { writer = prev })
+
+	if err := requireAuth(); err != nil {
+		t.Fatalf("requireAuth: %v", err)
+	}
+	if *logins != 1 || *hookCalls != 1 {
+		t.Errorf("logins=%d hook=%d, want 1/1", *logins, *hookCalls)
+	}
+}
+
+// --- The wizard ---
+
+func TestLiteWizardRunsTheOmarchyHookOnceAndFullDoesNot(t *testing.T) {
+	isolateAgents(t)
+	stubInteractive(t, true)
+	stubStdinTerminal(t, true)
+	logins := stubLoginInteractively(t, nil)
+	hookCalls := stubOmarchyAfterLogin(t)
+	server := quietServer(t)
+	configHome := t.TempDir()
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", true, "config", "set", "onboarded", "true"); err != nil {
+		t.Fatalf("config set: %v", err)
+	}
+
+	// Lite: a logged-out bare `hey`, onboarded, signs in and hooks once.
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", false); err != nil {
+		t.Fatalf("bare hey: %v", err)
+	}
+	if *logins != 1 || *hookCalls != 1 {
+		t.Errorf("lite: logins=%d hook=%d, want 1/1", *logins, *hookCalls)
+	}
+
+	// Full: the wizard owns Step 3 and never fires the login hook.
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", true, "setup"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if *hookCalls != 1 {
+		t.Errorf("the full wizard must not double-fire the hook: %d", *hookCalls)
+	}
+}
+
+func TestSetupWizardStep3InstallsThePlugin(t *testing.T) {
+	isolateAgents(t)
+	stubInteractive(t, true)
+	confirms := stubConfirmOmarchyPanel(t, true, nil)
+	server := identityServer(t)
+	configHome := t.TempDir()
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", true, "auth", "login", "--cookie", "session-cookie"); err != nil {
+		t.Fatalf("auth login: %v", err)
+	}
+	origColor := colorDisabled
+	colorDisabled = true
+	t.Cleanup(func() { colorDisabled = origColor })
+
+	enabled := false
+	stubOmarchyRun(t, func(name string, args ...string) (string, error) {
+		command := strings.Join(append([]string{name}, args...), " ")
+		switch {
+		case name != "omarchy":
+			return "", exec.ErrNotFound
+		case strings.HasPrefix(command, "omarchy plugin list"):
+			if enabled {
+				return pluginListEnabled, nil
+			}
+			return pluginListAbsent, nil
+		case strings.HasPrefix(command, "omarchy plugin add"):
+			enabled = true
+			return "Installed", nil
+		default:
+			return "", nil
+		}
+	})
+	t.Setenv("OMARCHY_PATH", t.TempDir())
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	root.SetArgs([]string{"--base-url", server.URL, "setup", "--styled"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("setup: %v\n%s", err, stdout.String())
+	}
+	text := stdout.String()
+	for _, want := range []string{"Step 3: Omarchy desktop", "HEY is in your Omarchy bar", "✓ Omarchy desktop", "Setup complete!"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("missing %q:\n%s", want, text)
+		}
+	}
+	if *confirms != 1 {
+		t.Errorf("consent asked %d times, want 1", *confirms)
+	}
+}
+
+func TestSetupWizardMachineRunSkipsOmarchyAndPointsAtSetup(t *testing.T) {
+	isolateAgents(t)
+	server := identityServer(t)
+	configHome := t.TempDir()
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", true, "auth", "login", "--cookie", "session-cookie"); err != nil {
+		t.Fatalf("auth login: %v", err)
+	}
+	ran := stubOmarchyRun(t, omarchyUnavailable)
+	confirms := stubConfirmOmarchyPanel(t, true, nil)
+
+	// Roll our own run so OMARCHY_PATH stays set (runAuthCommand isolates it).
+	t.Setenv("HEY_TOKEN", "")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("HOME", configHome)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_STATE_HOME", configHome)
+	t.Setenv("XDG_CACHE_HOME", configHome)
+	t.Setenv("OMARCHY_PATH", t.TempDir())
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	root.SetArgs([]string{"--base-url", server.URL, "--json", "setup"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("setup --json: %v", err)
+	}
+	var response output.Response
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("decode: %v\n%s", err, stdout.String())
+	}
+	data := wizardData(t, response)
+	if _, has := data["omarchy"]; has {
+		t.Errorf("a machine run must not touch the desktop: %v", data["omarchy"])
+	}
+	if len(*ran) != 0 || *confirms != 0 {
+		t.Errorf("a machine run must be inert: %v %d", *ran, *confirms)
+	}
+	found := false
+	for _, crumb := range response.Breadcrumbs {
+		if crumb.Command == "hey setup omarchy" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the envelope must point at hey setup omarchy: %+v", response.Breadcrumbs)
+	}
+}
+
+func TestSetupWizardStep3CloneFailureIsIncomplete(t *testing.T) {
+	isolateAgents(t)
+	stubInteractive(t, true)
+	stubConfirmOmarchyPanel(t, true, nil)
+	server := identityServer(t)
+	configHome := t.TempDir()
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", true, "auth", "login", "--cookie", "session-cookie"); err != nil {
+		t.Fatalf("auth login: %v", err)
+	}
+	origColor := colorDisabled
+	colorDisabled = true
+	t.Cleanup(func() { colorDisabled = origColor })
+
+	stubOmarchyRun(t, func(name string, args ...string) (string, error) {
+		command := strings.Join(append([]string{name}, args...), " ")
+		switch {
+		case name != "omarchy":
+			return "", exec.ErrNotFound
+		case strings.HasPrefix(command, "omarchy plugin list"):
+			return pluginListAbsent, nil
+		case strings.HasPrefix(command, "omarchy plugin add"):
+			return "failed to clone " + omarchyBarPluginSource, errors.New("exit status 1")
+		default:
+			return "", nil
+		}
+	})
+	t.Setenv("OMARCHY_PATH", t.TempDir())
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	root.SetArgs([]string{"--base-url", server.URL, "setup", "--styled"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("setup: %v\n%s", err, stdout.String())
+	}
+	text := stdout.String()
+	if !strings.Contains(text, "needs attention") || !strings.Contains(text, "hey setup omarchy") {
+		t.Errorf("a clone failure must leave the wizard incomplete with the remediation:\n%s", text)
+	}
+}
+
+// --- hey setup omarchy, command level ---
+
+func TestSetupOmarchyJSONInstallsThePlugin(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("OMARCHY_PATH", t.TempDir())
+	enabled := false
+	ran := stubOmarchyRun(t, func(name string, args ...string) (string, error) {
+		command := strings.Join(append([]string{name}, args...), " ")
+		switch {
+		case name != "omarchy":
+			return "", exec.ErrNotFound
+		case strings.HasPrefix(command, "omarchy plugin list"):
+			if enabled {
+				return pluginListEnabled, nil
+			}
+			return pluginListAbsent, nil
+		case strings.HasPrefix(command, "omarchy plugin add"):
+			enabled = true
+			return "Installed", nil
+		default:
+			return "", nil
+		}
+	})
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	root.SetArgs([]string{"setup", "omarchy", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("explicit --json setup must install: %v\n%s", err, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "installed and enabled") {
+		t.Errorf("steps = %s", stdout.String())
+	}
+	found := false
+	for _, command := range *ran {
+		if strings.HasPrefix(command, "omarchy plugin add") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the plugin must actually be added: %v", *ran)
+	}
+}
+
+func TestSetupOmarchyForceFailsLoudWhenTheShellIsDown(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("OMARCHY_PATH", t.TempDir())
+	stubOmarchyRun(t, func(name string, args ...string) (string, error) {
+		if name == "omarchy" {
+			return "omarchy-shell is not running (run from the desktop)", errors.New("exit status 1")
+		}
+		return "", exec.ErrNotFound
+	})
+
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"setup", "omarchy", "--json"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("a forced install with no shell must fail")
+	}
+	typed := apierr.AsError(err)
+	if typed.Code != "setup_failed" || !strings.Contains(typed.Message, "shell is not running") {
+		t.Fatalf("err = %v", err)
+	}
+	marker, _, readErr := readOmarchyPluginMarker(filepath.Join(stateHome, "hey-cli", "omarchy", "bar-plugin.json"))
+	if readErr != nil || !marker.PendingEnable {
+		t.Errorf("the intent must be durable for the next explicit setup: %+v %v", marker, readErr)
+	}
+}
+
+func TestSetupOmarchyForceLockContentionFailsWithoutStateClaims(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("OMARCHY_PATH", t.TempDir())
+	var omarchyCalls []string
+	stubOmarchyRun(t, func(name string, args ...string) (string, error) {
+		if name == "omarchy" {
+			omarchyCalls = append(omarchyCalls, strings.Join(args, " "))
+		}
+		return "", exec.ErrNotFound
+	})
+	lockPath := filepath.Join(stateHome, "hey-cli", "omarchy", "bar-plugin.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lock := flock.New(lockPath)
+	locked, err := lock.TryLock()
+	if err != nil || !locked {
+		t.Fatalf("take the lock: %v %v", locked, err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"setup", "omarchy", "--json"})
+	execErr := root.Execute()
+	if execErr == nil {
+		t.Fatal("contention must fail a forced install")
+	}
+	typed := apierr.AsError(execErr)
+	if typed.Code != "setup_failed" || !strings.Contains(typed.Message, "another hey") {
+		t.Fatalf("err = %v", execErr)
+	}
+	if len(omarchyCalls) != 0 {
+		t.Errorf("no omarchy subprocess under contention: %v", omarchyCalls)
+	}
+	if _, statErr := os.Stat(filepath.Join(stateHome, "hey-cli", "omarchy", "bar-plugin.json")); !os.IsNotExist(statErr) {
+		t.Error("no pending claim may be written under contention")
+	}
+}
+
+// --- doctor ---
+
+func TestDoctorOmarchyBarPluginStates(t *testing.T) {
+	env := omarchyEnv{home: t.TempDir(), omarchyPath: t.TempDir(), stateDir: t.TempDir()}
+
+	check := checkOmarchyBarPlugin(env)
+	if check["status"] != "warning" || check["message"] != "Not installed" {
+		t.Errorf("fresh: %v", check)
+	}
+
+	seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-01T00:00:00Z", PendingEnable: true})
+	if check := checkOmarchyBarPlugin(env); check["status"] != "warning" || !strings.Contains(check["message"], "pending") {
+		t.Errorf("pending: %v", check)
+	}
+
+	seedMarker(t, env, omarchyPluginMarker{DeclinedAt: "2026-08-01T00:00:00Z"})
+	if check := checkOmarchyBarPlugin(env); check["status"] != "info" || !strings.Contains(check["message"], "Declined") {
+		t.Errorf("declined: %v", check)
+	}
+
+	seedMarker(t, env, omarchyPluginMarker{RemovedAt: "2026-08-01T00:00:00Z"})
+	if check := checkOmarchyBarPlugin(env); check["status"] != "info" || !strings.Contains(check["message"], "Removed") {
+		t.Errorf("removed: %v", check)
+	}
+
+	seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-01T00:00:00Z", InstalledAt: "2026-08-01T00:00:00Z"})
+	clonePluginCheckout(t, env)
+	if check := checkOmarchyBarPlugin(env); check["status"] != "warning" || !strings.Contains(check["message"], "not on the bar") {
+		t.Errorf("cloned off-bar: %v", check)
+	}
+
+	writeShell(t, env, pluginShellJSON)
+	if check := checkOmarchyBarPlugin(env); check["status"] != "ok" || check["message"] != "Installed and enabled" {
+		t.Errorf("enabled: %v", check)
+	}
+
+	if err := os.WriteFile(env.markerPath(), []byte("{bad"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if check := checkOmarchyBarPlugin(env); check["status"] != "error" || !strings.Contains(check["message"], "unreadable") {
+		t.Errorf("unreadable: %v", check)
+	}
+}
+
+func TestDoctorOmarchyCheckOnlyWhenDetected(t *testing.T) {
+	stubCompletionEnv(t, testCompletionEnv(t, "bash"))
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("OMARCHY_PATH", "")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	hasCheck := func() bool {
+		for _, check := range runDoctorChecks(context.Background(), newRootCmd()) {
+			if check["name"] == "Omarchy Bar Plugin" {
+				return true
+			}
+		}
+		return false
+	}
+	if hasCheck() {
+		t.Error("the check must not appear off Omarchy")
+	}
+	t.Setenv("OMARCHY_PATH", t.TempDir())
+	if !hasCheck() {
+		t.Error("the check must appear on Omarchy")
+	}
+}

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -447,14 +447,20 @@ func TestOmarchyPluginEnsureMissingCLISaysUpdateOmarchy(t *testing.T) {
 }
 
 func TestOmarchyPluginProbeFailsClosedOnAnUnexpectedAnswer(t *testing.T) {
-	env, _, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
-		"omarchy plugin list": {out: "I am not JSON"},
-	})
-	stubConfirmOmarchyPanel(t, true, nil)
+	for _, reply := range []omarchyReply{
+		{out: "I am not JSON"},
+		{out: "null"}, // unmarshals into a nil slice without error — still not a list
+		{out: "[]", err: errors.New("exit status 1")}, // a failing command whose output happens to parse
+	} {
+		env, _, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+			"omarchy plugin list": reply,
+		})
+		stubConfirmOmarchyPanel(t, true, nil)
 
-	step := omarchySetup{env: env}.installBarPlugin()
-	if step.Status != "failed" || !strings.Contains(step.Detail, "unexpected answer") {
-		t.Fatalf("step = %q %q", step.Status, step.Detail)
+		step := omarchySetup{env: env}.installBarPlugin()
+		if step.Status != "failed" || !strings.Contains(step.Detail, "unexpected answer") {
+			t.Fatalf("reply %q/%v: step = %q %q", reply.out, reply.err, step.Status, step.Detail)
+		}
 	}
 }
 
@@ -695,11 +701,68 @@ func TestOmarchyPluginRemoveTombstoneFirst(t *testing.T) {
 		t.Error("the checkout must survive removal")
 	}
 
-	// Off the bar: nothing to disable, tombstone still written.
+	// Off the bar and not enabled per the shell: nothing to disable,
+	// tombstone still written; the probe is the only command that runs.
 	countBefore := len(*ran)
 	step = omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(false)
-	if step.Status != "absent" || len(*ran) != countBefore {
-		t.Errorf("off-bar remove = %q, ran %v", step.Status, (*ran)[countBefore:])
+	if step.Status != "absent" {
+		t.Errorf("off-bar remove = %q %q", step.Status, step.Detail)
+	}
+	if got := mutationCommands((*ran)[countBefore:]); len(got) != 0 {
+		t.Errorf("nothing to disable for an absent plugin: %v", got)
+	}
+}
+
+func TestOmarchyPluginRemoveDisablesAnEnabledPluginWithoutALayoutEntry(t *testing.T) {
+	// An enabled plugin needs no spelled-out shell.json entry, and an
+	// unreadable shell.json reads the same way: the shell, not the layout,
+	// says whether there is something to disable.
+	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListEnabled},
+	})
+	step := omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(false)
+	if step.Status != "removed" || !strings.Contains(step.Detail, "checkout stays") {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
+	}
+	if !contains(*ran, "omarchy plugin disable "+omarchyBarPluginID) {
+		t.Errorf("the enabled plugin must be disabled: %v", *ran)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if marker.RemovedAt == "" {
+		t.Errorf("tombstone first: %+v", marker)
+	}
+}
+
+func TestOmarchyPluginRemoveFailsWhenTheShellCannotAnswer(t *testing.T) {
+	// With the shell down we can neither see nor disable an enabled plugin:
+	// the tombstone stands, and the command fails rather than reporting a
+	// removal that did not happen.
+	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: "omarchy-shell is not running", err: errors.New("exit status 1")},
+	})
+	step := omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(false)
+	if step.Status != "failed" || !strings.Contains(step.Detail, "shell is not running") {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if marker.RemovedAt == "" {
+		t.Errorf("the tombstone must land before the probe: %+v", marker)
+	}
+	if got := mutationCommands(*ran); len(got) != 0 {
+		t.Errorf("no mutation with no shell: %v", got)
+	}
+}
+
+func TestOmarchyPluginLockFailureIsNotContention(t *testing.T) {
+	env, _, _ := testOmarchyEnvScripted(t, nil)
+	// A file where the lock's directory must go: acquisition fails for a
+	// reason waiting cannot fix, and the message must say so.
+	if err := os.WriteFile(filepath.Join(env.stateDir, "omarchy"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	step := omarchySetup{env: env, forcePlugin: true}.installBarPlugin()
+	if step.failure == nil || !strings.Contains(step.Detail, "could not take the bar plugin lock") || strings.Contains(step.Detail, "another hey") {
+		t.Fatalf("step = %q %q", step.Status, step.Detail)
 	}
 }
 
@@ -993,6 +1056,9 @@ func TestSetupWizardStep3CloneFailureIsIncomplete(t *testing.T) {
 	if !strings.Contains(text, "needs attention") || !strings.Contains(text, "hey setup omarchy") {
 		t.Errorf("a clone failure must leave the wizard incomplete with the remediation:\n%s", text)
 	}
+	if !strings.Contains(text, "✗ Omarchy desktop") {
+		t.Errorf("the checklist must not contradict the issue list:\n%s", text)
+	}
 }
 
 // --- hey setup omarchy, command level ---
@@ -1159,6 +1225,12 @@ func TestDoctorOmarchyBarPluginStates(t *testing.T) {
 	writeShell(t, env, pluginShellJSON)
 	if check := checkOmarchyBarPlugin(env); check["status"] != "ok" || check["message"] != "Installed and enabled" {
 		t.Errorf("enabled: %v", check)
+	}
+
+	// A historical decline or removal does not outrank the present tense.
+	seedMarker(t, env, omarchyPluginMarker{DeclinedAt: "2026-08-01T00:00:00Z"})
+	if check := checkOmarchyBarPlugin(env); check["status"] != "ok" {
+		t.Errorf("an enabled plugin outranks a historical decline: %v", check)
 	}
 
 	if err := os.WriteFile(env.markerPath(), []byte("{bad"), 0o600); err != nil {

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -603,13 +603,17 @@ func TestOmarchyPluginMalformedMarkerFailsClosed(t *testing.T) {
 
 func TestOmarchyPluginSignInInstallMigratesTheLegacyIndicator(t *testing.T) {
 	// A migrating user signs in: the new plugin lands and the inline
-	// hey-unread module leaves with it — never two icons and two pollers.
+	// hey-unread module leaves with it — never two icons and two pollers —
+	// and its toast choice survives even with no layout entry to hold it.
 	env, _ := testOmarchyEnv(t)
 	stubConfirmOmarchyPanel(t, true, nil)
 	writeShell(t, env, legacyShellJSON)
+	var ran []string
 	enabled := false
+	barSetFails := false
 	env.run = func(name string, args ...string) (string, error) {
 		command := strings.Join(append([]string{name}, args...), " ")
+		ran = append(ran, command)
 		switch {
 		case strings.HasPrefix(command, "omarchy plugin list"):
 			if enabled {
@@ -619,6 +623,8 @@ func TestOmarchyPluginSignInInstallMigratesTheLegacyIndicator(t *testing.T) {
 		case strings.HasPrefix(command, "omarchy plugin add"):
 			enabled = true
 			return "Installed", nil
+		case strings.HasPrefix(command, "omarchy bar set") && barSetFails:
+			return "no shell", errors.New("exit status 1")
 		default:
 			return "", nil
 		}
@@ -630,6 +636,40 @@ func TestOmarchyPluginSignInInstallMigratesTheLegacyIndicator(t *testing.T) {
 	}
 	if strings.Contains(readText(t, env.shellPath()), "hey-unread") {
 		t.Error("a sign-in install must take the legacy indicator out")
+	}
+	// legacyShellJSON's module was toasting and no entry holds the key: the
+	// CLI materializes it.
+	if !contains(ran, "omarchy bar set "+omarchyBarPluginID+" notify true --json") {
+		t.Errorf("the toast choice must survive the migration: %v", ran)
+	}
+
+	// When the choice cannot land, the toasting module stays for the next
+	// explicit setup rather than the preference dying with it.
+	env2, _ := testOmarchyEnv(t)
+	writeShell(t, env2, legacyShellJSON)
+	enabledTwo := false
+	env2.run = func(name string, args ...string) (string, error) {
+		command := strings.Join(append([]string{name}, args...), " ")
+		switch {
+		case strings.HasPrefix(command, "omarchy plugin list"):
+			if enabledTwo {
+				return pluginListEnabled, nil
+			}
+			return pluginListAbsent, nil
+		case strings.HasPrefix(command, "omarchy plugin add"):
+			enabledTwo = true
+			return "Installed", nil
+		case strings.HasPrefix(command, "omarchy bar set"):
+			return "no shell", errors.New("exit status 1")
+		default:
+			return "", nil
+		}
+	}
+	if step := (omarchySetup{env: env2}).installBarPlugin(); step.Status != "installed" {
+		t.Fatalf("second install = %q %q", step.Status, step.Detail)
+	}
+	if !strings.Contains(readText(t, env2.shellPath()), "hey-unread") {
+		t.Error("an uncarried toast choice must keep the legacy module")
 	}
 }
 

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -1191,6 +1191,75 @@ func TestSetupOmarchyForceLockContentionFailsWithoutStateClaims(t *testing.T) {
 	}
 }
 
+func TestSetupOmarchyNotifyWithoutALayoutEntryUsesBarSet(t *testing.T) {
+	// An enabled plugin needs no spelled-out shell.json entry; --notify must
+	// still land, and seeding a partial layout would override the shell's
+	// defaults — the omarchy CLI materializes the setting instead.
+	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListEnabled},
+	})
+	clonePluginCheckout(t, env)
+	on := true
+
+	bar := stepNamed(omarchySetup{env: env, forcePlugin: true, notify: &on}.apply(), "bar plugin")
+	if bar.Status != "installed" || !strings.Contains(bar.Detail, "notifications on") {
+		t.Fatalf("bar = %q %q", bar.Status, bar.Detail)
+	}
+	if !contains(*ran, "omarchy bar set "+omarchyBarPluginID+" notify true --json") {
+		t.Errorf("the setting must be materialized by the CLI: %v", *ran)
+	}
+
+	// --no-notify with no entry is already off: nothing to write or run.
+	off := false
+	countBefore := len(*ran)
+	bar = stepNamed(omarchySetup{env: env, forcePlugin: true, notify: &off}.apply(), "bar plugin")
+	if bar.Status == "failed" {
+		t.Fatalf("bar = %q %q", bar.Status, bar.Detail)
+	}
+	for _, command := range (*ran)[countBefore:] {
+		if strings.HasPrefix(command, "omarchy bar set") {
+			t.Errorf("no key exists to turn off: %v", command)
+		}
+	}
+}
+
+func TestSetupWizardLoggedOutMachineRunStillPointsAtOmarchySetup(t *testing.T) {
+	// Logged out on Omarchy, the automatic hook can never run — the machine
+	// envelope must carry the explicit command alongside the login crumb.
+	isolateAgents(t)
+	server := quietServer(t)
+	stubOmarchyRun(t, omarchyUnavailable)
+	t.Setenv("HEY_TOKEN", "")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	configHome := t.TempDir()
+	t.Setenv("HOME", configHome)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_STATE_HOME", configHome)
+	t.Setenv("XDG_CACHE_HOME", configHome)
+	t.Setenv("OMARCHY_PATH", t.TempDir())
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	root.SetArgs([]string{"--base-url", server.URL, "--json", "setup"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("setup --json: %v", err)
+	}
+	var response output.Response
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("decode: %v\n%s", err, stdout.String())
+	}
+	commands := make([]string, 0, len(response.Breadcrumbs))
+	for _, crumb := range response.Breadcrumbs {
+		commands = append(commands, crumb.Command)
+	}
+	if !contains(commands, "hey auth login") || !contains(commands, "hey setup omarchy") {
+		t.Errorf("breadcrumbs = %v, want both the login and the omarchy remediation", commands)
+	}
+}
+
 // --- doctor ---
 
 func TestDoctorOmarchyBarPluginStates(t *testing.T) {
@@ -1218,8 +1287,8 @@ func TestDoctorOmarchyBarPluginStates(t *testing.T) {
 
 	seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-01T00:00:00Z", InstalledAt: "2026-08-01T00:00:00Z"})
 	clonePluginCheckout(t, env)
-	if check := checkOmarchyBarPlugin(env); check["status"] != "warning" || !strings.Contains(check["message"], "not on the bar") {
-		t.Errorf("cloned off-bar: %v", check)
+	if check := checkOmarchyBarPlugin(env); check["status"] != "warning" || !strings.Contains(check["message"], "not in the configured bar layout") {
+		t.Errorf("cloned off-layout: %v", check)
 	}
 
 	writeShell(t, env, pluginShellJSON)

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -404,6 +404,33 @@ func TestOmarchyRemoveKeepsLegacyWhenTheTombstoneCannotLand(t *testing.T) {
 	}
 }
 
+func TestOmarchyPluginEnsureMigratesBesideAManuallyClonedEnabledPlugin(t *testing.T) {
+	// Someone installed the plugin by hand (cloned, enabled, no marker) and
+	// the old hey-unread module is still there: the row stays a quiet skip
+	// — nothing recorded over someone else's install — but a verifiably
+	// live replacement still owes the migration.
+	env, ran, replies := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListEnabled},
+	})
+	clonePluginCheckout(t, env)
+	writeShell(t, env, legacyShellJSON)
+	replies["omarchy bar set"] = omarchyReply{}
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "skipped" || step.attempted {
+		t.Fatalf("the cloned row stays a quiet skip, got %q %q attempted=%v", step.Status, step.Detail, step.attempted)
+	}
+	if strings.Contains(readText(t, env.shellPath()), "hey-unread") {
+		t.Error("a live replacement owes the migration, whatever row decided")
+	}
+	if !contains(*ran, "omarchy bar set "+omarchyBarPluginID+" notify true --json") {
+		t.Errorf("the toast choice must ride along: %v", *ran)
+	}
+	if _, exists := readMarkerFile(t, env); exists {
+		t.Error("nothing may be recorded over someone else's install")
+	}
+}
+
 func TestOmarchyPluginCrashRepairMigratesTheLegacyIndicator(t *testing.T) {
 	// A first sign-in that crashed after the enable: the quiet self-repair
 	// still owes the migration, or a legacy user keeps two icons forever.

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -282,6 +282,29 @@ func TestOmarchyPluginEnsureNeverResurrectsADisabledPlugin(t *testing.T) {
 	}
 }
 
+func TestOmarchyPluginEnsurePendingClonedFinalizesWhenTheShellSaysEnabled(t *testing.T) {
+	// An enable that succeeded without a layout entry, crashed before the
+	// final write: the checkout and the pending marker both exist, and the
+	// read-only probe self-repairs the bookkeeping without enabling a thing.
+	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListEnabled},
+	})
+	clonePluginCheckout(t, env)
+	seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-24T00:00:00Z", PendingEnable: true})
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "unchanged" || step.attempted {
+		t.Fatalf("self-repair should be quiet, got %q %q attempted=%v", step.Status, step.Detail, step.attempted)
+	}
+	marker, _ := readMarkerFile(t, env)
+	if marker.PendingEnable || marker.InstalledAt == "" {
+		t.Errorf("marker = %+v", marker)
+	}
+	if got := mutationCommands(*ran); len(got) != 0 {
+		t.Errorf("the repair is read-only: %v", got)
+	}
+}
+
 func TestOmarchyPluginEnsureFinishesTheMarkerAfterACrash(t *testing.T) {
 	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
 		"omarchy plugin list": {out: pluginListEnabled},
@@ -623,7 +646,14 @@ func TestOmarchyPluginSignInInstallMigratesTheLegacyIndicator(t *testing.T) {
 		case strings.HasPrefix(command, "omarchy plugin add"):
 			enabled = true
 			return "Installed", nil
-		case strings.HasPrefix(command, "omarchy bar set") && barSetFails:
+		case strings.HasPrefix(command, "omarchy bar set") && !barSetFails:
+			// The CLI materializes the entry by rewriting shell.json, the
+			// legacy module still in place.
+			writeShell(t, env, `{"version":1,"bar":{"layout":{"left":[{"id":"omarchy.menu"}],"center":[{"id":"omarchy.clock"}],"right":[
+  {"id":"hey-unread","type":"command","exec":"hey omarchy bar-status --notify","interval":180},
+  {"id":"37signals.hey","notify":true},{"id":"omarchy.tray"},{"id":"omarchy.power"}]}}}`)
+			return "", nil
+		case strings.HasPrefix(command, "omarchy bar set"):
 			return "no shell", errors.New("exit status 1")
 		default:
 			return "", nil
@@ -638,9 +668,12 @@ func TestOmarchyPluginSignInInstallMigratesTheLegacyIndicator(t *testing.T) {
 		t.Error("a sign-in install must take the legacy indicator out")
 	}
 	// legacyShellJSON's module was toasting and no entry holds the key: the
-	// CLI materializes it.
+	// CLI materializes it — and the removal must not clobber what it wrote.
 	if !contains(ran, "omarchy bar set "+omarchyBarPluginID+" notify true --json") {
 		t.Errorf("the toast choice must survive the migration: %v", ran)
+	}
+	if entry := pluginEntry(t, env); entry == nil || entry["notify"] != true {
+		t.Errorf("the materialized entry must survive the legacy removal, got %v", entry)
 	}
 
 	// When the choice cannot land, the toasting module stays for the next

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -305,6 +305,51 @@ func TestOmarchyPluginEnsurePendingClonedFinalizesWhenTheShellSaysEnabled(t *tes
 	}
 }
 
+func TestOmarchyPluginCrashRepairMigratesTheLegacyIndicator(t *testing.T) {
+	// A first sign-in that crashed after the enable: the quiet self-repair
+	// still owes the migration, or a legacy user keeps two icons forever.
+	env, ran, replies := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListEnabled},
+	})
+	clonePluginCheckout(t, env)
+	writeShell(t, env, legacyShellJSON)
+	seedMarker(t, env, omarchyPluginMarker{AcceptedAt: "2026-08-24T00:00:00Z", PendingEnable: true})
+	replies["omarchy bar set"] = omarchyReply{}
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "unchanged" || step.attempted {
+		t.Fatalf("repair should stay quiet, got %q %q attempted=%v", step.Status, step.Detail, step.attempted)
+	}
+	if strings.Contains(readText(t, env.shellPath()), "hey-unread") {
+		t.Error("the crash repair must migrate the legacy indicator too")
+	}
+	if !contains(*ran, "omarchy bar set "+omarchyBarPluginID+" notify true --json") {
+		t.Errorf("the toast choice must ride along: %v", *ran)
+	}
+}
+
+func TestSetupOmarchyKeepsLegacyWhenTheCarryFails(t *testing.T) {
+	// The legacy module is the only copy of the toast choice: the explicit
+	// configure flow must not delete it while the carry has not landed.
+	env, _, replies := testOmarchyEnvScripted(t, map[string]omarchyReply{
+		"omarchy plugin list": {out: pluginListEnabled},
+	})
+	clonePluginCheckout(t, env)
+	writeShell(t, env, legacyShellJSON)
+	replies["omarchy bar set"] = omarchyReply{out: "no shell", err: errors.New("exit status 1")}
+
+	steps := omarchySetup{env: env, forcePlugin: true}.configureBarPlugin()
+	if bar := stepNamed(steps, "bar plugin"); bar.Status != "failed" {
+		t.Fatalf("a failed carry must fail the step, got %q %q", bar.Status, bar.Detail)
+	}
+	if stepNamed(steps, "bar indicator").Status == "removed" {
+		t.Error("the legacy module must survive a failed carry")
+	}
+	if !strings.Contains(readText(t, env.shellPath()), "hey-unread") {
+		t.Error("the toasting module is the only copy of the choice — it stays")
+	}
+}
+
 func TestOmarchyPluginEnsureFinishesTheMarkerAfterACrash(t *testing.T) {
 	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
 		"omarchy plugin list": {out: pluginListEnabled},
@@ -610,10 +655,11 @@ func TestOmarchyPluginMalformedMarkerFailsClosed(t *testing.T) {
 	}
 
 	// --remove is the exception: it still disables, leaves the marker, and
-	// fails with the repair hint.
+	// fails with a removal-shaped repair hint — a plain setup would
+	// re-enable what was just removed.
 	writeShell(t, env, pluginShellJSON)
 	step := omarchySetup{env: env, forcePlugin: true}.removeBarPluginLocked(true)
-	if step.Status != "failed" || !strings.Contains(step.Detail, "state unreadable") {
+	if step.Status != "failed" || !strings.Contains(step.Detail, "state unreadable") || !strings.Contains(step.Detail, "hey setup omarchy --remove") {
 		t.Fatalf("remove with a bad marker = %q %q", step.Status, step.Detail)
 	}
 	if !contains(*ran, "omarchy plugin disable "+omarchyBarPluginID) {

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -305,6 +305,30 @@ func TestOmarchyPluginEnsurePendingClonedFinalizesWhenTheShellSaysEnabled(t *tes
 	}
 }
 
+func TestOmarchyPluginEnsureOnBarMigratesTheLegacyIndicator(t *testing.T) {
+	// The plugin is already enabled (installed by hand, say) beside the old
+	// hey-unread module: a sign-in still migrates — the unchanged outcome
+	// means "on the bar", and the toast choice moves onto the entry.
+	env, ran, _ := testOmarchyEnvScripted(t, nil)
+	writeShell(t, env, `{"version":1,"bar":{"layout":{"left":[{"id":"omarchy.menu"}],"center":[],"right":[
+  {"id":"hey-unread","type":"command","exec":"hey omarchy bar-status --notify","interval":180},
+  {"id":"37signals.hey"},{"id":"omarchy.tray"}]}}}`)
+
+	step := omarchySetup{env: env}.installBarPlugin()
+	if step.Status != "unchanged" || step.attempted {
+		t.Fatalf("step = %q %q attempted=%v", step.Status, step.Detail, step.attempted)
+	}
+	if strings.Contains(readText(t, env.shellPath()), "hey-unread") {
+		t.Error("an already-enabled plugin still owes the migration")
+	}
+	if entry := pluginEntry(t, env); entry == nil || entry["notify"] != true {
+		t.Errorf("the toast choice must move onto the entry, got %v", entry)
+	}
+	if len(*ran) != 0 {
+		t.Errorf("the on-bar migration needs no subprocess: %v", *ran)
+	}
+}
+
 func TestOmarchyPluginCrashRepairMigratesTheLegacyIndicator(t *testing.T) {
 	// A first sign-in that crashed after the enable: the quiet self-repair
 	// still owes the migration, or a legacy user keeps two icons forever.

--- a/internal/cmd/omarchy_plugin_test.go
+++ b/internal/cmd/omarchy_plugin_test.go
@@ -526,6 +526,13 @@ func TestOmarchyPluginLockContention(t *testing.T) {
 	if force.failure == nil {
 		t.Error("force under contention is a failure")
 	}
+	// The notify rewrite shares the lock: a held lock means no shell.json
+	// write either, so a racing remove cannot be undone by an install.
+	on := true
+	steps := omarchySetup{env: env, forcePlugin: true, notify: &on}.configureBarPlugin()
+	if stepNamed(steps, "bar plugin").failure == nil {
+		t.Error("configureBarPlugin under contention is a failure")
+	}
 	if len(*ran) != 0 {
 		t.Errorf("no subprocess under contention: %v", *ran)
 	}
@@ -580,7 +587,7 @@ func TestOmarchyPluginMalformedMarkerFailsClosed(t *testing.T) {
 	// --remove is the exception: it still disables, leaves the marker, and
 	// fails with the repair hint.
 	writeShell(t, env, pluginShellJSON)
-	step := omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(true)
+	step := omarchySetup{env: env, forcePlugin: true}.removeBarPluginLocked(true)
 	if step.Status != "failed" || !strings.Contains(step.Detail, "state unreadable") {
 		t.Fatalf("remove with a bad marker = %q %q", step.Status, step.Detail)
 	}
@@ -669,7 +676,7 @@ func TestOmarchyPluginRemoveTombstoneFirst(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o700) })
-	step := omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(true)
+	step := omarchySetup{env: env, forcePlugin: true}.removeBarPluginLocked(true)
 	if step.Status != "failed" || !strings.Contains(step.Detail, "could not record the removal") {
 		t.Fatalf("step = %q %q", step.Status, step.Detail)
 	}
@@ -682,7 +689,7 @@ func TestOmarchyPluginRemoveTombstoneFirst(t *testing.T) {
 
 	// A failed disable keeps the tombstone and fails.
 	replies["omarchy plugin disable"] = omarchyReply{out: "no shell", err: errors.New("exit status 1")}
-	step = omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(true)
+	step = omarchySetup{env: env, forcePlugin: true}.removeBarPluginLocked(true)
 	if step.Status != "failed" {
 		t.Fatalf("failed disable = %q %q", step.Status, step.Detail)
 	}
@@ -693,7 +700,7 @@ func TestOmarchyPluginRemoveTombstoneFirst(t *testing.T) {
 
 	// A clean disable reports removed and keeps the checkout.
 	replies["omarchy plugin disable"] = omarchyReply{}
-	step = omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(true)
+	step = omarchySetup{env: env, forcePlugin: true}.removeBarPluginLocked(true)
 	if step.Status != "removed" || !strings.Contains(step.Detail, "checkout stays") {
 		t.Fatalf("step = %q %q", step.Status, step.Detail)
 	}
@@ -701,10 +708,19 @@ func TestOmarchyPluginRemoveTombstoneFirst(t *testing.T) {
 		t.Error("the checkout must survive removal")
 	}
 
+	// A stale layout entry with Omarchy itself uninstalled: removal keeps
+	// working — a missing CLI means nothing is running, on-layout or not.
+	replies["omarchy plugin disable"] = omarchyReply{err: exec.ErrNotFound}
+	step = omarchySetup{env: env, forcePlugin: true}.removeBarPluginLocked(true)
+	if step.Status != "absent" || step.failure != nil {
+		t.Errorf("stale entry with no CLI = %q %q", step.Status, step.Detail)
+	}
+	replies["omarchy plugin disable"] = omarchyReply{}
+
 	// Off the bar and not enabled per the shell: nothing to disable,
 	// tombstone still written; the probe is the only command that runs.
 	countBefore := len(*ran)
-	step = omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(false)
+	step = omarchySetup{env: env, forcePlugin: true}.removeBarPluginLocked(false)
 	if step.Status != "absent" {
 		t.Errorf("off-bar remove = %q %q", step.Status, step.Detail)
 	}
@@ -720,7 +736,7 @@ func TestOmarchyPluginRemoveDisablesAnEnabledPluginWithoutALayoutEntry(t *testin
 	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
 		"omarchy plugin list": {out: pluginListEnabled},
 	})
-	step := omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(false)
+	step := omarchySetup{env: env, forcePlugin: true}.removeBarPluginLocked(false)
 	if step.Status != "removed" || !strings.Contains(step.Detail, "checkout stays") {
 		t.Fatalf("step = %q %q", step.Status, step.Detail)
 	}
@@ -740,7 +756,7 @@ func TestOmarchyPluginRemoveFailsWhenTheShellCannotAnswer(t *testing.T) {
 	env, ran, _ := testOmarchyEnvScripted(t, map[string]omarchyReply{
 		"omarchy plugin list": {out: "omarchy-shell is not running", err: errors.New("exit status 1")},
 	})
-	step := omarchySetup{env: env, forcePlugin: true}.removeBarPlugin(false)
+	step := omarchySetup{env: env, forcePlugin: true}.removeBarPluginLocked(false)
 	if step.Status != "failed" || !strings.Contains(step.Detail, "shell is not running") {
 		t.Fatalf("step = %q %q", step.Status, step.Detail)
 	}
@@ -1292,7 +1308,7 @@ func TestDoctorOmarchyBarPluginStates(t *testing.T) {
 	}
 
 	writeShell(t, env, pluginShellJSON)
-	if check := checkOmarchyBarPlugin(env); check["status"] != "ok" || check["message"] != "Installed and enabled" {
+	if check := checkOmarchyBarPlugin(env); check["status"] != "ok" || check["message"] != "Installed (in the configured bar layout)" {
 		t.Errorf("enabled: %v", check)
 	}
 

--- a/internal/cmd/omarchy_test.go
+++ b/internal/cmd/omarchy_test.go
@@ -818,23 +818,17 @@ func TestOmarchySetupRemovesTheLegacyBarModule(t *testing.T) {
 	stubConfirmOmarchyPanel(t, false, nil)
 	writeShell(t, env, legacyShellJSON)
 
-	// No plugin yet: the legacy module goes, reported as its own step, and
-	// the plugin step skips (consent declined here). The layout equalled the
-	// defaults once the module was out, so it goes too and the user is back
-	// to inheriting Omarchy's defaults.
+	// No plugin and a declined consent: the working legacy indicator stays —
+	// removal waits until the replacement is on the bar.
 	steps := omarchySetup{env: env}.apply()
-	if legacy := stepNamed(steps, "bar indicator"); legacy.Status != "removed" || !strings.Contains(legacy.Detail, "hey-unread") {
-		t.Errorf("legacy removal should be its own step, got %q %q", legacy.Status, legacy.Detail)
+	if stepNamed(steps, "bar indicator").Name != "" {
+		t.Errorf("no legacy removal before the replacement lands, got %v", statuses(steps))
 	}
 	if bar := stepNamed(steps, "bar plugin"); bar.Status != "skipped" {
 		t.Errorf("without the plugin and without consent the step skips, got %q %q", bar.Status, bar.Detail)
 	}
-	if shell := readShell(t, env); shell["bar"] != nil {
-		t.Errorf("a defaults-seeded layout should be dropped with the module: %v", shell)
-	}
-	steps = omarchySetup{env: env}.apply()
-	if stepNamed(steps, "bar indicator").Name != "" || stepNamed(steps, "bar plugin").Status != "skipped" {
-		t.Errorf("once migrated there is no legacy step and the plugin step skips, got %v", statuses(steps))
+	if !strings.Contains(readText(t, env.shellPath()), "hey-unread") {
+		t.Error("a declined install must keep the legacy indicator working")
 	}
 
 	// With the plugin present and silent on notify, the legacy module's
@@ -880,6 +874,7 @@ func TestOmarchySetupRemovesTheLegacyBarModule(t *testing.T) {
 func TestOmarchyDefaultShellPathFallsBackToUserTree(t *testing.T) {
 	env, _ := testOmarchyEnv(t)
 	env.omarchyPath = "" // no OMARCHY_PATH, as in a non-login or agent shell
+	stubConfirmOmarchyPanel(t, true, nil)
 	userTree := filepath.Join(env.home, ".local", "share", "omarchy", "config", "omarchy")
 	if err := os.MkdirAll(userTree, 0o755); err != nil {
 		t.Fatal(err)
@@ -888,6 +883,23 @@ func TestOmarchyDefaultShellPathFallsBackToUserTree(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeShell(t, env, legacyShellJSON)
+	// The migration runs once the replacement is installed and verified.
+	enabled := false
+	env.run = func(name string, args ...string) (string, error) {
+		command := strings.Join(append([]string{name}, args...), " ")
+		switch {
+		case strings.HasPrefix(command, "omarchy plugin list"):
+			if enabled {
+				return pluginListEnabled, nil
+			}
+			return pluginListAbsent, nil
+		case strings.HasPrefix(command, "omarchy plugin add"):
+			enabled = true
+			return "Installed", nil
+		default:
+			return "", nil
+		}
+	}
 
 	if legacy := stepNamed(omarchySetup{env: env}.apply(), "bar indicator"); legacy.Status != "removed" {
 		t.Fatalf("legacy step = %q %q", legacy.Status, legacy.Detail)

--- a/internal/cmd/omarchy_test.go
+++ b/internal/cmd/omarchy_test.go
@@ -25,9 +25,26 @@ const defaultShellJSON = `{
 }
 `
 
-// testOmarchyEnv fakes an Omarchy install: a home dir, an OMARCHY_PATH with the
-// default shell.json, and a recorder for the commands setup would run.
+// testOmarchyEnv fakes an Omarchy install: a home dir, a state dir, an
+// OMARCHY_PATH with the default shell.json, and a recorder for the commands
+// setup would run. Replies are scripted per command prefix; the default
+// answers `omarchy plugin list --json` with an empty plugin list (the shell
+// up, nothing installed) and everything else with success and no output.
 func testOmarchyEnv(t *testing.T) (omarchyEnv, *[]string) {
+	env, ran, _ := testOmarchyEnvScripted(t, nil)
+	return env, ran
+}
+
+// omarchyReply is one scripted subprocess answer.
+type omarchyReply struct {
+	out string
+	err error
+}
+
+// testOmarchyEnvScripted is testOmarchyEnv with replies keyed by a command
+// prefix ("omarchy plugin list", "omarchy plugin add", ...); the longest
+// matching prefix wins. The returned map can be mutated mid-test.
+func testOmarchyEnvScripted(t *testing.T, replies map[string]omarchyReply) (omarchyEnv, *[]string, map[string]omarchyReply) {
 	t.Helper()
 	home := t.TempDir()
 	omarchyPath := t.TempDir()
@@ -37,16 +54,33 @@ func testOmarchyEnv(t *testing.T) (omarchyEnv, *[]string) {
 	if err := os.WriteFile(filepath.Join(omarchyPath, "config", "omarchy", "shell.json"), []byte(defaultShellJSON), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if replies == nil {
+		replies = map[string]omarchyReply{}
+	}
+	if _, has := replies["omarchy plugin list"]; !has {
+		replies["omarchy plugin list"] = omarchyReply{out: "[]"}
+	}
 	var ran []string
 	env := omarchyEnv{
 		home:        home,
 		omarchyPath: omarchyPath,
-		run: func(name string, args ...string) error {
-			ran = append(ran, strings.Join(append([]string{name}, args...), " "))
-			return nil
+		stateDir:    t.TempDir(),
+		run: func(name string, args ...string) (string, error) {
+			command := strings.Join(append([]string{name}, args...), " ")
+			ran = append(ran, command)
+			best := ""
+			for prefix := range replies {
+				if strings.HasPrefix(command, prefix) && len(prefix) > len(best) {
+					best = prefix
+				}
+			}
+			if best == "" {
+				return "", nil
+			}
+			return replies[best].out, replies[best].err
 		},
 	}
-	return env, &ran
+	return env, &ran, replies
 }
 
 func statuses(steps []omarchyStep) map[string]string {
@@ -118,7 +152,7 @@ func TestOmarchySetupInstallsEverythingOnce(t *testing.T) {
 }
 
 func TestOmarchySetupRemoveReversesEveryPiece(t *testing.T) {
-	env, _ := testOmarchyEnv(t)
+	env, ran := testOmarchyEnv(t)
 	writeShell(t, env, pluginShellJSON)
 	on := true
 	setup := omarchySetup{env: env, notify: &on}
@@ -139,22 +173,37 @@ func TestOmarchySetupRemoveReversesEveryPiece(t *testing.T) {
 		t.Fatalf("--notify should set notify on the plugin entry, got %v", entry)
 	}
 
-	removed := statuses(omarchySetup{env: env}.remove())
-	for name, status := range removed {
+	removed := omarchySetup{env: env, forcePlugin: true}.remove()
+	for name, status := range statuses(removed) {
 		switch name {
 		case "bar indicator":
 			if status != "absent" {
 				t.Errorf("no legacy module was installed, got %q", status)
 			}
 		case "bar plugin":
-			if status != "kept" {
-				t.Errorf("the plugin's notify setting is the plugin's own, got %q", status)
+			if status != "removed" {
+				t.Errorf("remove disables the plugin, got %q", status)
 			}
 		default:
 			if status != "removed" {
 				t.Errorf("%s: remove = %q, want removed", name, status)
 			}
 		}
+	}
+	if bar := stepNamed(removed, "bar plugin"); !strings.Contains(bar.Detail, "the checkout stays") {
+		t.Errorf("remove keeps the checkout and says so, got %q", bar.Detail)
+	}
+	if !contains(*ran, "omarchy plugin disable "+omarchyBarPluginID) {
+		t.Errorf("remove must disable the plugin, ran %v", *ran)
+	}
+	for _, command := range *ran {
+		if strings.Contains(command, "plugin remove") {
+			t.Errorf("remove must never delete the checkout: %q", command)
+		}
+	}
+	marker, _, err := readOmarchyPluginMarker(env.markerPath())
+	if err != nil || marker.RemovedAt == "" {
+		t.Errorf("the removal must be recorded before the command: %+v %v", marker, err)
 	}
 	if _, err := os.Stat(env.desktopPath()); !os.IsNotExist(err) {
 		t.Error("desktop entry still present")
@@ -165,28 +214,15 @@ func TestOmarchySetupRemoveReversesEveryPiece(t *testing.T) {
 	if menu := readText(t, env.menuPath()); menu != menuBefore {
 		t.Errorf("menu should be restored byte for byte:\n%s", menu)
 	}
-	// The plugin entry is the user's (omarchy plugin add wrote it), and its
-	// notify setting is set as readily from the panel as from here: removal
-	// cannot tell a preference it wrote from one it didn't, so it leaves it.
-	entry := pluginEntry(t, env)
-	if entry == nil {
-		t.Fatal("remove must not delete the plugin's layout entry")
-	}
-	if entry["notify"] != true {
-		t.Errorf("remove must leave the plugin's notify setting alone, got %v", entry)
+	// The layout entry and its notify setting are the shell's to take off
+	// with `omarchy plugin disable` — hey does not edit shell.json for it.
+	if entry := pluginEntry(t, env); entry == nil || entry["notify"] != true {
+		t.Errorf("remove must not edit the plugin's layout entry itself, got %v", entry)
 	}
 
-	again := statuses(omarchySetup{env: env}.remove())
-	for name, status := range again {
-		if name == "bar plugin" {
-			if status != "kept" {
-				t.Errorf("second remove: bar plugin = %q, want kept", status)
-			}
-			continue
-		}
-		if status != "absent" {
-			t.Errorf("%s: second remove = %q, want absent", name, status)
-		}
+	// A sign-in after removal owes nothing: the tombstone stands.
+	if step := (omarchySetup{env: env}).installBarPlugin(); step.attempted {
+		t.Errorf("a sign-in after removal owes nothing, got %q %q", step.Status, step.Detail)
 	}
 }
 
@@ -259,6 +295,7 @@ func TestOmarchySetupRefusesWrongTypedBarFields(t *testing.T) {
 }
 
 func TestSetupOmarchyRemoveIgnoresMalformedLocalConfig(t *testing.T) {
+	stubOmarchyRun(t, omarchyUnavailable)
 	repo := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repo, ".hey"), 0o755); err != nil {
 		t.Fatal(err)
@@ -284,6 +321,7 @@ func TestSetupOmarchyRemoveIgnoresMalformedLocalConfig(t *testing.T) {
 }
 
 func TestSetupOmarchyFailsWithoutAHomeDirectory(t *testing.T) {
+	stubOmarchyRun(t, omarchyUnavailable)
 	t.Setenv("HEY_NO_KEYRING", "1")
 	t.Setenv("HEY_BASE_URL", "")
 	t.Setenv("OMARCHY_PATH", t.TempDir())
@@ -307,7 +345,7 @@ func TestSetupOmarchyFailsWithoutAHomeDirectory(t *testing.T) {
 
 func TestOmarchyRemoveTemplateReportsDeferredRender(t *testing.T) {
 	env, _ := testOmarchyEnv(t)
-	env.run = func(name string, args ...string) error { return errors.New("not on PATH") }
+	env.run = func(name string, args ...string) (string, error) { return "", errors.New("not on PATH") }
 	setup := omarchySetup{env: env}
 
 	setup.apply()
@@ -323,6 +361,7 @@ func TestOmarchyRemoveTemplateReportsDeferredRender(t *testing.T) {
 }
 
 func TestSetupOmarchyRemoveWorksWithoutOmarchy(t *testing.T) {
+	stubOmarchyRun(t, omarchyUnavailable)
 	t.Setenv("HEY_NO_KEYRING", "1")
 	t.Setenv("HEY_BASE_URL", "")
 	t.Setenv("OMARCHY_PATH", "")
@@ -344,6 +383,7 @@ func TestSetupOmarchyRemoveWorksWithoutOmarchy(t *testing.T) {
 }
 
 func TestSetupOmarchyRejectsPositionalArgs(t *testing.T) {
+	stubOmarchyRun(t, omarchyUnavailable)
 	t.Setenv("HEY_NO_KEYRING", "1")
 	t.Setenv("OMARCHY_PATH", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
@@ -360,6 +400,7 @@ func TestSetupOmarchyRejectsPositionalArgs(t *testing.T) {
 }
 
 func TestSetupOmarchyFailureCarriesStepsInMeta(t *testing.T) {
+	stubOmarchyRun(t, omarchyUnavailable)
 	t.Setenv("HEY_NO_KEYRING", "1")
 	t.Setenv("HEY_BASE_URL", "")
 	home := t.TempDir()
@@ -467,6 +508,7 @@ func TestWriteFileIfChangedFollowsSymlinksAndKeepsMode(t *testing.T) {
 }
 
 func TestSetupOmarchyRefusesListFormatsBeforeTouchingFiles(t *testing.T) {
+	stubOmarchyRun(t, omarchyUnavailable)
 	t.Setenv("HEY_NO_KEYRING", "1")
 	t.Setenv("HEY_BASE_URL", "")
 	home := t.TempDir()
@@ -489,6 +531,7 @@ func TestSetupOmarchyRefusesListFormatsBeforeTouchingFiles(t *testing.T) {
 }
 
 func TestSetupOmarchyIsNotBlockedByAnUntrustedLocalConfig(t *testing.T) {
+	stubOmarchyRun(t, omarchyUnavailable)
 	repo := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repo, ".hey"), 0o755); err != nil {
 		t.Fatal(err)
@@ -531,6 +574,7 @@ func TestOmarchySetupPreservesLargeIntegersInShellConfig(t *testing.T) {
 }
 
 func TestSetupOmarchyRejectsARelativeHome(t *testing.T) {
+	stubOmarchyRun(t, omarchyUnavailable)
 	t.Setenv("HEY_NO_KEYRING", "1")
 	t.Setenv("HEY_BASE_URL", "")
 	t.Setenv("OMARCHY_PATH", t.TempDir())
@@ -596,7 +640,7 @@ func TestOmarchySetupKeepsForeignTemplate(t *testing.T) {
 	if readText(t, env.templatePath()) != foreign {
 		t.Error("foreign template was deleted")
 	}
-	if len(*ran) != 0 {
+	if contains(*ran, "omarchy-theme-refresh") {
 		t.Errorf("no theme refresh should run for a kept template, ran %v", *ran)
 	}
 }
@@ -642,6 +686,7 @@ func TestInsertMenuBlockReplacesStaleBlock(t *testing.T) {
 }
 
 func TestSetupOmarchyRequiresOmarchy(t *testing.T) {
+	stubOmarchyRun(t, omarchyUnavailable)
 	t.Setenv("HEY_NO_KEYRING", "1")
 	t.Setenv("HEY_BASE_URL", "")
 	t.Setenv("OMARCHY_PATH", "")
@@ -695,36 +740,32 @@ func pluginEntry(t *testing.T, env omarchyEnv) map[string]any {
 	return barLayoutModule(layout, omarchyBarPluginID)
 }
 
-func stepNamed(steps []omarchyStep, name string) omarchyStep {
-	for _, step := range steps {
-		if step.Name == name {
-			return step
-		}
-	}
-	return omarchyStep{}
-}
-
 func TestOmarchySetupSkipsTheBarWithoutThePlugin(t *testing.T) {
 	env, _ := testOmarchyEnv(t)
+	confirms := stubConfirmOmarchyPanel(t, false, nil)
 	on := true
 
-	// No shell.json at all: nothing to configure, and nothing is created —
-	// setup never adds a layout entry, the plugin install does.
+	// No shell.json at all: consent is asked, a no is recorded, and nothing
+	// is created — setup never adds a layout entry, the plugin install does.
 	bar := stepNamed(omarchySetup{env: env, notify: &on}.apply(), "bar plugin")
-	if bar.Status != "skipped" || !strings.Contains(bar.Detail, omarchyBarPluginInstall) {
-		t.Errorf("without the plugin the bar step should say how to install it, got %q %q", bar.Status, bar.Detail)
+	if bar.Status != "skipped" {
+		t.Errorf("a declined consent should skip, got %q %q", bar.Status, bar.Detail)
 	}
 	if _, err := os.Stat(env.shellPath()); !os.IsNotExist(err) {
 		t.Error("setup must not create a shell.json just to skip")
 	}
 
-	// A layout without the plugin entry is the same thing.
+	// A layout without the plugin entry is the same thing — and the recorded
+	// no means the question is never asked again.
 	writeShell(t, env, defaultShellJSON)
 	if bar := stepNamed(omarchySetup{env: env}.apply(), "bar plugin"); bar.Status != "skipped" {
 		t.Errorf("a layout without the plugin should be skipped, got %q", bar.Status)
 	}
 	if readText(t, env.shellPath()) != defaultShellJSON {
 		t.Error("skipping must leave shell.json untouched")
+	}
+	if *confirms != 1 {
+		t.Errorf("consent asked %d times, want 1", *confirms)
 	}
 }
 
@@ -774,18 +815,19 @@ func TestOmarchySetupFindsThePluginInAnySection(t *testing.T) {
 
 func TestOmarchySetupRemovesTheLegacyBarModule(t *testing.T) {
 	env, _ := testOmarchyEnv(t)
+	stubConfirmOmarchyPanel(t, false, nil)
 	writeShell(t, env, legacyShellJSON)
 
-	// No plugin yet: the legacy module goes, reported as its own step, and the
-	// plugin step says what to install — and how to keep the toasts the module
-	// had on. The layout equalled the defaults once the module was out, so it
-	// goes too and the user is back to inheriting Omarchy's defaults.
+	// No plugin yet: the legacy module goes, reported as its own step, and
+	// the plugin step skips (consent declined here). The layout equalled the
+	// defaults once the module was out, so it goes too and the user is back
+	// to inheriting Omarchy's defaults.
 	steps := omarchySetup{env: env}.apply()
 	if legacy := stepNamed(steps, "bar indicator"); legacy.Status != "removed" || !strings.Contains(legacy.Detail, "hey-unread") {
 		t.Errorf("legacy removal should be its own step, got %q %q", legacy.Status, legacy.Detail)
 	}
-	if bar := stepNamed(steps, "bar plugin"); bar.Status != "skipped" || !strings.Contains(bar.Detail, omarchyBarPluginInstall) || !strings.Contains(bar.Detail, "--notify") {
-		t.Errorf("the plugin step should say how to install and how to keep notifying, got %q %q", bar.Status, bar.Detail)
+	if bar := stepNamed(steps, "bar plugin"); bar.Status != "skipped" {
+		t.Errorf("without the plugin and without consent the step skips, got %q %q", bar.Status, bar.Detail)
 	}
 	if shell := readShell(t, env); shell["bar"] != nil {
 		t.Errorf("a defaults-seeded layout should be dropped with the module: %v", shell)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -397,7 +397,11 @@ func requireAuth() error {
 	}
 	if writer.IsStyled() && interactiveStdio() {
 		if yes, err := askToSignIn(); err == nil && yes {
-			return loginInteractively(os.Stderr)
+			if err := loginInteractively(os.Stderr); err != nil {
+				return err
+			}
+			ensureOmarchyBarPluginAfterLogin(os.Stderr)
+			return nil
 		}
 	}
 	return apierr.ErrAuth("Not logged in")

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -32,8 +33,11 @@ func newSetupCommand() *setupCommand {
 	setupCommand.cmd = &cobra.Command{
 		Use:   "setup",
 		Short: "Set up HEY for first use",
-		Long:  "Sign in and connect your coding agents.",
-		Args:  cobra.NoArgs,
+		Long: `Sign in and connect your coding agents. On Omarchy, a styled interactive run also
+installs hey into the desktop and offers the HEY bar plugin (asked once); machine
+and non-interactive runs never touch the desktop — hey setup omarchy does that
+explicitly.`,
+		Args: cobra.NoArgs,
 		Annotations: map[string]string{
 			"agent_notes": "Runs the first-run wizard: OAuth sign-in, a look at the linked accounts, and coding-agent setup. HEY_NONINTERACTIVE=1 suppresses OAuth and every prompt, but the wizard still connects detected agents (writing skill files) and persists the onboarded flag — there is no read-only mode; use `hey doctor` to inspect without changing anything. --json changes only the output format: a terminal on stdin (an allocated PTY included) still starts browser OAuth and waits for it. Logged out and non-interactive reports status incomplete with a remediation breadcrumb.",
 		},
@@ -97,6 +101,15 @@ type wizardResult struct {
 	CompletionsInstalled bool         `json:"completions_installed"`
 	Agents               []agentCheck `json:"agents"`
 	Issues               []agentIssue `json:"issues"`
+	// Omarchy reports the desktop step, which runs only in a full, styled,
+	// interactive, signed-in wizard on Omarchy — machine and non-interactive
+	// runs skip it and are pointed at `hey setup omarchy` instead.
+	Omarchy *omarchyOutcome `json:"omarchy,omitempty"`
+}
+
+// omarchyOutcome is the wizard's Omarchy step, mirrored into the envelope.
+type omarchyOutcome struct {
+	Steps []omarchyStep `json:"steps"`
 }
 
 // setupWizard carries one wizard run: the command it prints through and what
@@ -144,12 +157,19 @@ func (s *setupWizard) run() error {
 	if s.opts.full {
 		s.result.CompletionsInstalled = s.installCompletions()
 		s.outcome = s.setupAgents()
+	} else if signedIn {
+		// A lite wizard that just signed in gets the same one-line Omarchy
+		// hook as `hey auth login`; the full wizard runs the real step below.
+		ensureOmarchyBarPluginAfterLogin(s.cmd.ErrOrStderr())
 	}
 	s.result.SkillInstalled = baselineSkillInstalled()
 	s.result.Agents = s.outcome.Checks
 	s.result.Issues = append(s.result.Issues, s.outcome.Issues...)
 	if statusFromOutcome(s.outcome) == "incomplete" {
 		s.result.Status = "incomplete"
+	}
+	if s.opts.full {
+		s.setupOmarchy(signedIn)
 	}
 
 	s.persistOnboarded()
@@ -206,8 +226,9 @@ func canSignInInteractively() bool {
 
 // loginInteractively runs the OAuth flow with progress on out, then selects
 // the configured mail account (PersistentPreRunE skipped that while we were
-// logged out). Shared with requireAuth's sign-in prompt.
-func loginInteractively(out io.Writer) error {
+// logged out). Shared with requireAuth's sign-in prompt; a var so tests can
+// stand in for the browser wait.
+var loginInteractively = func(out io.Writer) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
 	defer cancel()
 
@@ -463,6 +484,42 @@ func (s *setupWizard) setupAgents() agentSetupOutcome {
 	return agentSetupOutcome{Checks: postChecks, Issues: issues}
 }
 
+// setupOmarchy is Step 3: on Omarchy, a full, styled, interactive, signed-in
+// wizard installs the desktop pieces and offers the bar plugin in ensure
+// mode — consent asked once and remembered, and a plugin the user disabled
+// stays disabled. Machine and non-interactive runs skip it entirely; the
+// envelope points at hey setup omarchy instead (wizardBreadcrumbs).
+func (s *setupWizard) setupOmarchy(signedIn bool) {
+	if !signedIn || !s.styled || !interactiveStdio() {
+		return
+	}
+	env := liveOmarchyEnv()
+	if !env.detected() || !filepath.IsAbs(env.home) {
+		return
+	}
+	w := s.cmd.OutOrStdout()
+	fmt.Fprintln(w, bold.format("  Step 3: Omarchy desktop"))
+	fmt.Fprintln(w)
+	steps := omarchySetup{env: env}.apply()
+	s.result.Omarchy = &omarchyOutcome{Steps: steps}
+	bar := stepNamed(steps, "bar plugin")
+	switch {
+	case bar.Status == "installed":
+		fmt.Fprintln(w, statusLine(true, "HEY is in your Omarchy bar"))
+	case bar.Status == "failed" || (bar.Status == "skipped" && bar.attempted):
+		fmt.Fprintln(w, warning.format("  Bar plugin: "+bar.Detail))
+	}
+	for _, step := range steps {
+		if step.Status == "failed" || (step.Status == "skipped" && step.attempted) {
+			s.result.Status = "incomplete"
+			s.result.Issues = append(s.result.Issues, agentIssue{Check: "Omarchy " + step.Name, Hint: "Run: hey setup omarchy"})
+		}
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, muted.format("  "+strings.ReplaceAll(strings.TrimRight(omarchyKeybindHint, "\n"), "\n", "\n  ")))
+	fmt.Fprintln(w)
+}
+
 // persistOnboarded records that the wizard ran, so a later logged-out bare
 // `hey` runs the lite wizard. Best-effort: a read-only config dir only costs
 // a repeat of the agent step next time.
@@ -528,6 +585,28 @@ func showWizardSuccess(w io.Writer, result wizardResult, outcome agentSetupOutco
 		for _, check := range outcome.Checks {
 			fmt.Fprintln(w, statusLine(check.Status == "pass", check.Name))
 		}
+	}
+	if result.Omarchy != nil {
+		ok := true
+		for _, step := range result.Omarchy.Steps {
+			if step.Status == "failed" || step.failure != nil {
+				ok = false
+			}
+		}
+		fmt.Fprintln(w, statusLine(ok, "Omarchy desktop"))
+		bar := stepNamed(result.Omarchy.Steps, "bar plugin")
+		barLine := bar.Status
+		if bar.Detail != "" {
+			barLine += " — " + bar.Detail
+		}
+		fmt.Fprintln(w, muted.format("    Bar plugin: "+barLine))
+		desktop := "launcher entry, menu row and theme template in place"
+		for _, step := range result.Omarchy.Steps {
+			if step.Name != "bar plugin" && step.Status == "failed" {
+				desktop = step.Name + " failed: " + step.Detail
+			}
+		}
+		fmt.Fprintln(w, muted.format("    Desktop: "+desktop))
 	}
 	fmt.Fprintln(w)
 
@@ -615,6 +694,11 @@ func wizardBreadcrumbs(result wizardResult) []output.Breadcrumb {
 	crumbs := []output.Breadcrumb{
 		{Action: "open", Command: "hey tui", Description: "Open the app"},
 		{Action: "boxes", Command: "hey box list", Description: "List your boxes"},
+	}
+	// A machine or non-interactive run on Omarchy never touches the desktop
+	// itself; the explicit command is how a script installs the bar plugin.
+	if result.Omarchy == nil && liveOmarchyEnv().detected() {
+		crumbs = append(crumbs, output.Breadcrumb{Action: "omarchy", Command: "hey setup omarchy", Description: "Put HEY in your Omarchy bar"})
 	}
 	if result.Status == "incomplete" {
 		crumbs = append(crumbs, output.Breadcrumb{Action: "doctor", Command: "hey doctor", Description: "Check CLI health"})

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -589,7 +589,9 @@ func showWizardSuccess(w io.Writer, result wizardResult, outcome agentSetupOutco
 	if result.Omarchy != nil {
 		ok := true
 		for _, step := range result.Omarchy.Steps {
-			if step.Status == "failed" || step.failure != nil {
+			// The same predicate that files the issue: a checkmark beside a
+			// step listed under "needs attention" would contradict itself.
+			if step.Status == "failed" || step.failure != nil || (step.Status == "skipped" && step.attempted) {
 				ok = false
 			}
 		}

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -679,31 +679,34 @@ func wizardSummaryLine(result wizardResult) string {
 
 // wizardBreadcrumbs returns next-step breadcrumbs based on wizard outcome.
 func wizardBreadcrumbs(result wizardResult) []output.Breadcrumb {
-	if hasIssue(result.Issues, "HEY_TOKEN rejected") {
+	var crumbs []output.Breadcrumb
+	switch {
+	case hasIssue(result.Issues, "HEY_TOKEN rejected"):
 		// HEY_TOKEN outranks anything hey auth login saves: the structured
 		// remediation must point at the environment or it loops forever.
-		return []output.Breadcrumb{
+		crumbs = []output.Breadcrumb{
 			{Action: "fix_token", Command: "unset HEY_TOKEN", Description: "Remove or replace the rejected environment token"},
 			{Action: "doctor", Command: "hey doctor", Description: "Check CLI health"},
 		}
-	}
-	if hasAuthIssue(result.Issues) {
-		return []output.Breadcrumb{
+	case hasAuthIssue(result.Issues):
+		crumbs = []output.Breadcrumb{
 			{Action: "login", Command: "hey auth login", Description: "Authenticate with HEY"},
 			{Action: "doctor", Command: "hey doctor", Description: "Check CLI health"},
 		}
-	}
-	crumbs := []output.Breadcrumb{
-		{Action: "open", Command: "hey tui", Description: "Open the app"},
-		{Action: "boxes", Command: "hey box list", Description: "List your boxes"},
+	default:
+		crumbs = []output.Breadcrumb{
+			{Action: "open", Command: "hey tui", Description: "Open the app"},
+			{Action: "boxes", Command: "hey box list", Description: "List your boxes"},
+		}
+		if result.Status == "incomplete" {
+			crumbs = append(crumbs, output.Breadcrumb{Action: "doctor", Command: "hey doctor", Description: "Check CLI health"})
+		}
 	}
 	// A machine or non-interactive run on Omarchy never touches the desktop
-	// itself; the explicit command is how a script installs the bar plugin.
+	// itself — logged out included, where the automatic hook can never run —
+	// so the explicit command rides along in every branch.
 	if result.Omarchy == nil && liveOmarchyEnv().detected() {
 		crumbs = append(crumbs, output.Breadcrumb{Action: "omarchy", Command: "hey setup omarchy", Description: "Put HEY in your Omarchy bar"})
-	}
-	if result.Status == "incomplete" {
-		crumbs = append(crumbs, output.Breadcrumb{Action: "doctor", Command: "hey doctor", Description: "Check CLI health"})
 	}
 	return crumbs
 }

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -490,7 +490,9 @@ func (s *setupWizard) setupAgents() agentSetupOutcome {
 // stays disabled. Machine and non-interactive runs skip it entirely; the
 // envelope points at hey setup omarchy instead (wizardBreadcrumbs).
 func (s *setupWizard) setupOmarchy(signedIn bool) {
-	if !signedIn || !s.styled || !interactiveStdio() {
+	// Stored-but-rejected credentials are not a login: greet recorded the
+	// auth issue, and the desktop step waits for a sign-in that works.
+	if !signedIn || hasAuthIssue(s.result.Issues) || !s.styled || !interactiveStdio() {
 		return
 	}
 	env := liveOmarchyEnv()

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -691,6 +691,9 @@ hey auth login                                # Log in (browser-based OAuth)
 hey auth status                               # Check if authenticated
 hey auth logout                               # Log out
 hey login / hey logout                        # Shortcuts for the two above
+hey setup omarchy                             # Omarchy only: put HEY in the bar. The interactive
+                                              # sign-in offer never fires for agents (non-TTY,
+                                              # machine output), so this command is the way
 hey setup                                     # First-run wizard: sign in + connect coding agents
 HEY_NONINTERACTIVE=1 hey setup --json         # No prompts and no OAuth wait — but still
                                               # installs agent skills and records onboarding;

--- a/tests/smoke/helpers_test.go
+++ b/tests/smoke/helpers_test.go
@@ -25,6 +25,7 @@ var (
 	baseURL       string
 	configDir     string
 	stateDir      string
+	homeDir       string
 	sessionCookie string
 	smokeEmail    string
 )
@@ -85,6 +86,13 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "Failed to create temp state dir: %v\n", err)
 		os.Exit(1)
 	}
+	// And an isolated home, so the CLI can never detect the developer's
+	// Omarchy desktop (or write agent skills into their real ~).
+	homeDir, err = os.MkdirTemp("", "hey-smoke-home-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create temp home dir: %v\n", err)
+		os.Exit(1)
+	}
 	// Launch headless Chrome browser and log in to obtain a session cookie.
 	sessionCookie, err = browserLogin(baseURL, smokeEmail, password)
 	if err != nil {
@@ -101,6 +109,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	os.RemoveAll(configDir)
 	os.RemoveAll(stateDir)
+	os.RemoveAll(homeDir)
 	os.Exit(code)
 }
 
@@ -183,15 +192,21 @@ func dataAs[T any](t *testing.T, resp Response) T {
 // cliEnv returns the environment variables used for all CLI invocations. The
 // caller's HEY_TOKEN is dropped: the suite authenticates with the cookie TestMain
 // stored, and an inherited token would silently stand in for it on every command.
+// The caller's HOME and OMARCHY_PATH are replaced too, so a suite run on a
+// developer's Omarchy desktop can never detect it — the sign-in hook and
+// `hey setup omarchy` would otherwise talk to the real shell.
 func cliEnv() []string {
-	env := make([]string, 0, len(os.Environ())+6)
+	env := make([]string, 0, len(os.Environ())+8)
 	for _, kv := range os.Environ() {
-		if !strings.HasPrefix(kv, "HEY_TOKEN=") {
-			env = append(env, kv)
+		if strings.HasPrefix(kv, "HEY_TOKEN=") || strings.HasPrefix(kv, "HOME=") || strings.HasPrefix(kv, "OMARCHY_PATH=") {
+			continue
 		}
+		env = append(env, kv)
 	}
 	env = append(env,
 		"HEY_BASE_URL="+baseURL,
+		"HOME="+homeDir,
+		"OMARCHY_PATH=",
 		"XDG_CONFIG_HOME="+configDir,
 		"XDG_STATE_HOME="+stateDir,
 		"HEY_NO_KEYRING=1",


### PR DESCRIPTION
DHH: the Omarchy panel should "magically appear when you're logged in", with no hand-copied commands. This delivers the hey-cli half of that promise: **signing in with hey puts HEY in your Omarchy bar** — asked once, remembered, verified against the running shell. The location-independent half (the panel present before hey-cli is installed) is Omarchy's to ship and is recorded as a follow-up in docs/omarchy.md.

## What changed

One idempotent routine (`internal/cmd/omarchy_plugin.go`), three entry points, one state file, one lock:

- **Ensure mode** — the interactive OAuth sign-in (`hey auth login` / `hey login`, `requireAuth`'s "Sign in now?", the lite wizard) and the full wizard's new **Step 3: Omarchy desktop**. Gated on styled interactive stdio; probes the shell (`omarchy plugin list --json`) before asking; consent ("Put HEY in your Omarchy bar?") is asked once and recorded; the intent is durable on disk before anything is cloned; `installed` is reported only after the shell lists the plugin enabled *and* the final write lands. **Ensure never enables an off-bar checkout** — a plugin the user disabled is never resurrected by a sign-in, pending intent included (that state owes exactly one line: "install incomplete — run hey setup omarchy"). Machine output, `HEY_NONINTERACTIVE`, non-TTY, and `--token`/`--cookie` logins never run any of it.
- **Force mode** — `hey setup omarchy` installs in every output format (`--json` included), finishes interrupted installs, re-enables a disabled plugin, and exits `setup_failed` on **every** incomplete outcome: shell down, missing omarchy CLI, lock contention, unwritable marker, clone failure, verify failure, failed final write. The intent write comes first (clearing a decline, a removal, and the clone throttle), so a crash leaves a pending install the next explicit setup finishes — never a quiet skip. Before a successful intent write, a failure leaves no state change.
- **`--remove`** — tombstone first (a removal that cannot be recorded runs nothing), then `omarchy plugin disable`; the checkout stays. A malformed marker fails installation closed but never traps removal.

Supporting pieces: marker + flock under `StateDir()/omarchy/`; 24 h clone-failure throttle (clone failures only); a subprocess runner that caps combined output at 64 KiB while draining to EOF and kills the whole process group on timeout (`Setpgid` on unix); `hey doctor` reports every plugin state on Omarchy; the wizard's machine envelope points at `hey setup omarchy` via a breadcrumb; the plugin source URL is a package var **as a test seam only** — no flag, env var, or build override exists.

## One deviation from the reviewed plan

The plan specified `omarchy bar put` for force-mode re-enable. The real CLI reverses `omarchy plugin disable` with `omarchy plugin enable`; `bar put` only places a widget in the layout. Force mode uses `plugin enable`, and the verify probe (`enabled: true` from the shell) remains the guarantee either way. Verified against the omarchy CLI on a live Omarchy machine (probe shape `[{id, enabled, …}]` confirmed).

## Tests

- The ensure transition table row by row, hermetically: fresh consent → intent-before-clone → verify → finalize; asks-once (decline recorded, esc asks again); the resurrect test (pending + off-bar → notice, zero commands); crash repair (pending + on-bar → finalize quietly); quiet rows (declined/removed/installed-then-deleted/someone-else's-clone: zero prompts, zero subprocesses, zero writes); throttled and un-throttled clone retries without re-prompting; shell-down / missing-CLI / non-JSON probe (three distinct outcomes, fail-closed on the last); verify failure and final-write failure keep pending and fail loudly; malformed marker fail-closed with `--remove`'s exception; lock contention (ensure quiet, force fails, zero state claims); bad state dir; the source seam by assignment.
- Force: suppressions cleared before acting (asserted at the moment the enable runs); already-enabled → zero mutations; command-level `--json` install; shell-down and lock-contention exits with durable/absent state respectively.
- Removal ordering: unwritable tombstone → zero commands; failed disable → tombstone kept; success keeps the checkout; never `plugin remove`, never `rm`.
- Hook: machine/non-interactive inert; styled+interactive installs and prints exactly one line; second login silent. `--token`/`--cookie` never call it; `requireAuth` calls it once after sign-in; the lite wizard hooks once and the full wizard never double-fires.
- Wizard: Step 3 installs with consent; machine run inert with the `hey setup omarchy` breadcrumb; clone failure → incomplete with remediation. Doctor: every state. Runner: timeout kills a sleeping child's process group; >64 KiB output capped and drained.
- Isolation: `runAuthCommand` clears `OMARCHY_PATH`; every command-level omarchy test stubs the live runner; smoke's `cliEnv` now replaces `HOME` and clears `OMARCHY_PATH` so a suite run can never detect (or mutate) a developer's desktop.

## Gates

`make lint` 0 issues · `go test ./internal/cmd` (and `-race`) green · `make security` green · `make test-release` (goreleaser snapshot) green · `GOOS=windows`/`darwin` build · surface snapshot unchanged. Pre-existing, environment-only failures reproduced byte-for-byte on pristine `origin/main` and untouched here: four `internal/tui` tests (long tmpdir socket paths, emoji width) and four `install.ps1` e2e tests (no pwsh under mise).

## Not in this PR

- The live pass on a real Omarchy machine (force-enable cycle, sign-in idempotency, removal, shell-down force, doctor at each state, ending enabled) — sequenced after merge per the plan; the sign-in legs need a real browser OAuth.
- The release gate: Linux Installer Smoke is red (HTTP 403, #210) and is never waived — that fix is its own PR before v0.3.0 tags.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs the `37signals.hey` Omarchy bar plugin on interactive sign-in and migrates from the legacy `hey-unread` panel. Before: users copied a command; now the login hook asks once, records intent, verifies against the running shell, and never re-enables a disabled plugin.

- Ensure mode (interactive sign-in/wizard only): gates on styled TTY; skips machine output, `HEY_NONINTERACTIVE`, non‑TTY, and `--token`/`--cookie`; probes the shell before asking; writes intent before acting; treats both installed and unchanged as “on the bar.” Migration rule: whenever `hey-unread` exists and the plugin is verifiably live (freshly installed or confirmed by a read‑only probe), remove legacy; failed runs do nothing; cloned‑by‑hand installs are left untouched.
- Force mode (`hey setup omarchy`): installs in every output format; writes intent first; re‑enables if disabled; exits `setup_failed` on any incomplete outcome; a crash leaves a pending install the next explicit setup finishes.
- Removal (`--remove`): tombstones first, disables via `omarchy plugin disable` (even with no layout entry), keeps the checkout; if the plugin step cannot be recorded or completed, removal rewrites nothing else.
- No‑layout‑entry support: `--notify` materializes notify via `omarchy bar set`; the sign‑in migration carries and reloads notify; if carry cannot land, the legacy module stays for the next explicit setup.
- Safeguards: a flocked marker under `StateDir()/omarchy/`; a typed shell probe (no CLI, shell down, unexpected); a 24 h retry throttle on any failed `plugin add` (including timeouts); subprocess runner caps output and kills the process group on timeout or interrupt.
- Tooling: `hey doctor` reports pending bookkeeping and present‑tense bar status; tests isolate `OMARCHY_PATH`/HOME to avoid touching a developer’s desktop.

<sup>Written for commit 598ff64b18e75b839d4a1316cacde5307761d8b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

