### PR TITLE
Take scheduling off hey draft send until the API can name an instant

### DIFF
--- a/.surface
+++ b/.surface
@@ -133,8 +133,6 @@ hey draft list --all
 hey draft list --limit
 hey draft list --page
 hey draft send
-hey draft send --hour
-hey draft send --on
 hey draft show
 hey event
 hey event add

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ hey reply 123 -m "Drafting a longer answer." --draft  # save a reply draft
 hey draft list                     # list drafts (--all and --page follow HEY's cursor)
 hey draft show 12345               # read a draft back
 hey draft edit 12345 --to alice@example.com --subject "Board update (v2)"
-hey draft send 12345               # deliver it, or --on tomorrow --hour 9 to schedule
+hey draft send 12345               # deliver it
 hey draft delete 12345             # trash it
 hey seen 12345                     # mark a thread as seen
 hey unseen 12345 67890             # mark threads as unseen
@@ -431,7 +431,7 @@ Email bodies come back as Markdown. `hey thread read` and the TUI render that Ma
 
 Writing is Markdown too, everywhere text goes in: `-m`, `--content`, `--note`, positional content, stdin, and `$EDITOR` (which opens prefilled with the existing entry or note as Markdown). Every such flag has a raw-HTML twin — `--message-html`, `--content-html`, `--note-html` — for sending markup verbatim; each pair is mutually exclusive. The TUI's compose and bulk-reply forms convert Markdown the same way, and the compose editor renders it live as you type — `**bold**` turns bold, markers and all. A fenced code block's language (` ```ruby `) is carried the way HEY's own editor stores it, so the web app syntax-highlights it.
 
-Drafts are the review-before-send lane: `hey compose --draft` (and `hey reply --draft`) saves instead of sending — recipients optional on a draft — and answers the draft's ID. `hey draft show` reads it back with the body as Markdown, `hey draft edit` revises it (each flag replaces its field; what is not flagged is kept, by reading the draft and resending the whole of it, since a revision is not a patch on HEY's side), `hey draft send` delivers through HEY's undo window — or schedules to the hour with `--on` and `--hour`, in the account's time zone — and `hey draft delete` trashes it. A draft prepared here is reviewed and sent from any HEY app, which is the workflow this is for: an agent writes, a person decides.
+Drafts are the review-before-send lane: `hey compose --draft` (and `hey reply --draft`) saves instead of sending — recipients optional on a draft — and answers the draft's ID. `hey draft show` reads it back with the body as Markdown, `hey draft edit` revises it (each flag replaces its field; what is not flagged is kept, by reading the draft and resending the whole of it, since a revision is not a patch on HEY's side), `hey draft send` delivers through HEY's undo window, and `hey draft delete` trashes it. Scheduling a delivery is done in a HEY app for now — the API cannot yet name an exact instant — and a schedule set there survives CLI edits untouched. A draft prepared here is reviewed and sent from any HEY app, which is the workflow this is for: an agent writes, a person decides.
 
 `hey share <thread_id>` gets a sharing link for a thread. Anyone with the link can see the entire thread and future emails or replies sent to it. `hey unshare <thread_id>` turns off the sharing link.
 

--- a/internal/cmd/draft.go
+++ b/internal/cmd/draft.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -95,47 +94,19 @@ func draftContentFrom(edit *generated.MessageEditState) hey.DraftContent {
 	return content
 }
 
-// draftScheduleLocation answers the clock a person means when they say "tomorrow at 9":
-// the identity's HEY time zone. The host's local clock stands in only when the identity
-// does not name a zone this host knows.
-func draftScheduleLocation(ctx context.Context) *time.Location {
-	identity, err := sdk.Identity().GetIdentity(ctx)
-	if err != nil || identity == nil || identity.TimeZoneName == "" {
-		return time.Local
+// preservableSchedule refuses an edit that could not keep the draft's scheduled
+// delivery where it is. HEY's API expresses a schedule as a whole UTC hour, so an
+// instant between hours — set from a HEY app on a fractional-offset clock like
+// India's or Adelaide's — would be silently moved by the resend. Refusing is the
+// honest answer until the API can name an exact instant.
+func preservableSchedule(edit *generated.MessageEditState) error {
+	at := edit.ScheduledDeliveryAt.UTC()
+	if at.IsZero() || (at.Minute() == 0 && at.Second() == 0) {
+		return nil
 	}
-	location, err := time.LoadLocation(identity.TimeZoneName)
-	if err != nil {
-		return time.Local
-	}
-	return location
-}
-
-// draftScheduleFor turns "--on and --hour on the identity's clock" into the UTC date and
-// hour HEY's API reads (Time.zone is UTC for JSON requests, so the params are UTC on the
-// wire — the web app's identity-zone reading does not apply here). today and tomorrow are
-// resolved on the identity's clock too, since HEY would otherwise read them as UTC dates.
-// A zone offset with fractional hours cannot land on a whole UTC hour and is refused
-// rather than silently shifted.
-func draftScheduleFor(location *time.Location, on string, hour int, now time.Time) (*hey.DraftSchedule, error) {
-	base := now.In(location)
-	var day time.Time
-	switch on {
-	case "today":
-		day = base
-	case "tomorrow":
-		day = base.AddDate(0, 0, 1)
-	default:
-		parsed, err := time.ParseInLocation("2006-01-02", on, location)
-		if err != nil {
-			return nil, apierr.ErrUsage(fmt.Sprintf("invalid --on date %q: use YYYY-MM-DD, today or tomorrow", on))
-		}
-		day = parsed
-	}
-	at := time.Date(day.Year(), day.Month(), day.Day(), hour, 0, 0, 0, location).UTC()
-	if at.Minute() != 0 {
-		return nil, apierr.ErrUsage(fmt.Sprintf("your HEY time zone (%s) is offset from UTC by a fraction of an hour, and HEY schedules deliveries on whole UTC hours — this hour cannot be expressed exactly", location))
-	}
-	return &hey.DraftSchedule{Date: at.Format("2006-01-02"), Hour: at.Hour()}, nil
+	return apierr.ErrUsage(fmt.Sprintf(
+		"this draft is scheduled for %s, between the whole hours HEY's API can express — editing here would move its delivery; adjust it in a HEY app first",
+		at.Format(time.RFC3339)))
 }
 
 // --- show ---
@@ -259,6 +230,9 @@ func (c *draftEditCommand) run(cmd *cobra.Command, args []string) error {
 	if edit == nil {
 		return apierr.ErrNotFound("draft", args[0])
 	}
+	if scheduleErr := preservableSchedule(edit); scheduleErr != nil {
+		return scheduleErr
+	}
 	content := draftContentFrom(edit)
 
 	flags := cmd.Flags()
@@ -306,9 +280,7 @@ func (c *draftEditCommand) run(cmd *cobra.Command, args []string) error {
 // --- send ---
 
 type draftSendCommand struct {
-	cmd  *cobra.Command
-	on   string
-	hour int
+	cmd *cobra.Command
 }
 
 func newDraftSendCommand() *draftSendCommand {
@@ -317,17 +289,12 @@ func newDraftSendCommand() *draftSendCommand {
 		Use:   "send <draft-id>",
 		Short: "Deliver a draft",
 		Annotations: map[string]string{
-			"agent_notes": "Sends the draft as it stands — recipients are required, added with `hey draft edit --to`. Delivery goes through HEY's undo window. --on with --hour schedules it instead, read on the HEY account's clock and scheduled to the hour; the draft stays listed until it goes out.",
+			"agent_notes": "Sends the draft as it stands — recipients are required, added with `hey draft edit --to`. Delivery goes through HEY's undo window. Scheduling a delivery is done in a HEY app for now; the API cannot yet name an exact instant.",
 		},
-		Example: `  hey draft send 12345
-  hey draft send 12345 --on tomorrow --hour 9
-  hey draft send 12345 --on 2026-09-01 --hour 14`,
-		RunE: sendCommand.run,
-		Args: usageExactOneArg(),
+		Example: `  hey draft send 12345`,
+		RunE:    sendCommand.run,
+		Args:    usageExactOneArg(),
 	}
-	sendCommand.cmd.Flags().StringVar(&sendCommand.on, "on", "", "Schedule delivery for this date on your HEY account's clock (YYYY-MM-DD, today or tomorrow)")
-	sendCommand.cmd.Flags().IntVar(&sendCommand.hour, "hour", -1, "Hour of --on to deliver at, 0-23, on your HEY account's clock")
-	sendCommand.cmd.MarkFlagsRequiredTogether("on", "hour")
 	return sendCommand
 }
 
@@ -338,14 +305,6 @@ func (c *draftSendCommand) run(cmd *cobra.Command, args []string) error {
 	draftID, err := parseDraftID(args[0])
 	if err != nil {
 		return err
-	}
-	if c.on != "" {
-		if c.hour < 0 || c.hour > 23 {
-			return apierr.ErrUsage("--hour must be between 0 and 23")
-		}
-		if dateErr := validateScheduleDate(c.on); dateErr != nil {
-			return dateErr
-		}
 	}
 	ctx := cmd.Context()
 
@@ -359,19 +318,6 @@ func (c *draftSendCommand) run(cmd *cobra.Command, args []string) error {
 	content := draftContentFrom(edit)
 	if len(content.To)+len(content.CC)+len(content.BCC) == 0 {
 		return apierr.ErrUsageHint("the draft has no recipients", fmt.Sprintf("hey draft edit %d --to <email>", draftID))
-	}
-
-	if c.on != "" {
-		schedule, scheduleErr := draftScheduleFor(draftScheduleLocation(ctx), c.on, c.hour, time.Now())
-		if scheduleErr != nil {
-			return scheduleErr
-		}
-		content.Schedule = schedule
-		if err := sdk.Messages().UpdateDraft(ctx, draftID, content); err != nil {
-			return apierr.FromSDK(err)
-		}
-		return writeMutationLine(cmd, fmt.Sprintf("Draft %d scheduled for delivery.", draftID),
-			"Draft scheduled for delivery", map[string]any{"id": draftID})
 	}
 
 	content.Schedule = nil
@@ -430,16 +376,4 @@ func draftNoun(count int) string {
 		return "draft"
 	}
 	return "drafts"
-}
-
-// validateScheduleDate holds --on to what it advertises — YYYY-MM-DD, today or
-// tomorrow — so a typo is a usage error before anything is fetched or written.
-func validateScheduleDate(on string) error {
-	if on == "today" || on == "tomorrow" {
-		return nil
-	}
-	if _, err := time.Parse("2006-01-02", on); err != nil {
-		return apierr.ErrUsage(fmt.Sprintf("invalid --on date %q: use YYYY-MM-DD, today or tomorrow", on))
-	}
-	return nil
 }

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 )
 
 // draftLifecycleServer serves the identity the SDK's sending operations resolve, a
@@ -227,28 +226,6 @@ func TestDraftSendRefusesADraftWithNoRecipients(t *testing.T) {
 	}
 }
 
-func TestDraftSendSchedulesWithOnAndHour(t *testing.T) {
-	var writes []draftWrite
-	// The fixture identity keeps America/New_York, so 9 on its clock in December
-	// (EST, UTC-5) is 14:00Z — the UTC values HEY's API actually reads.
-	response, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
-		"draft", "send", "12345", "--on", "2026-12-01", "--hour", "9")
-	if err != nil {
-		t.Fatalf("draft send --on: %v", err)
-	}
-
-	entry, _ := writes[0].Body["entry"].(map[string]any)
-	if entry["status"] != "drafted" {
-		t.Errorf("a scheduled send stays drafted, got status %v", entry["status"])
-	}
-	if entry["scheduled_delivery"] != "true" || entry["scheduled_delivery_at_date"] != "2026-12-01" || entry["scheduled_delivery_at_hour"] != "14" {
-		t.Errorf("schedule = %v", entry)
-	}
-	if response.Summary != "Draft scheduled for delivery" {
-		t.Errorf("summary = %q", response.Summary)
-	}
-}
-
 func TestDraftDeleteTrashesEachDraft(t *testing.T) {
 	var writes []draftWrite
 	response, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
@@ -307,59 +284,21 @@ func TestDraftEditPreservesAScheduleExactly(t *testing.T) {
 }
 
 // --on is validated against what it advertises before anything is fetched or written.
-func TestDraftSendRefusesAMalformedOnDate(t *testing.T) {
+
+// A schedule set from a HEY app on a fractional-offset clock sits between the whole
+// UTC hours the API can express. An edit must refuse rather than move the delivery —
+// and must refuse before writing anything.
+func TestDraftEditRefusesAScheduleItCannotPreserve(t *testing.T) {
+	fractional := `{"id":12345,"subject":"Quarterly planning","content":"<div>Agenda.</div>",
+		"scheduled_delivery_at":"2026-09-01T03:30:00Z",
+		"addressed":{"directly":[{"id":7,"name":"Maria Delgado","email_address":"maria@example.com"}]}}`
 	var writes []draftWrite
-	_, err := runJSONCommand(t, draftLifecycleServer(t, draftEditJSON, &writes),
-		"draft", "send", "12345", "--on", "next-week", "--hour", "9")
-	if err == nil || !strings.Contains(err.Error(), "invalid --on date") {
-		t.Fatalf("err = %v, want an invalid --on usage error", err)
+	_, err := runJSONCommand(t, draftLifecycleServer(t, fractional, &writes),
+		"draft", "edit", "12345", "--subject", "Quarterly planning (v2)")
+	if err == nil || !strings.Contains(err.Error(), "adjust it in a HEY app") {
+		t.Fatalf("err = %v, want a cannot-preserve refusal", err)
 	}
 	if len(writes) != 0 {
 		t.Errorf("nothing should be written, wrote %+v", writes)
-	}
-}
-
-// draftScheduleFor is the identity-clock-to-UTC conversion itself.
-func TestDraftScheduleFor(t *testing.T) {
-	newYork, err := time.LoadLocation("America/New_York")
-	if err != nil {
-		t.Skipf("time zone database unavailable: %v", err)
-	}
-	adelaide, err := time.LoadLocation("Australia/Adelaide")
-	if err != nil {
-		t.Skipf("time zone database unavailable: %v", err)
-	}
-	// A fixed moment: 2026-12-01 20:00 in New York (2026-12-02 01:00Z).
-	now := time.Date(2026, 12, 1, 20, 0, 0, 0, newYork)
-
-	tests := []struct {
-		name     string
-		on       string
-		hour     int
-		wantDate string
-		wantHour int
-	}{
-		{name: "explicit winter date", on: "2026-12-10", hour: 9, wantDate: "2026-12-10", wantHour: 14},
-		{name: "today is the identity's today", on: "today", hour: 23, wantDate: "2026-12-02", wantHour: 4},
-		{name: "tomorrow rolls the identity's clock", on: "tomorrow", hour: 9, wantDate: "2026-12-02", wantHour: 14},
-		{name: "a late hour crosses into the next UTC day", on: "2026-12-10", hour: 22, wantDate: "2026-12-11", wantHour: 3},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			schedule, err := draftScheduleFor(newYork, tt.on, tt.hour, now)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if schedule.Date != tt.wantDate || schedule.Hour != tt.wantHour {
-				t.Errorf("schedule = %s/%d, want %s/%d", schedule.Date, schedule.Hour, tt.wantDate, tt.wantHour)
-			}
-		})
-	}
-
-	if _, err := draftScheduleFor(adelaide, "2026-12-10", 9, now); err == nil {
-		t.Error("a half-hour zone offset cannot land on a whole UTC hour and must be refused")
-	}
-	if _, err := draftScheduleFor(newYork, "soon", 9, now); err == nil {
-		t.Error("an unrecognized --on date must be refused")
 	}
 }

--- a/internal/cmd/draft_test.go
+++ b/internal/cmd/draft_test.go
@@ -283,8 +283,6 @@ func TestDraftEditPreservesAScheduleExactly(t *testing.T) {
 	}
 }
 
-// --on is validated against what it advertises before anything is fetched or written.
-
 // A schedule set from a HEY app on a fractional-offset clock sits between the whole
 // UTC hours the API can express. An edit must refuse rather than move the delivery —
 // and must refuse before writing anything.

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -194,7 +194,7 @@ notice on stderr. Both need list data, so they work on `hey box list`, `hey box 
 | Draft a reply for human review | `hey reply <topic_id> -m "Drafting this." --draft` |
 | Read a draft back | `hey draft show <draft_id> --json` |
 | Change a draft | `hey draft edit <draft_id> --to alice@example.com --subject "New subject"` |
-| Send a draft | `hey draft send <draft_id>` (or `--on tomorrow --hour 9` to schedule, on the account's clock) |
+| Send a draft | `hey draft send <draft_id>` |
 | Trash drafts | `hey draft delete <draft_id>...` |
 | Who is waiting in The Screener | `hey screener list --json` (clearance IDs) |
 | Number waiting | `hey screener list --count` |
@@ -293,7 +293,7 @@ Want to send email?
 ├── Draft instead of sending (human reviews in HEY)? → add --draft to compose or reply; the answer carries the draft id
 │   ├── Read it back? → hey draft show <draft_id> --json
 │   ├── Change it? → hey draft edit <draft_id> --subject/--to/--cc/--bcc/-m (flags replace; omitted fields are kept)
-│   ├── Deliver it? → hey draft send <draft_id> (recipients required; --on <date> --hour <n> schedules, on the account's clock)
+│   ├── Deliver it? → hey draft send <draft_id> (recipients required)
 │   └── Discard it? → hey draft delete <draft_id>
 └── Check drafts? → hey draft list --json
 ```
@@ -587,7 +587,6 @@ hey draft list --json                             # List drafts; --all and --pag
 hey draft show <draft_id> --json                  # The draft's editable state; body is Markdown
 hey draft edit <draft_id> --to alice@example.com  # Each flag replaces its field; omitted flags keep the draft's
 hey draft send <draft_id>                         # Deliver now (through HEY's undo window)
-hey draft send <draft_id> --on tomorrow --hour 9  # Schedule instead — see the clock rules below
 hey draft delete <draft_id> [<draft_id>...]       # Trash drafts
 ```
 
@@ -601,14 +600,12 @@ whole of it, so an omitted flag keeps that field. `--to`/`--cc`/`--bcc` replace 
 entire recipient kind; an explicit empty value (`--cc ""`) clears it. Any scheduled
 delivery is preserved through edits.
 
-**Scheduling and clocks.** `--on` (YYYY-MM-DD, `today` or `tomorrow`) and `--hour` (0-23)
-are read on the HEY account's clock — its own time zone, not the machine's — and HEY
-schedules to the hour; there are no minutes. `today` and `tomorrow` resolve on that clock
-too. JSON output reports `scheduled_delivery_at` in UTC like every HEY timestamp, so
-scheduling 9am for a US Eastern account reports `14:00:00Z` — that is the same moment,
-not an error. An account whose zone is offset from UTC by a fraction of an hour cannot
-land on a whole hour and is refused rather than silently shifted. A scheduled draft stays
-in `hey draft list` until it goes out; `hey draft delete` cancels it entirely.
+**Scheduled deliveries.** Scheduling is done in a HEY app for now; the CLI cannot set a
+schedule (HEY's API cannot yet name an exact instant). A draft scheduled in an app stays
+in `hey draft list` until it goes out, `hey draft show` reports `scheduled_delivery_at`
+in UTC like every HEY timestamp, an edit preserves the schedule untouched — refusing the
+rare schedule it could not keep exact rather than moving it — and `hey draft delete`
+cancels it entirely.
 
 ### Calendars
 


### PR DESCRIPTION
Follow-up to #311, before any release carries the flags.

## Why

`hey draft send --on/--hour` could only express whole UTC hours: HEY's schedule params are the web form's date-plus-hour fields, and the API channel parses them with `Time.zone` pinned to UTC (the web app parses the same params on the account's clock, which is why scheduling works there for every zone). The CLI converted the account-clock intent to UTC correctly for whole-hour zones — live-verified — but an account offset by a fraction of an hour (India +5:30, Adelaide +9:30, Nepal +5:45) has *no* expressible local hour at all. Shipping a scheduler that structurally excludes whole time zones isn't worth it for the interim.

## What changed

- `--on` and `--hour` removed from `hey draft send`, along with the account-clock-to-UTC conversion and its validation. `hey draft send` delivers now, full stop.
- **Schedule preservation on edit stays** — removing it would make `hey draft edit` silently *clear* a schedule set in a HEY app (HEY revises a draft from the whole request). A whole-UTC-hour schedule is resent exactly as it is.
- New guard: an edit **refuses** a schedule sitting between whole hours (a fractional-offset account's app-set schedule, e.g. `03:30:00Z`) instead of silently moving its delivery — with a message pointing at the HEY app. Covered by a test proving the refusal happens before anything is written.
- README and the agent skill updated: scheduling is done in a HEY app for now; `scheduled_delivery_at` remains visible on `hey draft show`; edits preserve app-set schedules.

The real fix — HEY's API accepting an ISO8601 instant, modelled through the SDK, scheduling then restored to the CLI with minute precision for every zone — is tracked as a card on the project board.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `--on` and `--hour` from `hey draft send`, so the CLI no longer schedules; sending always delivers immediately. Scheduling now happens in HEY apps; CLI edits preserve app-set schedules and refuse edits that would move a between-hour schedule.

**Migration**
- Remove any use of `--on`/`--hour` in automation; schedule in a HEY app instead.
- If a draft is scheduled between whole hours, adjust it in a HEY app before changing it via CLI; the CLI will refuse edits that would shift delivery.
- `scheduled_delivery_at` remains visible in `hey draft show`, and schedules set in apps are preserved by CLI edits.

<sup>Written for commit c1c3ded1de832daa753b90f09e661e8547b8b80f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

