### PR TITLE
The long-thread smoke fixture is Markdown, like compose

### DIFF
--- a/tests/smoke/threads_test.go
+++ b/tests/smoke/threads_test.go
@@ -23,9 +23,9 @@ type threadEntry struct {
 	} `json:"creator"`
 }
 
-// firstMessage is the plain text the long thread starts with. compose sends it as
-// text, so in the thread it is prose: the asterisks and the list dashes come back
-// escaped, and the URL comes back as the literal it is.
+// firstMessage is the Markdown the long thread starts with. compose sends -m as
+// Markdown, so in the thread the emphasis and the list survive as structure, and the
+// bare URL stays a literal the reader can follow.
 const firstMessage = "First: the **quarterly** numbers are at https://example.com/reports/q3 — see the bullets\n\n- Revenue up\n- Churn down"
 
 // longThread composes a message and replies to it until the thread is longer than one
@@ -112,17 +112,17 @@ func TestThreadsReadsALongThreadAsMarkdown(t *testing.T) {
 		}
 	}
 
-	// The text was sent as text, so it is prose in the Markdown: the asterisks are
-	// escaped rather than emphasis, the URL is the literal it was, and the em dash —
+	// The message went in as Markdown, so it comes back as Markdown: the emphasis
+	// and the list are structure, the URL is the literal it was, and the em dash —
 	// a multibyte character — survives intact.
 	first := entries[0].Body
-	for _, want := range []string{`\*\*quarterly\*\*`, "https://example.com/reports/q3", "— see the bullets", "Revenue up", "Churn down"} {
+	for _, want := range []string{"**quarterly**", "https://example.com/reports/q3", "— see the bullets", "- Revenue up", "- Churn down"} {
 		if !strings.Contains(first, want) {
 			t.Errorf("first body = %q, want %q in it", first, want)
 		}
 	}
-	if strings.Contains(first, "**quarterly**") {
-		t.Errorf("first body = %q, want the asterisks escaped, not emphasis", first)
+	if strings.Contains(first, `\*\*quarterly\*\*`) {
+		t.Errorf("first body = %q, want emphasis, not escaped asterisks", first)
 	}
 	if last := entries[len(entries)-1].Body; !strings.Contains(last, fmt.Sprintf("Reply %d of %d", replies, replies)) {
 		t.Errorf("last body = %q, want the last reply", last)

--- a/tests/smoke/threads_test.go
+++ b/tests/smoke/threads_test.go
@@ -112,17 +112,25 @@ func TestThreadsReadsALongThreadAsMarkdown(t *testing.T) {
 		}
 	}
 
-	// The message went in as Markdown, so it comes back as Markdown: the emphasis
-	// and the list are structure, the URL is the literal it was, and the em dash —
-	// a multibyte character — survives intact.
+	// The message went in as Markdown, so it comes back as Markdown. The assertions
+	// anchor on the surroundings so weaker shapes cannot sneak through the substring
+	// check: the URL is anchored in its prose (a link or autolink would wrap it in
+	// brackets there), and the list block is anchored on its newlines (an escaped
+	// \- would sit between the newline and the dash).
 	first := entries[0].Body
-	for _, want := range []string{"**quarterly**", "https://example.com/reports/q3", "— see the bullets", "- Revenue up", "- Churn down"} {
+	for _, want := range []string{
+		"**quarterly**",
+		"at https://example.com/reports/q3 — see the bullets",
+		"\n- Revenue up\n- Churn down",
+	} {
 		if !strings.Contains(first, want) {
 			t.Errorf("first body = %q, want %q in it", first, want)
 		}
 	}
-	if strings.Contains(first, `\*\*quarterly\*\*`) {
-		t.Errorf("first body = %q, want emphasis, not escaped asterisks", first)
+	for _, reject := range []string{`\*\*quarterly\*\*`, `\-`, "<https://example.com"} {
+		if strings.Contains(first, reject) {
+			t.Errorf("first body = %q, must not contain %q", first, reject)
+		}
 	}
 	if last := entries[len(entries)-1].Body; !strings.Contains(last, fmt.Sprintf("Reply %d of %d", replies, replies)) {
 		t.Errorf("last body = %q, want the last reply", last)


### PR DESCRIPTION
Test-only. TestThreadsReadsALongThreadAsMarkdown was written before compose started sending `-m` as Markdown ("Write in Markdown wherever text goes in", Aug 22): it still expected `**quarterly**` to come back as escaped plain text, so it has failed deterministically on every dev-server smoke run since — hidden until now because the smoke suite doesn't run in CI. The fixture now asserts what compose actually produces: the emphasis and list survive as structure, the bare URL stays a literal, and the em dash survives intact. Verified passing against a live dev server; the negative assertion flipped to catch a regression back to escaping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the long-thread smoke test to expect Markdown from `compose` instead of escaped text, matching current behavior and stopping deterministic dev‑server failures. Assertions are now anchored to distinguish real Markdown structure from escaped shapes and linked URLs.

**Bug Fixes**
- Verifies emphasis and list render, the bare URL stays literal, and the em dash survives.
- Anchors the URL inside its prose and the list on newlines; rejects escaped `\*\*`/`\-` and autolink forms.
- Test-only; verified against a live dev server.

<sup>Written for commit 5f955ee1cf640badb8e7c711867452b26f7b9a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

