### PR TITLE
Add hey bubble: list, up with schedule slots, and pop

### DIFF
--- a/.surface
+++ b/.surface
@@ -46,8 +46,11 @@ hey box view --page
 hey bubble
 hey bubble pop
 hey bubble up
+hey bubble up --next-week
 hey bubble up --now
 hey bubble up --on
+hey bubble up --tomorrow
+hey bubble up --weekend
 hey bulk-reply
 hey bulk-reply preview
 hey bulk-reply send

--- a/.surface
+++ b/.surface
@@ -44,6 +44,9 @@ hey box view --all
 hey box view --limit
 hey box view --page
 hey bubble
+hey bubble list
+hey bubble list --all
+hey bubble list --limit
 hey bubble pop
 hey bubble up
 hey bubble up --next-week

--- a/.surface
+++ b/.surface
@@ -43,6 +43,10 @@ hey box view
 hey box view --all
 hey box view --limit
 hey box view --page
+hey bubble
+hey bubble pop
+hey bubble up
+hey bubble up --now
 hey bulk-reply
 hey bulk-reply preview
 hey bulk-reply send

--- a/.surface
+++ b/.surface
@@ -47,6 +47,7 @@ hey bubble
 hey bubble pop
 hey bubble up
 hey bubble up --now
+hey bubble up --on
 hey bulk-reply
 hey bulk-reply preview
 hey bulk-reply send

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -81,6 +81,8 @@ which is what `Entries().ListDraftsPage` and `hey draft list --page` exist for.
 | `/postings/spam.json` | POST | SDK `Postings().MarkSpam` | `hey spam <id>`, TUI `!` | covered |
 | `/postings/mutings.json` | POST | SDK `Postings().Mute` | `hey ignore <id>`, TUI `-` | covered |
 | `/postings/mutings.json` | DELETE | SDK `Postings().Unmute` | `hey stop-ignoring <id>`, TUI `+` | covered |
+| `/postings/bulk_bubble_up_now.json` | POST | SDK `Postings().BubbleUpNow` | `hey bubble up <id> --now` | covered |
+| `/postings/bubble_up.json` | DELETE | SDK `Postings().CancelBubbleUp` | `hey bubble pop <id>` | covered |
 | `/calendar/events.json` | POST | SDK `CalendarEvents().Create` | `hey event add`, Calendar TUI `a` | covered |
 | `/calendar/events/{id}.json` | PATCH | SDK `CalendarEvents().Update` | `hey event edit <id>`, Calendar TUI `e` | covered: a write replaces rather than patches, so the caller reads the event and sends back what it keeps |
 | `/calendar/events/{id}` | DELETE | SDK `CalendarEvents().Delete` | `hey event delete <id>`, Calendar TUI `x` | covered |

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -20,7 +20,8 @@ which is what `Entries().ListDraftsPage` and `hey draft list --page` exist for.
 | `/trailbox.json` | GET | SDK `Boxes().GetTrailbox` | `hey box view trailbox` | covered |
 | `/asidebox.json` | GET | SDK `Boxes().GetAsidebox` | `hey box view asidebox` | covered |
 | `/laterbox.json` | GET | SDK `Boxes().GetLaterbox` | `hey box view laterbox` | covered |
-| `/bubblebox.json` | GET | SDK `Boxes().GetBubblebox` | `hey box view bubblebox` | covered |
+| `/bubblebox.json` | GET | SDK `Boxes().GetBubblebox` | `hey box view bubblebox`, `hey bubble list` (scheduled bucket) | covered |
+| `/imbox/bubbled_up` | GET | — | — | not served: HTML only; the Imbox JSON orders bubbled-up threads first, so `hey bubble list` reads that prefix instead |
 | `/my/navigation.json` | GET | SDK `Identity().GetNavigation` | `hey label list`, Mail TUI navigation | covered |
 | `/folders/{id}.json` | GET | SDK `Folders().GetPage` | `hey label view <id>`, Mail TUI labels | covered |
 | `/postings/filings.json` | POST | SDK `Postings().File` | `hey label add`, TUI `b/B` | covered |

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -82,6 +82,7 @@ which is what `Entries().ListDraftsPage` and `hey draft list --page` exist for.
 | `/postings/mutings.json` | POST | SDK `Postings().Mute` | `hey ignore <id>`, TUI `-` | covered |
 | `/postings/mutings.json` | DELETE | SDK `Postings().Unmute` | `hey stop-ignoring <id>`, TUI `+` | covered |
 | `/postings/bulk_bubble_up_now.json` | POST | SDK `Postings().BubbleUpNow` | `hey bubble up <id> --now` | covered |
+| `/postings/bubble_up.json` | POST | SDK `Postings().ScheduleBubbleUp` | `hey bubble up <id> --on <date>` | covered |
 | `/postings/bubble_up.json` | DELETE | SDK `Postings().CancelBubbleUp` | `hey bubble pop <id>` | covered |
 | `/calendar/events.json` | POST | SDK `CalendarEvents().Create` | `hey event add`, Calendar TUI `a` | covered |
 | `/calendar/events/{id}.json` | PATCH | SDK `CalendarEvents().Update` | `hey event edit <id>`, Calendar TUI `e` | covered: a write replaces rather than patches, so the caller reads the event and sends back what it keeps |

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ hey move 12345 --to feed           # move a thread to another box
 hey move 12345 67890 --to "paper trail"  # move multiple threads
 hey bubble up 12345 --now          # bubble a thread up to the top of the Imbox
 hey bubble up 12345 --on 2026-09-04  # bubble a thread up on a date
+hey bubble up 12345 --weekend      # bubble a thread up Saturday morning
 hey bubble pop 12345               # cancel a thread's bubble-up
 hey trash 12345                    # move a thread to Trash
 hey spam 12345                     # mark a thread as spam
@@ -460,7 +461,7 @@ Snippets are named reusable email content, separate from clips saved out of rece
 
 `hey box view <name|id>`, `hey label view <id>` and `hey collection view <id>` list the same postings and answer the same formats: `--json`, `--styled`, `--markdown`, `--ids-only`, and `--count`. The data-only formats print the pagination notice and any `next_page` cursor on stderr, so the IDs on stdout stay pipeable. `--json` differs only in what wraps the postings: a box answers with HEY's box payload, a label and a collection with the source and its `total_count`.
 
-Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up has its own commands: `hey bubble up` raises a thread right away with `--now` or on a date with `--on` (HEY resurfaces it at its morning hour of that day), and `hey bubble pop` cancels one. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
+Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up has its own commands: `hey bubble up` raises a thread right away with `--now`, on a date with `--on` (HEY resurfaces it at its morning hour of that day, or its evening hour when the date is today), or at the morning hour of tomorrow, Saturday, or next Monday with `--tomorrow`, `--weekend`, and `--next-week`; `hey bubble pop` cancels one. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 
 ### Watching for changes
 

--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ hey unseen 12345 67890             # mark threads as unseen
 hey move 12345 --to feed           # move a thread to another box
 hey move 12345 67890 --to "paper trail"  # move multiple threads
 hey bubble up 12345 --now          # bubble a thread up to the top of the Imbox
+hey bubble up 12345 --on 2026-09-04  # bubble a thread up on a date
 hey bubble pop 12345               # cancel a thread's bubble-up
 hey trash 12345                    # move a thread to Trash
 hey spam 12345                     # mark a thread as spam
@@ -459,7 +460,7 @@ Snippets are named reusable email content, separate from clips saved out of rece
 
 `hey box view <name|id>`, `hey label view <id>` and `hey collection view <id>` list the same postings and answer the same formats: `--json`, `--styled`, `--markdown`, `--ids-only`, and `--count`. The data-only formats print the pagination notice and any `next_page` cursor on stderr, so the IDs on stdout stay pipeable. `--json` differs only in what wraps the postings: a box answers with HEY's box payload, a label and a collection with the source and its `total_count`.
 
-Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up has its own commands: `hey bubble up --now` raises a thread right away (a scheduled bubble-up is not supported yet) and `hey bubble pop` cancels one. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
+Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up has its own commands: `hey bubble up` raises a thread right away with `--now` or on a date with `--on` (HEY resurfaces it at its morning hour of that day), and `hey bubble pop` cancels one. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 
 ### Watching for changes
 

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ hey seen 12345                     # mark a thread as seen
 hey unseen 12345 67890             # mark threads as unseen
 hey move 12345 --to feed           # move a thread to another box
 hey move 12345 67890 --to "paper trail"  # move multiple threads
+hey bubble up 12345 --now          # bubble a thread up to the top of the Imbox
+hey bubble pop 12345               # cancel a thread's bubble-up
 hey trash 12345                    # move a thread to Trash
 hey spam 12345                     # mark a thread as spam
 hey ignore 12345                   # ignore future activity on a thread
@@ -457,7 +459,7 @@ Snippets are named reusable email content, separate from clips saved out of rece
 
 `hey box view <name|id>`, `hey label view <id>` and `hey collection view <id>` list the same postings and answer the same formats: `--json`, `--styled`, `--markdown`, `--ids-only`, and `--count`. The data-only formats print the pagination notice and any `next_page` cursor on stderr, so the IDs on stdout stay pipeable. `--json` differs only in what wraps the postings: a box answers with HEY's box payload, a label and a collection with the source and its `total_count`.
 
-Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up requires a scheduled date and is not available through `hey move`. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
+Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up has its own commands: `hey bubble up --now` raises a thread right away (a scheduled bubble-up is not supported yet) and `hey bubble pop` cancels one. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 
 ### Watching for changes
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ hey move 12345 67890 --to "paper trail"  # move multiple threads
 hey bubble up 12345 --now          # bubble a thread up to the top of the Imbox
 hey bubble up 12345 --on 2026-09-04  # bubble a thread up on a date
 hey bubble up 12345 --weekend      # bubble a thread up Saturday morning
+hey bubble list                    # list bubbled-up and scheduled threads
 hey bubble pop 12345               # cancel a thread's bubble-up
 hey trash 12345                    # move a thread to Trash
 hey spam 12345                     # mark a thread as spam
@@ -461,7 +462,7 @@ Snippets are named reusable email content, separate from clips saved out of rece
 
 `hey box view <name|id>`, `hey label view <id>` and `hey collection view <id>` list the same postings and answer the same formats: `--json`, `--styled`, `--markdown`, `--ids-only`, and `--count`. The data-only formats print the pagination notice and any `next_page` cursor on stderr, so the IDs on stdout stay pipeable. `--json` differs only in what wraps the postings: a box answers with HEY's box payload, a label and a collection with the source and its `total_count`.
 
-Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up has its own commands: `hey bubble up` raises a thread right away with `--now`, on a date with `--on` (HEY resurfaces it at its morning hour of that day, or its evening hour when the date is today), or at the morning hour of tomorrow, Saturday, or next Monday with `--tomorrow`, `--weekend`, and `--next-week`; `hey bubble pop` cancels one. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
+Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up has its own commands: `hey bubble up` raises a thread right away with `--now`, on a date with `--on` (HEY resurfaces it at its morning hour of that day, or its evening hour when the date is today), or at the morning hour of tomorrow, Saturday, or next Monday with `--tomorrow`, `--weekend`, and `--next-week`; `hey bubble pop` cancels one. `hey bubble list` shows both buckets — the threads back in the Imbox after bubbling up and the ones still scheduled, each with when it resurfaces. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 
 ### Watching for changes
 

--- a/go.mod
+++ b/go.mod
@@ -118,3 +118,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 )
+
+replace github.com/basecamp/hey-sdk/go => /home/stanko/Work/basecamp/hey-sdk/go

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655
-	github.com/basecamp/hey-sdk/go v0.23.0
+	github.com/basecamp/hey-sdk/go v0.24.0
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gofrs/flock v0.13.0
@@ -118,5 +118,3 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 )
-
-replace github.com/basecamp/hey-sdk/go => /home/stanko/Work/basecamp/hey-sdk/go

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655 h1:zz0WUSEmjURj0T+soXuTtgX291nYouqa+UoyYY3Xxk8=
 github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655/go.mod h1:ezaV5z1GXQAsqyejqTs6wCFl2D8Wj+COLQkHc/kwoRs=
-github.com/basecamp/hey-sdk/go v0.23.0 h1:NjM4XvZTdjfL0bKNwHDM1ro3nAOZzaLppCeBczCi15U=
-github.com/basecamp/hey-sdk/go v0.23.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655 h1:zz0WUSEmjURj0T+soXuTtgX291nYouqa+UoyYY3Xxk8=
 github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655/go.mod h1:ezaV5z1GXQAsqyejqTs6wCFl2D8Wj+COLQkHc/kwoRs=
+github.com/basecamp/hey-sdk/go v0.24.0 h1:yEKHXAcX2yGhiphe6NetBLlfxtjJoM8r8pat3N1lYxs=
+github.com/basecamp/hey-sdk/go v0.24.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/cmd/bubble.go
+++ b/internal/cmd/bubble.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
 )
@@ -27,22 +30,26 @@ func newBubbleCommand() *bubbleCommand {
 }
 
 type bubbleUpCommand struct {
-	cmd *cobra.Command
-	now bool
-	on  string
+	cmd      *cobra.Command
+	now      bool
+	on       string
+	tomorrow bool
+	weekend  bool
+	nextWeek bool
 }
 
 func newBubbleUpCommand() *bubbleUpCommand {
 	bubbleUpCommand := &bubbleUpCommand{}
 	bubbleUpCommand.cmd = &cobra.Command{
-		Use:   "up <box-item-id>... (--now | --on <date>)",
+		Use:   "up <box-item-id>... (--now | --on <date> | --tomorrow | --weekend | --next-week)",
 		Short: "Bubble email threads up",
-		Long:  "Bubble one or more email threads up to the top of the Imbox, right away with --now or at HEY's morning hour of a date with --on.",
+		Long:  "Bubble one or more email threads up to the top of the Imbox: right away with --now, at HEY's morning hour of a date with --on, or at its morning hour of tomorrow, Saturday, or next Monday with the named flags. Today's date under --on schedules HEY's Later today slot instead — its evening hour (18:00) — since this morning has already passed.",
 		Example: `  hey bubble up 12345 --now
   hey bubble up 12345 67890 --now
-  hey bubble up 12345 --on 2026-09-04`,
+  hey bubble up 12345 --on 2026-09-04
+  hey bubble up 12345 --weekend`,
 		Annotations: map[string]string{
-			"agent_notes": "Accepts one or more box item IDs from hey box view output. Exactly one of --now and --on is required. --on takes a YYYY-MM-DD date; HEY bubbles the threads up at its morning hour of that day.",
+			"agent_notes": "Accepts one or more box item IDs from hey box view output. Exactly one of --now, --on, --tomorrow, --weekend and --next-week is required. --on takes a YYYY-MM-DD date; HEY bubbles the threads up at its morning hour of that day, or at its evening hour (18:00) when the date is today. --tomorrow, --weekend and --next-week land at the morning hour of tomorrow, the coming Saturday, and next Monday.",
 		},
 		RunE: bubbleUpCommand.run,
 		Args: usageMinOneArg(),
@@ -50,6 +57,9 @@ func newBubbleUpCommand() *bubbleUpCommand {
 
 	bubbleUpCommand.cmd.Flags().BoolVar(&bubbleUpCommand.now, "now", false, "Bubble the threads up right away")
 	bubbleUpCommand.cmd.Flags().StringVar(&bubbleUpCommand.on, "on", "", "Bubble the threads up on a date (YYYY-MM-DD)")
+	bubbleUpCommand.cmd.Flags().BoolVar(&bubbleUpCommand.tomorrow, "tomorrow", false, "Bubble the threads up tomorrow morning")
+	bubbleUpCommand.cmd.Flags().BoolVar(&bubbleUpCommand.weekend, "weekend", false, "Bubble the threads up Saturday morning")
+	bubbleUpCommand.cmd.Flags().BoolVar(&bubbleUpCommand.nextWeek, "next-week", false, "Bubble the threads up Monday morning")
 
 	return bubbleUpCommand
 }
@@ -58,11 +68,8 @@ func (c *bubbleUpCommand) run(cmd *cobra.Command, args []string) error {
 	if err := requireAuth(); err != nil {
 		return err
 	}
-	if c.now && c.on != "" {
-		return apierr.ErrUsage("--now and --on are mutually exclusive")
-	}
-	if !c.now && c.on == "" {
-		return apierr.ErrUsage("either --now or --on <date> is required")
+	if err := c.requireOneSchedule(); err != nil {
+		return err
 	}
 
 	ids, err := parseIntArgs(args)
@@ -77,15 +84,52 @@ func (c *bubbleUpCommand) run(cmd *cobra.Command, args []string) error {
 		return writeMutation(cmd, fmt.Sprintf("%d %s bubbled up", len(ids), threadNoun(len(ids))), nil)
 	}
 
+	switch {
+	case c.tomorrow:
+		return c.scheduleFor(cmd, hey.BubbleUpTomorrow, "tomorrow morning", ids)
+	case c.weekend:
+		return c.scheduleFor(cmd, hey.BubbleUpThisWeekend, "Saturday morning", ids)
+	case c.nextWeek:
+		return c.scheduleFor(cmd, hey.BubbleUpNextWeek, "Monday morning", ids)
+	}
+
 	on, err := parseDateArg("on date", c.on)
 	if err != nil {
 		return err
 	}
 
-	if err := sdk.Postings().ScheduleBubbleUp(cmd.Context(), on.Format(dateLayout), ids...); err != nil {
+	if on.Format(dateLayout) == time.Now().Format(dateLayout) {
+		return c.scheduleFor(cmd, hey.BubbleUpLaterToday, "this evening", ids)
+	}
+
+	if err = sdk.Postings().ScheduleBubbleUp(cmd.Context(), on.Format(dateLayout), ids...); err != nil {
 		return apierr.FromSDK(err)
 	}
 	return writeMutation(cmd, fmt.Sprintf("%d %s will bubble up on %s", len(ids), threadNoun(len(ids)), on.Format(dateLayout)), nil)
+}
+
+func (c *bubbleUpCommand) requireOneSchedule() error {
+	chosen := 0
+	for _, picked := range []bool{c.now, c.on != "", c.tomorrow, c.weekend, c.nextWeek} {
+		if picked {
+			chosen++
+		}
+	}
+
+	if chosen > 1 {
+		return apierr.ErrUsage("--now, --on, --tomorrow, --weekend and --next-week are mutually exclusive")
+	}
+	if chosen == 0 {
+		return apierr.ErrUsage("one of --now, --on <date>, --tomorrow, --weekend or --next-week is required")
+	}
+	return nil
+}
+
+func (c *bubbleUpCommand) scheduleFor(cmd *cobra.Command, slot hey.BubbleUpSlot, when string, ids []int64) error {
+	if err := sdk.Postings().ScheduleBubbleUpFor(cmd.Context(), slot, ids...); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutation(cmd, fmt.Sprintf("%d %s will bubble up %s", len(ids), threadNoun(len(ids)), when), nil)
 }
 
 type bubblePopCommand struct {

--- a/internal/cmd/bubble.go
+++ b/internal/cmd/bubble.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+)
+
+type bubbleCommand struct {
+	cmd *cobra.Command
+}
+
+func newBubbleCommand() *bubbleCommand {
+	bubbleCommand := &bubbleCommand{}
+	bubbleCommand.cmd = &cobra.Command{
+		Use:   "bubble",
+		Short: "Bubble email threads up in the Imbox",
+		Long:  "Bubble email threads up to the top of the Imbox, or cancel a bubble-up.",
+	}
+
+	bubbleCommand.cmd.AddCommand(newBubbleUpCommand().cmd)
+	bubbleCommand.cmd.AddCommand(newBubblePopCommand().cmd)
+
+	return bubbleCommand
+}
+
+type bubbleUpCommand struct {
+	cmd *cobra.Command
+	now bool
+}
+
+func newBubbleUpCommand() *bubbleUpCommand {
+	bubbleUpCommand := &bubbleUpCommand{}
+	bubbleUpCommand.cmd = &cobra.Command{
+		Use:   "up <box-item-id>... --now",
+		Short: "Bubble email threads up now",
+		Long:  "Bubble one or more email threads up to the top of the Imbox right away.",
+		Example: `  hey bubble up 12345 --now
+  hey bubble up 12345 67890 --now`,
+		Annotations: map[string]string{
+			"agent_notes": "Accepts one or more box item IDs from hey box view output. --now is required; scheduled bubble-up is not supported yet.",
+		},
+		RunE: bubbleUpCommand.run,
+		Args: usageMinOneArg(),
+	}
+
+	bubbleUpCommand.cmd.Flags().BoolVar(&bubbleUpCommand.now, "now", false, "Bubble the threads up right away (required)")
+
+	return bubbleUpCommand
+}
+
+func (c *bubbleUpCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+	if !c.now {
+		return apierr.ErrUsage("scheduled bubble-up is not supported yet (use --now)")
+	}
+
+	ids, err := parseIntArgs(args)
+	if err != nil {
+		return err
+	}
+
+	if err := sdk.Postings().BubbleUpNow(cmd.Context(), ids...); err != nil {
+		return apierr.FromSDK(err)
+	}
+
+	return writeMutation(cmd, fmt.Sprintf("%d %s bubbled up", len(ids), threadNoun(len(ids))), nil)
+}
+
+type bubblePopCommand struct {
+	cmd *cobra.Command
+}
+
+func newBubblePopCommand() *bubblePopCommand {
+	bubblePopCommand := &bubblePopCommand{}
+	bubblePopCommand.cmd = &cobra.Command{
+		Use:   "pop <box-item-id>...",
+		Short: "Cancel bubble-ups",
+		Long:  "Cancel the bubble-up on one or more email threads.",
+		Example: `  hey bubble pop 12345
+  hey bubble pop 12345 67890`,
+		Annotations: map[string]string{
+			"agent_notes": "Accepts one or more box item IDs from hey box view output. Cancels each thread's bubble-up.",
+		},
+		RunE: bubblePopCommand.run,
+		Args: usageMinOneArg(),
+	}
+
+	return bubblePopCommand
+}
+
+func (c *bubblePopCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	ids, err := parseIntArgs(args)
+	if err != nil {
+		return err
+	}
+
+	if err := sdk.Postings().CancelBubbleUp(cmd.Context(), ids...); err != nil {
+		return apierr.FromSDK(err)
+	}
+
+	return writeMutation(cmd, fmt.Sprintf("%d %s no longer bubbled up", len(ids), threadNoun(len(ids))), nil)
+}

--- a/internal/cmd/bubble.go
+++ b/internal/cmd/bubble.go
@@ -29,24 +29,27 @@ func newBubbleCommand() *bubbleCommand {
 type bubbleUpCommand struct {
 	cmd *cobra.Command
 	now bool
+	on  string
 }
 
 func newBubbleUpCommand() *bubbleUpCommand {
 	bubbleUpCommand := &bubbleUpCommand{}
 	bubbleUpCommand.cmd = &cobra.Command{
-		Use:   "up <box-item-id>... --now",
-		Short: "Bubble email threads up now",
-		Long:  "Bubble one or more email threads up to the top of the Imbox right away.",
+		Use:   "up <box-item-id>... (--now | --on <date>)",
+		Short: "Bubble email threads up",
+		Long:  "Bubble one or more email threads up to the top of the Imbox, right away with --now or at HEY's morning hour of a date with --on.",
 		Example: `  hey bubble up 12345 --now
-  hey bubble up 12345 67890 --now`,
+  hey bubble up 12345 67890 --now
+  hey bubble up 12345 --on 2026-09-04`,
 		Annotations: map[string]string{
-			"agent_notes": "Accepts one or more box item IDs from hey box view output. --now is required; scheduled bubble-up is not supported yet.",
+			"agent_notes": "Accepts one or more box item IDs from hey box view output. Exactly one of --now and --on is required. --on takes a YYYY-MM-DD date; HEY bubbles the threads up at its morning hour of that day.",
 		},
 		RunE: bubbleUpCommand.run,
 		Args: usageMinOneArg(),
 	}
 
-	bubbleUpCommand.cmd.Flags().BoolVar(&bubbleUpCommand.now, "now", false, "Bubble the threads up right away (required)")
+	bubbleUpCommand.cmd.Flags().BoolVar(&bubbleUpCommand.now, "now", false, "Bubble the threads up right away")
+	bubbleUpCommand.cmd.Flags().StringVar(&bubbleUpCommand.on, "on", "", "Bubble the threads up on a date (YYYY-MM-DD)")
 
 	return bubbleUpCommand
 }
@@ -55,8 +58,11 @@ func (c *bubbleUpCommand) run(cmd *cobra.Command, args []string) error {
 	if err := requireAuth(); err != nil {
 		return err
 	}
-	if !c.now {
-		return apierr.ErrUsage("scheduled bubble-up is not supported yet (use --now)")
+	if c.now && c.on != "" {
+		return apierr.ErrUsage("--now and --on are mutually exclusive")
+	}
+	if !c.now && c.on == "" {
+		return apierr.ErrUsage("either --now or --on <date> is required")
 	}
 
 	ids, err := parseIntArgs(args)
@@ -64,11 +70,22 @@ func (c *bubbleUpCommand) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := sdk.Postings().BubbleUpNow(cmd.Context(), ids...); err != nil {
-		return apierr.FromSDK(err)
+	if c.now {
+		if err = sdk.Postings().BubbleUpNow(cmd.Context(), ids...); err != nil {
+			return apierr.FromSDK(err)
+		}
+		return writeMutation(cmd, fmt.Sprintf("%d %s bubbled up", len(ids), threadNoun(len(ids))), nil)
 	}
 
-	return writeMutation(cmd, fmt.Sprintf("%d %s bubbled up", len(ids), threadNoun(len(ids))), nil)
+	on, err := parseDateArg("on date", c.on)
+	if err != nil {
+		return err
+	}
+
+	if err := sdk.Postings().ScheduleBubbleUp(cmd.Context(), on.Format(dateLayout), ids...); err != nil {
+		return apierr.FromSDK(err)
+	}
+	return writeMutation(cmd, fmt.Sprintf("%d %s will bubble up on %s", len(ids), threadNoun(len(ids)), on.Format(dateLayout)), nil)
 }
 
 type bubblePopCommand struct {

--- a/internal/cmd/bubble.go
+++ b/internal/cmd/bubble.go
@@ -23,6 +23,7 @@ func newBubbleCommand() *bubbleCommand {
 		Long:  "Bubble email threads up to the top of the Imbox, or cancel a bubble-up.",
 	}
 
+	bubbleCommand.cmd.AddCommand(newBubbleListCommand().cmd)
 	bubbleCommand.cmd.AddCommand(newBubbleUpCommand().cmd)
 	bubbleCommand.cmd.AddCommand(newBubblePopCommand().cmd)
 

--- a/internal/cmd/bubble_list.go
+++ b/internal/cmd/bubble_list.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+	hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/mail"
+	"github.com/basecamp/hey-cli/internal/output"
+	"github.com/basecamp/hey-cli/internal/terminal"
+)
+
+type bubbleListCommand struct {
+	cmd   *cobra.Command
+	limit int
+	all   bool
+}
+
+type bubbleListOutput struct {
+	BubbledUp         []sourcePostingOutput `json:"bubbled_up"`
+	Scheduled         []sourcePostingOutput `json:"scheduled"`
+	ScheduledNextPage string                `json:"scheduled_next_page,omitempty"`
+}
+
+type bubbleListRow struct {
+	ID          int64  `json:"id"`
+	TopicID     int64  `json:"topic_id,omitempty"`
+	From        string `json:"from,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+	Status      string `json:"status"`
+	BubblesUpAt string `json:"bubbles_up_at,omitempty"`
+}
+
+func newBubbleListCommand() *bubbleListCommand {
+	bubbleListCommand := &bubbleListCommand{}
+	bubbleListCommand.cmd = &cobra.Command{
+		Use:   "list",
+		Short: "List bubbled-up and scheduled email threads",
+		Long:  "List the email threads that have bubbled up in the Imbox and the ones scheduled to bubble up, with when each is due.",
+		Example: `  hey bubble list
+  hey bubble list --json`,
+		Annotations: map[string]string{
+			"agent_notes": "Lists two buckets: bubbled_up, the threads back in the Imbox, and scheduled, the threads waiting in Bubble Up with bubble_up_schedule.bubble_up_at saying when. Use id with hey bubble pop; use topic_id with hey thread read. --limit caps each bucket.",
+		},
+		RunE: bubbleListCommand.run,
+		Args: cobra.NoArgs,
+	}
+
+	bubbleListCommand.cmd.Flags().IntVar(&bubbleListCommand.limit, "limit", 0, "Maximum number of threads to show per bucket")
+	bubbleListCommand.cmd.Flags().BoolVar(&bubbleListCommand.all, "all", false, "Fetch all results (override --limit)")
+
+	return bubbleListCommand
+}
+
+func (c *bubbleListCommand) run(cmd *cobra.Command, args []string) error {
+	if err := requireAuth(); err != nil {
+		return err
+	}
+
+	imbox, bubblebox, err := bubbleSources(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	request := pageRequest{Limit: c.limit, All: c.all, MaxPages: maxPostingPages}
+
+	bubbled, err := readBubbledUp(cmd.Context(), imbox, request)
+	if err != nil {
+		return err
+	}
+
+	scheduled, err := readScheduled(cmd.Context(), bubblebox, request)
+	if err != nil {
+		return err
+	}
+
+	if request.Limit > 0 && !request.All {
+		if len(bubbled) > request.Limit {
+			bubbled = bubbled[:request.Limit]
+		}
+		if len(scheduled.Items) > request.Limit {
+			scheduled.Items = scheduled.Items[:request.Limit]
+			scheduled.Cursor = ""
+		}
+	}
+
+	switch writer.EffectiveFormat() {
+	case output.FormatStyled:
+		return c.writeStyled(cmd, bubbled, scheduled.Items)
+	case output.FormatIDs, output.FormatCount:
+		return writeOK(append(bubbled, scheduled.Items...))
+	case output.FormatMarkdown:
+		return c.writeMarkdown(cmd, bubbled, scheduled.Items)
+	default:
+		return writeOK(bubbleListOutput{
+			BubbledUp:         makeSourcePostings(bubbled),
+			Scheduled:         makeSourcePostings(scheduled.Items),
+			ScheduledNextPage: scheduled.Cursor,
+		}, output.WithSummary(fmt.Sprintf("%d bubbled up, %d scheduled", len(bubbled), len(scheduled.Items))))
+	}
+}
+
+func (c *bubbleListCommand) writeStyled(cmd *cobra.Command, bubbled, scheduled []generated.Posting) error {
+	fmt.Fprintln(cmd.OutOrStdout(), "Bubbled up:")
+	fmt.Fprintln(cmd.OutOrStdout())
+	table := newTable(cmd.OutOrStdout())
+	table.addRow([]string{"ID", "Thread", "From", "Summary", "Date"})
+	for _, posting := range bubbled {
+		table.addRow([]string{
+			fmt.Sprintf("%d", posting.Id),
+			postingTopicIDCell(posting),
+			terminal.SanitizeLine(posting.Creator.Name),
+			truncate(terminal.SanitizeLine(posting.Summary), 60),
+			formatDate(posting.CreatedAt),
+		})
+	}
+	table.print()
+
+	fmt.Fprintln(cmd.OutOrStdout())
+	fmt.Fprintln(cmd.OutOrStdout(), "Scheduled to bubble up:")
+	fmt.Fprintln(cmd.OutOrStdout())
+	table = newTable(cmd.OutOrStdout())
+	table.addRow([]string{"ID", "Thread", "From", "Summary", "Bubbles up"})
+	for _, posting := range scheduled {
+		table.addRow([]string{
+			fmt.Sprintf("%d", posting.Id),
+			postingTopicIDCell(posting),
+			terminal.SanitizeLine(posting.Creator.Name),
+			truncate(terminal.SanitizeLine(posting.Summary), 60),
+			bubblesUpAt(posting),
+		})
+	}
+	table.print()
+	return nil
+}
+
+func (c *bubbleListCommand) writeMarkdown(cmd *cobra.Command, bubbled, scheduled []generated.Posting) error {
+	fmt.Fprintf(cmd.OutOrStdout(), "# Bubble Up\n\n")
+	rows := make([]bubbleListRow, 0, len(bubbled)+len(scheduled))
+	for _, posting := range bubbled {
+		rows = append(rows, bubbleListRow{
+			ID:      posting.Id,
+			TopicID: resolvePostingTopicID(posting),
+			From:    posting.Creator.Name,
+			Summary: posting.Summary,
+			Status:  "bubbled_up",
+		})
+	}
+	for _, posting := range scheduled {
+		rows = append(rows, bubbleListRow{
+			ID:          posting.Id,
+			TopicID:     resolvePostingTopicID(posting),
+			From:        posting.Creator.Name,
+			Summary:     posting.Summary,
+			Status:      "scheduled",
+			BubblesUpAt: bubblesUpAt(posting),
+		})
+	}
+	return writeOK(rows)
+}
+
+// bubbleSources names the two boxes the listing reads: the Imbox, whose ordering puts
+// bubbled-up threads first, and Bubble Up, which holds the scheduled ones.
+func bubbleSources(ctx context.Context) (imbox, bubblebox mail.Source, err error) {
+	boxes, err := sdk.Boxes().List(ctx)
+	if err != nil {
+		return mail.Source{}, mail.Source{}, apierr.FromSDK(err)
+	}
+
+	for _, box := range *boxes {
+		switch box.Kind {
+		case hey.BoxKindImbox:
+			imbox = mail.ListedBoxSource(box)
+		case hey.BoxKindBubbleUp:
+			bubblebox = mail.ListedBoxSource(box)
+		}
+	}
+
+	if imbox.ID == 0 {
+		return mail.Source{}, mail.Source{}, apierr.ErrNotFound("box", "imbox")
+	}
+	if bubblebox.ID == 0 {
+		return mail.Source{}, mail.Source{}, apierr.ErrNotFound("box", "bubblebox")
+	}
+	return imbox, bubblebox, nil
+}
+
+// readBubbledUp reads the Imbox from the top and keeps its bubbled-up prefix. HEY orders
+// the Imbox bubbled-up first — that ordering is what draws the web app's Bubbled Up
+// section — so the first row that is not bubbled up ends the read.
+func readBubbledUp(ctx context.Context, imbox mail.Source, request pageRequest) ([]generated.Posting, error) {
+	var rows []generated.Posting
+	cursor := ""
+
+	for read := 0; read < request.MaxPages; read++ {
+		page, err := mail.ReadPage(ctx, sdk, imbox, cursor)
+		if err != nil {
+			return nil, apierr.FromSDK(err)
+		}
+		for _, posting := range page.Postings {
+			if !posting.BubbledUp {
+				return rows, nil
+			}
+			rows = append(rows, posting)
+		}
+		if len(page.Postings) == 0 || page.Cursor == "" {
+			return rows, nil
+		}
+		if request.Limit > 0 && !request.All && len(rows) >= request.Limit {
+			return rows, nil
+		}
+		cursor = page.Cursor
+	}
+	return rows, nil
+}
+
+func readScheduled(ctx context.Context, bubblebox mail.Source, request pageRequest) (collectedPages[generated.Posting], error) {
+	first, err := mail.ReadPage(ctx, sdk, bubblebox, "")
+	if err != nil {
+		return collectedPages[generated.Posting]{}, apierr.FromSDK(err)
+	}
+	seed := pageResult[generated.Posting]{Items: first.Postings, Cursor: first.Cursor, Total: first.Total}
+	return collectPages(ctx, seed, request, readSourcePage(bubblebox))
+}
+
+// bubblesUpAt is when a scheduled posting resurfaces, in the reader's zone. A surprise
+// schedule shows the web app's "???" — its time is HEY's secret to keep.
+func bubblesUpAt(posting generated.Posting) string {
+	schedule := posting.BubbleUpSchedule
+	if schedule.SurpriseMe {
+		return "???"
+	}
+	if schedule.BubbleUpAt.IsZero() {
+		return ""
+	}
+	return schedule.BubbleUpAt.Local().Format("2006-01-02 15:04")
+}
+
+func postingTopicIDCell(posting generated.Posting) string {
+	if id := resolvePostingTopicID(posting); id != 0 {
+		return fmt.Sprintf("%d", id)
+	}
+	return ""
+}

--- a/internal/cmd/bubble_test.go
+++ b/internal/cmd/bubble_test.go
@@ -36,6 +36,22 @@ func bubbleServer(t *testing.T) (*httptest.Server, *recordedBubble) {
 		recorded.path = r.URL.Path
 
 		switch {
+		case r.URL.Path == "/boxes.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":1,"kind":"imbox","name":"Imbox"},{"id":6,"kind":"bubblebox","name":"Bubble Up"}]`))
+		case r.URL.Path == "/imbox.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":1,"kind":"imbox","name":"Imbox","postings":[
+				{"id":11,"bubbled_up":true,"creator":{"name":"Jane Herrera"},"summary":"Re: Renewal quote","created_at":"2026-08-24T09:15:00Z"},
+				{"id":12,"creator":{"name":"Ravi Patel"},"summary":"Standup notes","created_at":"2026-08-23T16:40:00Z"},
+				{"id":13,"bubbled_up":true,"creator":{"name":"Priya Raman"},"summary":"Follow up on the offsite venue","created_at":"2026-08-22T11:05:00Z"}
+			]}`))
+		case r.URL.Path == "/bubble_up.json" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":6,"kind":"bubblebox","name":"Bubble Up","postings":[
+				{"id":21,"creator":{"name":"Miles Cooper"},"summary":"Invoice for July","bubble_up_schedule":{"bubble_up_at":"2026-09-04T08:00:00Z"}},
+				{"id":22,"creator":{"name":"Dana Whitfield"},"summary":"Conference travel options","bubble_up_schedule":{"bubble_up_at":"2026-09-01T10:00:00Z","surprise_me":true}}
+			]}`))
 		case r.URL.Path == "/postings/bulk_bubble_up_now.json":
 			var body struct {
 				PostingIDs []int64 `json:"posting_ids"`
@@ -78,6 +94,16 @@ func bubbleServer(t *testing.T) (*httptest.Server, *recordedBubble) {
 
 func runBubble(t *testing.T, server *httptest.Server, args ...string) (output.Response, error) {
 	t.Helper()
+	stdout, err := runBubbleOutput(t, server, append(args, "--json")...)
+	var resp output.Response
+	if stdout != "" {
+		_ = json.Unmarshal([]byte(stdout), &resp)
+	}
+	return resp, err
+}
+
+func runBubbleOutput(t *testing.T, server *httptest.Server, args ...string) (string, error) {
+	t.Helper()
 	t.Setenv("HEY_TOKEN", "test-token")
 	t.Setenv("HEY_NO_KEYRING", "1")
 	t.Setenv("HEY_BASE_URL", "")
@@ -90,14 +116,10 @@ func runBubble(t *testing.T, server *httptest.Server, args ...string) (output.Re
 	var buf bytes.Buffer
 	root.SetOut(&buf)
 	root.SetErr(&buf)
-	root.SetArgs(append([]string{"bubble"}, append(args, "--json", "--base-url", server.URL)...))
+	root.SetArgs(append([]string{"bubble"}, append(args, "--base-url", server.URL)...))
 
 	err := root.Execute()
-	var resp output.Response
-	if buf.Len() > 0 {
-		_ = json.Unmarshal(buf.Bytes(), &resp)
-	}
-	return resp, err
+	return buf.String(), err
 }
 
 func TestBubbleUpAndPop(t *testing.T) {
@@ -257,5 +279,95 @@ func TestBubbleUpAndPopReportServerFailures(t *testing.T) {
 				t.Fatal("server failure should be reported")
 			}
 		})
+	}
+}
+
+func TestBubbleList(t *testing.T) {
+	server, _ := bubbleServer(t)
+	resp, err := runBubble(t, server, "list")
+	if err != nil {
+		t.Fatalf("bubble list failed: %v", err)
+	}
+	if resp.Summary != "1 bubbled up, 2 scheduled" {
+		t.Errorf("summary = %q, want %q", resp.Summary, "1 bubbled up, 2 scheduled")
+	}
+
+	raw, err := json.Marshal(resp.Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var data struct {
+		BubbledUp []struct {
+			ID int64 `json:"id"`
+		} `json:"bubbled_up"`
+		Scheduled []struct {
+			ID               int64 `json:"id"`
+			BubbleUpSchedule struct {
+				BubbleUpAt string `json:"bubble_up_at"`
+				SurpriseMe bool   `json:"surprise_me"`
+			} `json:"bubble_up_schedule"`
+		} `json:"scheduled"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(data.BubbledUp) != 1 || data.BubbledUp[0].ID != 11 {
+		t.Errorf("bubbled_up = %v, want the bubbled-up prefix [11] and nothing after the first seen row", data.BubbledUp)
+	}
+	if len(data.Scheduled) != 2 || data.Scheduled[0].ID != 21 || data.Scheduled[1].ID != 22 {
+		t.Fatalf("scheduled = %v, want [21 22]", data.Scheduled)
+	}
+	if data.Scheduled[0].BubbleUpSchedule.BubbleUpAt != "2026-09-04T08:00:00Z" {
+		t.Errorf("scheduled[0].bubble_up_at = %q, want 2026-09-04T08:00:00Z", data.Scheduled[0].BubbleUpSchedule.BubbleUpAt)
+	}
+	if !data.Scheduled[1].BubbleUpSchedule.SurpriseMe {
+		t.Error("scheduled[1] should carry surprise_me")
+	}
+}
+
+func TestBubbleListStyled(t *testing.T) {
+	server, _ := bubbleServer(t)
+	stdout, err := runBubbleOutput(t, server, "list", "--styled")
+	if err != nil {
+		t.Fatalf("bubble list failed: %v", err)
+	}
+	for _, want := range []string{"Bubbled up:", "Scheduled to bubble up:", "Jane Herrera", "Miles Cooper", "???", "Bubbles up"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("styled output missing %q:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "Ravi Patel") {
+		t.Errorf("styled output lists a thread that is not bubbled up:\n%s", stdout)
+	}
+}
+
+func TestBubbleListIDsAndCount(t *testing.T) {
+	server, _ := bubbleServer(t)
+	stdout, err := runBubbleOutput(t, server, "list", "--ids-only")
+	if err != nil {
+		t.Fatalf("bubble list --ids-only failed: %v", err)
+	}
+	if stdout != "11\n21\n22\n" {
+		t.Errorf("ids = %q, want %q", stdout, "11\n21\n22\n")
+	}
+
+	stdout, err = runBubbleOutput(t, server, "list", "--count")
+	if err != nil {
+		t.Fatalf("bubble list --count failed: %v", err)
+	}
+	if stdout != "3\n" {
+		t.Errorf("count = %q, want %q", stdout, "3\n")
+	}
+}
+
+func TestBubbleListLimitCapsEachBucket(t *testing.T) {
+	server, _ := bubbleServer(t)
+	resp, err := runBubble(t, server, "list", "--limit", "1")
+	if err != nil {
+		t.Fatalf("bubble list failed: %v", err)
+	}
+	if resp.Summary != "1 bubbled up, 1 scheduled" {
+		t.Errorf("summary = %q, want %q", resp.Summary, "1 bubbled up, 1 scheduled")
 	}
 }

--- a/internal/cmd/bubble_test.go
+++ b/internal/cmd/bubble_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/basecamp/hey-cli/internal/apierr"
 	"github.com/basecamp/hey-cli/internal/output"
@@ -20,6 +22,7 @@ type recordedBubble struct {
 	postingIDs []int64
 	slot       string
 	date       string
+	dateSent   bool
 	status     int
 	requests   int
 }
@@ -41,15 +44,19 @@ func bubbleServer(t *testing.T) (*httptest.Server, *recordedBubble) {
 			recorded.postingIDs = body.PostingIDs
 			w.WriteHeader(recorded.status)
 		case r.URL.Path == "/postings/bubble_up.json" && r.Method == http.MethodPost:
+			raw, _ := io.ReadAll(r.Body)
 			var body struct {
 				PostingIDs []int64 `json:"posting_ids"`
 				Slot       string  `json:"slot"`
 				Date       string  `json:"date"`
 			}
-			_ = json.NewDecoder(r.Body).Decode(&body)
+			_ = json.Unmarshal(raw, &body)
+			var keys map[string]json.RawMessage
+			_ = json.Unmarshal(raw, &keys)
 			recorded.postingIDs = body.PostingIDs
 			recorded.slot = body.Slot
 			recorded.date = body.Date
+			_, recorded.dateSent = keys["date"]
 			w.WriteHeader(recorded.status)
 		case r.URL.Path == "/postings/bubble_up.json":
 			for _, part := range strings.Split(r.URL.Query().Get("posting_ids"), ",") {
@@ -94,6 +101,7 @@ func runBubble(t *testing.T, server *httptest.Server, args ...string) (output.Re
 }
 
 func TestBubbleUpAndPop(t *testing.T) {
+	today := time.Now().Format("2006-01-02")
 	tests := []struct {
 		name     string
 		args     []string
@@ -108,6 +116,11 @@ func TestBubbleUpAndPop(t *testing.T) {
 		{"up multiple now", []string{"up", "12345", "67890", "--now"}, http.MethodPost, "/postings/bulk_bubble_up_now.json", []int64{12345, 67890}, "", "", "2 threads bubbled up"},
 		{"up one on a date", []string{"up", "12345", "--on", "2026-09-04"}, http.MethodPost, "/postings/bubble_up.json", []int64{12345}, "custom", "2026-09-04", "1 thread will bubble up on 2026-09-04"},
 		{"up multiple on a date", []string{"up", "12345", "67890", "--on", "2026-09-04"}, http.MethodPost, "/postings/bubble_up.json", []int64{12345, 67890}, "custom", "2026-09-04", "2 threads will bubble up on 2026-09-04"},
+		{"up one on today", []string{"up", "12345", "--on", today}, http.MethodPost, "/postings/bubble_up.json", []int64{12345}, "today", "", "1 thread will bubble up this evening"},
+		{"up multiple on today", []string{"up", "12345", "67890", "--on", today}, http.MethodPost, "/postings/bubble_up.json", []int64{12345, 67890}, "today", "", "2 threads will bubble up this evening"},
+		{"up tomorrow", []string{"up", "12345", "--tomorrow"}, http.MethodPost, "/postings/bubble_up.json", []int64{12345}, "tomorrow", "", "1 thread will bubble up tomorrow morning"},
+		{"up weekend", []string{"up", "12345", "67890", "--weekend"}, http.MethodPost, "/postings/bubble_up.json", []int64{12345, 67890}, "weekend", "", "2 threads will bubble up Saturday morning"},
+		{"up next week", []string{"up", "12345", "--next-week"}, http.MethodPost, "/postings/bubble_up.json", []int64{12345}, "next_week", "", "1 thread will bubble up Monday morning"},
 		{"pop one", []string{"pop", "12345"}, http.MethodDelete, "/postings/bubble_up.json", []int64{12345}, "", "", "1 thread no longer bubbled up"},
 		{"pop multiple", []string{"pop", "12345", "67890"}, http.MethodDelete, "/postings/bubble_up.json", []int64{12345, 67890}, "", "", "2 threads no longer bubbled up"},
 	}
@@ -136,6 +149,9 @@ func TestBubbleUpAndPop(t *testing.T) {
 			if recorded.date != tt.wantDate {
 				t.Errorf("date = %q, want %q", recorded.date, tt.wantDate)
 			}
+			if recorded.dateSent != (tt.wantDate != "") {
+				t.Errorf("date sent = %v, want %v", recorded.dateSent, tt.wantDate != "")
+			}
 			if resp.Summary != tt.summary {
 				t.Errorf("summary = %q, want %q", resp.Summary, tt.summary)
 			}
@@ -143,13 +159,17 @@ func TestBubbleUpAndPop(t *testing.T) {
 	}
 }
 
-func TestBubbleUpRequiresExactlyOneOfNowAndOn(t *testing.T) {
+func TestBubbleUpRequiresExactlyOneSchedule(t *testing.T) {
+	exclusive := "--now, --on, --tomorrow, --weekend and --next-week are mutually exclusive"
 	tests := map[string]struct {
 		args    []string
 		message string
 	}{
-		"neither": {[]string{"up", "12345"}, "either --now or --on <date> is required"},
-		"both":    {[]string{"up", "12345", "--now", "--on", "2026-09-04"}, "--now and --on are mutually exclusive"},
+		"none":                  {[]string{"up", "12345"}, "one of --now, --on <date>, --tomorrow, --weekend or --next-week is required"},
+		"now and on":            {[]string{"up", "12345", "--now", "--on", "2026-09-04"}, exclusive},
+		"now and tomorrow":      {[]string{"up", "12345", "--now", "--tomorrow"}, exclusive},
+		"on and weekend":        {[]string{"up", "12345", "--on", "2026-09-04", "--weekend"}, exclusive},
+		"weekend and next-week": {[]string{"up", "12345", "--weekend", "--next-week"}, exclusive},
 	}
 
 	for name, tt := range tests {
@@ -225,6 +245,7 @@ func TestBubbleUpAndPopReportServerFailures(t *testing.T) {
 	tests := map[string][]string{
 		"up now":       {"up", "12345", "--now"},
 		"up on a date": {"up", "12345", "--on", "2026-09-04"},
+		"up tomorrow":  {"up", "12345", "--tomorrow"},
 		"pop":          {"pop", "12345"},
 	}
 

--- a/internal/cmd/bubble_test.go
+++ b/internal/cmd/bubble_test.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/apierr"
+	"github.com/basecamp/hey-cli/internal/output"
+)
+
+type recordedBubble struct {
+	method     string
+	path       string
+	postingIDs []int64
+	status     int
+	requests   int
+}
+
+func bubbleServer(t *testing.T) (*httptest.Server, *recordedBubble) {
+	t.Helper()
+	recorded := &recordedBubble{status: http.StatusNoContent}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorded.requests++
+		recorded.method = r.Method
+		recorded.path = r.URL.Path
+
+		switch r.URL.Path {
+		case "/postings/bulk_bubble_up_now.json":
+			var body struct {
+				PostingIDs []int64 `json:"posting_ids"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			recorded.postingIDs = body.PostingIDs
+			w.WriteHeader(recorded.status)
+		case "/postings/bubble_up.json":
+			for _, part := range strings.Split(r.URL.Query().Get("posting_ids"), ",") {
+				id, err := strconv.ParseInt(part, 10, 64)
+				if err != nil {
+					t.Errorf("posting_ids carries %q, want integers", part)
+					continue
+				}
+				recorded.postingIDs = append(recorded.postingIDs, id)
+			}
+			w.WriteHeader(recorded.status)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, recorded
+}
+
+func runBubble(t *testing.T, server *httptest.Server, args ...string) (output.Response, error) {
+	t.Helper()
+	t.Setenv("HEY_TOKEN", "test-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+	t.Setenv("HEY_BASE_URL", "")
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(append([]string{"bubble"}, append(args, "--json", "--base-url", server.URL)...))
+
+	err := root.Execute()
+	var resp output.Response
+	if buf.Len() > 0 {
+		_ = json.Unmarshal(buf.Bytes(), &resp)
+	}
+	return resp, err
+}
+
+func TestBubbleUpAndPop(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		method  string
+		path    string
+		summary string
+	}{
+		{"up one", []string{"up", "12345", "--now"}, http.MethodPost, "/postings/bulk_bubble_up_now.json", "1 thread bubbled up"},
+		{"up multiple", []string{"up", "12345", "67890", "--now"}, http.MethodPost, "/postings/bulk_bubble_up_now.json", "2 threads bubbled up"},
+		{"pop one", []string{"pop", "12345"}, http.MethodDelete, "/postings/bubble_up.json", "1 thread no longer bubbled up"},
+		{"pop multiple", []string{"pop", "12345", "67890"}, http.MethodDelete, "/postings/bubble_up.json", "2 threads no longer bubbled up"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, recorded := bubbleServer(t)
+			resp, err := runBubble(t, server, tt.args...)
+			if err != nil {
+				t.Fatalf("bubble %s failed: %v", tt.args[0], err)
+			}
+			if recorded.method != tt.method || recorded.path != tt.path {
+				t.Errorf("request = %s %s, want %s %s", recorded.method, recorded.path, tt.method, tt.path)
+			}
+			ids := tt.args[1 : len(tt.args)-1]
+			if tt.args[0] == "pop" {
+				ids = tt.args[1:]
+			}
+			if len(recorded.postingIDs) != len(ids) {
+				t.Fatalf("posting_ids = %v, want %d IDs", recorded.postingIDs, len(ids))
+			}
+			for i, want := range []int64{12345, 67890}[:len(ids)] {
+				if recorded.postingIDs[i] != want {
+					t.Errorf("posting_ids[%d] = %d, want %d", i, recorded.postingIDs[i], want)
+				}
+			}
+			if resp.Summary != tt.summary {
+				t.Errorf("summary = %q, want %q", resp.Summary, tt.summary)
+			}
+		})
+	}
+}
+
+func TestBubbleUpRequiresNow(t *testing.T) {
+	server, recorded := bubbleServer(t)
+	_, err := runBubble(t, server, "up", "12345")
+	var cliErr *apierr.Error
+	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+		t.Fatalf("bubble up without --now should produce a usage error, got %v", err)
+	}
+	if !strings.Contains(cliErr.Message, "scheduled bubble-up is not supported yet") {
+		t.Errorf("message = %q, want it to say scheduled bubble-up is not supported yet", cliErr.Message)
+	}
+	if recorded.requests != 0 {
+		t.Errorf("missing --now made %d requests", recorded.requests)
+	}
+}
+
+func TestBubbleUpAndPopRequireIDs(t *testing.T) {
+	for _, subcommand := range []string{"up", "pop"} {
+		t.Run(subcommand, func(t *testing.T) {
+			server, recorded := bubbleServer(t)
+			_, err := runBubble(t, server, subcommand)
+			if err == nil || !strings.Contains(err.Error(), "Usage:") {
+				t.Fatalf("missing ID should produce a usage error, got %v", err)
+			}
+			if recorded.requests != 0 {
+				t.Errorf("missing ID made %d requests", recorded.requests)
+			}
+		})
+	}
+}
+
+func TestBubbleUpAndPopRejectInvalidIDsBeforeRequest(t *testing.T) {
+	tests := map[string][]string{
+		"up":  {"up", "not-an-id", "--now"},
+		"pop": {"pop", "not-an-id"},
+	}
+
+	for subcommand, args := range tests {
+		t.Run(subcommand, func(t *testing.T) {
+			server, recorded := bubbleServer(t)
+			_, err := runBubble(t, server, args...)
+			var cliErr *apierr.Error
+			if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+				t.Fatalf("invalid ID should produce a usage error, got %v", err)
+			}
+			if recorded.requests != 0 {
+				t.Errorf("invalid ID made %d requests", recorded.requests)
+			}
+		})
+	}
+}
+
+func TestBubbleUpAndPopReportServerFailures(t *testing.T) {
+	tests := map[string][]string{
+		"up":  {"up", "12345", "--now"},
+		"pop": {"pop", "12345"},
+	}
+
+	for subcommand, args := range tests {
+		t.Run(subcommand, func(t *testing.T) {
+			server, recorded := bubbleServer(t)
+			recorded.status = http.StatusUnprocessableEntity
+			if _, err := runBubble(t, server, args...); err == nil {
+				t.Fatal("server failure should be reported")
+			}
+		})
+	}
+}

--- a/internal/cmd/bubble_test.go
+++ b/internal/cmd/bubble_test.go
@@ -18,6 +18,8 @@ type recordedBubble struct {
 	method     string
 	path       string
 	postingIDs []int64
+	slot       string
+	date       string
 	status     int
 	requests   int
 }
@@ -30,15 +32,26 @@ func bubbleServer(t *testing.T) (*httptest.Server, *recordedBubble) {
 		recorded.method = r.Method
 		recorded.path = r.URL.Path
 
-		switch r.URL.Path {
-		case "/postings/bulk_bubble_up_now.json":
+		switch {
+		case r.URL.Path == "/postings/bulk_bubble_up_now.json":
 			var body struct {
 				PostingIDs []int64 `json:"posting_ids"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			recorded.postingIDs = body.PostingIDs
 			w.WriteHeader(recorded.status)
-		case "/postings/bubble_up.json":
+		case r.URL.Path == "/postings/bubble_up.json" && r.Method == http.MethodPost:
+			var body struct {
+				PostingIDs []int64 `json:"posting_ids"`
+				Slot       string  `json:"slot"`
+				Date       string  `json:"date"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			recorded.postingIDs = body.PostingIDs
+			recorded.slot = body.Slot
+			recorded.date = body.Date
+			w.WriteHeader(recorded.status)
+		case r.URL.Path == "/postings/bubble_up.json":
 			for _, part := range strings.Split(r.URL.Query().Get("posting_ids"), ",") {
 				id, err := strconv.ParseInt(part, 10, 64)
 				if err != nil {
@@ -82,16 +95,21 @@ func runBubble(t *testing.T, server *httptest.Server, args ...string) (output.Re
 
 func TestBubbleUpAndPop(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    []string
-		method  string
-		path    string
-		summary string
+		name     string
+		args     []string
+		method   string
+		path     string
+		wantIDs  []int64
+		wantSlot string
+		wantDate string
+		summary  string
 	}{
-		{"up one", []string{"up", "12345", "--now"}, http.MethodPost, "/postings/bulk_bubble_up_now.json", "1 thread bubbled up"},
-		{"up multiple", []string{"up", "12345", "67890", "--now"}, http.MethodPost, "/postings/bulk_bubble_up_now.json", "2 threads bubbled up"},
-		{"pop one", []string{"pop", "12345"}, http.MethodDelete, "/postings/bubble_up.json", "1 thread no longer bubbled up"},
-		{"pop multiple", []string{"pop", "12345", "67890"}, http.MethodDelete, "/postings/bubble_up.json", "2 threads no longer bubbled up"},
+		{"up one now", []string{"up", "12345", "--now"}, http.MethodPost, "/postings/bulk_bubble_up_now.json", []int64{12345}, "", "", "1 thread bubbled up"},
+		{"up multiple now", []string{"up", "12345", "67890", "--now"}, http.MethodPost, "/postings/bulk_bubble_up_now.json", []int64{12345, 67890}, "", "", "2 threads bubbled up"},
+		{"up one on a date", []string{"up", "12345", "--on", "2026-09-04"}, http.MethodPost, "/postings/bubble_up.json", []int64{12345}, "custom", "2026-09-04", "1 thread will bubble up on 2026-09-04"},
+		{"up multiple on a date", []string{"up", "12345", "67890", "--on", "2026-09-04"}, http.MethodPost, "/postings/bubble_up.json", []int64{12345, 67890}, "custom", "2026-09-04", "2 threads will bubble up on 2026-09-04"},
+		{"pop one", []string{"pop", "12345"}, http.MethodDelete, "/postings/bubble_up.json", []int64{12345}, "", "", "1 thread no longer bubbled up"},
+		{"pop multiple", []string{"pop", "12345", "67890"}, http.MethodDelete, "/postings/bubble_up.json", []int64{12345, 67890}, "", "", "2 threads no longer bubbled up"},
 	}
 
 	for _, tt := range tests {
@@ -104,17 +122,19 @@ func TestBubbleUpAndPop(t *testing.T) {
 			if recorded.method != tt.method || recorded.path != tt.path {
 				t.Errorf("request = %s %s, want %s %s", recorded.method, recorded.path, tt.method, tt.path)
 			}
-			ids := tt.args[1 : len(tt.args)-1]
-			if tt.args[0] == "pop" {
-				ids = tt.args[1:]
+			if len(recorded.postingIDs) != len(tt.wantIDs) {
+				t.Fatalf("posting_ids = %v, want %v", recorded.postingIDs, tt.wantIDs)
 			}
-			if len(recorded.postingIDs) != len(ids) {
-				t.Fatalf("posting_ids = %v, want %d IDs", recorded.postingIDs, len(ids))
-			}
-			for i, want := range []int64{12345, 67890}[:len(ids)] {
+			for i, want := range tt.wantIDs {
 				if recorded.postingIDs[i] != want {
 					t.Errorf("posting_ids[%d] = %d, want %d", i, recorded.postingIDs[i], want)
 				}
+			}
+			if recorded.slot != tt.wantSlot {
+				t.Errorf("slot = %q, want %q", recorded.slot, tt.wantSlot)
+			}
+			if recorded.date != tt.wantDate {
+				t.Errorf("date = %q, want %q", recorded.date, tt.wantDate)
 			}
 			if resp.Summary != tt.summary {
 				t.Errorf("summary = %q, want %q", resp.Summary, tt.summary)
@@ -123,18 +143,45 @@ func TestBubbleUpAndPop(t *testing.T) {
 	}
 }
 
-func TestBubbleUpRequiresNow(t *testing.T) {
+func TestBubbleUpRequiresExactlyOneOfNowAndOn(t *testing.T) {
+	tests := map[string]struct {
+		args    []string
+		message string
+	}{
+		"neither": {[]string{"up", "12345"}, "either --now or --on <date> is required"},
+		"both":    {[]string{"up", "12345", "--now", "--on", "2026-09-04"}, "--now and --on are mutually exclusive"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			server, recorded := bubbleServer(t)
+			_, err := runBubble(t, server, tt.args...)
+			var cliErr *apierr.Error
+			if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
+				t.Fatalf("bubble up should produce a usage error, got %v", err)
+			}
+			if cliErr.Message != tt.message {
+				t.Errorf("message = %q, want %q", cliErr.Message, tt.message)
+			}
+			if recorded.requests != 0 {
+				t.Errorf("usage error made %d requests", recorded.requests)
+			}
+		})
+	}
+}
+
+func TestBubbleUpRejectsInvalidDateBeforeRequest(t *testing.T) {
 	server, recorded := bubbleServer(t)
-	_, err := runBubble(t, server, "up", "12345")
+	_, err := runBubble(t, server, "up", "12345", "--on", "next tuesday")
 	var cliErr *apierr.Error
 	if !errors.As(err, &cliErr) || cliErr.Code != "usage" {
-		t.Fatalf("bubble up without --now should produce a usage error, got %v", err)
+		t.Fatalf("invalid date should produce a usage error, got %v", err)
 	}
-	if !strings.Contains(cliErr.Message, "scheduled bubble-up is not supported yet") {
-		t.Errorf("message = %q, want it to say scheduled bubble-up is not supported yet", cliErr.Message)
+	if !strings.Contains(cliErr.Message, "invalid on date") {
+		t.Errorf("message = %q, want it to name the on date", cliErr.Message)
 	}
 	if recorded.requests != 0 {
-		t.Errorf("missing --now made %d requests", recorded.requests)
+		t.Errorf("invalid date made %d requests", recorded.requests)
 	}
 }
 
@@ -176,8 +223,9 @@ func TestBubbleUpAndPopRejectInvalidIDsBeforeRequest(t *testing.T) {
 
 func TestBubbleUpAndPopReportServerFailures(t *testing.T) {
 	tests := map[string][]string{
-		"up":  {"up", "12345", "--now"},
-		"pop": {"pop", "12345"},
+		"up now":       {"up", "12345", "--now"},
+		"up on a date": {"up", "12345", "--on", "2026-09-04"},
+		"pop":          {"pop", "12345"},
 	}
 
 	for subcommand, args := range tests {

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -33,7 +33,7 @@ var curatedCategories = []struct {
 	},
 	{
 		heading: "ORGANIZE",
-		names:   []string{"label", "collection", "workflow", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring"},
+		names:   []string{"label", "collection", "workflow", "seen", "unseen", "move", "bubble", "trash", "spam", "ignore", "stop-ignoring"},
 	},
 	{
 		heading: "CALENDAR & TASKS",

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -34,7 +34,7 @@ func TestCuratedCommandHelpUsesUserFacingLanguage(t *testing.T) {
 
 func TestEmailCommandHelpKeepsPostingAsAnInternalTerm(t *testing.T) {
 	root := newRootCmd()
-	for _, name := range []string{"box", "label", "workflow", "clip", "snippet", "thread", "attachment", "bulk-reply", "search", "seen", "unseen", "move", "trash", "spam", "ignore", "stop-ignoring", "watch"} {
+	for _, name := range []string{"box", "label", "workflow", "clip", "snippet", "thread", "attachment", "bulk-reply", "search", "seen", "unseen", "move", "bubble", "trash", "spam", "ignore", "stop-ignoring", "watch"} {
 		t.Run(name, func(t *testing.T) {
 			command, _, err := root.Find([]string{name})
 			if err != nil {
@@ -138,6 +138,7 @@ ORGANIZE
   seen           Mark email threads as seen
   unseen         Mark email threads as unseen
   move           Move email threads to another box
+  bubble         Bubble email threads up in the Imbox
   trash          Move email threads to Trash
   spam           Mark email threads as spam
   ignore         Ignore email threads

--- a/internal/cmd/move.go
+++ b/internal/cmd/move.go
@@ -97,7 +97,7 @@ func resolveMoveDestination(ctx context.Context, nameOrID string) (*generated.Bo
 
 func validateMoveDestination(box *generated.Box) (*generated.Box, error) {
 	if strings.EqualFold(box.Kind, hey.BoxKindBubbleUp) {
-		return nil, apierr.ErrUsageHint("Bubble Up is not a move destination", "Run: hey bubble up <box-item-id> --now")
+		return nil, apierr.ErrUsageHint("Bubble Up is not a move destination", "Run: hey bubble up <box-item-id> --now (or --on <date>)")
 	}
 	return box, nil
 }

--- a/internal/cmd/move.go
+++ b/internal/cmd/move.go
@@ -30,7 +30,7 @@ func newMoveCommand() *moveCommand {
   hey move 12345 67890 --to "paper trail"
   hey move 12345 --to 987`,
 		Annotations: map[string]string{
-			"agent_notes": "Accepts box item IDs from hey box view output. --to accepts a box name, kind, or ID. Use HEY's scheduled Bubble Up flow for Bubble Up.",
+			"agent_notes": "Accepts box item IDs from hey box view output. --to accepts a box name, kind, or ID. Use hey bubble up for Bubble Up.",
 		},
 		RunE: moveCommand.run,
 		Args: usageMinOneArg(),
@@ -97,7 +97,7 @@ func resolveMoveDestination(ctx context.Context, nameOrID string) (*generated.Bo
 
 func validateMoveDestination(box *generated.Box) (*generated.Box, error) {
 	if strings.EqualFold(box.Kind, hey.BoxKindBubbleUp) {
-		return nil, apierr.ErrUsage("Bubble Up requires a scheduled date and is not supported by hey move")
+		return nil, apierr.ErrUsageHint("Bubble Up is not a move destination", "Run: hey bubble up <box-item-id> --now")
 	}
 	return box, nil
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -212,6 +212,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newSeenCommand().cmd)
 	root.AddCommand(newUnseenCommand().cmd)
 	root.AddCommand(newMoveCommand().cmd)
+	root.AddCommand(newBubbleCommand().cmd)
 	root.AddCommand(newTrashCommand().cmd)
 	root.AddCommand(newSpamCommand().cmd)
 	root.AddCommand(newIgnoreCommand().cmd)

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-25eebsQ8+i67Ly2cie51OYDc+H8Q5AZrigl7RqYeAlo=";
+  vendorHash = "sha256-aQ5nmKDTTEVb2lnVlhMfoVlm4VdsR2hm2YBbvq7Ks1A=";
 
   subPackages = [ "cmd/hey" ];
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -222,6 +222,7 @@ notice on stderr. Both need list data, so they work on `hey box list`, `hey box 
 | Bubble a thread up now | `hey bubble up 12345 --now` |
 | Bubble a thread up on a date | `hey bubble up 12345 --on 2026-09-04` |
 | Bubble a thread up this weekend | `hey bubble up 12345 --weekend` |
+| List bubbled-up and scheduled threads | `hey bubble list --json` |
 | Cancel a bubble-up | `hey bubble pop 12345` |
 | Move email threads to Trash | `hey trash 12345` |
 | Mark email threads as spam | `hey spam 12345` |
@@ -532,10 +533,13 @@ hey bubble up 12345 --on 2026-09-04           # Bubble a thread up on a date
 hey bubble up 12345 --tomorrow                # Bubble a thread up tomorrow morning
 hey bubble up 12345 --weekend                 # Bubble a thread up Saturday morning
 hey bubble up 12345 --next-week               # Bubble a thread up Monday morning
+hey bubble list                               # List bubbled-up and scheduled threads
 hey bubble pop 12345                          # Cancel a thread's bubble-up
 ```
 
 Takes box item IDs (the `id` field from `hey box view --json`). `hey bubble up` requires exactly one of `--now`, `--on`, `--tomorrow`, `--weekend`, and `--next-week`. `--on` takes a YYYY-MM-DD date; HEY bubbles the threads up at its morning hour of that day, or at its evening hour (18:00) when the date is today.
+
+`hey bubble list --json` answers two buckets: `bubbled_up`, the threads back in the Imbox after bubbling up, and `scheduled`, the threads waiting in Bubble Up — each scheduled row carries `bubble_up_schedule.bubble_up_at`, and `surprise_me` when HEY picked the time. Use `id` with `hey bubble pop`, `topic_id` with `hey thread read`.
 
 ### Email - Trash and Spam
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -221,6 +221,7 @@ notice on stderr. Both need list data, so they work on `hey box list`, `hey box 
 | Move email threads | `hey move 12345 --to feed` |
 | Bubble a thread up now | `hey bubble up 12345 --now` |
 | Bubble a thread up on a date | `hey bubble up 12345 --on 2026-09-04` |
+| Bubble a thread up this weekend | `hey bubble up 12345 --weekend` |
 | Cancel a bubble-up | `hey bubble pop 12345` |
 | Move email threads to Trash | `hey trash 12345` |
 | Mark email threads as spam | `hey spam 12345` |
@@ -528,10 +529,13 @@ Takes box item IDs (the `id` field from `hey box view --json`). `--to` accepts a
 hey bubble up 12345 --now                     # Bubble a thread up to the top of the Imbox
 hey bubble up 12345 67890 --now               # Bubble multiple threads up
 hey bubble up 12345 --on 2026-09-04           # Bubble a thread up on a date
+hey bubble up 12345 --tomorrow                # Bubble a thread up tomorrow morning
+hey bubble up 12345 --weekend                 # Bubble a thread up Saturday morning
+hey bubble up 12345 --next-week               # Bubble a thread up Monday morning
 hey bubble pop 12345                          # Cancel a thread's bubble-up
 ```
 
-Takes box item IDs (the `id` field from `hey box view --json`). `hey bubble up` requires exactly one of `--now` and `--on`. `--on` takes a YYYY-MM-DD date; HEY bubbles the threads up at its morning hour of that day.
+Takes box item IDs (the `id` field from `hey box view --json`). `hey bubble up` requires exactly one of `--now`, `--on`, `--tomorrow`, `--weekend`, and `--next-week`. `--on` takes a YYYY-MM-DD date; HEY bubbles the threads up at its morning hour of that day, or at its evening hour (18:00) when the date is today.
 
 ### Email - Trash and Spam
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -43,11 +43,13 @@ triggers:
   - hey seen
   - hey unseen
   - hey move
+  - hey bubble
   - hey trash
   - hey spam
   - hey ignore
   - hey stop-ignoring
   - move email
+  - bubble a thread up
   - trash email
   - mark as spam
   - ignore email thread
@@ -217,6 +219,8 @@ notice on stderr. Both need list data, so they work on `hey box list`, `hey box 
 | Mark as seen | `hey seen 12345` |
 | Mark as unseen | `hey unseen 12345` |
 | Move email threads | `hey move 12345 --to feed` |
+| Bubble a thread up now | `hey bubble up 12345 --now` |
+| Cancel a bubble-up | `hey bubble pop 12345` |
 | Move email threads to Trash | `hey trash 12345` |
 | Mark email threads as spam | `hey spam 12345` |
 | Ignore email threads | `hey ignore 12345` |
@@ -515,7 +519,17 @@ hey move 12345 --to imbox                     # Move one thread
 hey move 12345 67890 --to "paper trail"       # Move multiple threads
 ```
 
-Takes box item IDs (the `id` field from `hey box view --json`). `--to` accepts a box name, kind, or ID. Supported destinations are Imbox, The Feed, Set Aside, Reply Later, and Paper Trail. Bubble Up requires a scheduled date and is not supported by this command.
+Takes box item IDs (the `id` field from `hey box view --json`). `--to` accepts a box name, kind, or ID. Supported destinations are Imbox, The Feed, Set Aside, Reply Later, and Paper Trail. Bubble Up goes through `hey bubble` instead.
+
+### Email - Bubble Up
+
+```bash
+hey bubble up 12345 --now                     # Bubble a thread up to the top of the Imbox
+hey bubble up 12345 67890 --now               # Bubble multiple threads up
+hey bubble pop 12345                          # Cancel a thread's bubble-up
+```
+
+Takes box item IDs (the `id` field from `hey box view --json`). `--now` is required for `hey bubble up`; a scheduled bubble-up is not supported yet.
 
 ### Email - Trash and Spam
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -220,6 +220,7 @@ notice on stderr. Both need list data, so they work on `hey box list`, `hey box 
 | Mark as unseen | `hey unseen 12345` |
 | Move email threads | `hey move 12345 --to feed` |
 | Bubble a thread up now | `hey bubble up 12345 --now` |
+| Bubble a thread up on a date | `hey bubble up 12345 --on 2026-09-04` |
 | Cancel a bubble-up | `hey bubble pop 12345` |
 | Move email threads to Trash | `hey trash 12345` |
 | Mark email threads as spam | `hey spam 12345` |
@@ -526,10 +527,11 @@ Takes box item IDs (the `id` field from `hey box view --json`). `--to` accepts a
 ```bash
 hey bubble up 12345 --now                     # Bubble a thread up to the top of the Imbox
 hey bubble up 12345 67890 --now               # Bubble multiple threads up
+hey bubble up 12345 --on 2026-09-04           # Bubble a thread up on a date
 hey bubble pop 12345                          # Cancel a thread's bubble-up
 ```
 
-Takes box item IDs (the `id` field from `hey box view --json`). `--now` is required for `hey bubble up`; a scheduled bubble-up is not supported yet.
+Takes box item IDs (the `id` field from `hey box view --json`). `hey bubble up` requires exactly one of `--now` and `--on`. `--on` takes a YYYY-MM-DD date; HEY bubbles the threads up at its morning hour of that day.
 
 ### Email - Trash and Spam
 

--- a/tests/smoke/bubble_test.go
+++ b/tests/smoke/bubble_test.go
@@ -42,6 +42,16 @@ func TestBubbleUpAndPop(t *testing.T) {
 	}
 	assertContains(t, onResp.Summary, "will bubble up on "+onDate)
 
+	stdout, stderr, code = hey(t, "bubble", "up", postingID, "--tomorrow", "--json")
+	if code != 0 {
+		skipf(t, "bubble up --tomorrow failed (exit %d): %s", code, stderr)
+	}
+	var tomorrowResp Response
+	if err := json.Unmarshal([]byte(stdout), &tomorrowResp); err != nil {
+		t.Fatalf("failed to parse bubble up --tomorrow response: %v", err)
+	}
+	assertContains(t, tomorrowResp.Summary, "will bubble up tomorrow morning")
+
 	stdout, stderr, code = hey(t, "bubble", "pop", postingID, "--json")
 	if code != 0 {
 		skipf(t, "bubble pop failed (exit %d): %s", code, stderr)
@@ -53,9 +63,10 @@ func TestBubbleUpAndPop(t *testing.T) {
 	assertContains(t, popResp.Summary, "no longer bubbled up")
 }
 
-func TestBubbleUpRequiresExactlyOneOfNowAndOn(t *testing.T) {
+func TestBubbleUpRequiresExactlyOneSchedule(t *testing.T) {
 	heyFail(t, "bubble", "up", "12345")
 	heyFail(t, "bubble", "up", "12345", "--now", "--on", "2026-09-04")
+	heyFail(t, "bubble", "up", "12345", "--weekend", "--next-week")
 }
 
 func TestBubbleUpInvalidID(t *testing.T) {

--- a/tests/smoke/bubble_test.go
+++ b/tests/smoke/bubble_test.go
@@ -63,6 +63,24 @@ func TestBubbleUpAndPop(t *testing.T) {
 	assertContains(t, popResp.Summary, "no longer bubbled up")
 }
 
+func TestBubbleList(t *testing.T) {
+	resp := heyJSON(t, "bubble", "list")
+	type BubbleList struct {
+		BubbledUp []struct {
+			ID int `json:"id"`
+		} `json:"bubbled_up"`
+		Scheduled []struct {
+			ID int `json:"id"`
+		} `json:"scheduled"`
+	}
+	data := dataAs[BubbleList](t, resp)
+	for _, row := range append(data.BubbledUp, data.Scheduled...) {
+		if row.ID == 0 {
+			t.Errorf("bubble list row without an id: %+v", row)
+		}
+	}
+}
+
 func TestBubbleUpRequiresExactlyOneSchedule(t *testing.T) {
 	heyFail(t, "bubble", "up", "12345")
 	heyFail(t, "bubble", "up", "12345", "--now", "--on", "2026-09-04")

--- a/tests/smoke/bubble_test.go
+++ b/tests/smoke/bubble_test.go
@@ -1,0 +1,54 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBubbleUpAndPop(t *testing.T) {
+	resp := heyJSON(t, "box", "imbox")
+	type Posting struct {
+		ID int `json:"id"`
+	}
+	type BoxResp struct {
+		Postings []Posting `json:"postings"`
+	}
+	data := dataAs[BoxResp](t, resp)
+	if len(data.Postings) == 0 {
+		t.Fatal("no postings in imbox to test bubble up")
+	}
+
+	postingID := intStr(data.Postings[0].ID)
+
+	stdout, stderr, code := hey(t, "bubble", "up", postingID, "--now", "--json")
+	if code != 0 {
+		skipf(t, "bubble up failed (exit %d): %s", code, stderr)
+	}
+	var upResp Response
+	if err := json.Unmarshal([]byte(stdout), &upResp); err != nil {
+		t.Fatalf("failed to parse bubble up response: %v", err)
+	}
+	assertContains(t, upResp.Summary, "bubbled up")
+
+	stdout, stderr, code = hey(t, "bubble", "pop", postingID, "--json")
+	if code != 0 {
+		skipf(t, "bubble pop failed (exit %d): %s", code, stderr)
+	}
+	var popResp Response
+	if err := json.Unmarshal([]byte(stdout), &popResp); err != nil {
+		t.Fatalf("failed to parse bubble pop response: %v", err)
+	}
+	assertContains(t, popResp.Summary, "no longer bubbled up")
+}
+
+func TestBubbleUpRequiresNow(t *testing.T) {
+	heyFail(t, "bubble", "up", "12345")
+}
+
+func TestBubbleUpInvalidID(t *testing.T) {
+	heyFail(t, "bubble", "up", "not-a-number", "--now")
+}
+
+func TestBubblePopRequiresArgs(t *testing.T) {
+	heyFail(t, "bubble", "pop")
+}

--- a/tests/smoke/bubble_test.go
+++ b/tests/smoke/bubble_test.go
@@ -3,6 +3,7 @@ package smoke_test
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 func TestBubbleUpAndPop(t *testing.T) {
@@ -30,6 +31,17 @@ func TestBubbleUpAndPop(t *testing.T) {
 	}
 	assertContains(t, upResp.Summary, "bubbled up")
 
+	onDate := time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+	stdout, stderr, code = hey(t, "bubble", "up", postingID, "--on", onDate, "--json")
+	if code != 0 {
+		skipf(t, "bubble up --on failed (exit %d): %s", code, stderr)
+	}
+	var onResp Response
+	if err := json.Unmarshal([]byte(stdout), &onResp); err != nil {
+		t.Fatalf("failed to parse bubble up --on response: %v", err)
+	}
+	assertContains(t, onResp.Summary, "will bubble up on "+onDate)
+
 	stdout, stderr, code = hey(t, "bubble", "pop", postingID, "--json")
 	if code != 0 {
 		skipf(t, "bubble pop failed (exit %d): %s", code, stderr)
@@ -41,8 +53,9 @@ func TestBubbleUpAndPop(t *testing.T) {
 	assertContains(t, popResp.Summary, "no longer bubbled up")
 }
 
-func TestBubbleUpRequiresNow(t *testing.T) {
+func TestBubbleUpRequiresExactlyOneOfNowAndOn(t *testing.T) {
 	heyFail(t, "bubble", "up", "12345")
+	heyFail(t, "bubble", "up", "12345", "--now", "--on", "2026-09-04")
 }
 
 func TestBubbleUpInvalidID(t *testing.T) {


### PR DESCRIPTION
Bubble Up has been read-only from the CLI — `hey box view bubblebox` shows the queue, and `hey move` refuses the box outright. This adds the missing verbs as a `hey bubble` command:

```
hey bubble list [--limit N | --all]
hey bubble up <box-item-id>... (--now | --on <date> | --tomorrow | --weekend | --next-week)
hey bubble pop <box-item-id>...
```

`bubble up` mirrors HEY's own schedule menu. `--now` bubbles immediately. `--on <date>` schedules the morning of that day; given today's date it schedules this evening instead, the same thing "Later today" does in the web app — a custom schedule for today would otherwise land at a time already in the past. `--tomorrow`, `--weekend` and `--next-week` are the named slots, landing the morning of tomorrow, Saturday, and Monday. Exactly one is required, and each confirmation says in plain words when the threads will surface. `bubble pop` cancels a scheduled bubble-up.

`bubble list` shows both halves of the feature: threads that have already bubbled up, and threads scheduled to, with their scheduled time (a surprise-me schedule shows `???`, as in the web app). The scheduled rows come from the Bubble Up box; the bubbled-up rows are the contiguous prefix HEY sorts to the top of the Imbox, which is the same data the web app's Bubbled Up section draws.

`hey move`'s refusal now points here instead of a dead end.

This depends on new SDK operations (`ScheduleBubbleUp`/`ScheduleBubbleUpFor` over `POST /postings/bubble_up.json`) that aren't released yet — go.mod carries a local `replace` directive until they ship, so CI will stay red until the SDK release lands and the directive is dropped for a pinned version.

Replaces #164 — thanks to @jr-lillard for the original take on bubble-up commands, credited as co-author on the first commit here.