### PR TITLE
Draft support: save, list, edit, send and delete drafts

### DIFF
--- a/.surface
+++ b/.surface
@@ -122,6 +122,7 @@ hey draft
 hey draft list
 hey draft list --all
 hey draft list --limit
+hey draft list --page
 hey event
 hey event add
 hey event add --all-day

--- a/.surface
+++ b/.surface
@@ -247,6 +247,7 @@ hey move
 hey move --to
 hey reply
 hey reply --attach
+hey reply --draft
 hey reply --message
 hey reply --message-html
 hey screener

--- a/.surface
+++ b/.surface
@@ -82,6 +82,7 @@ hey compose
 hey compose --attach
 hey compose --bcc
 hey compose --cc
+hey compose --draft
 hey compose --message
 hey compose --message-html
 hey compose --subject
@@ -119,10 +120,22 @@ hey contact update --email
 hey contact update --name
 hey doctor
 hey draft
+hey draft delete
+hey draft edit
+hey draft edit --bcc
+hey draft edit --cc
+hey draft edit --message
+hey draft edit --message-html
+hey draft edit --subject
+hey draft edit --to
 hey draft list
 hey draft list --all
 hey draft list --limit
 hey draft list --page
+hey draft send
+hey draft send --hour
+hey draft send --on
+hey draft show
 hey event
 hey event add
 hey event add --all-day

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -3,20 +3,13 @@
 Mapping of HEY API endpoints used by the CLI. API interactions use the HEY SDK (`hey-sdk/go`).
 Every endpoint below is read as JSON through a typed SDK operation; nothing parses HTML.
 
-One operation HEY has and the SDK does not: `GET /entries/{id}/replies/new.json`, which
-answers the exact recipients HEY would put on a reply. Until the SDK exposes it, a reply's
-recipients are derived from the answered entry's own `addressed` — see AGENTS.md's
-`### HTML content`.
-
 **`/topics/{id}/entries.json` cannot be paged by number.** `Topics::EntriesController` uses
 `set_page_and_extract_portion_from`, so like every other list here its `page` is
 geared_pagination's opaque cursor out of the `Link` header, not an offset. An integer there
-is not an error — it is ignored, and the first page comes back again. There is no
-`Topics().GetEntriesPage` in SDK v0.10.0 to read that header with, so anything walking this
-endpoint page-by-page reads page one repeatedly until it hits its own cap. `hey thread read` and
-`hey attachment list` both do; that is the bug behind a three-entry thread answering with 300
-entries and 400 requests. The fix is either a `GetEntriesPage` in the SDK or a single read,
-since `Topics().Get` already carries the entry list.
+is not an error — it is ignored, and the first page comes back again. `Topics().GetEntriesPage`
+is the SDK read that keeps that header; `hey thread read` and `hey attachment list` walk it
+through `internal/threadload`. The drafts index (`/entries/drafts.json`) pages the same way,
+which is what `Entries().ListDraftsPage` and `hey draft list --page` exist for.
 
 | Endpoint | Method | Client | CLI Command | Status |
 |----------|--------|--------|-------------|--------|
@@ -64,13 +57,17 @@ since `Topics().Get` already carries the entry list.
 | `/topics/{id}/publication` | POST | SDK `Publications().Create` | `hey share <thread-id>` | covered |
 | `/topics/{id}/publication.json` | GET | SDK `Publications().Create` readback | `hey share <thread-id>` | covered |
 | `/topics/{id}/publication` | DELETE | SDK `Publications().Delete` | `hey unshare <thread-id>` | covered |
-| `/messages/{id}.json` | GET | SDK `Messages().Get` | `hey thread read <id>` (bodies), `hey reply <topic-id>` and TUI `r` (recipients), `hey attachment list <topic-id>`, `hey attachment save <id>` | covered |
-| `/entries/drafts.json` | GET | SDK `Entries().ListDrafts` | `hey draft list` | covered |
+| `/messages/{id}.json` | GET | SDK `Messages().Get` | `hey thread read <id>` (bodies), `hey reply <topic-id>` and TUI `r` (recipient fallback), `hey attachment list <topic-id>`, `hey attachment save <id>` | covered |
+| `/messages/{id}` | PUT | SDK `Messages().UpdateDraft`, `Messages().SendDraft` | `hey draft edit <id>`, `hey draft send <id>` | covered |
+| `/messages/{id}/edit.json` | GET | SDK `Messages().GetEdit` | `hey draft show <id>`, `hey draft edit/send` (reading the state an update resends) | covered |
+| `/entries/{id}/replies/new.json` | GET | SDK `Entries().NewReply` | `hey reply <topic-id>` and `hey compose --thread-id` (recipients, with the acting user excluded) | covered |
+| `/entries/drafts.json` | GET | SDK `Entries().ListDraftsPage` | `hey draft list` (`--all`/`--page` follow its cursor) | covered |
+| `/entries/drafts/{id}` | DELETE | SDK `Entries().DeleteDraft` | `hey draft delete <id>...` | covered |
 | `/rails/active_storage/direct_uploads.json` | POST | SDK `Attachments().Upload` | `hey compose --attach`, `hey reply --attach`, `hey bulk-reply send --attach` | covered |
 | signed Active Storage upload URL | PUT | SDK `Attachments().Upload` | `hey compose --attach`, `hey reply --attach`, `hey bulk-reply send --attach` | covered |
 | signed Active Storage blob URL | GET | SDK `DownloadBlob` | `hey attachment save <id>` | covered |
-| `/messages.json` | POST | SDK `Messages().Create` | `hey compose`, `hey forward <topic-id>` | covered |
-| `/entries/{id}/replies` | POST | SDK `Entries().CreateReply` | `hey reply <topic-id>` | covered |
+| `/messages.json` | POST | SDK `Messages().Create`, `Messages().CreateDraft` | `hey compose`, `hey compose --draft`, `hey forward <topic-id>` | covered |
+| `/entries/{id}/replies` | POST | SDK `Entries().CreateReply`, `Entries().CreateReplyDraft` | `hey reply <topic-id>`, `hey reply --draft`, `hey compose --thread-id [--draft]` | covered |
 | `/topics/{id}.json` | GET | SDK `Topics().Get` | `hey forward <topic-id>`, `hey reply <topic-id>`, TUI `r` | covered |
 | `/entries/{id}/forwards/new.json` | GET | SDK `Entries().NewForward` | `hey forward <topic-id>` | covered |
 | `/bulk_replies/new.json` | GET | SDK `BulkReplies().Draft` | `hey bulk-reply preview`, `hey bulk-reply send`, TUI `ctrl+b` | covered |

--- a/README.md
+++ b/README.md
@@ -408,7 +408,13 @@ hey compose --to alice@example.com --subject "Q3 revenue report" -m "The numbers
 hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Kitchen remodel timeline"  # with CC/BCC
 hey compose --to alice@example.com --subject "Sprint recap" -m "We **shipped** the pagination fix."
 hey compose --to alice@example.com --subject "Newsletter draft" --message-html "<h1>March</h1><p>What we shipped.</p>"
-hey draft list                     # list drafts
+hey compose --subject "Board update" -m "Numbers to follow." --draft  # save a draft instead of sending
+hey reply 123 -m "Drafting a longer answer." --draft  # save a reply draft
+hey draft list                     # list drafts (--all and --page follow HEY's cursor)
+hey draft show 12345               # read a draft back
+hey draft edit 12345 --to alice@example.com --subject "Board update (v2)"
+hey draft send 12345               # deliver it, or --on tomorrow --hour 9 to schedule
+hey draft delete 12345             # trash it
 hey seen 12345                     # mark a thread as seen
 hey unseen 12345 67890             # mark threads as unseen
 hey move 12345 --to feed           # move a thread to another box
@@ -419,11 +425,13 @@ hey ignore 12345                   # ignore future activity on a thread
 hey stop-ignoring 12345            # resume attention for a thread
 ```
 
-`hey thread read` reads a whole thread, oldest entry first, however many pages HEY serves it in — within limits it states: a hundred pages past the first, two thousand entries, as many bodies, 64 MiB of content and two minutes in all. A thread that could only be read in part — a body HEY would not serve, a limit reached — is refused rather than passed off as whole; `--allow-partial` takes what was read, with a `notice` saying what is missing and each entry's `body_state` saying whether its body was `hydrated`, `bodyless` (HEY served none), `over_limit` or `failed`. `--count` and `--ids-only` read the entry index and no bodies, so only a truncated index can make them partial. `--markdown` writes the thread as one Markdown document — a heading per entry naming the sender, date and ID, then the body — which is the shape to hand an agent or a notes app. `hey attachment list` reads the bodies in every format, since that is where attachment metadata lives, and answers a partial thread the same way. `hey reply` answers the thread's latest entry and addresses the reply the way HEY does: everyone that entry was addressed to, plus whoever wrote it.
+`hey thread read` reads a whole thread, oldest entry first, however many pages HEY serves it in — within limits it states: a hundred pages past the first, two thousand entries, as many bodies, 64 MiB of content and two minutes in all. A thread that could only be read in part — a body HEY would not serve, a limit reached — is refused rather than passed off as whole; `--allow-partial` takes what was read, with a `notice` saying what is missing and each entry's `body_state` saying whether its body was `hydrated`, `bodyless` (HEY served none), `over_limit` or `failed`. `--count` and `--ids-only` read the entry index and no bodies, so only a truncated index can make them partial. `--markdown` writes the thread as one Markdown document — a heading per entry naming the sender, date and ID, then the body — which is the shape to hand an agent or a notes app. `hey attachment list` reads the bodies in every format, since that is where attachment metadata lives, and answers a partial thread the same way. `hey reply` answers the thread's latest entry and addresses the reply the way HEY does: it asks HEY for the reply's recipients — everyone that entry was addressed to, its sender moved onto the To line, and your own addresses, aliases and catch-alls excluded — falling back to computing them from the entry when that read is unavailable.
 
 Email bodies come back as Markdown. `hey thread read` and the TUI render that Markdown for the terminal — headings, emphasis, lists, quotes, tables and code survive, and links keep their URLs and stay clickable where the terminal supports it. `--json` carries the same Markdown in `body`, so an agent reading a thread sees the structure a human sees rather than a flattened wall of text. `--html` still returns HEY's original HTML.
 
 Writing is Markdown too, everywhere text goes in: `-m`, `--content`, `--note`, positional content, stdin, and `$EDITOR` (which opens prefilled with the existing entry or note as Markdown). Every such flag has a raw-HTML twin — `--message-html`, `--content-html`, `--note-html` — for sending markup verbatim; each pair is mutually exclusive. The TUI's compose and bulk-reply forms convert Markdown the same way, and the compose editor renders it live as you type — `**bold**` turns bold, markers and all. A fenced code block's language (` ```ruby `) is carried the way HEY's own editor stores it, so the web app syntax-highlights it.
+
+Drafts are the review-before-send lane: `hey compose --draft` (and `hey reply --draft`) saves instead of sending — recipients optional on a draft — and answers the draft's ID. `hey draft show` reads it back with the body as Markdown, `hey draft edit` revises it (each flag replaces its field; what is not flagged is kept, by reading the draft and resending the whole of it, since a revision is not a patch on HEY's side), `hey draft send` delivers through HEY's undo window — or schedules to the hour with `--on` and `--hour`, in the account's time zone — and `hey draft delete` trashes it. A draft prepared here is reviewed and sent from any HEY app, which is the workflow this is for: an agent writes, a person decides.
 
 `hey share <thread_id>` gets a sharing link for a thread. Anyone with the link can see the entire thread and future emails or replies sent to it. `hey unshare <thread_id>` turns off the sharing link.
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/actioncable-go v0.0.0-20260821132720-3f7811951537
-	github.com/basecamp/hey-sdk/go v0.21.0
+	github.com/basecamp/hey-sdk/go v0.22.0
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/actioncable-go v0.0.0-20260821132720-3f7811951537 h1:OE1VMvKkpI+Vo7aP5IDRG6PNXW2IVMlLUWLgBcybGNc=
 github.com/basecamp/actioncable-go v0.0.0-20260821132720-3f7811951537/go.mod h1:9+DEydJMniIKraEsd4fDJpFEnqlLUJ6XhAswxRBaITk=
-github.com/basecamp/hey-sdk/go v0.21.0 h1:/CpoFDkD8uh0U5n/AjObF3GqPOTIprAxP79l1TuTL34=
-github.com/basecamp/hey-sdk/go v0.21.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
+github.com/basecamp/hey-sdk/go v0.22.0 h1:7hsvhyIXH/kWiFEiksKgCHAa+haqRdNCqK0AMxPErAM=
+github.com/basecamp/hey-sdk/go v0.22.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/cmd/compose.go
+++ b/internal/cmd/compose.go
@@ -7,9 +7,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/editor"
 	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/output"
 )
 
 type composeCommand struct {
@@ -22,6 +25,7 @@ type composeCommand struct {
 	messageHTML string
 	threadID    string
 	attachments []string
+	draft       bool
 }
 
 func newComposeCommand() *composeCommand {
@@ -30,7 +34,7 @@ func newComposeCommand() *composeCommand {
 		Use:   "compose",
 		Short: "Write and send a new email",
 		Annotations: map[string]string{
-			"agent_notes": "Starts a new thread with --to (optionally --cc/--bcc), which requires --subject, or replies to an existing one with --thread-id, which does not. Repeatable --attach files are uploaded before sending and can be sent without body text. The body is Markdown; use --message-html to send raw HTML instead.",
+			"agent_notes": "Starts a new thread with --to (optionally --cc/--bcc), which requires --subject, or replies to an existing one with --thread-id, which does not. Repeatable --attach files are uploaded before sending and can be sent without body text. The body is Markdown; use --message-html to send raw HTML instead. --draft saves instead of sending — recipients become optional — and answers the draft ID for hey draft show/edit/send/delete.",
 		},
 		Example: `  hey compose --to alice@example.com --subject "Lunch plans" -m "Are you free Friday?"
   hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Kitchen remodel timeline" -m "Cabinets land the week of the 14th."
@@ -38,7 +42,8 @@ func newComposeCommand() *composeCommand {
   hey compose --thread-id 12345 -m "Confirmed — see you then." --attach ./diagram.png
   hey compose --to alice@example.com --subject "Sprint recap" -m "We **shipped** the pagination fix."
   hey compose --to alice@example.com --subject "Newsletter draft" --message-html "<h1>March</h1><p>What we shipped.</p>"
-  echo "Notes from the offsite" | hey compose --to bob@example.com --subject "Offsite recap"`,
+  echo "Notes from the offsite" | hey compose --to bob@example.com --subject "Offsite recap"
+  hey compose --subject "Board update" -m "Numbers to follow." --draft  # save a draft; add recipients later`,
 		RunE: composeCommand.run,
 	}
 
@@ -50,6 +55,7 @@ func newComposeCommand() *composeCommand {
 	composeCommand.cmd.Flags().StringVar(&composeCommand.messageHTML, "message-html", "", "Message body as raw HTML instead of Markdown")
 	composeCommand.cmd.Flags().StringVar(&composeCommand.threadID, "thread-id", "", "Reply to this thread instead of starting a new one")
 	composeCommand.cmd.Flags().StringArrayVar(&composeCommand.attachments, "attach", nil, "File to attach (repeatable)")
+	composeCommand.cmd.Flags().BoolVar(&composeCommand.draft, "draft", false, "Save as a draft instead of sending")
 	composeCommand.cmd.MarkFlagsMutuallyExclusive("message", "message-html")
 
 	return composeCommand
@@ -106,6 +112,14 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		if attachErr != nil {
 			return attachErr
 		}
+		if c.draft {
+			draftID, draftErr := replySDK.Entries().CreateReplyDraft(ctx, target.EntryID, messageWithAttachments,
+				target.Addressed.To, target.Addressed.CC, target.Addressed.BCC)
+			if draftErr != nil {
+				return apierr.FromSDK(draftErr)
+			}
+			return writeDraftSaved(cmd, draftID, len(c.attachments))
+		}
 		if err := replySDK.Entries().CreateReply(ctx, target.EntryID, messageWithAttachments,
 			target.Addressed.To, target.Addressed.CC, target.Addressed.BCC); err != nil {
 			return apierr.FromSDK(err)
@@ -114,12 +128,22 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 		to := parseAddresses(c.to)
 		cc := parseAddresses(c.cc)
 		bcc := parseAddresses(c.bcc)
-		if len(to)+len(cc)+len(bcc) == 0 {
+		// A draft needs nobody on it yet; only a send does.
+		if len(to)+len(cc)+len(bcc) == 0 && !c.draft {
 			return apierr.ErrUsage("a message needs at least one recipient (to, cc or bcc)")
 		}
 		messageWithAttachments, attachErr := attachFiles(ctx, message, c.attachments)
 		if attachErr != nil {
 			return attachErr
+		}
+		if c.draft {
+			draftID, draftErr := sdk.Messages().CreateDraft(ctx, hey.DraftContent{
+				Subject: c.subject, Content: messageWithAttachments, To: to, CC: cc, BCC: bcc,
+			})
+			if draftErr != nil {
+				return apierr.FromSDK(draftErr)
+			}
+			return writeDraftSaved(cmd, draftID, len(c.attachments))
 		}
 		if err := sdk.Messages().Create(ctx, c.subject, messageWithAttachments, to, cc, bcc); err != nil {
 			return apierr.FromSDK(err)
@@ -127,6 +151,20 @@ func (c *composeCommand) run(cmd *cobra.Command, args []string) error {
 	}
 
 	return writeMutation(cmd, sentWithAttachmentsSummary("Message sent", len(c.attachments)), nil)
+}
+
+// writeDraftSaved confirms a saved draft, naming the id every draft verb takes.
+func writeDraftSaved(cmd *cobra.Command, draftID int64, attachments int) error {
+	summary := sentWithAttachmentsSummary("Draft saved", attachments)
+	return writeMutationLine(cmd, fmt.Sprintf("%s (id %d).", summary, draftID), summary,
+		map[string]any{"id": draftID},
+		output.WithBreadcrumbs(
+			output.Breadcrumb{Action: "show", Command: fmt.Sprintf("hey draft show %d", draftID), Description: "Read the draft back"},
+			output.Breadcrumb{Action: "edit", Command: fmt.Sprintf("hey draft edit %d", draftID), Description: "Change it"},
+			output.Breadcrumb{Action: "send", Command: fmt.Sprintf("hey draft send %d", draftID), Description: "Deliver it"},
+			output.Breadcrumb{Action: "delete", Command: fmt.Sprintf("hey draft delete %d", draftID), Description: "Trash it"},
+		),
+	)
 }
 
 func parseAddresses(s string) []string {

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -1,0 +1,377 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/editor"
+	"github.com/basecamp/hey-cli/internal/htmlutil"
+	"github.com/basecamp/hey-cli/internal/markdown"
+	"github.com/basecamp/hey-cli/internal/output"
+	"github.com/basecamp/hey-cli/internal/terminal"
+)
+
+// draftOutput is what hey draft show answers with: the draft's editable state, its body
+// as Markdown the way every email body leaves this CLI.
+type draftOutput struct {
+	ID                  int64             `json:"id"`
+	Subject             string            `json:"subject,omitempty"`
+	Body                htmlutil.Markdown `json:"body"`
+	To                  []string          `json:"to,omitempty"`
+	CC                  []string          `json:"cc,omitempty"`
+	BCC                 []string          `json:"bcc,omitempty"`
+	IsReply             bool              `json:"is_reply,omitempty"`
+	ScheduledDeliveryAt *time.Time        `json:"scheduled_delivery_at,omitempty"`
+	UpdatedAt           *time.Time        `json:"updated_at,omitempty"`
+}
+
+func draftOutputFor(id int64, edit *generated.MessageEditState) draftOutput {
+	out := draftOutput{
+		ID:      id,
+		Subject: edit.Subject,
+		Body:    htmlutil.ToMarkdown(edit.Content),
+		To:      addressEmails(edit.Addressed.Directly),
+		CC:      addressEmails(edit.Addressed.Copied),
+		BCC:     addressEmails(edit.Addressed.Blindcopied),
+		IsReply: edit.IsReply,
+	}
+	if !edit.ScheduledDeliveryAt.IsZero() {
+		at := edit.ScheduledDeliveryAt
+		out.ScheduledDeliveryAt = &at
+	}
+	if !edit.UpdatedAt.IsZero() {
+		at := edit.UpdatedAt
+		out.UpdatedAt = &at
+	}
+	return out
+}
+
+func addressEmails(contacts []generated.Contact) []string {
+	var emails []string
+	for _, contact := range contacts {
+		if contact.EmailAddress != "" {
+			emails = append(emails, contact.EmailAddress)
+		}
+	}
+	return emails
+}
+
+func parseDraftID(arg string) (int64, error) {
+	id, err := strconv.ParseInt(arg, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, apierr.ErrUsage(fmt.Sprintf("invalid draft ID: %s", arg))
+	}
+	return id, nil
+}
+
+// draftContentFrom is the edit state as the full DraftContent an update resends. HEY
+// revises a draft from the whole request, so every verb that writes one starts here.
+func draftContentFrom(edit *generated.MessageEditState) hey.DraftContent {
+	content := hey.DraftContent{
+		Subject: edit.Subject,
+		Content: edit.Content,
+		To:      addressEmails(edit.Addressed.Directly),
+		CC:      addressEmails(edit.Addressed.Copied),
+		BCC:     addressEmails(edit.Addressed.Blindcopied),
+	}
+	if !edit.ScheduledDeliveryAt.IsZero() {
+		// HEY serves the moment in UTC and schedules by a date and an hour read in
+		// the identity's time zone; the local clock is this CLI's best stand-in.
+		local := edit.ScheduledDeliveryAt.Local()
+		content.Schedule = &hey.DraftSchedule{Date: local.Format("2006-01-02"), Hour: local.Hour()}
+	}
+	return content
+}
+
+// --- show ---
+
+type draftShowCommand struct {
+	cmd *cobra.Command
+}
+
+func newDraftShowCommand() *draftShowCommand {
+	showCommand := &draftShowCommand{}
+	showCommand.cmd = &cobra.Command{
+		Use:   "show <draft-id>",
+		Short: "Read a draft back",
+		Annotations: map[string]string{
+			"agent_notes": "Draft IDs come from `hey draft list` or from saving with `hey compose --draft`. The body is Markdown.",
+		},
+		Example: `  hey draft show 12345
+  hey draft show 12345 --json`,
+		RunE: showCommand.run,
+		Args: usageExactOneArg(),
+	}
+	return showCommand
+}
+
+func (c *draftShowCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	draftID, err := parseDraftID(args[0])
+	if err != nil {
+		return err
+	}
+
+	edit, err := sdk.Messages().GetEdit(cmd.Context(), draftID)
+	if err != nil {
+		return apierr.FromSDK(err)
+	}
+	if edit == nil {
+		return apierr.ErrNotFound("draft", args[0])
+	}
+	out := draftOutputFor(draftID, edit)
+
+	if writer.IsStyled() {
+		w := cmd.OutOrStdout()
+		fmt.Fprintf(w, "Draft %d: %s\n", out.ID, terminal.SanitizeLine(out.Subject))
+		for _, kind := range []struct {
+			label  string
+			emails []string
+		}{{"To", out.To}, {"CC", out.CC}, {"BCC", out.BCC}} {
+			if len(kind.emails) > 0 {
+				fmt.Fprintf(w, "%s: %s\n", kind.label, terminal.SanitizeLine(strings.Join(kind.emails, ", ")))
+			}
+		}
+		if out.ScheduledDeliveryAt != nil {
+			fmt.Fprintf(w, "Scheduled: %s\n", out.ScheduledDeliveryAt.Local().Format("2006-01-02 15:04"))
+		}
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, markdown.Render(out.Body, stdoutWidth()))
+		return nil
+	}
+	return writeOK(out,
+		output.WithSummary(fmt.Sprintf("Draft %d", out.ID)),
+		output.WithBreadcrumbs(
+			output.Breadcrumb{Action: "edit", Command: fmt.Sprintf("hey draft edit %d", out.ID), Description: "Change the draft"},
+			output.Breadcrumb{Action: "send", Command: fmt.Sprintf("hey draft send %d", out.ID), Description: "Deliver it"},
+		),
+	)
+}
+
+// --- edit ---
+
+type draftEditCommand struct {
+	cmd         *cobra.Command
+	subject     string
+	to          string
+	cc          string
+	bcc         string
+	message     string
+	messageHTML string
+}
+
+func newDraftEditCommand() *draftEditCommand {
+	editCommand := &draftEditCommand{}
+	editCommand.cmd = &cobra.Command{
+		Use:   "edit <draft-id>",
+		Short: "Change a draft",
+		Annotations: map[string]string{
+			"agent_notes": "Each flag replaces its field and an omitted flag keeps what the draft has — --to/--cc/--bcc replace that whole recipient kind (an explicit empty value clears it). With no field flags the body opens in $EDITOR as Markdown. A scheduled delivery is preserved.",
+		},
+		Example: `  hey draft edit 12345 --subject "Quarterly planning (v2)"
+  hey draft edit 12345 --to maria@example.com --cc finance@example.com
+  hey draft edit 12345 -m "Rewritten agenda: budget first, hiring second."
+  hey draft edit 12345    # open the body in $EDITOR`,
+		RunE: editCommand.run,
+		Args: usageExactOneArg(),
+	}
+	editCommand.cmd.Flags().StringVar(&editCommand.subject, "subject", "", "Replace the subject")
+	editCommand.cmd.Flags().StringVar(&editCommand.to, "to", "", "Replace the To recipients (comma separated; empty clears)")
+	editCommand.cmd.Flags().StringVar(&editCommand.cc, "cc", "", "Replace the CC recipients (comma separated; empty clears)")
+	editCommand.cmd.Flags().StringVar(&editCommand.bcc, "bcc", "", "Replace the BCC recipients (comma separated; empty clears)")
+	editCommand.cmd.Flags().StringVarP(&editCommand.message, "message", "m", "", "Replace the body with this Markdown")
+	editCommand.cmd.Flags().StringVar(&editCommand.messageHTML, "message-html", "", "Replace the body with raw HTML instead of Markdown")
+	editCommand.cmd.MarkFlagsMutuallyExclusive("message", "message-html")
+	return editCommand
+}
+
+func (c *draftEditCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	draftID, err := parseDraftID(args[0])
+	if err != nil {
+		return err
+	}
+	ctx := cmd.Context()
+
+	edit, err := sdk.Messages().GetEdit(ctx, draftID)
+	if err != nil {
+		return apierr.FromSDK(err)
+	}
+	if edit == nil {
+		return apierr.ErrNotFound("draft", args[0])
+	}
+	content := draftContentFrom(edit)
+
+	flags := cmd.Flags()
+	fieldFlagged := false
+	if flags.Changed("subject") {
+		content.Subject = c.subject
+		fieldFlagged = true
+	}
+	if flags.Changed("to") {
+		content.To = parseAddresses(c.to)
+		fieldFlagged = true
+	}
+	if flags.Changed("cc") {
+		content.CC = parseAddresses(c.cc)
+		fieldFlagged = true
+	}
+	if flags.Changed("bcc") {
+		content.BCC = parseAddresses(c.bcc)
+		fieldFlagged = true
+	}
+	switch {
+	case flags.Changed("message-html"):
+		content.Content = c.messageHTML
+	case flags.Changed("message"):
+		content.Content = htmlutil.FromMarkdown(c.message)
+	case !fieldFlagged:
+		// No field named: the edit is the body, in $EDITOR, prefilled as Markdown.
+		body, editorErr := editor.Open(htmlutil.ToMarkdown(edit.Content).String())
+		if editorErr != nil {
+			return apierr.ErrAPI(0, fmt.Sprintf("could not open editor: %v", editorErr))
+		}
+		if body == "" {
+			return apierr.ErrUsage("empty body, aborting — delete the draft with `hey draft delete` instead")
+		}
+		content.Content = htmlutil.FromMarkdown(body)
+	}
+
+	if err := sdk.Messages().UpdateDraft(ctx, draftID, content); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutationLine(cmd, fmt.Sprintf("Draft %d updated.", draftID), "Draft updated",
+		map[string]any{"id": draftID})
+}
+
+// --- send ---
+
+type draftSendCommand struct {
+	cmd  *cobra.Command
+	on   string
+	hour int
+}
+
+func newDraftSendCommand() *draftSendCommand {
+	sendCommand := &draftSendCommand{}
+	sendCommand.cmd = &cobra.Command{
+		Use:   "send <draft-id>",
+		Short: "Deliver a draft",
+		Annotations: map[string]string{
+			"agent_notes": "Sends the draft as it stands — recipients are required, added with `hey draft edit --to`. Delivery goes through HEY's undo window. --on with --hour schedules it instead (to the hour, in the account's time zone); the draft stays listed until it goes out.",
+		},
+		Example: `  hey draft send 12345
+  hey draft send 12345 --on tomorrow --hour 9
+  hey draft send 12345 --on 2026-09-01 --hour 14`,
+		RunE: sendCommand.run,
+		Args: usageExactOneArg(),
+	}
+	sendCommand.cmd.Flags().StringVar(&sendCommand.on, "on", "", "Schedule delivery for this date (YYYY-MM-DD, today or tomorrow)")
+	sendCommand.cmd.Flags().IntVar(&sendCommand.hour, "hour", -1, "Hour of --on to deliver at (0-23)")
+	sendCommand.cmd.MarkFlagsRequiredTogether("on", "hour")
+	return sendCommand
+}
+
+func (c *draftSendCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	draftID, err := parseDraftID(args[0])
+	if err != nil {
+		return err
+	}
+	if c.on != "" && (c.hour < 0 || c.hour > 23) {
+		return apierr.ErrUsage("--hour must be between 0 and 23")
+	}
+	ctx := cmd.Context()
+
+	edit, err := sdk.Messages().GetEdit(ctx, draftID)
+	if err != nil {
+		return apierr.FromSDK(err)
+	}
+	if edit == nil {
+		return apierr.ErrNotFound("draft", args[0])
+	}
+	content := draftContentFrom(edit)
+	if len(content.To)+len(content.CC)+len(content.BCC) == 0 {
+		return apierr.ErrUsageHint("the draft has no recipients", fmt.Sprintf("hey draft edit %d --to <email>", draftID))
+	}
+
+	if c.on != "" {
+		content.Schedule = &hey.DraftSchedule{Date: c.on, Hour: c.hour}
+		if err := sdk.Messages().UpdateDraft(ctx, draftID, content); err != nil {
+			return apierr.FromSDK(err)
+		}
+		return writeMutationLine(cmd, fmt.Sprintf("Draft %d scheduled for delivery.", draftID),
+			"Draft scheduled for delivery", map[string]any{"id": draftID})
+	}
+
+	content.Schedule = nil
+	if err := sdk.Messages().SendDraft(ctx, draftID, content); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutationLine(cmd, fmt.Sprintf("Draft %d sent.", draftID), "Draft sent",
+		map[string]any{"id": draftID})
+}
+
+// --- delete ---
+
+type draftDeleteCommand struct {
+	cmd *cobra.Command
+}
+
+func newDraftDeleteCommand() *draftDeleteCommand {
+	deleteCommand := &draftDeleteCommand{}
+	deleteCommand.cmd = &cobra.Command{
+		Use:   "delete <draft-id>...",
+		Short: "Trash drafts",
+		Annotations: map[string]string{
+			"agent_notes": "Takes draft IDs from `hey draft list`. Trashes the draft; there is no undo here.",
+		},
+		Example: `  hey draft delete 12345
+  hey draft delete 12345 67890`,
+		RunE: deleteCommand.run,
+		Args: usageMinOneArg(),
+	}
+	return deleteCommand
+}
+
+func (c *draftDeleteCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	ids := make([]int64, 0, len(args))
+	for _, arg := range args {
+		id, err := parseDraftID(arg)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, id)
+	}
+
+	for _, id := range ids {
+		if err := sdk.Entries().DeleteDraft(cmd.Context(), id); err != nil {
+			return apierr.FromSDK(err)
+		}
+	}
+	return writeMutation(cmd, fmt.Sprintf("%d %s deleted", len(ids), draftNoun(len(ids))), nil)
+}
+
+func draftNoun(count int) string {
+	if count == 1 {
+		return "draft"
+	}
+	return "drafts"
+}

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -75,7 +75,7 @@ func parseDraftID(arg string) (int64, error) {
 
 // draftContentFrom is the edit state as the full DraftContent an update resends. HEY
 // revises a draft from the whole request, so every verb that writes one starts here.
-func draftContentFrom(ctx context.Context, edit *generated.MessageEditState) hey.DraftContent {
+func draftContentFrom(edit *generated.MessageEditState) hey.DraftContent {
 	content := hey.DraftContent{
 		Subject: edit.Subject,
 		Content: edit.Content,
@@ -84,18 +84,20 @@ func draftContentFrom(ctx context.Context, edit *generated.MessageEditState) hey
 		BCC:     addressEmails(edit.Addressed.Blindcopied),
 	}
 	if !edit.ScheduledDeliveryAt.IsZero() {
-		// HEY serves the moment in UTC but schedules by a date and an hour read in
-		// the identity's time zone, so the moment is said back in that zone — the
-		// host's own clock would move the delivery by the difference between them.
-		at := edit.ScheduledDeliveryAt.In(draftScheduleLocation(ctx))
+		// HEY's API reads a schedule's date and hour in UTC (ApiRequest sets
+		// Time.zone to UTC for every JSON request), so the served UTC moment is
+		// said back as its own UTC date and hour — the exact round-trip, whatever
+		// clock the host or the identity keeps. Proven live: an identity-zone
+		// conversion here moved a 09:00Z delivery to 04:00Z on the first edit.
+		at := edit.ScheduledDeliveryAt.UTC()
 		content.Schedule = &hey.DraftSchedule{Date: at.Format("2006-01-02"), Hour: at.Hour()}
 	}
 	return content
 }
 
-// draftScheduleLocation answers the clock a draft's schedule is read in: the identity's
-// time zone, which is HEY's own for every scheduled delivery. The host's local clock
-// stands in only when the identity does not name a zone this host knows.
+// draftScheduleLocation answers the clock a person means when they say "tomorrow at 9":
+// the identity's HEY time zone. The host's local clock stands in only when the identity
+// does not name a zone this host knows.
 func draftScheduleLocation(ctx context.Context) *time.Location {
 	identity, err := sdk.Identity().GetIdentity(ctx)
 	if err != nil || identity == nil || identity.TimeZoneName == "" {
@@ -106,6 +108,34 @@ func draftScheduleLocation(ctx context.Context) *time.Location {
 		return time.Local
 	}
 	return location
+}
+
+// draftScheduleFor turns "--on and --hour on the identity's clock" into the UTC date and
+// hour HEY's API reads (Time.zone is UTC for JSON requests, so the params are UTC on the
+// wire — the web app's identity-zone reading does not apply here). today and tomorrow are
+// resolved on the identity's clock too, since HEY would otherwise read them as UTC dates.
+// A zone offset with fractional hours cannot land on a whole UTC hour and is refused
+// rather than silently shifted.
+func draftScheduleFor(location *time.Location, on string, hour int, now time.Time) (*hey.DraftSchedule, error) {
+	base := now.In(location)
+	var day time.Time
+	switch on {
+	case "today":
+		day = base
+	case "tomorrow":
+		day = base.AddDate(0, 0, 1)
+	default:
+		parsed, err := time.ParseInLocation("2006-01-02", on, location)
+		if err != nil {
+			return nil, apierr.ErrUsage(fmt.Sprintf("invalid --on date %q: use YYYY-MM-DD, today or tomorrow", on))
+		}
+		day = parsed
+	}
+	at := time.Date(day.Year(), day.Month(), day.Day(), hour, 0, 0, 0, location).UTC()
+	if at.Minute() != 0 {
+		return nil, apierr.ErrUsage(fmt.Sprintf("your HEY time zone (%s) is offset from UTC by a fraction of an hour, and HEY schedules deliveries on whole UTC hours — this hour cannot be expressed exactly", location))
+	}
+	return &hey.DraftSchedule{Date: at.Format("2006-01-02"), Hour: at.Hour()}, nil
 }
 
 // --- show ---
@@ -229,7 +259,7 @@ func (c *draftEditCommand) run(cmd *cobra.Command, args []string) error {
 	if edit == nil {
 		return apierr.ErrNotFound("draft", args[0])
 	}
-	content := draftContentFrom(ctx, edit)
+	content := draftContentFrom(edit)
 
 	flags := cmd.Flags()
 	fieldFlagged := false
@@ -287,7 +317,7 @@ func newDraftSendCommand() *draftSendCommand {
 		Use:   "send <draft-id>",
 		Short: "Deliver a draft",
 		Annotations: map[string]string{
-			"agent_notes": "Sends the draft as it stands — recipients are required, added with `hey draft edit --to`. Delivery goes through HEY's undo window. --on with --hour schedules it instead (to the hour, in the account's time zone); the draft stays listed until it goes out.",
+			"agent_notes": "Sends the draft as it stands — recipients are required, added with `hey draft edit --to`. Delivery goes through HEY's undo window. --on with --hour schedules it instead, read on the HEY account's clock and scheduled to the hour; the draft stays listed until it goes out.",
 		},
 		Example: `  hey draft send 12345
   hey draft send 12345 --on tomorrow --hour 9
@@ -295,8 +325,8 @@ func newDraftSendCommand() *draftSendCommand {
 		RunE: sendCommand.run,
 		Args: usageExactOneArg(),
 	}
-	sendCommand.cmd.Flags().StringVar(&sendCommand.on, "on", "", "Schedule delivery for this date (YYYY-MM-DD, today or tomorrow)")
-	sendCommand.cmd.Flags().IntVar(&sendCommand.hour, "hour", -1, "Hour of --on to deliver at (0-23)")
+	sendCommand.cmd.Flags().StringVar(&sendCommand.on, "on", "", "Schedule delivery for this date on your HEY account's clock (YYYY-MM-DD, today or tomorrow)")
+	sendCommand.cmd.Flags().IntVar(&sendCommand.hour, "hour", -1, "Hour of --on to deliver at, 0-23, on your HEY account's clock")
 	sendCommand.cmd.MarkFlagsRequiredTogether("on", "hour")
 	return sendCommand
 }
@@ -326,13 +356,17 @@ func (c *draftSendCommand) run(cmd *cobra.Command, args []string) error {
 	if edit == nil {
 		return apierr.ErrNotFound("draft", args[0])
 	}
-	content := draftContentFrom(ctx, edit)
+	content := draftContentFrom(edit)
 	if len(content.To)+len(content.CC)+len(content.BCC) == 0 {
 		return apierr.ErrUsageHint("the draft has no recipients", fmt.Sprintf("hey draft edit %d --to <email>", draftID))
 	}
 
 	if c.on != "" {
-		content.Schedule = &hey.DraftSchedule{Date: c.on, Hour: c.hour}
+		schedule, scheduleErr := draftScheduleFor(draftScheduleLocation(ctx), c.on, c.hour, time.Now())
+		if scheduleErr != nil {
+			return scheduleErr
+		}
+		content.Schedule = schedule
 		if err := sdk.Messages().UpdateDraft(ctx, draftID, content); err != nil {
 			return apierr.FromSDK(err)
 		}

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -74,7 +75,7 @@ func parseDraftID(arg string) (int64, error) {
 
 // draftContentFrom is the edit state as the full DraftContent an update resends. HEY
 // revises a draft from the whole request, so every verb that writes one starts here.
-func draftContentFrom(edit *generated.MessageEditState) hey.DraftContent {
+func draftContentFrom(ctx context.Context, edit *generated.MessageEditState) hey.DraftContent {
 	content := hey.DraftContent{
 		Subject: edit.Subject,
 		Content: edit.Content,
@@ -83,12 +84,28 @@ func draftContentFrom(edit *generated.MessageEditState) hey.DraftContent {
 		BCC:     addressEmails(edit.Addressed.Blindcopied),
 	}
 	if !edit.ScheduledDeliveryAt.IsZero() {
-		// HEY serves the moment in UTC and schedules by a date and an hour read in
-		// the identity's time zone; the local clock is this CLI's best stand-in.
-		local := edit.ScheduledDeliveryAt.Local()
-		content.Schedule = &hey.DraftSchedule{Date: local.Format("2006-01-02"), Hour: local.Hour()}
+		// HEY serves the moment in UTC but schedules by a date and an hour read in
+		// the identity's time zone, so the moment is said back in that zone — the
+		// host's own clock would move the delivery by the difference between them.
+		at := edit.ScheduledDeliveryAt.In(draftScheduleLocation(ctx))
+		content.Schedule = &hey.DraftSchedule{Date: at.Format("2006-01-02"), Hour: at.Hour()}
 	}
 	return content
+}
+
+// draftScheduleLocation answers the clock a draft's schedule is read in: the identity's
+// time zone, which is HEY's own for every scheduled delivery. The host's local clock
+// stands in only when the identity does not name a zone this host knows.
+func draftScheduleLocation(ctx context.Context) *time.Location {
+	identity, err := sdk.Identity().GetIdentity(ctx)
+	if err != nil || identity == nil || identity.TimeZoneName == "" {
+		return time.Local
+	}
+	location, err := time.LoadLocation(identity.TimeZoneName)
+	if err != nil {
+		return time.Local
+	}
+	return location
 }
 
 // --- show ---
@@ -212,7 +229,7 @@ func (c *draftEditCommand) run(cmd *cobra.Command, args []string) error {
 	if edit == nil {
 		return apierr.ErrNotFound("draft", args[0])
 	}
-	content := draftContentFrom(edit)
+	content := draftContentFrom(ctx, edit)
 
 	flags := cmd.Flags()
 	fieldFlagged := false
@@ -292,8 +309,13 @@ func (c *draftSendCommand) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if c.on != "" && (c.hour < 0 || c.hour > 23) {
-		return apierr.ErrUsage("--hour must be between 0 and 23")
+	if c.on != "" {
+		if c.hour < 0 || c.hour > 23 {
+			return apierr.ErrUsage("--hour must be between 0 and 23")
+		}
+		if dateErr := validateScheduleDate(c.on); dateErr != nil {
+			return dateErr
+		}
 	}
 	ctx := cmd.Context()
 
@@ -304,7 +326,7 @@ func (c *draftSendCommand) run(cmd *cobra.Command, args []string) error {
 	if edit == nil {
 		return apierr.ErrNotFound("draft", args[0])
 	}
-	content := draftContentFrom(edit)
+	content := draftContentFrom(ctx, edit)
 	if len(content.To)+len(content.CC)+len(content.BCC) == 0 {
 		return apierr.ErrUsageHint("the draft has no recipients", fmt.Sprintf("hey draft edit %d --to <email>", draftID))
 	}
@@ -374,4 +396,16 @@ func draftNoun(count int) string {
 		return "draft"
 	}
 	return "drafts"
+}
+
+// validateScheduleDate holds --on to what it advertises — YYYY-MM-DD, today or
+// tomorrow — so a typo is a usage error before anything is fetched or written.
+func validateScheduleDate(on string) error {
+	if on == "today" || on == "tomorrow" {
+		return nil
+	}
+	if _, err := time.Parse("2006-01-02", on); err != nil {
+		return apierr.ErrUsage(fmt.Sprintf("invalid --on date %q: use YYYY-MM-DD, today or tomorrow", on))
+	}
+	return nil
 }

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 // draftLifecycleServer serves the identity the SDK's sending operations resolve, a
@@ -228,8 +229,10 @@ func TestDraftSendRefusesADraftWithNoRecipients(t *testing.T) {
 
 func TestDraftSendSchedulesWithOnAndHour(t *testing.T) {
 	var writes []draftWrite
+	// The fixture identity keeps America/New_York, so 9 on its clock in December
+	// (EST, UTC-5) is 14:00Z — the UTC values HEY's API actually reads.
 	response, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
-		"draft", "send", "12345", "--on", "tomorrow", "--hour", "9")
+		"draft", "send", "12345", "--on", "2026-12-01", "--hour", "9")
 	if err != nil {
 		t.Fatalf("draft send --on: %v", err)
 	}
@@ -238,7 +241,7 @@ func TestDraftSendSchedulesWithOnAndHour(t *testing.T) {
 	if entry["status"] != "drafted" {
 		t.Errorf("a scheduled send stays drafted, got status %v", entry["status"])
 	}
-	if entry["scheduled_delivery"] != "true" || entry["scheduled_delivery_at_date"] != "tomorrow" || entry["scheduled_delivery_at_hour"] != "9" {
+	if entry["scheduled_delivery"] != "true" || entry["scheduled_delivery_at_date"] != "2026-12-01" || entry["scheduled_delivery_at_hour"] != "14" {
 		t.Errorf("schedule = %v", entry)
 	}
 	if response.Summary != "Draft scheduled for delivery" {
@@ -278,11 +281,11 @@ func TestDraftCommandsRejectBadIDs(t *testing.T) {
 	}
 }
 
-// A schedule is a date and an hour on the identity's clock, so resending one converts
-// the served UTC moment into the identity's zone — never the host's, whose clock would
-// move the delivery by the difference between them. 13:00Z is 09:00 in the fixture
-// identity's America/New_York, whatever machine this test runs on.
-func TestDraftEditPreservesAScheduleOnTheIdentitysClock(t *testing.T) {
+// HEY's API reads a schedule's date and hour in UTC, so preserving one through an edit
+// says the served UTC moment back as its own UTC date and hour — the exact round-trip.
+// Converting into any other zone here is the live bug this pins: a 09:00Z delivery
+// became 04:00Z on the first edit from a US Eastern identity.
+func TestDraftEditPreservesAScheduleExactly(t *testing.T) {
 	scheduled := `{"id":12345,"subject":"Quarterly planning","content":"<div>Agenda.</div>",
 		"scheduled_delivery_at":"2026-09-01T13:00:00Z",
 		"addressed":{"directly":[{"id":7,"name":"Maria Delgado","email_address":"maria@example.com"}]}}`
@@ -297,8 +300,8 @@ func TestDraftEditPreservesAScheduleOnTheIdentitysClock(t *testing.T) {
 	if entry["scheduled_delivery"] != "true" {
 		t.Fatalf("schedule was not preserved: %v", entry)
 	}
-	if entry["scheduled_delivery_at_date"] != "2026-09-01" || entry["scheduled_delivery_at_hour"] != "9" {
-		t.Errorf("schedule = %v/%v, want the identity zone's 2026-09-01 hour 9",
+	if entry["scheduled_delivery_at_date"] != "2026-09-01" || entry["scheduled_delivery_at_hour"] != "13" {
+		t.Errorf("schedule = %v/%v, want the served moment's own UTC 2026-09-01 hour 13",
 			entry["scheduled_delivery_at_date"], entry["scheduled_delivery_at_hour"])
 	}
 }
@@ -313,5 +316,50 @@ func TestDraftSendRefusesAMalformedOnDate(t *testing.T) {
 	}
 	if len(writes) != 0 {
 		t.Errorf("nothing should be written, wrote %+v", writes)
+	}
+}
+
+// draftScheduleFor is the identity-clock-to-UTC conversion itself.
+func TestDraftScheduleFor(t *testing.T) {
+	newYork, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("time zone database unavailable: %v", err)
+	}
+	adelaide, err := time.LoadLocation("Australia/Adelaide")
+	if err != nil {
+		t.Skipf("time zone database unavailable: %v", err)
+	}
+	// A fixed moment: 2026-12-01 20:00 in New York (2026-12-02 01:00Z).
+	now := time.Date(2026, 12, 1, 20, 0, 0, 0, newYork)
+
+	tests := []struct {
+		name     string
+		on       string
+		hour     int
+		wantDate string
+		wantHour int
+	}{
+		{name: "explicit winter date", on: "2026-12-10", hour: 9, wantDate: "2026-12-10", wantHour: 14},
+		{name: "today is the identity's today", on: "today", hour: 23, wantDate: "2026-12-02", wantHour: 4},
+		{name: "tomorrow rolls the identity's clock", on: "tomorrow", hour: 9, wantDate: "2026-12-02", wantHour: 14},
+		{name: "a late hour crosses into the next UTC day", on: "2026-12-10", hour: 22, wantDate: "2026-12-11", wantHour: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schedule, err := draftScheduleFor(newYork, tt.on, tt.hour, now)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if schedule.Date != tt.wantDate || schedule.Hour != tt.wantHour {
+				t.Errorf("schedule = %s/%d, want %s/%d", schedule.Date, schedule.Hour, tt.wantDate, tt.wantHour)
+			}
+		})
+	}
+
+	if _, err := draftScheduleFor(adelaide, "2026-12-10", 9, now); err == nil {
+		t.Error("a half-hour zone offset cannot land on a whole UTC hour and must be refused")
+	}
+	if _, err := draftScheduleFor(newYork, "soon", 9, now); err == nil {
+		t.Error("an unrecognized --on date must be refused")
 	}
 }

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -1,0 +1,279 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// draftLifecycleServer serves the identity the SDK's sending operations resolve, a
+// draft's edit state, and records every write so a test can say what actually went out.
+type draftWrite struct {
+	Method string
+	Path   string
+	Body   map[string]any
+}
+
+func draftLifecycleServer(t *testing.T, editJSON string, writes *[]draftWrite) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "identity"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"email_address":"user@hey.com","id":1,"senders":[{"id":42,"default":true}],"primary_contact":{"id":42}}`)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/edit.json"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, editJSON)
+		case r.Method == http.MethodPost && r.URL.Path == "/messages.json",
+			r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/messages/"):
+			var body map[string]any
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &body)
+			*writes = append(*writes, draftWrite{Method: r.Method, Path: r.URL.Path, Body: body})
+			entry, _ := body["entry"].(map[string]any)
+			if entry != nil && entry["status"] == "drafted" {
+				w.Header().Set("Location", "https://app.hey.com/messages/12345")
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":12345}`)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/entries/drafts/"):
+			*writes = append(*writes, draftWrite{Method: r.Method, Path: r.URL.Path})
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	})
+}
+
+const draftEditJSON = `{"id":12345,"subject":"Quarterly planning","content":"<div>Agenda to follow.</div>",
+	"updated_at":"2026-08-24T10:00:00Z",
+	"addressed":{"directly":[{"id":7,"name":"Maria Delgado","email_address":"maria@example.com"}],
+	             "copied":[{"id":8,"name":"Priya Natarajan","email_address":"priya@example.com"}]}}`
+
+func TestComposeDraftSavesInsteadOfSending(t *testing.T) {
+	var writes []draftWrite
+	response, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
+		"compose", "--subject", "Board update", "-m", "Numbers to follow.", "--draft")
+	if err != nil {
+		t.Fatalf("compose --draft: %v", err)
+	}
+
+	if len(writes) != 1 || writes[0].Method != "POST" || writes[0].Path != "/messages.json" {
+		t.Fatalf("writes = %+v", writes)
+	}
+	entry, _ := writes[0].Body["entry"].(map[string]any)
+	if entry["status"] != "drafted" {
+		t.Errorf("entry.status = %v, want drafted", entry["status"])
+	}
+	if response.Summary != "Draft saved" {
+		t.Errorf("summary = %q", response.Summary)
+	}
+	data, _ := response.Data.(map[string]any)
+	if data["id"] != float64(12345) {
+		t.Errorf("data = %#v, want the Location's draft id", response.Data)
+	}
+}
+
+// A draft needs nobody on it yet — only a send does.
+func TestComposeDraftNeedsNoRecipients(t *testing.T) {
+	var writes []draftWrite
+	_, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
+		"compose", "--subject", "Board update", "-m", "Numbers.", "--draft")
+	if err != nil {
+		t.Fatalf("compose --draft without recipients: %v", err)
+	}
+	_, err = runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
+		"compose", "--subject", "Board update", "-m", "Numbers.")
+	if err == nil || !strings.Contains(err.Error(), "recipient") {
+		t.Fatalf("a send without recipients must still be refused, got %v", err)
+	}
+}
+
+func TestComposeThreadIDDraftSavesAReplyDraft(t *testing.T) {
+	server, sent := threadReplyServer(t, messageAddressedToJane, 11, 12)
+
+	if err := runCLI(t, server, "--account", "8", "compose", "--thread-id", "7", "-m", "reply draft body", "--draft"); err != nil {
+		t.Fatalf("compose --thread-id --draft: %v", err)
+	}
+	if sent.Status != "drafted" {
+		t.Errorf("entry.status = %q, want drafted", sent.Status)
+	}
+	if !strings.Contains(sent.Path, "/entries/12/replies") {
+		t.Errorf("path = %q, want the latest entry's replies", sent.Path)
+	}
+	if len(sent.To) == 0 {
+		t.Errorf("a reply draft carries the thread's recipients, got none")
+	}
+}
+
+func TestDraftShowAnswersTheEditableState(t *testing.T) {
+	var writes []draftWrite
+	response, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
+		"draft", "show", "12345")
+	if err != nil {
+		t.Fatalf("draft show: %v", err)
+	}
+	data, _ := response.Data.(map[string]any)
+	if data["id"] != float64(12345) || data["subject"] != "Quarterly planning" {
+		t.Errorf("data = %#v", data)
+	}
+	if body, _ := data["body"].(string); !strings.Contains(body, "Agenda to follow") {
+		t.Errorf("body = %q, want Markdown of the draft's content", data["body"])
+	}
+	to, _ := data["to"].([]any)
+	if len(to) != 1 || to[0] != "maria@example.com" {
+		t.Errorf("to = %v", data["to"])
+	}
+	if len(writes) != 0 {
+		t.Errorf("show must not write, wrote %+v", writes)
+	}
+}
+
+// An edit is a revision of the whole draft, so what is not flagged is read first and
+// sent back unchanged.
+func TestDraftEditReplacesOnlyTheFlaggedFields(t *testing.T) {
+	var writes []draftWrite
+	_, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
+		"draft", "edit", "12345", "--to", "sam@example.org")
+	if err != nil {
+		t.Fatalf("draft edit: %v", err)
+	}
+
+	if len(writes) != 1 || writes[0].Method != "PUT" || writes[0].Path != "/messages/12345.json" {
+		t.Fatalf("writes = %+v", writes)
+	}
+	body := writes[0].Body
+	message, _ := body["message"].(map[string]any)
+	if message["subject"] != "Quarterly planning" {
+		t.Errorf("subject = %v, want the existing subject resent", message["subject"])
+	}
+	if content, _ := message["content"].(string); !strings.Contains(content, "Agenda to follow") {
+		t.Errorf("content = %q, want the existing body resent", message["content"])
+	}
+	entry, _ := body["entry"].(map[string]any)
+	if entry["status"] != "drafted" {
+		t.Errorf("entry.status = %v, want drafted", entry["status"])
+	}
+	addressed, _ := entry["addressed"].(map[string]any)
+	directly, _ := addressed["directly"].([]any)
+	if len(directly) != 1 || directly[0] != "sam@example.org" {
+		t.Errorf("directly = %v, want the flag's replacement", addressed["directly"])
+	}
+	copied, _ := addressed["copied"].([]any)
+	if len(copied) != 1 || copied[0] != "priya@example.com" {
+		t.Errorf("copied = %v, want the existing CC kept", addressed["copied"])
+	}
+}
+
+func TestDraftEditClearsARecipientKindWithAnEmptyValue(t *testing.T) {
+	var writes []draftWrite
+	_, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
+		"draft", "edit", "12345", "--cc", "")
+	if err != nil {
+		t.Fatalf("draft edit --cc '': %v", err)
+	}
+	entry, _ := writes[0].Body["entry"].(map[string]any)
+	addressed, _ := entry["addressed"].(map[string]any)
+	if _, present := addressed["copied"]; present {
+		t.Errorf("copied = %v, want cleared", addressed["copied"])
+	}
+	directly, _ := addressed["directly"].([]any)
+	if len(directly) != 1 {
+		t.Errorf("directly = %v, want the To kind kept", addressed["directly"])
+	}
+}
+
+func TestDraftSendDeliversWithTheDraftsOwnState(t *testing.T) {
+	var writes []draftWrite
+	response, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
+		"draft", "send", "12345")
+	if err != nil {
+		t.Fatalf("draft send: %v", err)
+	}
+
+	if len(writes) != 1 || writes[0].Method != "PUT" {
+		t.Fatalf("writes = %+v", writes)
+	}
+	entry, _ := writes[0].Body["entry"].(map[string]any)
+	if _, present := entry["status"]; present {
+		t.Errorf("sending must omit entry.status, got %v", entry["status"])
+	}
+	addressed, _ := entry["addressed"].(map[string]any)
+	directly, _ := addressed["directly"].([]any)
+	if len(directly) != 1 || directly[0] != "maria@example.com" {
+		t.Errorf("directly = %v, want the draft's own recipients", addressed["directly"])
+	}
+	if response.Summary != "Draft sent" {
+		t.Errorf("summary = %q", response.Summary)
+	}
+}
+
+func TestDraftSendRefusesADraftWithNoRecipients(t *testing.T) {
+	var writes []draftWrite
+	bare := `{"id":12345,"subject":"Quarterly planning","content":"<div>Agenda.</div>","addressed":{}}`
+	_, err := runJSONCommand(t, draftLifecycleServer(t, bare, &writes),
+		"draft", "send", "12345")
+	if err == nil || !strings.Contains(err.Error(), "no recipients") {
+		t.Fatalf("err = %v, want a no-recipients refusal", err)
+	}
+	if len(writes) != 0 {
+		t.Errorf("nothing should be written, wrote %+v", writes)
+	}
+}
+
+func TestDraftSendSchedulesWithOnAndHour(t *testing.T) {
+	var writes []draftWrite
+	response, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
+		"draft", "send", "12345", "--on", "tomorrow", "--hour", "9")
+	if err != nil {
+		t.Fatalf("draft send --on: %v", err)
+	}
+
+	entry, _ := writes[0].Body["entry"].(map[string]any)
+	if entry["status"] != "drafted" {
+		t.Errorf("a scheduled send stays drafted, got status %v", entry["status"])
+	}
+	if entry["scheduled_delivery"] != "true" || entry["scheduled_delivery_at_date"] != "tomorrow" || entry["scheduled_delivery_at_hour"] != "9" {
+		t.Errorf("schedule = %v", entry)
+	}
+	if response.Summary != "Draft scheduled for delivery" {
+		t.Errorf("summary = %q", response.Summary)
+	}
+}
+
+func TestDraftDeleteTrashesEachDraft(t *testing.T) {
+	var writes []draftWrite
+	response, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
+		"draft", "delete", "12345", "67890")
+	if err != nil {
+		t.Fatalf("draft delete: %v", err)
+	}
+	if len(writes) != 2 || writes[0].Path != "/entries/drafts/12345.json" || writes[1].Path != "/entries/drafts/67890.json" {
+		t.Errorf("writes = %+v", writes)
+	}
+	if response.Summary != "2 drafts deleted" {
+		t.Errorf("summary = %q", response.Summary)
+	}
+}
+
+func TestDraftCommandsRejectBadIDs(t *testing.T) {
+	var writes []draftWrite
+	for _, args := range [][]string{
+		{"draft", "show", "abc"},
+		{"draft", "edit", "0"},
+		{"draft", "send", "999999999999999999999"},
+		{"draft", "delete", "abc"},
+	} {
+		if _, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes), args...); err == nil || !strings.Contains(err.Error(), "invalid draft ID") {
+			t.Errorf("%v: err = %v, want invalid draft ID", args, err)
+		}
+	}
+	if len(writes) != 0 {
+		t.Errorf("nothing should be written, wrote %+v", writes)
+	}
+}

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -22,7 +22,7 @@ func draftLifecycleServer(t *testing.T, editJSON string, writes *[]draftWrite) h
 		switch {
 		case strings.Contains(r.URL.Path, "identity"):
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, `{"email_address":"user@hey.com","id":1,"senders":[{"id":42,"default":true}],"primary_contact":{"id":42}}`)
+			_, _ = io.WriteString(w, `{"email_address":"user@hey.com","id":1,"time_zone_name":"America/New_York","senders":[{"id":42,"default":true}],"primary_contact":{"id":42}}`)
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/edit.json"):
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, editJSON)
@@ -272,6 +272,44 @@ func TestDraftCommandsRejectBadIDs(t *testing.T) {
 		if _, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes), args...); err == nil || !strings.Contains(err.Error(), "invalid draft ID") {
 			t.Errorf("%v: err = %v, want invalid draft ID", args, err)
 		}
+	}
+	if len(writes) != 0 {
+		t.Errorf("nothing should be written, wrote %+v", writes)
+	}
+}
+
+// A schedule is a date and an hour on the identity's clock, so resending one converts
+// the served UTC moment into the identity's zone — never the host's, whose clock would
+// move the delivery by the difference between them. 13:00Z is 09:00 in the fixture
+// identity's America/New_York, whatever machine this test runs on.
+func TestDraftEditPreservesAScheduleOnTheIdentitysClock(t *testing.T) {
+	scheduled := `{"id":12345,"subject":"Quarterly planning","content":"<div>Agenda.</div>",
+		"scheduled_delivery_at":"2026-09-01T13:00:00Z",
+		"addressed":{"directly":[{"id":7,"name":"Maria Delgado","email_address":"maria@example.com"}]}}`
+	var writes []draftWrite
+	_, err := runJSONCommand(t, draftLifecycleServer(t, scheduled, &writes),
+		"draft", "edit", "12345", "--subject", "Quarterly planning (v2)")
+	if err != nil {
+		t.Fatalf("draft edit: %v", err)
+	}
+
+	entry, _ := writes[0].Body["entry"].(map[string]any)
+	if entry["scheduled_delivery"] != "true" {
+		t.Fatalf("schedule was not preserved: %v", entry)
+	}
+	if entry["scheduled_delivery_at_date"] != "2026-09-01" || entry["scheduled_delivery_at_hour"] != "9" {
+		t.Errorf("schedule = %v/%v, want the identity zone's 2026-09-01 hour 9",
+			entry["scheduled_delivery_at_date"], entry["scheduled_delivery_at_hour"])
+	}
+}
+
+// --on is validated against what it advertises before anything is fetched or written.
+func TestDraftSendRefusesAMalformedOnDate(t *testing.T) {
+	var writes []draftWrite
+	_, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
+		"draft", "send", "12345", "--on", "next-week", "--hour", "9")
+	if err == nil || !strings.Contains(err.Error(), "invalid --on date") {
+		t.Fatalf("err = %v, want an invalid --on usage error", err)
 	}
 	if len(writes) != 0 {
 		t.Errorf("nothing should be written, wrote %+v", writes)

--- a/internal/cmd/drafts.go
+++ b/internal/cmd/drafts.go
@@ -25,12 +25,16 @@ type draftsCommand struct {
 func newDraftCommand() *cobra.Command {
 	draft := &cobra.Command{
 		Use:   "draft",
-		Short: "Browse unsent drafts",
+		Short: "Manage unsent drafts",
 		Annotations: map[string]string{
-			"agent_notes": "Subcommands: list. Returns saved draft messages with IDs, summaries, and subjects. --page continues from the next_page cursor of an earlier listing.",
+			"agent_notes": "Subcommands: list, show, edit, send, delete. Draft IDs come from `hey draft list` or from `hey compose --draft`/`hey reply --draft`. list's --page continues from the next_page cursor of an earlier listing.",
 		},
 	}
 	draft.AddCommand(newDraftsCommand().cmd)
+	draft.AddCommand(newDraftShowCommand().cmd)
+	draft.AddCommand(newDraftEditCommand().cmd)
+	draft.AddCommand(newDraftSendCommand().cmd)
+	draft.AddCommand(newDraftDeleteCommand().cmd)
 	return draft
 }
 

--- a/internal/cmd/drafts.go
+++ b/internal/cmd/drafts.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -11,10 +12,14 @@ import (
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
+// maxDraftPages is how many pages of drafts one command reads, counting the first.
+const maxDraftPages = 100
+
 type draftsCommand struct {
 	cmd   *cobra.Command
 	limit int
 	all   bool
+	page  string
 }
 
 func newDraftCommand() *cobra.Command {
@@ -22,7 +27,7 @@ func newDraftCommand() *cobra.Command {
 		Use:   "draft",
 		Short: "Browse unsent drafts",
 		Annotations: map[string]string{
-			"agent_notes": "Subcommands: list. Returns saved draft messages with IDs, summaries, and subjects.",
+			"agent_notes": "Subcommands: list. Returns saved draft messages with IDs, summaries, and subjects. --page continues from the next_page cursor of an earlier listing.",
 		},
 	}
 	draft.AddCommand(newDraftsCommand().cmd)
@@ -36,13 +41,14 @@ func newDraftsCommand() *draftsCommand {
 		Short: "List draft emails",
 		Example: `  hey draft list
   hey draft list --limit 10
-  hey draft list --json`,
+  hey draft list --all --json`,
 		RunE: draftsCommand.run,
 		Args: cobra.NoArgs,
 	}
 
 	draftsCommand.cmd.Flags().IntVar(&draftsCommand.limit, "limit", 0, "Maximum number of drafts to show")
 	draftsCommand.cmd.Flags().BoolVar(&draftsCommand.all, "all", false, "Fetch all results (override --limit)")
+	draftsCommand.cmd.Flags().StringVar(&draftsCommand.page, "page", "", "Continue from a next_page cursor")
 
 	return draftsCommand
 }
@@ -52,21 +58,23 @@ func (c *draftsCommand) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx := cmd.Context()
-	result, err := sdk.Entries().ListDrafts(ctx, nil)
+	first, err := readDraftsPage(cmd.Context(), c.page)
 	if err != nil {
-		return apierr.FromSDK(err)
+		return err
+	}
+	collected, err := collectPages(cmd.Context(), first, pageRequest{Limit: c.limit, All: c.all, MaxPages: maxDraftPages}, readDraftsPage)
+	if err != nil {
+		return err
 	}
 
-	var drafts []generated.DraftMessage
-	if result != nil {
-		drafts = *result
-	}
-	total := len(drafts)
+	drafts := collected.Items
+	nextPage := collected.Cursor
+	notice := draftsTruncationNotice(collected.Read, collected.Truncated)
 	if c.limit > 0 && !c.all && len(drafts) > c.limit {
 		drafts = drafts[:c.limit]
+		nextPage = ""
+		notice = output.TruncationNotice(len(drafts), len(collected.Items))
 	}
-	notice := output.TruncationNotice(len(drafts), total)
 
 	if writer.IsStyled() {
 		if len(drafts) == 0 {
@@ -81,13 +89,42 @@ func (c *draftsCommand) run(cmd *cobra.Command, args []string) error {
 		}
 		table.print()
 		if notice != "" {
-			fmt.Fprintln(cmd.OutOrStdout(), notice)
+			fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n", notice)
 		}
 		return nil
 	}
+	if stderrNotice := paginationNoticeForStderr(writer.EffectiveFormat(), notice); stderrNotice != "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), stderrNotice)
+	}
 
-	return writeOK(drafts,
+	opts := []output.ResponseOption{
 		output.WithSummary(fmt.Sprintf("%d drafts", len(drafts))),
 		output.WithNotice(notice),
-	)
+		output.WithMeta("pages_fetched", collected.Read),
+	}
+	if nextPage != "" {
+		opts = append(opts, output.WithMeta("next_page", nextPage))
+	}
+	return writeOK(drafts, opts...)
+}
+
+// readDraftsPage reads one page of drafts. The index pages by geared_pagination's opaque
+// cursor out of the Link header — a page number is answered with the first page forever
+// — which is what ListDraftsPage exists for; an empty cursor is the first page.
+func readDraftsPage(ctx context.Context, cursor string) (pageResult[generated.DraftMessage], error) {
+	page, err := sdk.Entries().ListDraftsPage(ctx, cursor)
+	if err != nil {
+		return pageResult[generated.DraftMessage]{}, apierr.FromSDK(err)
+	}
+	if page == nil {
+		return pageResult[generated.DraftMessage]{}, nil
+	}
+	return pageResult[generated.DraftMessage]{Items: page.Drafts, Cursor: page.NextPage}, nil
+}
+
+func draftsTruncationNotice(pages int, truncated bool) string {
+	if !truncated {
+		return ""
+	}
+	return fmt.Sprintf("Draft listing stopped after %d pages. Continue with --page using next_page.", pages)
 }

--- a/internal/cmd/drafts_test.go
+++ b/internal/cmd/drafts_test.go
@@ -135,6 +135,69 @@ func TestDraftsCommandStyledEmpty(t *testing.T) {
 	}
 }
 
+// The drafts index pages by geared_pagination's opaque cursor out of the Link header, so
+// --all follows the cursor each page answers rather than counting pages.
+func TestDraftsCommandFollowsTheCursor(t *testing.T) {
+	var queries []string
+	response, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "draft-cursor-2" {
+			_, _ = io.WriteString(w, `[{"id":102,"subject":"Team retreat itinerary"}]`)
+			return
+		}
+		w.Header().Set("Link", `<https://app.hey.com/entries/drafts.json?page=draft-cursor-2>; rel="next"`)
+		_, _ = io.WriteString(w, `[{"id":101,"subject":"Quarterly planning follow-up"}]`)
+	}), "draft", "list", "--all")
+	if err != nil {
+		t.Fatalf("execute drafts: %v", err)
+	}
+	if len(queries) != 2 || strings.Contains(queries[0], "page=") || !strings.Contains(queries[1], "page=draft-cursor-2") {
+		t.Errorf("queries = %v", queries)
+	}
+	items, ok := response.Data.([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("data = %#v, want both pages' drafts", response.Data)
+	}
+	if response.Notice != "" {
+		t.Errorf("notice = %q, want none for a complete walk", response.Notice)
+	}
+}
+
+// --page continues from a next_page cursor, and a first page with more behind it names
+// the cursor in its meta so a script can carry on.
+func TestDraftsCommandReportsAndAcceptsTheCursor(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "draft-cursor-2" {
+			_, _ = io.WriteString(w, `[{"id":102,"subject":"Team retreat itinerary"}]`)
+			return
+		}
+		w.Header().Set("Link", `<https://app.hey.com/entries/drafts.json?page=draft-cursor-2>; rel="next"`)
+		_, _ = io.WriteString(w, `[{"id":101,"subject":"Quarterly planning follow-up"}]`)
+	})
+
+	response, err := runJSONCommand(t, handler, "draft", "list")
+	if err != nil {
+		t.Fatalf("execute drafts: %v", err)
+	}
+	if response.Meta == nil || response.Meta["next_page"] != "draft-cursor-2" {
+		t.Errorf("meta = %#v, want next_page cursor", response.Meta)
+	}
+
+	response, err = runJSONCommand(t, handler, "draft", "list", "--page", "draft-cursor-2")
+	if err != nil {
+		t.Fatalf("execute drafts --page: %v", err)
+	}
+	items, ok := response.Data.([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("data = %#v, want the second page", response.Data)
+	}
+	if draft, ok := items[0].(map[string]any); !ok || draft["id"] != float64(102) {
+		t.Errorf("draft = %#v, want ID 102", items[0])
+	}
+}
+
 func TestDraftsCommandAPIError(t *testing.T) {
 	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "drafts unavailable", http.StatusBadRequest)

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -118,7 +118,7 @@ CORE COMMANDS
 MAIL
   screener    Decide who gets to email you
   attachment  List and save files from a thread
-  draft       Browse unsent drafts
+  draft       Manage unsent drafts
   watch       Follow email threads and calendars as they change
 
 WRITE & SHARE

--- a/internal/cmd/reply.go
+++ b/internal/cmd/reply.go
@@ -17,6 +17,7 @@ type replyCommand struct {
 	message     string
 	messageHTML string
 	attachments []string
+	draft       bool
 }
 
 func newReplyCommand() *replyCommand {
@@ -30,10 +31,11 @@ The reply is addressed the way HEY's own web app addresses one: everyone that en
 addressed to, with whoever wrote it on the To line. HEY saves an unaddressed reply as a
 draft rather than sending it, so the command fails when it cannot work the recipients out.`,
 		Annotations: map[string]string{
-			"agent_notes": "Replies to the latest entry in a thread, addressed the way HEY addresses a reply: everyone that entry was addressed to, plus its sender on the To line. Accepts message via -m, stdin, or $EDITOR, plus repeatable --attach files; an attachment can be sent without body text. The message is Markdown; use --message-html to send raw HTML instead.",
+			"agent_notes": "Replies to the latest entry in a thread, addressed the way HEY addresses a reply: everyone that entry was addressed to, plus its sender on the To line, minus the acting user's own addresses. Accepts message via -m, stdin, or $EDITOR, plus repeatable --attach files; an attachment can be sent without body text. The message is Markdown; use --message-html to send raw HTML instead. --draft saves the reply as a draft — carrying those recipients — and answers the draft ID for hey draft show/edit/send/delete.",
 		},
 		Example: `  hey reply 12345 -m "Friday works for me — I'll send an agenda."
   hey reply 12345 -m "Attached is the report." --attach ./report.pdf
+  hey reply 12345 -m "Drafting a longer answer — sending tomorrow." --draft
   echo "Longer reply from a file or a heredoc" | hey reply 12345`,
 		RunE: replyCommand.run,
 		Args: usageExactOneArg(),
@@ -42,6 +44,7 @@ draft rather than sending it, so the command fails when it cannot work the recip
 	replyCommand.cmd.Flags().StringVarP(&replyCommand.message, "message", "m", "", "Reply message as Markdown (or opens $EDITOR)")
 	replyCommand.cmd.Flags().StringVar(&replyCommand.messageHTML, "message-html", "", "Reply message as raw HTML instead of Markdown")
 	replyCommand.cmd.Flags().StringArrayVar(&replyCommand.attachments, "attach", nil, "File to attach (repeatable)")
+	replyCommand.cmd.Flags().BoolVar(&replyCommand.draft, "draft", false, "Save as a draft instead of sending")
 	replyCommand.cmd.MarkFlagsMutuallyExclusive("message", "message-html")
 
 	return replyCommand
@@ -91,6 +94,14 @@ func (c *replyCommand) run(cmd *cobra.Command, args []string) error {
 	message, err = attachFilesWithClient(ctx, replySDK, message, c.attachments)
 	if err != nil {
 		return err
+	}
+	if c.draft {
+		draftID, draftErr := replySDK.Entries().CreateReplyDraft(ctx, target.EntryID, message,
+			target.Addressed.To, target.Addressed.CC, target.Addressed.BCC)
+		if draftErr != nil {
+			return apierr.FromSDK(draftErr)
+		}
+		return writeDraftSaved(cmd, draftID, len(c.attachments))
 	}
 	if err = replySDK.Entries().CreateReply(ctx, target.EntryID, message, target.Addressed.To, target.Addressed.CC, target.Addressed.BCC); err != nil {
 		return apierr.FromSDK(err)

--- a/internal/cmd/thread_reply.go
+++ b/internal/cmd/thread_reply.go
@@ -45,6 +45,17 @@ func resolveThreadReply(ctx context.Context, threadID int64) (*threadReplyTarget
 		return nil, err
 	}
 	entryID := topic.Entries[len(topic.Entries)-1].Id
+
+	target := &threadReplyTarget{
+		EntryID:   entryID,
+		AccountID: topic.AccountId,
+		client:    threadSDK,
+	}
+	if addressed, ok := replyRecipientsFromServer(ctx, threadSDK, entryID); ok {
+		target.Addressed = addressed
+		return target, nil
+	}
+
 	message, err := threadSDK.Messages().Get(ctx, entryID)
 	if err != nil {
 		return nil, apierr.FromSDK(err)
@@ -58,12 +69,31 @@ func resolveThreadReply(ctx context.Context, threadID int64) (*threadReplyTarget
 		return nil, apierr.ErrUsage("could not determine thread recipients")
 	}
 
-	return &threadReplyTarget{
-		EntryID:   entryID,
-		AccountID: topic.AccountId,
-		Addressed: addressed,
-		client:    threadSDK,
-	}, nil
+	target.Addressed = addressed
+	return target, nil
+}
+
+// replyRecipientsFromServer asks HEY who a reply to the entry goes to
+// (GET /entries/{id}/replies/new): the entry's sender moved onto the To line and the
+// acting user's own addresses, aliases and catch-alls excluded — the exclusion this CLI
+// cannot compute locally, and the reason a reply used to be able to CC its writer back
+// to themselves. A failed read falls back to the local computation, and so does an
+// empty answer: on a thread with yourself, everyone HEY excludes is everyone there is,
+// and the local list is what keeps that reply addressable.
+func replyRecipientsFromServer(ctx context.Context, client *hey.Client, entryID int64) (replyRecipients, bool) {
+	prefilled, err := client.Entries().NewReply(ctx, entryID)
+	if err != nil || prefilled == nil {
+		return replyRecipients{}, false
+	}
+	addressed := replyRecipients{
+		To:  addressEmails(prefilled.Addressed.Directly),
+		CC:  addressEmails(prefilled.Addressed.Copied),
+		BCC: addressEmails(prefilled.Addressed.Blindcopied),
+	}
+	if len(addressed.To)+len(addressed.CC)+len(addressed.BCC) == 0 {
+		return replyRecipients{}, false
+	}
+	return addressed, true
 }
 
 // recipientsForReplyTo answers who a reply to this message goes to: the message's own

--- a/internal/cmd/thread_reply_test.go
+++ b/internal/cmd/thread_reply_test.go
@@ -39,6 +39,7 @@ type sentReply struct {
 	TopicAccountFilter   string
 	MessageAccountFilter string
 	ActingSenderID       int64
+	Status               string
 	To                   []string
 	CC                   []string
 	BCC                  []string
@@ -62,6 +63,7 @@ func threadReplyServer(t *testing.T, messageJSON string, entryIDs ...int64) (*ht
 					Content string `json:"content"`
 				} `json:"message"`
 				Entry struct {
+					Status    string `json:"status"`
 					Addressed struct {
 						Directly    []string `json:"directly"`
 						Copied      []string `json:"copied"`
@@ -73,7 +75,14 @@ func threadReplyServer(t *testing.T, messageJSON string, entryIDs ...int64) (*ht
 			sent.Path = r.URL.Path
 			sent.Content = body.Message.Content
 			sent.ActingSenderID = body.ActingSenderID
+			sent.Status = body.Entry.Status
 			sent.To, sent.CC, sent.BCC = body.Entry.Addressed.Directly, body.Entry.Addressed.Copied, body.Entry.Addressed.Blindcopied
+			if body.Entry.Status == "drafted" {
+				// A saved draft answers no body; the entry id rides in Location.
+				w.Header().Set("Location", "https://app.hey.com/messages/9101")
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
 			fmt.Fprint(w, `{}`)

--- a/internal/cmd/thread_reply_test.go
+++ b/internal/cmd/thread_reply_test.go
@@ -43,6 +43,11 @@ type sentReply struct {
 	To                   []string
 	CC                   []string
 	BCC                  []string
+
+	// ReplyNewJSON, when set before the command runs, is what GET
+	// /entries/{id}/replies/new answers — HEY's own computed reply recipients.
+	// Empty means the endpoint 404s and the CLI falls back to computing locally.
+	ReplyNewJSON string
 }
 
 // threadReplyServer answers the typed topic, the latest entry's message, the identity
@@ -53,6 +58,14 @@ func threadReplyServer(t *testing.T, messageJSON string, entryIDs ...int64) (*ht
 	sent := &sentReply{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case strings.HasSuffix(r.URL.Path, "/replies/new.json"):
+			if sent.ReplyNewJSON == "" {
+				w.Header().Set("Content-Type", "application/json")
+				http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, sent.ReplyNewJSON)
 		case strings.Contains(r.URL.Path, "/replies"):
 			if got := r.URL.Query().Get("filtered_account_id"); got != "9" {
 				t.Errorf("reply account = %q, want 9", got)
@@ -342,4 +355,59 @@ func runCLI(t *testing.T, server *httptest.Server, args ...string) error {
 	root.SetArgs(append([]string{"--json", "--base-url", server.URL}, args...))
 
 	return root.Execute()
+}
+
+// HEY's replies/new endpoint answers the reply's recipients with the acting user's own
+// addresses excluded — the exclusion the local computation cannot do. When it answers,
+// its list wins.
+func TestReplyPrefersTheServersComputedRecipients(t *testing.T) {
+	server, sent := threadReplyServer(t, messageAddressedToJane, 11, 12)
+	sent.ReplyNewJSON = `{"content":"<div>quoted</div>","is_reply":true,
+		"addressed":{"directly":[{"id":31,"name":"Rick Ramirez","email_address":"rick@example.com"}]}}`
+
+	if err := runCLI(t, server, "--account", "8", "reply", "7", "-m", "sounds good"); err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if len(sent.To) != 1 || sent.To[0] != "rick@example.com" {
+		t.Errorf("to = %v, want the server-computed list alone", sent.To)
+	}
+	if len(sent.CC) != 0 {
+		t.Errorf("cc = %v, want none", sent.CC)
+	}
+}
+
+// An empty answer from replies/new means everyone HEY excludes is everyone there is —
+// a thread with yourself — and the local computation is what keeps that reply
+// addressable. The 404 case rides through every other test in this file, which runs
+// against a fake that does not serve the endpoint at all.
+func TestReplyFallsBackWhenTheServerAnswersNobody(t *testing.T) {
+	server, sent := threadReplyServer(t, messageAddressedToJane, 11, 12)
+	sent.ReplyNewJSON = `{"content":"<div>quoted</div>","is_reply":true,"addressed":{}}`
+
+	if err := runCLI(t, server, "--account", "8", "reply", "7", "-m", "note to self"); err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if len(sent.To) == 0 {
+		t.Errorf("to = %v, want the locally computed recipients", sent.To)
+	}
+}
+
+func TestReplyDraftSavesInsteadOfSending(t *testing.T) {
+	server, sent := threadReplyServer(t, messageAddressedToJane, 11, 12)
+
+	if err := runCLI(t, server, "--account", "8", "reply", "7", "-m", "drafting this", "--draft"); err != nil {
+		t.Fatalf("reply --draft: %v", err)
+	}
+	if sent.Status != "drafted" {
+		t.Errorf("entry.status = %q, want drafted", sent.Status)
+	}
+	if !strings.Contains(sent.Path, "/entries/12/replies") {
+		t.Errorf("path = %q, want the latest entry's replies", sent.Path)
+	}
+	if len(sent.To) == 0 {
+		t.Errorf("a reply draft carries the thread's recipients, got none")
+	}
+	if !strings.Contains(sent.Content, "drafting this") {
+		t.Errorf("content = %q", sent.Content)
+	}
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-lLydS6Petq+Mkq6ehH/ZKk8wjm0Lu1NFCqkJ/Hvejic=";
+  vendorHash = "sha256-jbTU32gq2ZUAkKW2YdmQD0jMLRlWPalnJHANVHcSdwo=";
 
   subPackages = [ "cmd/hey" ];
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -26,6 +26,10 @@ triggers:
   - hey forward
   - hey compose
   - hey draft list
+  - hey draft show
+  - hey draft edit
+  - hey draft send
+  - hey draft delete
   - hey screener
   - screen a sender
   - approve a sender
@@ -185,7 +189,13 @@ notice on stderr. Both need list data, so they work on `hey box list`, `hey box 
 | Forward email | `hey forward <topic_id> --to alice@example.com -m "For your review"` |
 | Compose email | `hey compose --to alice@example.com --subject "Lunch plans" -m "Are you free Friday?"` |
 | Compose with CC/BCC | `hey compose --to alice@example.com --cc bob@example.com --bcc carol@example.org --subject "Kitchen remodel timeline"` |
-| List drafts | `hey draft list --json` |
+| List drafts | `hey draft list --json` (`--all`/`--page` follow the cursor) |
+| Draft an email for human review | `hey compose --to alice@example.com --subject "Lunch plans" -m "Free Friday?" --draft` |
+| Draft a reply for human review | `hey reply <topic_id> -m "Drafting this." --draft` |
+| Read a draft back | `hey draft show <draft_id> --json` |
+| Change a draft | `hey draft edit <draft_id> --to alice@example.com --subject "New subject"` |
+| Send a draft | `hey draft send <draft_id>` (or `--on tomorrow --hour 9` to schedule) |
+| Trash drafts | `hey draft delete <draft_id>...` |
 | Who is waiting in The Screener | `hey screener list --json` (clearance IDs) |
 | Number waiting | `hey screener list --count` |
 | Let a sender through | `hey screener approve <clearance_id>` |
@@ -280,6 +290,11 @@ Want to send email?
 │   └── With BCC? → add --bcc <email>
 ├── List files in a thread? → hey attachment list <topic_id> --json
 │   └── Save one? → hey attachment save <attachment_id> [--output <path>]
+├── Draft instead of sending (human reviews in HEY)? → add --draft to compose or reply; the answer carries the draft id
+│   ├── Read it back? → hey draft show <draft_id> --json
+│   ├── Change it? → hey draft edit <draft_id> --subject/--to/--cc/--bcc/-m (flags replace; omitted fields are kept)
+│   ├── Deliver it? → hey draft send <draft_id> (recipients required; --on <date> --hour <n> schedules)
+│   └── Discard it? → hey draft delete <draft_id>
 └── Check drafts? → hey draft list --json
 ```
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -194,7 +194,7 @@ notice on stderr. Both need list data, so they work on `hey box list`, `hey box 
 | Draft a reply for human review | `hey reply <topic_id> -m "Drafting this." --draft` |
 | Read a draft back | `hey draft show <draft_id> --json` |
 | Change a draft | `hey draft edit <draft_id> --to alice@example.com --subject "New subject"` |
-| Send a draft | `hey draft send <draft_id>` (or `--on tomorrow --hour 9` to schedule) |
+| Send a draft | `hey draft send <draft_id>` (or `--on tomorrow --hour 9` to schedule, on the account's clock) |
 | Trash drafts | `hey draft delete <draft_id>...` |
 | Who is waiting in The Screener | `hey screener list --json` (clearance IDs) |
 | Number waiting | `hey screener list --count` |
@@ -293,7 +293,7 @@ Want to send email?
 ├── Draft instead of sending (human reviews in HEY)? → add --draft to compose or reply; the answer carries the draft id
 │   ├── Read it back? → hey draft show <draft_id> --json
 │   ├── Change it? → hey draft edit <draft_id> --subject/--to/--cc/--bcc/-m (flags replace; omitted fields are kept)
-│   ├── Deliver it? → hey draft send <draft_id> (recipients required; --on <date> --hour <n> schedules)
+│   ├── Deliver it? → hey draft send <draft_id> (recipients required; --on <date> --hour <n> schedules, on the account's clock)
 │   └── Discard it? → hey draft delete <draft_id>
 └── Check drafts? → hey draft list --json
 ```
@@ -581,8 +581,34 @@ otherwise — and both take over stdout.
 ### Drafts
 
 ```bash
-hey draft list --json                             # List drafts
+hey compose --subject "Board update" -m "Numbers to follow." --draft   # save instead of sending; answers the draft id
+hey reply <topic_id> -m "Drafting this." --draft  # save a reply draft, addressed like a real reply
+hey draft list --json                             # List drafts; --all and --page follow the next_page cursor
+hey draft show <draft_id> --json                  # The draft's editable state; body is Markdown
+hey draft edit <draft_id> --to alice@example.com  # Each flag replaces its field; omitted flags keep the draft's
+hey draft send <draft_id>                         # Deliver now (through HEY's undo window)
+hey draft send <draft_id> --on tomorrow --hour 9  # Schedule instead — see the clock rules below
+hey draft delete <draft_id> [<draft_id>...]       # Trash drafts
 ```
+
+This is the review-before-send lane: an agent prepares the email as a draft, a person
+reviews and sends it from any HEY app (or the agent sends it later with `hey draft send`).
+A draft needs no recipients until it is sent; `--draft` on `hey compose` lifts the
+recipient requirement.
+
+**An edit is a revision, not a patch.** The CLI reads the draft first and resends the
+whole of it, so an omitted flag keeps that field. `--to`/`--cc`/`--bcc` replace their
+entire recipient kind; an explicit empty value (`--cc ""`) clears it. Any scheduled
+delivery is preserved through edits.
+
+**Scheduling and clocks.** `--on` (YYYY-MM-DD, `today` or `tomorrow`) and `--hour` (0-23)
+are read on the HEY account's clock — its own time zone, not the machine's — and HEY
+schedules to the hour; there are no minutes. `today` and `tomorrow` resolve on that clock
+too. JSON output reports `scheduled_delivery_at` in UTC like every HEY timestamp, so
+scheduling 9am for a US Eastern account reports `14:00:00Z` — that is the same moment,
+not an error. An account whose zone is offset from UTC by a fraction of an hour cannot
+land on a whole hour and is refused rather than silently shifted. A scheduled draft stays
+in `hey draft list` until it goes out; `hey draft delete` cancels it entirely.
 
 ### Calendars
 

--- a/tests/smoke/draft_lifecycle_test.go
+++ b/tests/smoke/draft_lifecycle_test.go
@@ -135,3 +135,66 @@ func TestDraftSendRefusesWithoutRecipients(t *testing.T) {
 		t.Errorf("stderr = %q, want a no-recipients refusal", stderr)
 	}
 }
+
+// findSmokeThread composes a message to self and finds its topic in the imbox, falling
+// back to any thread there.
+func findSmokeThread(t *testing.T, subject string) string {
+	t.Helper()
+	_, _, composeCode := hey(t, "compose", "--to", smokeEmail, "--subject", subject,
+		"-m", "Original message for the reply draft test", "--json")
+
+	resp := heyJSON(t, "box", "imbox")
+	type posting struct {
+		AppURL  string `json:"app_url"`
+		Summary string `json:"summary"`
+	}
+	type boxResp struct {
+		Postings []posting `json:"postings"`
+	}
+	data := dataAs[boxResp](t, resp)
+
+	if composeCode == 0 {
+		for _, p := range data.Postings {
+			if p.Summary == subject {
+				return extractTopicID(p.AppURL)
+			}
+		}
+	}
+	for _, p := range data.Postings {
+		if p.AppURL != "" {
+			return extractTopicID(p.AppURL)
+		}
+	}
+	return ""
+}
+
+func TestReplyDraft(t *testing.T) {
+	topicID := findSmokeThread(t, "Reply draft smoke "+uniqueID())
+	if topicID == "" {
+		skipf(t, "no thread available to draft a reply on")
+	}
+
+	stdout, stderr, code := hey(t, "reply", topicID, "-m", "Drafting this reply.", "--draft", "--json")
+	if code != 0 {
+		skipf(t, "reply --draft not accepted by server (exit %d): %s", code, stderr)
+	}
+	draft := dataAs[draftData](t, parseResponse(t, stdout))
+	if draft.ID <= 0 {
+		t.Fatalf("draft id = %d, want positive", draft.ID)
+	}
+	t.Cleanup(func() {
+		_, _, _ = hey(t, "draft", "delete", fmt.Sprintf("%d", draft.ID), "--json")
+	})
+
+	resp := heyJSON(t, "draft", "show", fmt.Sprintf("%d", draft.ID))
+	state := dataAs[draftState](t, resp)
+	if !state.IsReply {
+		t.Errorf("draft %d should know it is a reply: %+v", draft.ID, state)
+	}
+	if !strings.Contains(state.Body, "Drafting this reply") {
+		t.Errorf("body = %q", state.Body)
+	}
+	if !draftListedIDs(t)[draft.ID] {
+		t.Errorf("reply draft %d missing from hey draft list --all", draft.ID)
+	}
+}

--- a/tests/smoke/draft_lifecycle_test.go
+++ b/tests/smoke/draft_lifecycle_test.go
@@ -1,0 +1,137 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func parseResponse(t *testing.T, stdout string) Response {
+	t.Helper()
+	var resp Response
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("failed to parse JSON: %v\nraw: %s", err, stdout)
+	}
+	if !resp.OK {
+		t.Fatalf("response ok=false: %s", stdout)
+	}
+	return resp
+}
+
+type draftData struct {
+	ID int64 `json:"id"`
+}
+
+type draftState struct {
+	ID      int64    `json:"id"`
+	Subject string   `json:"subject"`
+	Body    string   `json:"body"`
+	To      []string `json:"to"`
+	CC      []string `json:"cc"`
+	IsReply bool     `json:"is_reply"`
+}
+
+// composeDraft saves a draft and answers its id, skipping (or failing under
+// HEY_SMOKE_STRICT) when the server refuses the write.
+func composeDraft(t *testing.T, subject string, extra ...string) int64 {
+	t.Helper()
+	args := append([]string{"compose", "--subject", subject, "-m", "Smoke test draft body.", "--draft", "--json"}, extra...)
+	stdout, stderr, code := hey(t, args...)
+	if code != 0 {
+		skipf(t, "compose --draft not accepted by server (exit %d): %s", code, stderr)
+	}
+	resp := parseResponse(t, stdout)
+	draft := dataAs[draftData](t, resp)
+	if draft.ID <= 0 {
+		t.Fatalf("draft id = %d, want positive", draft.ID)
+	}
+	t.Cleanup(func() {
+		_, _, _ = hey(t, "draft", "delete", fmt.Sprintf("%d", draft.ID), "--json")
+	})
+	return draft.ID
+}
+
+func draftListedIDs(t *testing.T) map[int64]bool {
+	t.Helper()
+	resp := heyJSON(t, "draft", "list", "--all")
+	ids := map[int64]bool{}
+	if resp.Data == nil {
+		return ids
+	}
+	for _, d := range dataAs[[]draftData](t, resp) {
+		ids[d.ID] = true
+	}
+	return ids
+}
+
+func TestDraftLifecycle(t *testing.T) {
+	subject := "Draft lifecycle smoke " + uniqueID()
+	id := composeDraft(t, subject)
+
+	if !draftListedIDs(t)[id] {
+		t.Errorf("draft %d missing from hey draft list --all", id)
+	}
+
+	// Read it back.
+	resp := heyJSON(t, "draft", "show", fmt.Sprintf("%d", id))
+	state := dataAs[draftState](t, resp)
+	if state.Subject != subject || !strings.Contains(state.Body, "Smoke test draft body") {
+		t.Errorf("draft show = %+v", state)
+	}
+	if len(state.To) != 0 {
+		t.Errorf("a fresh draft should have no recipients, got %v", state.To)
+	}
+
+	// Edit adds a recipient and rewrites the subject; unflagged fields survive.
+	newSubject := subject + " (v2)"
+	stdout, stderr, code := hey(t, "draft", "edit", fmt.Sprintf("%d", id),
+		"--subject", newSubject, "--to", smokeEmail, "--json")
+	if code != 0 {
+		skipf(t, "draft edit not accepted by server (exit %d): %s", code, stderr)
+	}
+	_ = stdout
+	resp = heyJSON(t, "draft", "show", fmt.Sprintf("%d", id))
+	state = dataAs[draftState](t, resp)
+	if state.Subject != newSubject {
+		t.Errorf("subject = %q, want %q", state.Subject, newSubject)
+	}
+	if len(state.To) != 1 || state.To[0] != smokeEmail {
+		t.Errorf("to = %v, want [%s]", state.To, smokeEmail)
+	}
+	if !strings.Contains(state.Body, "Smoke test draft body") {
+		t.Errorf("body was not preserved through the edit: %q", state.Body)
+	}
+
+	// Send it (to self); it leaves the drafts index.
+	stdout, stderr, code = hey(t, "draft", "send", fmt.Sprintf("%d", id), "--json")
+	if code != 0 {
+		skipf(t, "draft send not accepted by server (exit %d): %s", code, stderr)
+	}
+	_ = stdout
+	if draftListedIDs(t)[id] {
+		t.Errorf("draft %d still listed after sending", id)
+	}
+}
+
+func TestDraftDelete(t *testing.T) {
+	id := composeDraft(t, "Draft delete smoke "+uniqueID())
+
+	stdout, stderr, code := hey(t, "draft", "delete", fmt.Sprintf("%d", id), "--json")
+	if code != 0 {
+		skipf(t, "draft delete not accepted by server (exit %d): %s", code, stderr)
+	}
+	_ = stdout
+	if draftListedIDs(t)[id] {
+		t.Errorf("draft %d still listed after delete", id)
+	}
+}
+
+func TestDraftSendRefusesWithoutRecipients(t *testing.T) {
+	id := composeDraft(t, "Draft no-recipients smoke "+uniqueID())
+
+	_, stderr := heyFail(t, "draft", "send", fmt.Sprintf("%d", id))
+	if !strings.Contains(stderr, "no recipients") {
+		t.Errorf("stderr = %q, want a no-recipients refusal", stderr)
+	}
+}


### PR DESCRIPTION
## Why

Closes #103 — the review-before-send lane: an agent (or a script) prepares an email, a person reviews and sends it from any HEY app. Built on SDK v0.22.0's draft lifecycle operations (basecamp/hey-sdk#121), pinned here.

## What's in it

Four commits, one per concern:

**1. `hey draft list` follows the cursor.** The listing read one page and `--all` never fetched a second; the index pages by geared_pagination's opaque cursor, so it now reads through `Entries().ListDraftsPage` — `--all` walks to the end (up to 100 pages), `--page` continues from a `next_page` cursor, and the JSON meta names the cursor whenever more remains. A `--limit` below what was read keeps its client-side trim and notice.

**2. The draft lifecycle.** `hey compose --draft` saves instead of sending — recipients become optional, since a draft with nobody on it yet is the normal case — and answers the draft ID parsed from HEY's 204 `Location` header. Then:
- `hey draft show <id>` — the editable state, body as Markdown
- `hey draft edit <id>` — each flag replaces its field; an omitted flag keeps what the draft has, done honestly: the state is read first and the whole of it resent, because a revision is not a patch on HEY's side (an explicit empty `--to`/`--cc`/`--bcc` clears that kind; no flags at all opens the body in `$EDITOR`)
- `hey draft send <id>` — delivers through HEY's undo window, refusing a draft with no recipients before any write; `--on <date> --hour <n>` schedules to the hour instead
- `hey draft delete <id>...` — trashes
- `hey compose --thread-id <id> --draft` saves a reply draft on the same path

**3. Reply drafts, and HEY-computed reply recipients.** `hey reply <topic-id> --draft` saves the reply as a draft carrying the thread's recipients. And reply addressing now comes from HEY itself: `resolveThreadReply` asks `GET /entries/{id}/replies/new`, which moves the sender onto the To line and excludes the acting user's own addresses, aliases and catch-alls — the exclusion this CLI could not compute locally, and the residual noted in AGENTS.md from #113 (a reply could CC its writer back to themselves). A failed read falls back to the local computation, and so does an empty answer, which is what keeps a reply to yourself addressable.

**4. Docs.** README (draft lane + updated reply-addressing prose), the embedded skill (quick-reference rows and a decision-tree branch for the draft-for-human-review workflow), API-COVERAGE (four new endpoint rows; retires the note about `replies/new` being the operation the SDK lacked).

## Testing

- Unit tests throughout: cursor following, the 204+Location parse, edit's read-merge-resend semantics (kept fields, cleared kinds), send's no-status payload and no-recipients refusal, scheduling params, reply-draft status, server-computed recipients winning and both fallback paths.
- New smoke tests run the whole lifecycle against a live dev HEY server: create → list → show → edit → send → gone, delete, the no-recipients refusal, and a reply draft verified as `is_reply` — all passing, no skips.
- Full existing smoke suite passes against dev HEY. Two known pre-existing failures stand apart, both reproducible on clean main: the TUI calendar tests (`TestDayLabelsCoverTodosAndHabits`, `TestWeekDrawsTheHabitsKeptEachDay`) and the smoke `TestVersionJSON` (Go 1.26 stamps local builds with a VCS pseudo-version, so `dev` is overridden). Untouched here.

No TUI changes in this batch — that's tracked separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full draft lifecycle to the CLI and fixes draft pagination. Replies now use HEY’s server-computed recipients, and scheduling reads --on/--hour on the account’s clock while preserving the exact scheduled time.

- New: `hey compose --draft` and `hey reply --draft` save drafts and return the draft ID; `hey draft show|edit|send|delete` manage drafts, and `send` can schedule with `--on <date> --hour <n>`.
- Detail: `--on` accepts YYYY-MM-DD, today, or tomorrow; `--hour` is 0–23; both are validated before any fetch; scheduling is read on the identity’s time zone, transmitted as UTC date/hour, and fractional-hour offsets are refused.
- Change: `hey draft list` follows HEY’s cursor; `--all` walks up to 100 pages, `--page` continues from a `next_page` cursor, and JSON meta includes `next_page` and `pages_fetched` when more remains.
- Change: Replies fetch recipients from HEY (`/entries/{id}/replies/new`), move the sender to To, and exclude the acting user’s addresses; fall back to local computation only when the server is unavailable or answers nobody.
- Docs: `README` and `skills/hey/SKILL.md` cover the workflow and scheduling clocks; `API-COVERAGE` maps the new endpoints.
- Bump: `github.com/basecamp/hey-sdk/go` to `v0.22.0`; update Nix `vendorHash`.

Migration:
- Scripts paginating drafts must use `--page` with the `next_page` cursor and can read `pages_fetched` in JSON meta.
- Reply behavior no longer CCs the acting user; update any automation that depended on local recipient computation.
- Scheduled sends must use `--on` as YYYY-MM-DD, today, or tomorrow with `--hour` 0–23; schedules are computed on the account’s clock, stored as UTC date/hour, and fractional-offset time zones are not supported.

<sup>Written for commit 393a1d6ebd6702c21d4cd64df9dc988ceb0afc4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

