### PR TITLE
Prepare v1.2.0 release metadata

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hey",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "HEY integration for Claude Code. Read email, manage todos, track time.",
   "author": {
     "name": "37signals",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
   pname = "hey";
   # Bumped by `make update-nix-hash VERSION=vX.Y.Z` before each stable
   # release; scripts/release.sh refuses to tag until it matches.
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = lib.cleanSource ./..;
 


### PR DESCRIPTION
Stamp the Nix package and Claude plugin metadata for the v1.2.0 release. The full release preflight passed twice before repository protection rejected the release script’s direct main push; no tag or release was published.

After this merges, rerunning `make release VERSION=v1.2.0` can push the tag without changing protected `main`.

Validation:
- `GOWORK=off make release VERSION=v1.2.0 DRY_RUN=1` — passed
- Full non-dry-run release preflight — passed before the protected push was rejected
- No `v1.2.0` tag exists locally or remotely