### PR TITLE
Reject non-positive posting IDs and drop duplicates

### DIFF
--- a/internal/cmd/seen.go
+++ b/internal/cmd/seen.go
@@ -89,11 +89,16 @@ func (c *unseenCommand) run(cmd *cobra.Command, args []string) error {
 
 func parseIntArgs(args []string) ([]int64, error) {
 	ids := make([]int64, 0, len(args))
+	seen := make(map[int64]struct{}, len(args))
 	for _, arg := range args {
 		id, err := strconv.ParseInt(arg, 10, 64)
-		if err != nil {
+		if err != nil || id <= 0 {
 			return nil, apierr.ErrUsage(fmt.Sprintf("invalid ID: %s", arg))
 		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
 		ids = append(ids, id)
 	}
 	return ids, nil

--- a/internal/cmd/seen_test.go
+++ b/internal/cmd/seen_test.go
@@ -144,6 +144,50 @@ func TestSeenInvalidID(t *testing.T) {
 	}
 }
 
+func TestSeenNonPositiveID(t *testing.T) {
+	server := seenServer(t)
+	defer server.Close()
+
+	for _, arg := range []string{"0", "-12345"} {
+		_, err := runSeen(t, server, "--", arg)
+		if err == nil {
+			t.Fatalf("expected error for ID %q", arg)
+		}
+		if err.Error() != "invalid ID: "+arg {
+			t.Errorf("error = %q, want %q", err, "invalid ID: "+arg)
+		}
+	}
+}
+
+func TestSeenDuplicateIDs(t *testing.T) {
+	server := seenServer(t)
+	defer server.Close()
+
+	resp, err := runSeen(t, server, "12345", "67890", "12345")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if resp.Summary != "2 threads marked as seen" {
+		t.Errorf("summary = %q, want %q", resp.Summary, "2 threads marked as seen")
+	}
+}
+
+func TestParseIntArgsDropsDuplicatesPreservingOrder(t *testing.T) {
+	ids, err := parseIntArgs([]string{"67890", "12345", "67890", "12345", "24680"})
+	if err != nil {
+		t.Fatalf("parseIntArgs: %v", err)
+	}
+	want := []int64{67890, 12345, 24680}
+	if len(ids) != len(want) {
+		t.Fatalf("ids = %v, want %v", ids, want)
+	}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("ids = %v, want %v", ids, want)
+		}
+	}
+}
+
 func TestUnseenSingle(t *testing.T) {
 	server := seenServer(t)
 	defer server.Close()


### PR DESCRIPTION
`parseIntArgs` — shared by `seen`, `unseen`, `ignore`, `stop-ignoring`, `trash`, `spam`, and `move` — accepted any int64, so `hey seen 0` or `hey trash -- -5` sent a request HEY could only refuse, and a repeated id was sent twice.

Now a zero or negative id is a usage error before any request, with the same `invalid ID: <arg>` wording non-numeric input already gets, and duplicate ids are dropped with the first occurrence winning, order preserved. `bulk-reply`'s own parser is untouched — its duplicates are per-recipient and erroring on them is the right call there.

Replaces #155 — thanks to @martinlaws for the original take, credited as co-author.