### PR TITLE
Use gosec suppression syntax for mise commands

### DIFF
--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -530,7 +530,7 @@ func miseConfigPath(data []byte, version string) (string, error) {
 
 func resolveMiseBinary(ctx context.Context, mise, version string) (string, error) {
 	tool := miseTool + "@" + version
-	resolve := exec.CommandContext(ctx, mise, "which", "hey", "--tool="+tool) //nolint:gosec // mise is independently matched to the running install layout
+	resolve := exec.CommandContext(ctx, mise, "which", "hey", "--tool="+tool) // #nosec G204 -- mise is independently matched to the running install layout
 	return miseBinaryPath(resolve)
 }
 
@@ -553,7 +553,7 @@ func miseBinaryPath(resolve *exec.Cmd) (string, error) {
 }
 
 func upgradeMise(ctx context.Context, mise, configPath, version string, stdout io.Writer, stderr io.Writer) error {
-	upgrade := exec.CommandContext(ctx, mise, "use", "--path", configPath, miseTool+"@"+version) //nolint:gosec // mise is independently matched to the running install layout
+	upgrade := exec.CommandContext(ctx, mise, "use", "--path", configPath, miseTool+"@"+version) // #nosec G204 -- mise is independently matched to the running install layout
 	upgrade.Stdout = stdout
 	upgrade.Stderr = stderr
 	return upgrade.Run()


### PR DESCRIPTION
The main-branch security workflow runs gosec directly, so the mise command exemptions need gosec’s `#nosec G204` syntax rather than golangci-lint’s `nolint` syntax. This keeps the existing narrowly scoped exemptions and lets the release security gate recognize them.

Validation:
- `GOWORK=off make gosec` — 0 issues
- `GOWORK=off make lint` — 0 issues
- `GOWORK=off go test ./internal/cmd -run 'TestMise|TestUpgrade' -count=1` \u2014 passed