### PR TITLE
Test the build provenance decision itself

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,26 +17,30 @@ var (
 var fromBuildInfo bool
 
 func init() {
-	if Version != "dev" {
-		return
-	}
 	info, ok := debug.ReadBuildInfo()
-	if !ok || info.Main.Version == "" || info.Main.Version == "(devel)" {
-		return
+	Version, fromBuildInfo = classify(Version, info, ok)
+}
+
+// classify decides what a binary reports itself as. An ldflags-stamped version stands as
+// stamped. An unstamped ("dev") binary adopts the toolchain-recorded module version only
+// for a true `go install module@version` build. A build from a source checkout is still a
+// dev build — Go stamps such a build's main-module version with a pseudo-version derived
+// from the checkout's VCS state, which is exactly the shape a `go install` build reports,
+// and the difference is that only the checkout build carries the VCS settings. So a
+// version with vcs metadata behind it stays "dev".
+func classify(stamped string, info *debug.BuildInfo, ok bool) (version string, fromBuildInfo bool) {
+	if stamped != "dev" {
+		return stamped, false
 	}
-	// A build from a source checkout is still a dev build. Go stamps such a build's
-	// main-module version with a pseudo-version derived from the checkout's VCS
-	// state, which is exactly the shape a `go install module@version` build reports —
-	// the difference is that only the checkout build carries the VCS settings. So a
-	// version with vcs metadata behind it stays "dev", and only a true module build
-	// (no checkout, no vcs.revision) adopts what the toolchain recorded.
+	if !ok || info == nil || info.Main.Version == "" || info.Main.Version == "(devel)" {
+		return stamped, false
+	}
 	for _, setting := range info.Settings {
 		if setting.Key == "vcs.revision" {
-			return
+			return stamped, false
 		}
 	}
-	Version = strings.TrimPrefix(info.Main.Version, "v")
-	fromBuildInfo = true
+	return strings.TrimPrefix(info.Main.Version, "v"), true
 }
 
 // Full returns the full version string for display.

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,6 +1,9 @@
 package version
 
-import "testing"
+import (
+	"runtime/debug"
+	"testing"
+)
 
 func stubVersion(t *testing.T, v string, goInstall bool) {
 	t.Helper()
@@ -81,6 +84,45 @@ func TestSource(t *testing.T) {
 			stubVersion(t, tt.version, tt.goInstall)
 			if got := Source(); got != tt.want {
 				t.Errorf("Source() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// classify is the provenance decision itself: what an unstamped binary adopts from
+// build info, and what it refuses. The vcs.revision branch is the point — a source
+// checkout's build carries a toolchain-stamped pseudo-version in exactly the shape a
+// `go install` build reports, and only the VCS settings tell the two apart.
+func TestClassify(t *testing.T) {
+	moduleBuild := func(version string, settings ...debug.BuildSetting) *debug.BuildInfo {
+		info := &debug.BuildInfo{Settings: settings}
+		info.Main.Version = version
+		return info
+	}
+	vcs := debug.BuildSetting{Key: "vcs.revision", Value: "c426c98b3ea4"}
+
+	tests := []struct {
+		name          string
+		stamped       string
+		info          *debug.BuildInfo
+		ok            bool
+		wantVersion   string
+		wantBuildInfo bool
+	}{
+		{name: "release ldflags stand", stamped: "1.2.3", info: moduleBuild("v0.9.9"), ok: true, wantVersion: "1.2.3"},
+		{name: "go install adopts the module version", stamped: "dev", info: moduleBuild("v1.0.1"), ok: true, wantVersion: "1.0.1", wantBuildInfo: true},
+		{name: "go install pseudo-version adopts too", stamped: "dev", info: moduleBuild("v1.0.1-0.20260825032930-c426c98b3ea4"), ok: true, wantVersion: "1.0.1-0.20260825032930-c426c98b3ea4", wantBuildInfo: true},
+		{name: "checkout build stays dev", stamped: "dev", info: moduleBuild("v1.0.1-0.20260825032930-c426c98b3ea4+dirty", vcs), ok: true, wantVersion: "dev"},
+		{name: "devel stays dev", stamped: "dev", info: moduleBuild("(devel)"), ok: true, wantVersion: "dev"},
+		{name: "no build info stays dev", stamped: "dev", info: nil, ok: false, wantVersion: "dev"},
+		{name: "empty module version stays dev", stamped: "dev", info: moduleBuild(""), ok: true, wantVersion: "dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, fromInfo := classify(tt.stamped, tt.info, tt.ok)
+			if version != tt.wantVersion || fromInfo != tt.wantBuildInfo {
+				t.Errorf("classify(%q) = %q, %v; want %q, %v", tt.stamped, version, fromInfo, tt.wantVersion, tt.wantBuildInfo)
 			}
 		})
 	}


### PR DESCRIPTION
Follow-up to the review note on #312: the `vcs.revision` classification wasn't covered — the existing tests assign the already-classified globals, so they'd pass with the branch removed or inverted. The decision is now a pure function, `classify(stamped, buildInfo, ok)`, called from `init`, and `TestClassify` pins every arm: ldflags-stamped versions stand untouched, a module build adopts stable and pseudo-versions alike, and a checkout build — VCS settings present — stays `dev` regardless of the version shape the toolchain stamped. No behavior change; `make build` still reports `dev`/`dev`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts version provenance into a pure `classify(stamped, info, ok)` and adds `TestClassify` to pin every branch. No behavior change: `make build` still reports `dev`/`dev`.

- `init` delegates to `classify`; ldflags-stamped versions return unchanged.
- Unstamped binaries adopt `debug.BuildInfo.Main.Version` only when no `vcs.revision` is present; otherwise they remain `dev`.
- `TestClassify` covers stable and pseudo-version module installs and asserts checkout builds (with VCS settings) refuse adoption.

<sup>Written for commit a9a5e4762f168599fea837d92815b7f2f77ee385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

