### PR TITLE
Read an event's day as a window a timed event can be inside

### DIFF
--- a/internal/cmd/events.go
+++ b/internal/cmd/events.go
@@ -362,11 +362,20 @@ func (c *eventsEditCommand) run(cmd *cobra.Command, args []string) error {
 // no event on its own, so it is looked for among the recordings of the calendars it could be
 // on — every one of them, or the one --calendar names, over the day given or a window wide
 // enough to cover an event somebody is editing.
+//
+// The day is read as the window [day, day+1): HEY's recordings window is a pair of
+// instants, and the degenerate same-day window — midnight to the same midnight — can
+// never contain a timed event, which is how editing an event by its own day used to
+// answer not-found. Reading a day too many is harmless here: the event is matched by id.
 func (c *eventsEditCommand) findEvent(ctx context.Context, id int64, on string) (generated.Recording, error) {
+	endsOn := on
+	if day, err := time.Parse("2006-01-02", on); err == nil {
+		endsOn = day.AddDate(0, 0, 1).Format("2006-01-02")
+	}
 	filter := recordingFilter{
 		calendar:         c.fields.calendar,
 		startsOn:         on,
-		endsOn:           on,
+		endsOn:           endsOn,
 		defaultWindow:    func(now time.Time) (time.Time, time.Time) { return now.AddDate(-1, 0, 0), now.AddDate(1, 0, 0) },
 		defaultCalendars: allCalendarIDs,
 	}

--- a/internal/cmd/events_test.go
+++ b/internal/cmd/events_test.go
@@ -217,7 +217,9 @@ func TestEventsEditKeepsWhatItWasNotAskedToChange(t *testing.T) {
 	}
 }
 
-// Giving a date reads that day alone rather than a window around today.
+// Giving a date reads that day rather than a window around today — as the window
+// [day, day+1), since HEY's recordings window is a pair of instants and the degenerate
+// same-day window can never contain a timed event.
 func TestEventsEditReadsTheDayItIsGiven(t *testing.T) {
 	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -226,8 +228,8 @@ func TestEventsEditReadsTheDayItIsGiven(t *testing.T) {
 			if got := r.URL.Query().Get("starts_on"); got != "2026-09-02" {
 				t.Errorf("starts_on = %q", got)
 			}
-			if got := r.URL.Query().Get("ends_on"); got != "2026-09-02" {
-				t.Errorf("ends_on = %q", got)
+			if got := r.URL.Query().Get("ends_on"); got != "2026-09-03" {
+				t.Errorf("ends_on = %q, want the day after so a timed event is inside the window", got)
 			}
 			_, _ = io.WriteString(w, `{"Calendar::Event":[{"id":4821,"title":"Design review","all_day":true,"starts_at":"2026-09-02T00:00:00Z","ends_at":"2026-09-02T00:00:00Z"}]}`)
 		case r.Method == http.MethodPatch:

--- a/tests/smoke/clips_test.go
+++ b/tests/smoke/clips_test.go
@@ -24,7 +24,10 @@ func TestClipLifecycle(t *testing.T) {
 		t.Fatalf("thread %s has no source entry", topicID)
 	}
 	entryID := strconv.FormatInt(entries[0].ID, 10)
-	content := "**quarterly** numbers are at https://example.com/reports/q3"
+	// The thread's first message went in as Markdown, so **quarterly** is emphasis in
+	// the stored entry: its text carries the word, not the asterisks. A clip quotes
+	// the entry's text.
+	content := "quarterly numbers are at https://example.com/reports/q3"
 
 	_, stderr := heyFail(t, "clip", "create", entryID, "--content", "Text that is not present in the source entry", "--json")
 	if !strings.Contains(stderr, "does not match text in entry") {

--- a/tests/smoke/events_test.go
+++ b/tests/smoke/events_test.go
@@ -11,7 +11,7 @@ type smokeEvent struct {
 	Title    string `json:"title"`
 	StartsAt string `json:"starts_at"`
 	AllDay   bool   `json:"all_day"`
-	Notes    string `json:"notes"`
+	Notes    string `json:"description"`
 	Location string `json:"location"`
 }
 
@@ -70,7 +70,7 @@ func TestEventCRUD(t *testing.T) {
 		t.Fatal("add response carries no event ID")
 	}
 	id := fmt.Sprint(event.ID)
-	t.Cleanup(func() { _, _, _ = hey(t, "event", "delete", id, day) })
+	t.Cleanup(func() { _, _, _ = hey(t, "event", "delete", id) })
 
 	if event.Title != title {
 		t.Errorf("created title = %q, want %q", event.Title, title)
@@ -101,7 +101,7 @@ func TestEventCRUD(t *testing.T) {
 		t.Error("edit dropped the notes")
 	}
 
-	stdout, stderr, code = hey(t, "event", "delete", id, day, "--json")
+	stdout, stderr, code = hey(t, "event", "delete", id, "--json")
 	if code != 0 {
 		skipf(t, "event delete failed (exit %d): %s", code, stderr)
 	}


### PR DESCRIPTION
Release-gate work: running `HEY_SMOKE_STRICT=1 make test-smoke` (the release gate) surfaced three failures. All were proven pre-existing against the v1.0.0 binary. One was a real CLI bug; the rest were stale tests and a stale dev server.

## The bug

`hey event edit <id> <day>` resolved the event by reading `starts_on=<day>&ends_on=<day>` — and HEY's recordings window is a pair of instants, so the degenerate same-day window (midnight to the same midnight) can never contain a *timed* event. Editing an event by its own day has answered not-found since events shipped, hidden because the smoke test skips on write failures outside strict mode. Proven directly against the server: `in_window(day..day)` misses the event, `in_window(day..day+1)` finds it. The edit now reads `[day, day+1)`; it matches by ID afterward, so the extra day is harmless. Unit expectation updated to pin the widened window.

Known residual, deliberately out of scope: `hey event list --starts-on X --ends-on X` inherits the same server-side window semantics (a single-day list misses that day's timed events), but the widening trick over-corrects for a *listing* (the all-day branch would pull in the next day's all-day events). The honest fix is server-side — a date `ends_on` read as end-of-day — and is being tracked separately.

## The stale tests

- The clip test quoted `**quarterly**` literally, but compose sends `-m` as Markdown, so the stored entry text carries the word without the asterisks (same era as #314's fixture fix).
- The event test read notes from a `notes` JSON field; the wire carries `description`. A live debug run proved the edit round-trip never dropped the notes — the test was looking in the wrong place.
- The event test called `event delete <id> <day>` against a command that takes one argument.

## Result

With these fixes (and a dev-server restart clearing a Rails dev-mode stale-class artifact behind an attachment 500), the **full strict release gate passes: exit 0, zero failures, zero skips promoted** — clearing the path to the v1.1.0 release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Editing an event by day now searches [day, day+1) so timed events are found. Previously hey event edit <id> <day> queried the same start and end date and often returned not found; the wider window is safe because the edit still matches by ID.

- Bug Fixes
  - Updated smoke tests: clip content reflects stored Markdown text, event notes come from the description field, and delete takes a single argument.
  - Strict release gate (HEY_SMOKE_STRICT=1 make test-smoke) passes end to end.
  - Known limitation: event list with --starts-on X --ends-on X still uses server window semantics and can miss timed events; not changed here.

<sup>Written for commit 1e903efa383404f1c1aadd3a1a5b9fe713944cf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

