### PR TITLE
Render layout tables as the block flow their cells hold

### DIFF
--- a/internal/htmlutil/markdown.go
+++ b/internal/htmlutil/markdown.go
@@ -270,10 +270,25 @@ func codeLanguage(n *html.Node) string {
 	return ""
 }
 
+// table writes a data table as a pipe table. HTML email lays whole pages out in
+// tables, and a pipe table cannot hold what those cells hold — headings, lists,
+// nested tables, spanned cells — so a table that is scaffolding rather than data
+// renders each cell as the block flow it contains instead.
 func (m *markdownizer) table(n *html.Node) {
-	rows := tableRows(n)
-	if len(rows) == 0 {
+	cells := tableCells(n)
+	if len(cells) == 0 {
 		return
+	}
+	if isLayoutTable(n, cells) {
+		m.layoutTable(n)
+		return
+	}
+
+	rows := make([][]string, len(cells))
+	for i, row := range cells {
+		for _, cell := range row {
+			rows[i] = append(rows[i], inlineMarkdown(cell))
+		}
 	}
 
 	m.flushLine()
@@ -292,24 +307,77 @@ func (m *markdownizer) table(n *html.Node) {
 	m.blank()
 }
 
-func tableRows(n *html.Node) [][]string {
-	var rows [][]string
+func tableCells(n *html.Node) [][]*html.Node {
 	if n.Type == html.ElementNode && n.Data == "tr" {
-		var cells []string
+		var cells []*html.Node
 		for cell := n.FirstChild; cell != nil; cell = cell.NextSibling {
 			if cell.Type == html.ElementNode && (cell.Data == "td" || cell.Data == "th") {
-				cells = append(cells, inlineMarkdown(cell))
+				cells = append(cells, cell)
 			}
 		}
 		if len(cells) > 0 {
-			return [][]string{cells}
+			return [][]*html.Node{cells}
 		}
 		return nil
 	}
+	var rows [][]*html.Node
 	for child := n.FirstChild; child != nil; child = child.NextSibling {
-		rows = append(rows, tableRows(child)...)
+		rows = append(rows, tableCells(child)...)
 	}
 	return rows
+}
+
+func isLayoutTable(n *html.Node, cells [][]*html.Node) bool {
+	if role := getAttr(n, "role"); role == "presentation" || role == "none" {
+		return true
+	}
+	columns := 0
+	for _, row := range cells {
+		if len(row) > columns {
+			columns = len(row)
+		}
+		for _, cell := range row {
+			if getAttr(cell, "colspan") != "" || getAttr(cell, "rowspan") != "" || holdsBlockContent(cell) {
+				return true
+			}
+		}
+	}
+	return columns < 2
+}
+
+// holdsBlockContent reports whether a cell holds content a pipe-table cell
+// cannot: block elements that flattening to one line would destroy. A <p> or a
+// <div> is not counted — a wrapped cell value flattens without loss.
+func holdsBlockContent(n *html.Node) bool {
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		if child.Type == html.ElementNode && (blockContentTags[child.Data] || holdsBlockContent(child)) {
+			return true
+		}
+	}
+	return false
+}
+
+var blockContentTags = map[string]bool{
+	"h1": true, "h2": true, "h3": true, "h4": true, "h5": true, "h6": true,
+	"ul": true, "ol": true, "table": true, "pre": true, "blockquote": true,
+	"figure": true, "hr": true, "action-text-attachment": true,
+}
+
+func (m *markdownizer) layoutTable(n *html.Node) {
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		if child.Type != html.ElementNode {
+			m.walk(child)
+			continue
+		}
+		switch child.Data {
+		case "td", "th":
+			m.block(func() { m.children(child) })
+		case "tbody", "thead", "tfoot", "tr":
+			m.layoutTable(child)
+		default:
+			m.walk(child)
+		}
+	}
 }
 
 func (m *markdownizer) emphasis(n *html.Node, delimiter string) {

--- a/internal/htmlutil/markdown_safety_test.go
+++ b/internal/htmlutil/markdown_safety_test.go
@@ -455,8 +455,8 @@ func TestToMarkdownAttachmentNamesAreSerialized(t *testing.T) {
 }
 
 func TestToMarkdownTableCellsEscapePipes(t *testing.T) {
-	got := toMarkdown("<table><tr><th>a|b</th></tr><tr><td>c | d</td></tr></table>")
-	want := "| a\\|b |\n| --- |\n| c \\| d |"
+	got := toMarkdown("<table><tr><th>a|b</th><th>e</th></tr><tr><td>c | d</td><td>f</td></tr></table>")
+	want := "| a\\|b | e |\n| --- | --- |\n| c \\| d | f |"
 	if got != want {
 		t.Errorf("ToMarkdown = %q, want %q", got, want)
 	}

--- a/internal/htmlutil/markdown_test.go
+++ b/internal/htmlutil/markdown_test.go
@@ -92,6 +92,75 @@ func TestToMarkdownTable(t *testing.T) {
 	}
 }
 
+func TestToMarkdownTableWithoutHeaderRow(t *testing.T) {
+	got := toMarkdown("<table><tr><td>Personal</td><td>$99/yr</td></tr><tr><td>Team</td><td>$299/yr</td></tr></table>")
+	want := "| Personal | $99/yr |\n| --- | --- |\n| Team | $299/yr |"
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
+func TestToMarkdownLayoutTableWithBlockContent(t *testing.T) {
+	got := toMarkdown(`<table><tbody><tr><td><div>
+		<h3>Spotlights</h3>
+		<ul><li>Polished off the animation controller</li><li>Fixed reordering in generated projects</li></ul>
+		<p>Pending code review, this is ready to ship!</p>
+	</div></td></tr></tbody></table>`)
+	want := "### Spotlights\n\n- Polished off the animation controller\n- Fixed reordering in generated projects\n\nPending code review, this is ready to ship!"
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
+func TestToMarkdownLayoutTableWithSpannedCells(t *testing.T) {
+	got := toMarkdown(`<table><tbody>
+		<tr><td colspan="2"></td></tr>
+		<tr><td>Sent with Basecamp</td><td>You can reply to this email or <a href="https://example.com/answers/42">respond in Basecamp</a>.</td></tr>
+	</tbody></table>`)
+	want := "Sent with Basecamp\n\nYou can reply to this email or [respond in Basecamp](https://example.com/answers/42)."
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
+func TestToMarkdownLayoutTableWithPresentationRole(t *testing.T) {
+	got := toMarkdown(`<table role="presentation"><tr><td>Weekly digest</td><td>Everything that happened this week</td></tr></table>`)
+	want := "Weekly digest\n\nEverything that happened this week"
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
+func TestToMarkdownSingleColumnTable(t *testing.T) {
+	got := toMarkdown("<table><tr><td>Thanks for signing up!</td></tr><tr><td>Your trial ends on March 14.</td></tr></table>")
+	want := "Thanks for signing up!\n\nYour trial ends on March 14."
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
+func TestToMarkdownDataTableInsideLayoutTable(t *testing.T) {
+	got := toMarkdown(`<table><tbody><tr><td>
+		<p>Here is where the launch stands:</p>
+		<table><tr><th>Task</th><th>Owner</th></tr><tr><td>Ship the beta</td><td>Priya</td></tr></table>
+	</td></tr></tbody></table>`)
+	want := "Here is where the launch stands:\n\n| Task | Owner |\n| --- | --- |\n| Ship the beta | Priya |"
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
+func TestToMarkdownLayoutTableInsideLayoutTable(t *testing.T) {
+	got := toMarkdown(`<table><tbody><tr><td>
+		<p>The launch checklist is done.</p>
+		<table><tbody><tr><td><action-text-attachment content-type="image" url="https://example.com/logo.png"></action-text-attachment></td><td>Reply to this email to comment.</td></tr></tbody></table>
+	</td></tr></tbody></table>`)
+	want := "The launch checklist is done.\n\n![attachment](https://example.com/logo.png)\n\nReply to this email to comment."
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
 func TestToMarkdownHardBreak(t *testing.T) {
 	got := toMarkdown("<p>Thanks,<br>Jason</p>")
 	want := "Thanks,  \nJason"


### PR DESCRIPTION
Opening a typical HTML email — a Basecamp notification, most newsletters — showed a wall of pipes instead of the message. Those emails lay the whole page out in tables, and `htmlutil.ToMarkdown` converted every `<table>` into a Markdown pipe table: each cell went through `inlineMarkdown`, which flattens headings, lists and nested tables into one line, so the entire body arrived as a single enormous table cell.

A table is now converted as a pipe table only when a pipe table can actually carry it. It renders as the block flow its cells hold instead when any of these is true:

- the HTML marks it as presentation (`role="presentation"`/`"none"`)
- a cell is spanned — a pipe table cannot express `colspan`/`rowspan`
- a cell holds block content a one-line cell would destroy (headings, lists, nested tables, pre, blockquote, figures, attachments)
- it has fewer than two columns

The decision is per table, so a genuine data table nested inside email scaffolding still comes out as a pipe table. A `<p>` or `<div>` inside a cell deliberately does not count as block content: a wrapped cell value flattens to one line without loss, and counting it would turn most pasted data tables into paragraphs.

One existing safety test used a single-column table to exercise pipe escaping; that shape is layout now, so it's widened to two columns to stay on the pipe-table path. Verified against the live email that surfaced this, plus `make test`, `make lint` and a 20s run of `FuzzToMarkdownTerminalSafety`.