### PR TITLE
Keep local builds dev, and calendar fixtures on the reader's clock

### DIFF
--- a/internal/tui/calendar_test.go
+++ b/internal/tui/calendar_test.go
@@ -523,10 +523,13 @@ func TestDaysBetweenIgnoresDaylightSavingShifts(t *testing.T) {
 }
 
 func TestDayLabelsCoverTodosAndHabits(t *testing.T) {
+	// atLocal, not at: a label belongs to the day the reader sees, so a fixture
+	// pinned to a UTC clock would slide to a neighbouring day on a zone behind UTC
+	// (a midnight-UTC todo is the evening before, US Eastern) and collide.
 	labels := dayLabelsFromRecordings(
-		[]Recording{{ID: 200, StartsAt: at("2025-03-01T09:00:00Z"), Type: "CalendarEvent", Label: "Launch day"}},
-		[]Recording{{ID: 203, StartsAt: at("2025-03-02T00:00:00Z"), Type: "CalendarTodo", Label: "Moving day"}},
-		[]Recording{{ID: 202, StartsAt: at("2025-03-03T06:00:00Z"), Type: "Habit", Label: "Rest day"}},
+		[]Recording{{ID: 200, StartsAt: atLocal("2025-03-01T09:00:00"), Type: "CalendarEvent", Label: "Launch day"}},
+		[]Recording{{ID: 203, StartsAt: atLocal("2025-03-02T00:00:00"), Type: "CalendarTodo", Label: "Moving day"}},
+		[]Recording{{ID: 202, StartsAt: atLocal("2025-03-03T06:00:00"), Type: "Habit", Label: "Rest day"}},
 	)
 	want := map[string]string{
 		"2025-03-01": "Launch day",
@@ -1335,8 +1338,11 @@ func weekView(t *testing.T, habits, completions []Recording) []string {
 	return strings.Split(stripANSI(out), "\n")
 }
 
+// habitDone pins the completion to the reader's own midnight, not UTC's: the week
+// buckets completions by local day, so a UTC-midnight fixture would land on the
+// evening before anywhere behind UTC and put the icons in the wrong column.
 func habitDone(habitID int64, day string) Recording {
-	return Recording{Type: "Calendar::Habit::Completion", ParentID: habitID, StartsAt: at(day + "T00:00:00Z")}
+	return Recording{Type: "Calendar::Habit::Completion", ParentID: habitID, StartsAt: atLocal(day + "T00:00:00")}
 }
 
 // The week says what was kept each day, as icons — it has room for seven days of those and

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,12 +17,26 @@ var (
 var fromBuildInfo bool
 
 func init() {
-	if Version == "dev" {
-		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
-			Version = strings.TrimPrefix(info.Main.Version, "v")
-			fromBuildInfo = true
+	if Version != "dev" {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info.Main.Version == "" || info.Main.Version == "(devel)" {
+		return
+	}
+	// A build from a source checkout is still a dev build. Go stamps such a build's
+	// main-module version with a pseudo-version derived from the checkout's VCS
+	// state, which is exactly the shape a `go install module@version` build reports —
+	// the difference is that only the checkout build carries the VCS settings. So a
+	// version with vcs metadata behind it stays "dev", and only a true module build
+	// (no checkout, no vcs.revision) adopts what the toolchain recorded.
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			return
 		}
 	}
+	Version = strings.TrimPrefix(info.Main.Version, "v")
+	fromBuildInfo = true
 }
 
 // Full returns the full version string for display.


### PR DESCRIPTION
Two test failures reproducible on any machine that is not UTC (or that builds from a git checkout on a recent Go):

## Local builds reported themselves as `go install`

`version.init` adopts the build-info main-module version when ldflags left `dev` in place — the intended way to recognize a `go install module@version` binary. But Go now stamps a **source-checkout** build's main-module version with a VCS-derived pseudo-version, the same shape, so every local `make build` came out as `version: 1.0.1-0.…+dirty, source: go install` and the smoke suite's `TestVersionJSON` failed. The two build kinds differ in one honest way: only the checkout build carries `vcs.*` settings in the build info. The init now stays `dev` when `vcs.revision` is present and adopts the toolchain's version only for a true module build. Release builds (real ldflags) and `go install` builds are unchanged.

## Calendar tests slid a day west of UTC

`TestDayLabelsCoverTodosAndHabits` and `TestWeekDrawsTheHabitsKeptEachDay` pinned fixtures to UTC instants (`T00:00:00Z`), but the views bucket by the reader's local day — correctly, per the repo's own rule that whatever shows a date converts `.Local()`. On US Eastern a midnight-UTC habit completion is the previous evening, so five Monday habits landed on Sunday and two day labels collided. The fixtures now use `atLocal`, the helper the grid tests already use for exactly this, with a comment saying why. Verified green in UTC, US Eastern, Sydney and UTC+14 (Kiritimati); UTC CI sees identical instants, so nothing changes there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps local source-checkout builds as `dev` and pins calendar test fixtures to the reader’s clock. Previously dev builds adopted a VCS pseudo-version and reported as `go install`; now builds with `vcs.revision` stay `dev`, and tests no longer shift a day in zones west of UTC.

- `internal/version`: adopt the toolchain’s version only when build info has no `vcs.revision`. Release builds and `go install module@version` remain unchanged.
- `internal/tui/calendar_test.go`: replace UTC-pinned `at(...)` fixtures with `atLocal(...)` for day labels and habit completions to match local-day bucketing. No migrations; CI behavior unchanged.

<sup>Written for commit d4d7c1015ee92011b73d2ebbe55f7abb261c6dcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

