### PR TITLE
Calendar settings: the first day of the week and the 24-hour clock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ make lint    # Lints the code
 make install # Installs the binary to /usr/local/bin/hey (not shown by make help)
 ```
 
+## Git
+
+History is linear: merge commits are disallowed in this repository. Bring a branch up to
+date by rebasing it onto main, never by merging main into it.
+
 ## Architecture Overview
 
 This is a Go project that uses:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655
-	github.com/basecamp/hey-sdk/go v0.22.0
+	github.com/basecamp/hey-sdk/go v0.23.0
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655 h1:zz0WUSEmjURj0T+soXuTtgX291nYouqa+UoyYY3Xxk8=
 github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655/go.mod h1:ezaV5z1GXQAsqyejqTs6wCFl2D8Wj+COLQkHc/kwoRs=
-github.com/basecamp/hey-sdk/go v0.22.0 h1:7hsvhyIXH/kWiFEiksKgCHAa+haqRdNCqK0AMxPErAM=
-github.com/basecamp/hey-sdk/go v0.22.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
+github.com/basecamp/hey-sdk/go v0.23.0 h1:NjM4XvZTdjfL0bKNwHDM1ro3nAOZzaLppCeBczCi15U=
+github.com/basecamp/hey-sdk/go v0.23.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/tui/calendar.go
+++ b/internal/tui/calendar.go
@@ -221,11 +221,19 @@ type yearLoadedMsg struct {
 	year CalendarYear
 }
 
-// identityLoadedMsg stays off the request lane: the first day of the week is read
-// once, alongside the calendars rather than instead of them, so putting it on the
+// identityLoadedMsg stays off the request lane: the identity's calendar preferences are
+// read once, alongside the calendars rather than instead of them, so putting it on the
 // lane would cancel the read it was batched with.
 type identityLoadedMsg struct {
 	firstWeekDay time.Weekday
+	use24Hour    bool
+}
+
+// calendarSettingsSavedMsg is the settings form's write landing — or not.
+type calendarSettingsSavedMsg struct {
+	requestResult
+	firstWeekDay time.Weekday
+	use24Hour    bool
 }
 
 type timeTrackCategoriesLoadedMsg struct {
@@ -364,6 +372,10 @@ type calendarView struct {
 	viewMode     calendarViewMode
 	firstWeekDay time.Weekday
 
+	// use24Hour is HEY's own time_format preference: every clock this section draws reads
+	// it, and the settings form writes it back.
+	use24Hour bool
+
 	// now is the clock the calendar anchors on. It is read on every fetch and
 	// every render, so a TUI left open overnight moves to the new day instead of
 	// fetching around the day it started on while the grid highlights today.
@@ -456,6 +468,9 @@ type calendarView struct {
 	// list: this read runs alongside whatever the reader asked for.
 	ongoingRequestID uint64
 
+	// settings is the open calendar settings form, standing over the calendar.
+	settings *calendarSettingsForm
+
 	timeTrack   *timeTrackMenu
 	trackedTime *trackedTimeScreen
 	// trackedTimeForm is the open edit form, standing over the tracked time screen.
@@ -521,8 +536,29 @@ func (v *calendarView) Update(msg tea.Msg) (tea.Cmd, bool) {
 
 	case identityLoadedMsg:
 		v.firstWeekDay = msg.firstWeekDay
+		v.use24Hour = msg.use24Hour
 		v.rebuildView()
 		return nil, true
+
+	case calendarSettingsSavedMsg:
+		if !v.requests.accepts(msg.requestResult) {
+			return nil, true
+		}
+		v.requests.finish(msg.requestID)
+		if msg.err != nil {
+			if v.settings != nil {
+				v.settings.saving = false
+				v.settings.status = errorNotice("Could not save the settings", msg.err)
+				v.settings.isError = true
+			}
+			return nil, true
+		}
+		v.settings = nil
+		v.firstWeekDay = msg.firstWeekDay
+		v.use24Hour = msg.use24Hour
+		// The year's grid padding is the server's answer, computed for the old week start,
+		// so the span is read again rather than just redrawn.
+		return tea.Batch(notify("Calendar settings saved"), v.reread()), true
 
 	case calendarsLoadedMsg:
 		if cmd, ok := v.requests.settle(msg.requestResult); !ok {
@@ -785,7 +821,7 @@ func (v *calendarView) View() string {
 	// The categories stand over the menu they were opened from, as a habit's form stands
 	// over the habit picker.
 	if v.timeTrack != nil {
-		view = v.timeTrack.draw(view, v.ongoing, v.ongoingKnown, v.now(), v.vc.width, v.vc.height)
+		view = v.timeTrack.draw(view, v.ongoing, v.ongoingKnown, v.now(), v.vc.width, v.vc.height, v.use24Hour)
 	}
 	if v.timeTrackCategories != nil {
 		view = v.timeTrackCategories.draw(view, v.vc.width, v.vc.height)
@@ -798,6 +834,10 @@ func (v *calendarView) View() string {
 	// with the arrows rather than from a list, so there is no picker underneath it.
 	if v.eventForm != nil {
 		frame := modalFrame(v.eventForm.formTitle(), v.eventForm.view(), v.vc.width)
+		view = overlayModal(view, frame, v.vc.width, v.vc.height)
+	}
+	if v.settings != nil {
+		frame := modalFrame(v.settings.title(), v.settings.view(), v.vc.width)
 		view = overlayModal(view, frame, v.vc.width, v.vc.height)
 	}
 	return view
@@ -827,6 +867,9 @@ func (v *calendarView) todosFooterHeight() int {
 }
 
 func (v *calendarView) HelpBindings() []helpBinding {
+	if v.settings != nil {
+		return v.settings.helpBindings()
+	}
 	if v.trackedTimeForm != nil {
 		return v.trackedTimeForm.helpBindings()
 	}
@@ -896,7 +939,7 @@ func (v *calendarView) HelpBindings() []helpBinding {
 	if v.showsHabits() {
 		bindings = append(bindings, helpBinding{"b", "habits"})
 	}
-	return bindings
+	return append(bindings, helpBinding{",", "settings"})
 }
 
 // showsHabits reports whether the day has habits to manage: the hint on the section
@@ -955,6 +998,16 @@ func (v *calendarView) handleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 	if v.timeTrack != nil {
 		return v.handleTimeTrackKey(msg)
+	}
+	if v.settings != nil {
+		if msg.Key().Code == tea.KeyEscape && !v.settings.saving {
+			v.settings = nil
+			return nil
+		}
+		if v.settings.handleKey(msg) {
+			return v.saveSettings()
+		}
+		return nil
 	}
 	if v.habitForm != nil {
 		if msg.Key().Code == tea.KeyEscape && !v.habitForm.saving {
@@ -1033,6 +1086,11 @@ func (v *calendarView) handleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "l":
 		v.timeTrack = newTimeTrackMenu()
 		return v.requestOngoingTrack()
+	// , for the calendar's settings, the conventional preferences key.
+	case ",":
+		v.settings = newCalendarSettingsForm(v.firstWeekDay, v.use24Hour)
+		v.settings.resize(v.vc.width, v.vc.height)
+		return nil
 	// The span is picked by number, as a box is in the mail list, and the row above the
 	// grid shows which one is on.
 	case "1":
@@ -1537,7 +1595,7 @@ func (v *calendarView) Loading() bool {
 }
 func (v *calendarView) CapturingInput() bool {
 	return v.timeTrack != nil || v.trackedTime != nil || v.timeTrackCategories != nil ||
-		v.habitForm != nil || v.eventForm != nil ||
+		v.habitForm != nil || v.eventForm != nil || v.settings != nil ||
 		v.habitPicker != nil || v.todoPicker != nil || v.calendarPicker != nil
 }
 
@@ -1595,6 +1653,9 @@ func (v *calendarView) Resize(width, height int) {
 	if v.trackedTimeForm != nil {
 		v.trackedTimeForm.resize(width, height)
 	}
+	if v.settings != nil {
+		v.settings.resize(width, height)
+	}
 	v.rebuildView()
 }
 
@@ -1620,9 +1681,9 @@ func (v *calendarView) rebuildView() {
 	cursorTop, cursorBottom := -1, -1
 	switch v.viewMode {
 	case viewDay:
-		content = renderDayView(v.events, v.habits, v.countdowns, anchor, v.now(), v.stepHint(), w, v.contentVP.Height(), v.selection(), v.trackBadge())
+		content = renderDayView(v.events, v.habits, v.countdowns, anchor, v.now(), v.stepHint(), w, v.contentVP.Height(), v.selection(), v.trackBadge(), v.use24Hour)
 	case viewWeek:
-		content = renderWeekView(v.events, v.habits, v.habitCompletions, anchor, v.firstWeekDay, w, v.contentVP.Height(), v.stepHint(), dayLabels, v.selection())
+		content = renderWeekView(v.events, v.habits, v.habitCompletions, anchor, v.firstWeekDay, w, v.contentVP.Height(), v.stepHint(), dayLabels, v.selection(), v.use24Hour)
 	case viewYear:
 		// The year's events are HEY's spanned_events — the all-day and multi-day ones —
 		// because that is all a year read carries. eventsByDate spreads a multi-day event
@@ -2315,7 +2376,10 @@ func (v *calendarView) fetchIdentity() tea.Cmd {
 		if wd < 0 || wd > 6 {
 			wd = 1 // default to Monday
 		}
-		return identityLoadedMsg{firstWeekDay: time.Weekday(wd)}
+		return identityLoadedMsg{
+			firstWeekDay: time.Weekday(wd),
+			use24Hour:    identity.TimeFormat == string(hey.TimeFormatTwentyFourHour),
+		}
 	}
 }
 
@@ -2522,7 +2586,7 @@ func isConflict(err error) bool {
 }
 
 func (v *calendarView) openTrackedTime() tea.Cmd {
-	v.trackedTime = newTrackedTimeScreen()
+	v.trackedTime = newTrackedTimeScreen(v.use24Hour)
 	v.trackedTimeForm = nil
 	v.trackedTime.resize(v.vc.width, v.vc.height)
 	return v.requestTrackedTime()
@@ -2606,6 +2670,38 @@ func readTrackedTimePage(ctx context.Context, sdk *hey.Client, cursor string) (t
 		tracks = append(tracks, trackedTimeFrom(recording))
 	}
 	return trackedTimePage{tracks: tracks, categories: page.Categories, nextPage: page.NextPage}, nil
+}
+
+// saveSettings writes the calendar preferences the form changed, and nothing else — each
+// is its own endpoint on HEY, so an untouched one costs no request. The message carries
+// what the server says it stored, not what was asked for.
+func (v *calendarView) saveSettings() tea.Cmd {
+	form := v.settings
+	weekStart, use24 := form.weekStart, form.use24
+	weekChanged := weekStart != form.weekStartArrived
+	clockChanged := use24 != form.use24Arrived
+	requestID, ctx := v.requests.begin(v.vc.ctx, calendarRequestMutation)
+	return func() tea.Msg {
+		var err error
+		if weekChanged {
+			weekStart, err = v.vc.sdk.Identity().UpdateFirstWeekDay(ctx, weekStart)
+		}
+		if err == nil && clockChanged {
+			asked := hey.TimeFormatTwelveHour
+			if use24 {
+				asked = hey.TimeFormatTwentyFourHour
+			}
+			var stored hey.TimeFormat
+			if stored, err = v.vc.sdk.Identity().UpdateTimeFormat(ctx, asked); err == nil {
+				use24 = stored == hey.TimeFormatTwentyFourHour
+			}
+		}
+		return calendarSettingsSavedMsg{
+			requestResult: newRequestResult(requestID, err),
+			firstWeekDay:  weekStart,
+			use24Hour:     use24,
+		}
+	}
 }
 
 // saveTrackedTime sends what the form changed and nothing else.

--- a/internal/tui/calendar_settings.go
+++ b/internal/tui/calendar_settings.go
@@ -1,0 +1,151 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+const (
+	settingsFieldWeekStart = iota
+	settingsFieldClock
+	settingsFieldCount
+)
+
+// calendarSettingsForm edits the two calendar preferences HEY keeps on the identity: which
+// day weeks start on, and whether times read on a 24-hour clock. Both live on the server —
+// the web and mobile apps read the same answer — so a save is a write to HEY, not to a
+// config file here.
+type calendarSettingsForm struct {
+	weekStart time.Weekday
+	use24     bool
+
+	// What arrived, to compare the form against: a form nobody changed makes no request.
+	weekStartArrived time.Weekday
+	use24Arrived     bool
+
+	focus   int
+	status  string
+	isError bool
+	saving  bool
+	width   int
+}
+
+func newCalendarSettingsForm(weekStart time.Weekday, use24 bool) *calendarSettingsForm {
+	return &calendarSettingsForm{
+		weekStart:        weekStart,
+		use24:            use24,
+		weekStartArrived: weekStart,
+		use24Arrived:     use24,
+	}
+}
+
+// calendarSettingsFormWidth is what the form asks for, for the reason the habit form gives: a
+// frame hugs its widest line, and left alone this one would draw a box the width of the
+// terminal around two short fields.
+const calendarSettingsFormWidth = 46
+
+const settingsFieldLabelWidth = 16
+
+func (f *calendarSettingsForm) resize(width, _ int) {
+	f.width = min(modalContentWidth(width), calendarSettingsFormWidth)
+}
+
+func (f *calendarSettingsForm) step(delta int) {
+	f.focus = (f.focus + delta + settingsFieldCount) % settingsFieldCount
+}
+
+// handleKey answers whether the key was the save.
+func (f *calendarSettingsForm) handleKey(msg tea.KeyPressMsg) bool {
+	if f.saving {
+		return false
+	}
+
+	switch {
+	case msg.Key().Code == tea.KeyTab && msg.Key().Mod == tea.ModShift:
+		f.step(-1)
+		return false
+	case msg.Key().Code == tea.KeyTab, msg.Key().Code == tea.KeyEnter:
+		f.step(1)
+		return false
+	case msg.String() == "ctrl+s":
+		return f.submit()
+	}
+
+	switch f.focus {
+	case settingsFieldWeekStart:
+		f.chooseWeekStart(msg)
+	case settingsFieldClock:
+		if isSpace(msg) {
+			f.use24 = !f.use24
+		}
+	}
+	return false
+}
+
+// chooseWeekStart walks the seven days with the arrows, wrapping at either end.
+func (f *calendarSettingsForm) chooseWeekStart(msg tea.KeyPressMsg) {
+	switch msg.Key().Code {
+	case tea.KeyUp, tea.KeyLeft:
+		f.weekStart = (f.weekStart + 6) % 7
+	case tea.KeyDown, tea.KeyRight:
+		f.weekStart = (f.weekStart + 1) % 7
+	}
+}
+
+// submit answers whether there is a write to make: a form nobody changed is told so
+// instead of asking HEY to store what it already holds.
+func (f *calendarSettingsForm) submit() bool {
+	if !f.changed() {
+		f.status = "Nothing changed"
+		f.isError = false
+		return false
+	}
+	f.saving = true
+	f.status = "Saving…"
+	f.isError = false
+	return true
+}
+
+func (f *calendarSettingsForm) changed() bool {
+	return f.weekStart != f.weekStartArrived || f.use24 != f.use24Arrived
+}
+
+func (f *calendarSettingsForm) helpBindings() []helpBinding {
+	bindings := []helpBinding{{"tab", "next field"}}
+	switch f.focus {
+	case settingsFieldWeekStart:
+		bindings = append(bindings, helpBinding{"↑↓", "a day"})
+	case settingsFieldClock:
+		bindings = append(bindings, helpBinding{"space", "toggle"})
+	}
+	return append(bindings, helpBinding{"ctrl+s", "save"}, helpBinding{"esc", "cancel"})
+}
+
+func (f *calendarSettingsForm) title() string { return "Calendar settings" }
+
+func (f *calendarSettingsForm) view() string {
+	var b strings.Builder
+	f.writeRow(&b, "Start weeks on", f.weekStart.String(), settingsFieldWeekStart)
+	f.writeRow(&b, "Use 24-hour time", checkbox(f.use24), settingsFieldClock)
+
+	if f.status != "" {
+		statusStyle := styleMuted
+		if f.isError {
+			statusStyle = lipgloss.NewStyle().Foreground(colorError)
+		}
+		b.WriteString("\n" + statusStyle.Render(truncateToWidth(f.status, max(f.width, 20))))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func (f *calendarSettingsForm) writeRow(b *strings.Builder, label, value string, field int) {
+	labelStyle := styleMuted
+	if f.focus == field {
+		labelStyle = lipgloss.NewStyle().Foreground(colorActive).Bold(true)
+	}
+	fmt.Fprintf(b, "%s %s\n", labelStyle.Render(fmt.Sprintf("%-*s", settingsFieldLabelWidth, label)), value)
+}

--- a/internal/tui/calendar_settings_test.go
+++ b/internal/tui/calendar_settings_test.go
@@ -1,0 +1,266 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- The form on its own ---
+
+func TestCalendarSettingsFormWalksTheWeekDays(t *testing.T) {
+	form := newCalendarSettingsForm(time.Monday, false)
+
+	form.handleKey(keyPress("down"))
+	if form.weekStart != time.Tuesday {
+		t.Errorf("down from Monday = %v, want Tuesday", form.weekStart)
+	}
+	form.handleKey(keyPress("up"))
+	form.handleKey(keyPress("up"))
+	if form.weekStart != time.Sunday {
+		t.Errorf("two up from Tuesday = %v, want Sunday", form.weekStart)
+	}
+	// The week wraps at either end rather than stopping.
+	form.handleKey(keyPress("left"))
+	if form.weekStart != time.Saturday {
+		t.Errorf("left from Sunday = %v, want Saturday", form.weekStart)
+	}
+	form.handleKey(keyPress("right"))
+	if form.weekStart != time.Sunday {
+		t.Errorf("right from Saturday = %v, want Sunday", form.weekStart)
+	}
+}
+
+func TestCalendarSettingsFormTogglesTheClock(t *testing.T) {
+	form := newCalendarSettingsForm(time.Monday, false)
+
+	// Space belongs to the clock field, so it does nothing while the weekday has the focus.
+	form.handleKey(keyPress(" "))
+	if form.use24 {
+		t.Error("space on the weekday field should not touch the clock")
+	}
+
+	form.handleKey(keyPress("tab"))
+	form.handleKey(keyPress(" "))
+	if !form.use24 {
+		t.Error("space on the clock field should toggle it on")
+	}
+	form.handleKey(keyPress(" "))
+	if form.use24 {
+		t.Error("space again should toggle it back off")
+	}
+}
+
+func TestCalendarSettingsFormSubmitsOnlyWhatChanged(t *testing.T) {
+	form := newCalendarSettingsForm(time.Monday, false)
+
+	if form.handleKey(keyPress("ctrl+s")) {
+		t.Fatal("an untouched form should not submit")
+	}
+	if form.status != "Nothing changed" || form.saving {
+		t.Errorf("untouched form said %q, saving=%v", form.status, form.saving)
+	}
+
+	form.handleKey(keyPress("down"))
+	if !form.handleKey(keyPress("ctrl+s")) {
+		t.Fatal("a changed form should submit")
+	}
+	if !form.saving {
+		t.Error("a submitted form should say it is saving")
+	}
+	// A saving form is deaf: nothing may change under a write already on the wire.
+	form.handleKey(keyPress("down"))
+	if form.weekStart != time.Tuesday {
+		t.Errorf("a saving form moved its week start to %v", form.weekStart)
+	}
+}
+
+func TestCalendarSettingsFormViewNamesBothSettings(t *testing.T) {
+	form := newCalendarSettingsForm(time.Wednesday, true)
+	form.resize(80, 24)
+	view := stripANSI(form.view())
+	if !strings.Contains(view, "Start weeks on") || !strings.Contains(view, "Wednesday") {
+		t.Errorf("the week start row is missing: %q", view)
+	}
+	if !strings.Contains(view, "Use 24-hour time") || !strings.Contains(view, "◉ yes") {
+		t.Errorf("the clock row is missing: %q", view)
+	}
+}
+
+// --- The form on the calendar ---
+
+func TestCalendarViewOpensSettingsWithComma(t *testing.T) {
+	v := calendarWithRecordings()
+	v.Update(identityLoadedMsg{firstWeekDay: time.Sunday, use24Hour: true})
+
+	v.HandleContentKey(keyPress(","))
+	if v.settings == nil {
+		t.Fatal(", should open the settings form")
+	}
+	// The model routes every key to a capturing view — without this, tab keeps moving the
+	// focus between the lanes behind the modal instead of between the form's fields.
+	if !v.CapturingInput() {
+		t.Error("an open settings form should capture input")
+	}
+	if v.settings.weekStart != time.Sunday || !v.settings.use24 {
+		t.Errorf("the form opened on %v/%v rather than what the identity holds",
+			v.settings.weekStart, v.settings.use24)
+	}
+	if !strings.Contains(stripANSI(v.View()), "Calendar settings") {
+		t.Error("the open form is not drawn")
+	}
+
+	v.HandleContentKey(keyPress("esc"))
+	if v.settings != nil {
+		t.Error("esc should close the settings form")
+	}
+}
+
+func TestCalendarViewSavesSettings(t *testing.T) {
+	v := calendarWithRecordings()
+	v.Update(identityLoadedMsg{firstWeekDay: time.Monday, use24Hour: false})
+
+	v.HandleContentKey(keyPress(","))
+	v.HandleContentKey(keyPress("tab"))
+	v.HandleContentKey(keyPress(" "))
+	cmd := v.HandleContentKey(keyPress("ctrl+s"))
+	if cmd == nil {
+		t.Fatal("saving should return a command")
+	}
+	if v.requests.kind != calendarRequestMutation {
+		t.Errorf("the save rides %v rather than the mutation lane", v.requests.kind)
+	}
+
+	_, consumed := v.Update(calendarSettingsSavedMsg{
+		requestResult: currentRequest(v),
+		firstWeekDay:  time.Monday,
+		use24Hour:     true,
+	})
+	if !consumed {
+		t.Fatal("calendarSettingsSavedMsg should be consumed")
+	}
+	if v.settings != nil {
+		t.Error("a landed save should close the form")
+	}
+	if !v.use24Hour {
+		t.Error("a landed save should move the view onto the new clock")
+	}
+}
+
+func TestCalendarViewKeepsSettingsFormOnAFailedSave(t *testing.T) {
+	v := calendarWithRecordings()
+	v.Update(identityLoadedMsg{firstWeekDay: time.Monday, use24Hour: false})
+
+	v.HandleContentKey(keyPress(","))
+	v.HandleContentKey(keyPress("down"))
+	v.HandleContentKey(keyPress("ctrl+s"))
+
+	v.Update(calendarSettingsSavedMsg{
+		requestResult: requestResult{requestID: v.requests.id, err: errors.New("boom")},
+		firstWeekDay:  time.Tuesday,
+	})
+	if v.settings == nil {
+		t.Fatal("a failed save should keep the form open")
+	}
+	if v.settings.saving || !v.settings.isError || v.settings.status == "" {
+		t.Errorf("the failure is not on the form: saving=%v isError=%v status=%q",
+			v.settings.saving, v.settings.isError, v.settings.status)
+	}
+	if v.firstWeekDay != time.Monday {
+		t.Error("a failed save should leave the view's week start alone")
+	}
+}
+
+func TestIdentityLoadedCarriesTheClock(t *testing.T) {
+	v := calendarWithRecordings()
+	v.Update(identityLoadedMsg{firstWeekDay: time.Saturday, use24Hour: true})
+	if v.firstWeekDay != time.Saturday || !v.use24Hour {
+		t.Errorf("identityLoadedMsg landed as %v/%v", v.firstWeekDay, v.use24Hour)
+	}
+}
+
+// --- The clock the views draw ---
+
+func TestClockTimeReadsBothClocks(t *testing.T) {
+	moment := time.Date(2026, 8, 20, 15, 5, 0, 0, time.Local)
+	if got := clockTime(moment, true); got != "15:05" {
+		t.Errorf("24-hour = %q", got)
+	}
+	if got := clockTime(moment, false); got != "3:05pm" {
+		t.Errorf("12-hour = %q", got)
+	}
+	midnight := time.Date(2026, 8, 20, 0, 30, 0, 0, time.Local)
+	if got := clockTime(midnight, false); got != "12:30am" {
+		t.Errorf("12-hour midnight = %q", got)
+	}
+}
+
+func TestEventTimeSpanOnTheTwelveHourClock(t *testing.T) {
+	event := Recording{
+		StartsAt: atLocal("2026-08-20T14:00:00"),
+		EndsAt:   atLocal("2026-08-20T15:30:00"),
+	}
+	if got := eventTimeSpan(event, 20, false); got != "2:00pm–3:30pm" {
+		t.Errorf("wide column = %q", got)
+	}
+	// A column too narrow for the span gets the start alone, as it does on the 24-hour clock.
+	if got := eventTimeSpan(event, 10, false); got != "2:00pm" {
+		t.Errorf("narrow column = %q", got)
+	}
+}
+
+func TestHourAxisLabels(t *testing.T) {
+	h24 := hourAxisLabels(true)
+	if h24[0] != "00" || h24[13] != "13" || h24[23] != "23" {
+		t.Errorf("24-hour axis = %v", h24)
+	}
+	h12 := hourAxisLabels(false)
+	if h12[0] != "12a" || h12[1] != "1a" || h12[12] != "12p" || h12[23] != "11p" {
+		t.Errorf("12-hour axis = %v", h12)
+	}
+}
+
+func TestDayViewAxisFollowsTheClockSetting(t *testing.T) {
+	day := time.Date(2026, 8, 20, 0, 0, 0, 0, time.Local)
+	twelve := stripANSI(renderDayView(nil, nil, nil, day, calendarFixtureNow(), "", 100, 16, selection{}, nil, false))
+	if !strings.Contains(twelve, "12a") || !strings.Contains(twelve, "12p") {
+		t.Errorf("the 12-hour axis is missing its halves:\n%s", twelve)
+	}
+	twentyFour := stripANSI(renderDayView(nil, nil, nil, day, calendarFixtureNow(), "", 100, 16, selection{}, nil, true))
+	if !strings.Contains(twentyFour, "13") || strings.Contains(twentyFour, "12a") {
+		t.Errorf("the 24-hour axis is not two digits an hour:\n%s", twentyFour)
+	}
+}
+
+func TestNowClockOnTheTwelveHourClock(t *testing.T) {
+	on := time.Date(2026, 8, 20, 15, 5, 0, 0, time.Local)
+	if got := nowClock(on, false); got != "3:05pm" {
+		t.Errorf("lit = %q", got)
+	}
+	if got := nowClock(on.Add(time.Second), false); got != "3 05pm" {
+		t.Errorf("blinked = %q", got)
+	}
+}
+
+func TestTrackedTimeRowsFollowTheClockSetting(t *testing.T) {
+	track := trackedTime{
+		ID:       1,
+		StartsAt: time.Date(2026, 8, 20, 13, 0, 0, 0, time.Local),
+		EndsAt:   time.Date(2026, 8, 20, 14, 30, 0, 0, time.Local),
+		Category: "Client work",
+	}
+	screen := newTrackedTimeScreen(false)
+	screen.resize(100, 20)
+	screen.setTracks([]trackedTime{track}, nil)
+	if view := stripANSI(screen.view()); !strings.Contains(view, "1:00pm – 2:30pm") {
+		t.Errorf("the 12-hour row is missing: %q", view)
+	}
+
+	screen = newTrackedTimeScreen(true)
+	screen.resize(100, 20)
+	screen.setTracks([]trackedTime{track}, nil)
+	if view := stripANSI(screen.view()); !strings.Contains(view, "13:00 – 14:30") {
+		t.Errorf("the 24-hour row is missing: %q", view)
+	}
+}

--- a/internal/tui/calendar_test.go
+++ b/internal/tui/calendar_test.go
@@ -952,7 +952,7 @@ func TestWeekArrowsSelectDaysAndThenEvents(t *testing.T) {
 
 	// And the week says which column that is, or neither pair of arrows would have anything
 	// visible to aim at.
-	week := renderWeekView(v.events, nil, nil, v.day(), time.Monday, 100, 14, "p/n week", nil, v.selection())
+	week := renderWeekView(v.events, nil, nil, v.day(), time.Monday, 100, 14, "p/n week", nil, v.selection(), true)
 	header := strings.Split(week, "\n")[1]
 	if !strings.Contains(header, cursorDayStyle(false).Render(centerPad("WED 19", 13))) {
 		t.Errorf("the week does not mark the day the cursor is on: %q", header)
@@ -1334,7 +1334,7 @@ func weekView(t *testing.T, habits, completions []Recording) []string {
 	}
 
 	anchor := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
-	out := renderWeekView(events, habits, completions, anchor, time.Monday, 100, weekViewRows, "p/n week", nil, selection{})
+	out := renderWeekView(events, habits, completions, anchor, time.Monday, 100, weekViewRows, "p/n week", nil, selection{}, true)
 	return strings.Split(stripANSI(out), "\n")
 }
 
@@ -1450,7 +1450,7 @@ func TestWeekGathersAllDayEventsAtTheFoot(t *testing.T) {
 	}
 
 	anchor := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
-	out := renderWeekView(events, nil, nil, anchor, time.Monday, 100, weekViewRows, "p/n week", nil, selection{})
+	out := renderWeekView(events, nil, nil, anchor, time.Monday, 100, weekViewRows, "p/n week", nil, selection{}, true)
 	lines := strings.Split(stripANSI(out), "\n")
 
 	// The band is under the grid, headed as the day view heads its own.
@@ -1633,7 +1633,7 @@ func TestDayViewLabelsItsSections(t *testing.T) {
 	habits := []Recording{{ID: 4, Title: "Read 20 pages"}}
 
 	day := time.Date(2026, 8, 24, 9, 0, 0, 0, time.Local)
-	view := stripANSI(renderDayView(events, habits, nil, day, calendarFixtureNow(), "p/n day", 100, 24, selection{}, nil))
+	view := stripANSI(renderDayView(events, habits, nil, day, calendarFixtureNow(), "p/n day", 100, 24, selection{}, nil, true))
 	for _, label := range []string{"Habits", "Monday, August 24", "p/n day", "All day"} {
 		if !strings.Contains(view, label) {
 			t.Errorf("day view did not label its %q section: %q", label, view)
@@ -1651,7 +1651,7 @@ func TestAllDayEventsAreBlocksInTheirCalendarsColor(t *testing.T) {
 	}
 	day := time.Date(2026, 8, 21, 9, 0, 0, 0, time.Local)
 
-	rendered := renderDayView(events, nil, nil, day, calendarFixtureNow(), "", 100, 14, selection{}, nil)
+	rendered := renderDayView(events, nil, nil, day, calendarFixtureNow(), "", 100, 14, selection{}, nil, true)
 	lines := strings.Split(rendered, "\n")
 
 	gold := lines[rowContaining(t, lines, "Summer friday")]
@@ -1686,7 +1686,7 @@ func TestDayViewRulesFallFromEveryHourWithoutCuttingIntoAnEvent(t *testing.T) {
 	// an hour every four columns and the 11:00 event's block on the four from 44. The
 	// day's header and the hour axis take the first two rows of the 40 it is given,
 	// leaving 38 for the grid.
-	lines := strings.Split(stripANSI(renderDayView(events, nil, nil, day, calendarFixtureNow(), "", 98, 40, selection{}, nil)), "\n")
+	lines := strings.Split(stripANSI(renderDayView(events, nil, nil, day, calendarFixtureNow(), "", 98, 40, selection{}, nil, true)), "\n")
 	grid := lines[2:]
 	if len(grid) != 38 {
 		t.Fatalf("grid is %d rows of the 38 left to it: %q", len(grid), grid)
@@ -1715,7 +1715,7 @@ func TestDayViewRulesFallFromEveryHourWithoutCuttingIntoAnEvent(t *testing.T) {
 
 func TestEmptyDayIsItsHoursRatherThanANotice(t *testing.T) {
 	day := time.Date(2026, 8, 22, 9, 0, 0, 0, time.Local)
-	view := stripANSI(renderDayView(nil, nil, nil, day, calendarFixtureNow(), "", 96, 20, selection{}, nil))
+	view := stripANSI(renderDayView(nil, nil, nil, day, calendarFixtureNow(), "", 96, 20, selection{}, nil, true))
 
 	if strings.Contains(view, "no events") {
 		t.Errorf("an empty day still announces itself: %q", view)
@@ -1769,7 +1769,7 @@ func TestDayViewGivesASingleEventTheWholeGrid(t *testing.T) {
 
 	// An hour every four columns, so 07:00 starts on column 28 and the block covers the
 	// rules at 28 and 32 for every one of the grid's 38 rows.
-	grid := strings.Split(stripANSI(renderDayView(events, nil, nil, day, calendarFixtureNow(), "", 98, 40, selection{}, nil)), "\n")[2:]
+	grid := strings.Split(stripANSI(renderDayView(events, nil, nil, day, calendarFixtureNow(), "", 98, 40, selection{}, nil, true)), "\n")[2:]
 	if len(grid) != 38 {
 		t.Fatalf("grid is %d rows, want 38: %q", len(grid), grid)
 	}
@@ -1957,7 +1957,7 @@ func TestTheDayMarksWhereTheClockIs(t *testing.T) {
 		StartsAt: now.Truncate(time.Hour).Add(-time.Hour), EndsAt: now.Truncate(time.Hour).Add(2 * time.Hour)}
 
 	lines := strings.Split(stripANSI(renderDayView([]Recording{event}, nil, nil,
-		now, now, "p/n day", 100, 16, selection{}, nil)), "\n")
+		now, now, "p/n day", 100, 16, selection{}, nil, true)), "\n")
 	if !strings.Contains(lines[1], now.Format("15")) || !strings.Contains(lines[1], now.Format("04")) {
 		t.Errorf("the clock is not named over the axis: %q", lines[1])
 	}
@@ -2002,8 +2002,8 @@ func TestTheDayMarksWhereTheClockIs(t *testing.T) {
 	// The colon blinks a second on and a second off, and is swapped for a space rather than
 	// dropped so the digits either side of it never move.
 	on := time.Date(2026, 8, 23, 15, 55, 0, 0, time.Local)
-	lit := nowRow(on, 40, 100, nil)
-	unlit := nowRow(on.Add(time.Second), 40, 100, nil)
+	lit := nowRow(on, 40, 100, nil, true)
+	unlit := nowRow(on.Add(time.Second), 40, 100, nil, true)
 	if !strings.Contains(lit, "15:55") {
 		t.Errorf("an even second reads %q, want the colon", stripANSI(lit))
 	}
@@ -2015,7 +2015,7 @@ func TestTheDayMarksWhereTheClockIs(t *testing.T) {
 	}
 
 	// A day the reader has stepped away from has no now on it, and gives back the row.
-	yesterday := stripANSI(renderDayView(nil, nil, nil, now.AddDate(0, 0, -1), now, "p/n day", 100, 16, selection{}, nil))
+	yesterday := stripANSI(renderDayView(nil, nil, nil, now.AddDate(0, 0, -1), now, "p/n day", 100, 16, selection{}, nil, true))
 	if strings.ContainsRune(yesterday, nowRule) {
 		t.Error("yesterday is marked with a now line")
 	}
@@ -2031,19 +2031,19 @@ func TestARunningTrackTakesTheEndTheClockLeaves(t *testing.T) {
 	track := &runningTrack{category: "Deep work", since: now.Add(-95 * time.Minute)}
 
 	// The clock near the right: the badge goes left.
-	left := stripANSI(nowRow(now, 90, 100, track))
+	left := stripANSI(nowRow(now, 90, 100, track, true))
 	if !strings.HasPrefix(left, "● Deep work 1:35:00") {
 		t.Errorf("with the clock at the right the row reads %q", left)
 	}
 
 	// And near the left it goes right, ending at the edge.
-	right := stripANSI(nowRow(now, 6, 100, track))
+	right := stripANSI(nowRow(now, 6, 100, track, true))
 	if !strings.HasSuffix(right, "● Deep work 1:35:00") {
 		t.Errorf("with the clock at the left the row reads %q", right)
 	}
 
 	// The clock is never given up for the badge: a row too narrow for both keeps the time.
-	narrow := stripANSI(nowRow(now, 10, 22, track))
+	narrow := stripANSI(nowRow(now, 10, 22, track, true))
 	if !strings.Contains(narrow, "15:55") {
 		t.Errorf("the badge crowded out the clock: %q", narrow)
 	}
@@ -2136,14 +2136,14 @@ func TestTheDayCountsDownToWhatIsComing(t *testing.T) {
 
 	day := time.Date(2026, 8, 23, 9, 0, 0, 0, time.Local)
 	lines := strings.Split(stripANSI(renderDayView(nil, nil, []Recording{countdown},
-		day, calendarFixtureNow(), "p/n day", 100, 20, selection{}, nil)), "\n")
+		day, calendarFixtureNow(), "p/n day", 100, 20, selection{}, nil, true)), "\n")
 	if got := strings.TrimSpace(lines[0]); got != "2 days until Kevin's leaving do" {
 		t.Errorf("the day says %q", got)
 	}
 
 	// One day out reads as a day, not as days.
 	lines = strings.Split(stripANSI(renderDayView(nil, nil, []Recording{countdown},
-		day.AddDate(0, 0, 1), calendarFixtureNow(), "p/n day", 100, 20, selection{}, nil)), "\n")
+		day.AddDate(0, 0, 1), calendarFixtureNow(), "p/n day", 100, 20, selection{}, nil, true)), "\n")
 	if got := strings.TrimSpace(lines[0]); got != "1 day until Kevin's leaving do" {
 		t.Errorf("the day before says %q", got)
 	}
@@ -2151,7 +2151,7 @@ func TestTheDayCountsDownToWhatIsComing(t *testing.T) {
 	// And on the day itself there is nothing left to count: HEY stops serving the countdown,
 	// and a day that was handed one anyway does not say "0 days".
 	view := stripANSI(renderDayView(nil, nil, []Recording{countdown},
-		time.Date(2026, 8, 25, 9, 0, 0, 0, time.Local), calendarFixtureNow(), "p/n day", 100, 20, selection{}, nil))
+		time.Date(2026, 8, 25, 9, 0, 0, 0, time.Local), calendarFixtureNow(), "p/n day", 100, 20, selection{}, nil, true))
 	if strings.Contains(view, "until") {
 		t.Errorf("the event's own day still counts down: %q", strings.Split(view, "\n")[0])
 	}
@@ -2180,7 +2180,7 @@ func TestOverlappingEventsAreDrawnApart(t *testing.T) {
 			StartsAt: atLocal("2026-08-20T09:00:00"), EndsAt: atLocal("2026-08-20T11:00:00")},
 		{ID: 2, Title: "Design review", Type: "Calendar::Event",
 			StartsAt: atLocal("2026-08-20T10:00:00"), EndsAt: atLocal("2026-08-20T12:00:00")},
-	}, nil, nil, time.Date(2026, 8, 20, 9, 0, 0, 0, time.Local), calendarFixtureNow(), "p/n day", 100, 20, selection{}, nil))
+	}, nil, nil, time.Date(2026, 8, 20, 9, 0, 0, 0, time.Local), calendarFixtureNow(), "p/n day", 100, 20, selection{}, nil, true))
 
 	// The row between the lanes belongs to the grid, so it carries an hour rule where an
 	// event's own rows carry the event.
@@ -2204,7 +2204,7 @@ func TestBackToBackEventsAreDividedFromEachOther(t *testing.T) {
 			StartsAt: atLocal("2026-08-20T15:00:00"), EndsAt: atLocal("2026-08-20T17:00:00")},
 		{ID: 2, Title: "Product Hangout", Type: "Calendar::Event",
 			StartsAt: atLocal("2026-08-20T17:00:00"), EndsAt: atLocal("2026-08-20T19:00:00")},
-	}, nil, nil, time.Date(2026, 8, 20, 9, 0, 0, 0, time.Local), calendarFixtureNow(), "p/n day", 100, 20, selection{}, nil))
+	}, nil, nil, time.Date(2026, 8, 20, 9, 0, 0, 0, time.Local), calendarFixtureNow(), "p/n day", 100, 20, selection{}, nil, true))
 
 	if !strings.ContainsRune(out, eventEdge) {
 		t.Errorf("nothing separates the two events:\n%s", out)
@@ -2217,15 +2217,15 @@ func TestWeekColumnSaysWhenAnEventRuns(t *testing.T) {
 	event := Recording{ID: 1, Title: "Design review", Type: "Calendar::Event",
 		StartsAt: atLocal("2026-08-20T14:00:00"), EndsAt: atLocal("2026-08-20T15:30:00")}
 
-	if got := eventTimeSpan(event, 13); got != "14:00–15:30" {
+	if got := eventTimeSpan(event, 13, true); got != "14:00–15:30" {
 		t.Errorf("a wide column says %q, want both ends", got)
 	}
 	// A narrow one gets the start alone rather than a truncated range.
-	if got := eventTimeSpan(event, 8); got != "14:00" {
+	if got := eventTimeSpan(event, 8, true); got != "14:00" {
 		t.Errorf("a narrow column says %q, want the start alone", got)
 	}
 	// An event with no end has only the one.
-	if got := eventTimeSpan(Recording{StartsAt: atLocal("2026-08-20T14:00:00")}, 13); got != "14:00" {
+	if got := eventTimeSpan(Recording{StartsAt: atLocal("2026-08-20T14:00:00")}, 13, true); got != "14:00" {
 		t.Errorf("an event with no end says %q", got)
 	}
 }

--- a/internal/tui/calendar_views.go
+++ b/internal/tui/calendar_views.go
@@ -504,8 +504,8 @@ func (track runningTrack) badge(now time.Time) string {
 // Which end that is depends on the clock, which moves across the day — a badge fixed to one side
 // would sit under the time at some point every day. So it takes the wider of the two gaps the
 // clock leaves, and gives up rather than crowding it when neither is wide enough.
-func nowRow(now time.Time, nowCol, gridWidth int, track *runningTrack) string {
-	clock := nowClock(now)
+func nowRow(now time.Time, nowCol, gridWidth int, track *runningTrack, use24 bool) string {
+	clock := nowClock(now, use24)
 	at := min(max(nowCol-len(clock)/2, 0), max(gridWidth-len(clock), 0))
 
 	row := make([]rune, gridWidth)
@@ -534,12 +534,24 @@ func nowRow(now time.Time, nowCol, gridWidth int, track *runningTrack) string {
 // the way a clock's does. It is swapped for a space rather than dropped so the digits either side
 // of it never move — and it is done here rather than with the terminal's own blink attribute,
 // which plenty of terminals ignore and none of them run to our second.
-func nowClock(now time.Time) string {
+func nowClock(now time.Time, use24 bool) string {
 	separator := ":"
 	if now.Second()%2 == 1 {
 		separator = " "
 	}
-	return now.Format("15") + separator + now.Format("04")
+	if use24 {
+		return now.Format("15") + separator + now.Format("04")
+	}
+	return now.Format("3") + separator + now.Format("04") + strings.ToLower(now.Format("PM"))
+}
+
+// clockTime is t on the clock the identity keeps — HEY's own preference decides whether
+// a quarter past three reads 15:15 or 3:15pm.
+func clockTime(t time.Time, use24 bool) string {
+	if use24 {
+		return t.Format("15:04")
+	}
+	return strings.ToLower(t.Format("3:04PM"))
 }
 
 // dayCountdownLines is what the day is counting down to, one line each, nearest first.
@@ -581,7 +593,30 @@ func dayCountdownLines(countdowns []Recording, anchor time.Time) []string {
 	return lines
 }
 
-func renderDayView(events, habits, countdowns []Recording, anchor, now time.Time, hint string, width, height int, sel selection, track *runningTrack) string {
+// hourAxisLabels is the day's axis in the reader's clock: two digits an hour on a 24-hour
+// one, the hour with its half of the day on a 12-hour one. The closing label — the next
+// day's midnight — is labels[0] either way.
+func hourAxisLabels(use24 bool) []string {
+	labels := make([]string, 24)
+	for h := range 24 {
+		if use24 {
+			labels[h] = fmt.Sprintf("%02d", h)
+			continue
+		}
+		half := "a"
+		if h >= 12 {
+			half = "p"
+		}
+		hour := h % 12
+		if hour == 0 {
+			hour = 12
+		}
+		labels[h] = fmt.Sprintf("%d%s", hour, half)
+	}
+	return labels
+}
+
+func renderDayView(events, habits, countdowns []Recording, anchor, now time.Time, hint string, width, height int, sel selection, track *runningTrack, use24 bool) string {
 	var b strings.Builder
 
 	// The day borrows the mail list's vocabulary: chrome for the structure a reader
@@ -605,11 +640,13 @@ func renderDayView(events, habits, countdowns []Recording, anchor, now time.Time
 		b.WriteString("\n")
 	}
 
-	// A day ends where the next one begins, so the axis closes on another 00 with a
+	// A day ends where the next one begins, so the axis closes on another midnight with a
 	// rule under it: twenty-four hours are twenty-five lines, and the day reads as a
-	// span rather than as columns that stop. The two columns that last label needs are
+	// span rather than as columns that stop. The columns that last label needs are
 	// what the hours are sized against.
-	colWidth := max((width-2)/24, 3)
+	labels := hourAxisLabels(use24)
+	closing := labels[0]
+	colWidth := max((width-len(closing))/24, 3)
 	daySpan := colWidth * 24
 	gridWidth := daySpan + 1
 
@@ -623,19 +660,19 @@ func renderDayView(events, habits, countdowns []Recording, anchor, now time.Time
 	// drawn on a day that is today: a day the reader has stepped away from has no now on it.
 	nowCol := nowColumn(anchor, now, daySpan)
 	if nowCol >= 0 {
-		b.WriteString(nowRow(now, nowCol, gridWidth, track))
+		b.WriteString(nowRow(now, nowCol, gridWidth, track, use24))
 		b.WriteString("\n")
 	}
 
 	// Hour header
 	var header strings.Builder
-	for h := range 24 {
-		fmt.Fprintf(&header, "%02d", h)
-		if pad := colWidth - 2; pad > 0 {
+	for _, label := range labels {
+		header.WriteString(label)
+		if pad := colWidth - len(label); pad > 0 {
 			header.WriteString(strings.Repeat(" ", pad))
 		}
 	}
-	header.WriteString("00")
+	header.WriteString(closing)
 	b.WriteString(chrome.Render(header.String()))
 	b.WriteString("\n")
 
@@ -1008,7 +1045,7 @@ type weekDayInfo struct {
 // spreadsheet of the week rather than as the week. The day never had a box: it is a header,
 // an axis, and events on open ground. That is what a week is too, with seven days across
 // instead of twenty-four hours.
-func renderWeekView(events, habits, completions []Recording, anchor time.Time, firstWeekDay time.Weekday, width, height int, hint string, dayLabels map[string]string, sel selection) string {
+func renderWeekView(events, habits, completions []Recording, anchor time.Time, firstWeekDay time.Weekday, width, height int, hint string, dayLabels map[string]string, sel selection, use24 bool) string {
 	var b strings.Builder
 	muted := styleMuted
 	chrome := lipgloss.NewStyle().Foreground(colorChrome)
@@ -1117,7 +1154,7 @@ func renderWeekView(events, habits, completions []Recording, anchor time.Time, f
 	// Build column content
 	cols := make([][]string, 7)
 	for i := range 7 {
-		cols[i] = buildWeekDayColumn(days[i], colWidth, muted, sel)
+		cols[i] = buildWeekDayColumn(days[i], colWidth, muted, sel, use24)
 	}
 
 	maxH := 0
@@ -1212,13 +1249,13 @@ func weekHabitBand(days []weekDayInfo, colWidth int) [][]string {
 
 // buildWeekDayColumn returns styled lines for one day column.
 // Order: habits at top, timed events in the middle, all-day at bottom.
-func buildWeekDayColumn(d weekDayInfo, width int, muted lipgloss.Style, sel selection) []string {
+func buildWeekDayColumn(d weekDayInfo, width int, muted lipgloss.Style, sel selection, use24 bool) []string {
 	// The day's habits are the band above the grid and its all-day events the band below
 	// it, so the column itself is the timed events alone.
 	var lines []string
 
 	for _, e := range d.events {
-		if when := eventTimeSpan(e, width); when != "" {
+		if when := eventTimeSpan(e, width, use24); when != "" {
 			lines = append(lines, muted.Render(when))
 		}
 		lines = append(lines, eventPill(e, width, sel))
@@ -1233,15 +1270,15 @@ func buildWeekDayColumn(d weekDayInfo, width int, muted lipgloss.Style, sel sele
 // Both ends are said where the column is wide enough for them, since when a meeting finishes is
 // half of what a reader is looking for; a narrow column gets the start alone rather than a
 // truncated range.
-func eventTimeSpan(event Recording, width int) string {
+func eventTimeSpan(event Recording, width int, use24 bool) string {
 	starts := event.Starts()
 	if starts.IsZero() {
 		return ""
 	}
 
-	from := starts.Format("15:04")
+	from := clockTime(starts, use24)
 	if ends := event.Ends(); !ends.IsZero() && ends.After(starts) {
-		if span := from + "–" + ends.Format("15:04"); len(span) <= width {
+		if span := from + "–" + clockTime(ends, use24); len(span) <= width {
 			return span
 		}
 	}

--- a/internal/tui/time_track.go
+++ b/internal/tui/time_track.go
@@ -121,10 +121,10 @@ func timeTrackActionLabel(action timeTrackAction, running bool) string {
 	return ""
 }
 
-func (m *timeTrackMenu) draw(base string, track *OngoingTrack, known bool, now time.Time, width, height int) string {
+func (m *timeTrackMenu) draw(base string, track *OngoingTrack, known bool, now time.Time, width, height int, use24 bool) string {
 	contentWidth := modalContentWidth(width)
 
-	rows := []string{m.trackingLine(track, known, contentWidth, now), ""}
+	rows := []string{m.trackingLine(track, known, contentWidth, now, use24), ""}
 	for i, action := range timeTrackActions {
 		label := truncateToWidth(timeTrackActionLabel(action, track != nil), max(contentWidth-2, 1))
 		if i == m.cursor {
@@ -146,7 +146,7 @@ func (m *timeTrackMenu) draw(base string, track *OngoingTrack, known bool, now t
 
 // trackingLine is the reason to open the menu while a track is running: what it is filed
 // under, when it started, and how long it has been going.
-func (m *timeTrackMenu) trackingLine(track *OngoingTrack, known bool, contentWidth int, now time.Time) string {
+func (m *timeTrackMenu) trackingLine(track *OngoingTrack, known bool, contentWidth int, now time.Time, use24 bool) string {
 	if track == nil {
 		if !known {
 			return styleMuted.Render("Reading what is being tracked…")
@@ -158,7 +158,7 @@ func (m *timeTrackMenu) trackingLine(track *OngoingTrack, known bool, contentWid
 	if track.Category != "" {
 		what += " " + track.Category
 	}
-	line := fmt.Sprintf("● %s since %s · %s", what, track.StartedAt.Format("15:04"), formatElapsed(track.Elapsed(now)))
+	line := fmt.Sprintf("● %s since %s · %s", what, clockTime(track.StartedAt, use24), formatElapsed(track.Elapsed(now)))
 	return lipgloss.NewStyle().Foreground(colorActive).Bold(true).
 		Render(truncateToWidth(line, contentWidth))
 }
@@ -231,10 +231,14 @@ type trackedTimeScreen struct {
 
 	contentVP viewport.Model
 	width     int
+	use24     bool
 }
 
-func newTrackedTimeScreen() *trackedTimeScreen {
-	return &trackedTimeScreen{contentVP: viewport.New(viewport.WithWidth(0), viewport.WithHeight(0))}
+func newTrackedTimeScreen(use24 bool) *trackedTimeScreen {
+	return &trackedTimeScreen{
+		contentVP: viewport.New(viewport.WithWidth(0), viewport.WithHeight(0)),
+		use24:     use24,
+	}
 }
 
 // setTracks is the first page, or the list read again from the top: the cursor goes back to
@@ -357,7 +361,7 @@ func (s *trackedTimeScreen) row(track trackedTime, selected bool) string {
 
 	line := marker +
 		strong.Render(fmt.Sprintf("%-16s", track.StartsAt.Format("Mon Jan 2 2006"))) + "  " +
-		soft.Render(fmt.Sprintf("%s – %s", track.StartsAt.Format("15:04"), track.EndsAt.Format("15:04"))) + "  " +
+		soft.Render(fmt.Sprintf("%s – %s", clockTime(track.StartsAt, s.use24), clockTime(track.EndsAt, s.use24))) + "  " +
 		accent.Render(fmt.Sprintf("%-9s", formatElapsed(track.Duration()))) + " " +
 		categoryStyle.Render(category)
 	if notes := terminal.SanitizeLine(track.Notes); notes != "" {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-FLHR/1dDErEaSM2xXuA2qYK3cMy0zpDsk2nZ+sJMIeQ=";
+  vendorHash = "sha256-K+uzl8NCJiirgosB64Wyl6qmyEMuDwjO3VR8kM9VnPA=";
 
   subPackages = [ "cmd/hey" ];
 


### PR DESCRIPTION
Press `,` in the Calendar section to open a settings form with the two calendar preferences HEY keeps on the identity — which day weeks start on (Sunday through Saturday) and whether times read on a 24-hour clock. Both are read from and written to HEY through SDK v0.23.0's `UpdateFirstWeekDay` and `UpdateTimeFormat`, so a change here shows up in the web and mobile apps, and what the calendar renders after a save is what the server answered it stored.

The 24-hour preference now decides every clock this section draws, where each was hardcoded to `15:04` before:

- the day view's hour axis (`00 01 02…` vs `12a 1a 2a…`, with the closing midnight label sized per format)
- the now clock above it, blinking colon included
- event time spans in the week columns (`14:00–15:30` vs `2:00pm–3:30pm`, falling back to the start alone in narrow columns as before)
- the time-tracking stopwatch line and the tracked-time rows

Form behavior follows the calendar's other modals: tab walks the fields, ↑↓ cycles the weekday, space toggles the clock, `ctrl+s` saves only what changed (a form nobody touched says "Nothing changed" instead of making a request), esc cancels. The open form captures input like every calendar modal, with a test pinning that so the next modal that forgets gets caught. A landed save re-reads the span, because the year grid's padding comes from the server computed for the old week start.

The read path needed nothing new — the calendar already fetched the identity for the week start and threw the time format away.

Also adds the linear-history rule to AGENTS.md: merges are disallowed, branches rebase.
