### PR TITLE
Let esc dismiss the TUI error box instead of locking the screen

### DIFF
--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -173,7 +173,11 @@ func newStyles() styles {
 
 // --- Error display ---
 
-// errorView renders a styled error message inside a bordered box.
+const errorViewHint = "esc to dismiss · ctrl+c ctrl+c to quit"
+
+// errorView renders a styled error message inside a bordered box. It is drawn over the
+// section it interrupted, so every line is padded to one width: an overlay's blank
+// cells are what keep the content beneath from bleeding through.
 func errorView(errMsg string, width int) string {
 	border := lipgloss.NewStyle().Foreground(colorError)
 	errStyle := lipgloss.NewStyle().Foreground(colorError).Bold(true)
@@ -185,25 +189,29 @@ func errorView(errMsg string, width int) string {
 	}
 
 	lines := wrapText(errMsg, maxInner)
-	innerWidth := 0
+	innerWidth := 6
 	for _, l := range lines {
 		if len(l) > innerWidth {
 			innerWidth = len(l)
 		}
 	}
 
-	top := border.Render("╭─ Error " + strings.Repeat("─", max(innerWidth-6, 0)) + "╮")
-	bot := border.Render("╰" + strings.Repeat("─", innerWidth+2) + "╯")
-
-	var mid strings.Builder
-	for _, l := range lines {
-		pad := strings.Repeat(" ", innerWidth-len(l))
-		mid.WriteString(border.Render("│") + " " + errStyle.Render(l) + pad + " " + border.Render("│") + "\n")
+	hintText := "  " + errorViewHint
+	blockWidth := max(innerWidth+4, lipgloss.Width(hintText))
+	padTo := func(rendered string) string {
+		return rendered + strings.Repeat(" ", max(blockWidth-lipgloss.Width(rendered), 0))
 	}
 
-	hintLine := hint.Render("  Press ctrl+c ctrl+c to quit")
-
-	return top + "\n" + mid.String() + bot + "\n\n" + hintLine
+	var b strings.Builder
+	b.WriteString(padTo(border.Render("╭─ Error "+strings.Repeat("─", innerWidth-6)+"╮")) + "\n")
+	for _, l := range lines {
+		pad := strings.Repeat(" ", innerWidth-len(l))
+		b.WriteString(padTo(border.Render("│")+" "+errStyle.Render(l)+pad+" "+border.Render("│")) + "\n")
+	}
+	b.WriteString(padTo(border.Render("╰"+strings.Repeat("─", innerWidth+2)+"╯")) + "\n")
+	b.WriteString(strings.Repeat(" ", blockWidth) + "\n")
+	b.WriteString(padTo(hint.Render(hintText)))
+	return b.String()
 }
 
 // wrapText wraps a string to fit within maxWidth characters.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -528,6 +528,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case errMsg:
 		m.loading = false
 		m.err = msg.err
+		m.updateHelpBindings()
 		return m, nil
 
 	case tea.KeyPressMsg:
@@ -635,7 +636,10 @@ const headerHeight = 6 // five drawn rows and the terminal's final safety row
 func (m model) contentView() string {
 	switch {
 	case m.err != nil:
-		return errorView(m.err.Error(), m.width)
+		// The section keeps its last good state underneath, so dismissing the error
+		// with esc puts the reader back where they were.
+		box := errorView(terminal.SanitizeLine(m.err.Error()), m.width)
+		return overlayModal(m.activeView.View(), box, m.width, m.contentHeight())
 	case m.loading:
 		return loadingView(m.width, m.contentHeight(), m.spinnerPhase)
 	default:
@@ -697,6 +701,11 @@ func (m *model) updateHelpBindings() {
 			{"↑↓", "account"},
 			{"enter", "switch"},
 			{"esc/q", "cancel"},
+			quitHint,
+		}
+	} else if m.err != nil {
+		bindings = []helpBinding{
+			{"esc/q", "dismiss"},
 			quitHint,
 		}
 	} else if ic, ok := m.activeView.(inputCapturer); ok && ic.CapturingInput() {
@@ -800,6 +809,16 @@ func (m model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	if m.mailAccountPicker {
 		return m.handleMailAccountKey(msg)
+	}
+
+	// An error box stands over the section until it is dismissed; nothing else should
+	// act on a screen it is covering.
+	if m.err != nil {
+		if msg.Key().Code == tea.KeyEscape || key == "q" {
+			m.err = nil
+			m.updateHelpBindings()
+		}
+		return m, nil
 	}
 
 	if key == "?" && m.canToggleHelp() {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -471,6 +471,121 @@ func TestSingleCtrlCDoesNotQuit(t *testing.T) {
 	}
 }
 
+// --- Errors are dismissible ---
+
+func TestEscDismissesAnErrorAndKeepsTheSection(t *testing.T) {
+	m := modelWithBoxes()
+	updated, _ := m.Update(errMsg{errors.New("resource not found")})
+	m = updated.(model)
+	if m.err == nil {
+		t.Fatal("errMsg should set the error state")
+	}
+	if !slices.Contains(m.help.bindings, helpBinding{"esc/q", "dismiss"}) {
+		t.Errorf("error help is missing the dismiss binding: %v", m.help.bindings)
+	}
+
+	updated, _ = m.Update(keyPress("esc"))
+	m = updated.(model)
+	if m.err != nil {
+		t.Error("esc should dismiss the error")
+	}
+	if m.section != sectionMail || m.activeView != m.mailView {
+		t.Errorf("dismissing the error moved the TUI to section=%d view=%T", m.section, m.activeView)
+	}
+	if !strings.Contains(m.contentView(), "Hello world") {
+		t.Error("the mail list should be back on screen after dismissing the error")
+	}
+}
+
+func TestQDismissesAnError(t *testing.T) {
+	m := modelWithBoxes()
+	updated, _ := m.Update(errMsg{errors.New("resource not found")})
+	m = updated.(model)
+
+	updated, _ = m.Update(keyPress("q"))
+	m = updated.(model)
+	if m.err != nil {
+		t.Error("q should dismiss the error")
+	}
+}
+
+func TestErrorKeepsTheSectionContentOnScreen(t *testing.T) {
+	m := modelWithBoxes()
+	updated, _ := m.Update(errMsg{errors.New("resource not found")})
+	m = updated.(model)
+
+	content := m.contentView()
+	if !strings.Contains(content, "resource not found") {
+		t.Error("the error box should name the error")
+	}
+	if !strings.Contains(content, errorViewHint) {
+		t.Error("the error box should say how to dismiss it")
+	}
+	if !strings.Contains(content, "Hello world") {
+		t.Error("the section's last good state should stay on screen under the error")
+	}
+}
+
+func TestErrorSwallowsOtherKeysWhileItIsUp(t *testing.T) {
+	m := modelWithBoxes()
+	updated, _ := m.Update(errMsg{errors.New("resource not found")})
+	m = updated.(model)
+
+	updated, cmd := m.Update(keyPress("O"))
+	m = updated.(model)
+	if m.section != sectionMail || cmd != nil {
+		t.Error("a section shortcut should wait until the error is dismissed")
+	}
+	if m.err == nil {
+		t.Error("another key should not dismiss the error")
+	}
+}
+
+func TestCtrlCStillQuitsFromAnError(t *testing.T) {
+	m := modelWithBoxes()
+	updated, _ := m.Update(errMsg{errors.New("resource not found")})
+	m = updated.(model)
+
+	updated, _ = m.Update(keyPress("ctrl+c"))
+	m = updated.(model)
+	_, cmd := m.Update(keyPress("ctrl+c"))
+	if cmd == nil {
+		t.Fatal("double ctrl+c should quit from the error state")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Error("double ctrl+c should produce tea.QuitMsg from the error state")
+	}
+}
+
+func TestEscDismissesAnErrorFromAFreshLoad(t *testing.T) {
+	m := sizedModel()
+	updated, _ := m.Update(errMsg{errors.New("could not reach HEY")})
+	m = updated.(model)
+	if m.loading {
+		t.Fatal("an error should end the loading state")
+	}
+
+	updated, _ = m.Update(keyPress("esc"))
+	m = updated.(model)
+	if m.err != nil {
+		t.Error("esc should dismiss a fresh-load error")
+	}
+	if m.contentView() == "" {
+		t.Error("the section should still render after dismissing a fresh-load error")
+	}
+}
+
+func TestErrorViewLinesShareOneWidth(t *testing.T) {
+	view := errorView("resource not found", 80)
+	lines := strings.Split(view, "\n")
+	want := lipgloss.Width(lines[0])
+	for index, line := range lines {
+		if lipgloss.Width(line) != want {
+			t.Errorf("line %d is %d cells wide, want %d — an uneven overlay lets the content beneath bleed through", index, lipgloss.Width(line), want)
+		}
+	}
+}
+
 func TestLoadingViewKeepsItsSectionUntilResponse(t *testing.T) {
 	m := modelWithBoxes()
 	m.loading = true


### PR DESCRIPTION
A failed read in the TUI — a resource not found, a dropped request, an unavailable account — replaced the whole screen with the error box, and nothing ever cleared `model.err`. The only key that did anything was ctrl+c ctrl+c, so one bad request locked the reader out of a session that was otherwise fine.

The error is now a modal over the section's last good state, composited with the same `overlayModal` the forms and pickers use. Esc or q clears it and the reader is exactly where they were, cursor and all; on a fresh load with nothing behind it, dismissal lands on the empty-but-alive section and ctrl+r retries. While the box is up every other key is swallowed, since nothing should act on content the box is covering — ctrl+c ctrl+c is handled before that and still quits.

Two things surfaced along the way: the error text can carry a server-written message, so it goes through `terminal.SanitizeLine` before rendering, and `errorView` pads every line to one width because a ragged overlay lets the content beneath bleed through.

The hint line now reads "esc to dismiss · ctrl+c ctrl+c to quit", and the help bar shows the same while an error is up.