### PR TITLE
Render nested Action Text attachment content

### DIFF
--- a/internal/htmlutil/htmlutil.go
+++ b/internal/htmlutil/htmlutil.go
@@ -96,8 +96,9 @@ func walkNode(b *strings.Builder, n *html.Node, depth int) {
 			}
 			return
 		case "action-text-attachment":
-			filename := getAttr(n, "filename")
-			if filename != "" {
+			if doc := parseEmbeddedActionText(n, depth); doc != nil {
+				walkNode(b, doc, depth+1)
+			} else if filename := getAttr(n, "filename"); filename != "" {
 				fmt.Fprintf(b, "\n[%s]\n", filename)
 			}
 			return
@@ -162,6 +163,13 @@ func walkMessageSourceNode(b *strings.Builder, n *html.Node, depth int) {
 		case "hr":
 			writeMessageSourceBoundary(b)
 			return
+		case "action-text-attachment":
+			if doc := parseEmbeddedActionText(n, depth); doc != nil {
+				writeMessageSourceBoundary(b)
+				walkMessageSourceNode(b, doc, depth+1)
+				writeMessageSourceBoundary(b)
+			}
+			return
 		case "template":
 			if depth == 0 || n.Parent == nil || n.Parent.Data != "shadow-content" {
 				return
@@ -196,7 +204,7 @@ func elementProvidesMessageSourceText(n *html.Node) bool {
 		return false
 	}
 	switch n.Data {
-	case "script", "style", "noscript", "head", "action-text-attachment":
+	case "script", "style", "noscript", "head":
 		return false
 	case "dialog":
 		return hasAttr(n, "open")
@@ -293,6 +301,21 @@ func parseTrixAttachment(n *html.Node) *trixAttachment {
 		return nil
 	}
 	return &att
+}
+
+func embeddedActionTextContent(n *html.Node) string {
+	if getAttr(n, "filename") != "" {
+		return ""
+	}
+	return getAttr(n, "content")
+}
+
+func parseEmbeddedActionText(n *html.Node, depth int) *html.Node {
+	content := embeddedActionTextContent(n)
+	if content == "" {
+		return nil
+	}
+	return parseEmbeddedContent(content, depth)
 }
 
 func getAttr(n *html.Node, key string) string {
@@ -401,7 +424,9 @@ func findImages(n *html.Node, urls *[]string, depth int) {
 				}
 			}
 		case "action-text-attachment":
-			if imageURL := getAttr(n, "url"); isImageContentType(getAttr(n, "content-type")) && imageURL != "" {
+			if doc := parseEmbeddedActionText(n, depth); doc != nil {
+				findImages(doc, urls, depth+1)
+			} else if imageURL := getAttr(n, "url"); isImageContentType(getAttr(n, "content-type")) && imageURL != "" {
 				*urls = append(*urls, imageURL)
 			}
 		case "figure":

--- a/internal/htmlutil/htmlutil.go
+++ b/internal/htmlutil/htmlutil.go
@@ -106,8 +106,9 @@ func walkNode(b *strings.Builder, n *html.Node, depth int) {
 			if isImageContentType(getAttr(n, "content-type")) && isDecorativeImage(getAttr(n, "width"), getAttr(n, "height")) {
 				return
 			}
-			filename := getAttr(n, "filename")
-			if filename != "" {
+			if doc := parseEmbeddedActionText(n, depth); doc != nil {
+				walkNode(b, doc, depth+1)
+			} else if filename := getAttr(n, "filename"); filename != "" {
 				fmt.Fprintf(b, "\n[%s]\n", filename)
 			}
 			return
@@ -172,6 +173,13 @@ func walkMessageSourceNode(b *strings.Builder, n *html.Node, depth int) {
 		case "hr":
 			writeMessageSourceBoundary(b)
 			return
+		case "action-text-attachment":
+			if doc := parseEmbeddedActionText(n, depth); doc != nil {
+				writeMessageSourceBoundary(b)
+				walkMessageSourceNode(b, doc, depth+1)
+				writeMessageSourceBoundary(b)
+			}
+			return
 		case "template":
 			if depth == 0 || n.Parent == nil || n.Parent.Data != "shadow-content" {
 				return
@@ -206,7 +214,7 @@ func elementProvidesMessageSourceText(n *html.Node) bool {
 		return false
 	}
 	switch n.Data {
-	case "script", "style", "noscript", "head", "action-text-attachment":
+	case "script", "style", "noscript", "head":
 		return false
 	case "dialog":
 		return hasAttr(n, "open")
@@ -303,6 +311,21 @@ func parseTrixAttachment(n *html.Node) *trixAttachment {
 		return nil
 	}
 	return &att
+}
+
+func embeddedActionTextContent(n *html.Node) string {
+	if getAttr(n, "filename") != "" {
+		return ""
+	}
+	return getAttr(n, "content")
+}
+
+func parseEmbeddedActionText(n *html.Node, depth int) *html.Node {
+	content := embeddedActionTextContent(n)
+	if content == "" {
+		return nil
+	}
+	return parseEmbeddedContent(content, depth)
 }
 
 func getAttr(n *html.Node, key string) string {
@@ -455,7 +478,9 @@ func findImages(n *html.Node, urls *[]string, depth int) {
 			if isImageContentType(getAttr(n, "content-type")) && isDecorativeImage(getAttr(n, "width"), getAttr(n, "height")) {
 				return
 			}
-			if imageURL := getAttr(n, "url"); isImageContentType(getAttr(n, "content-type")) && imageURL != "" {
+			if doc := parseEmbeddedActionText(n, depth); doc != nil {
+				findImages(doc, urls, depth+1)
+			} else if imageURL := getAttr(n, "url"); isImageContentType(getAttr(n, "content-type")) && imageURL != "" {
 				*urls = append(*urls, imageURL)
 			}
 		case "figure":

--- a/internal/htmlutil/htmlutil_test.go
+++ b/internal/htmlutil/htmlutil_test.go
@@ -87,6 +87,13 @@ func TestMessageSourceTextIncludesEmbeddedEmailBody(t *testing.T) {
 	}
 }
 
+func TestMessageSourceTextIncludesEmbeddedActionTextAttachment(t *testing.T) {
+	html := `<action-text-attachment content-type="text/html" content="<p>External confirmation: BLUE-42</p>"></action-text-attachment>`
+	if got := strings.Join(strings.Fields(MessageSourceText(html)), " "); got != "External confirmation: BLUE-42" {
+		t.Errorf("MessageSourceText = %q", got)
+	}
+}
+
 func TestMessageSourceTextFailsClosedWhenHTMLExceedsParserDepth(t *testing.T) {
 	html := strings.Repeat("<div>", 1_000) + "not selectable" + strings.Repeat("</div>", 1_000)
 	if got := MessageSourceText(html); got != "" {
@@ -158,6 +165,13 @@ func TestToTextActionTextAttachment(t *testing.T) {
 	}
 }
 
+func TestToTextRendersEmbeddedActionTextAttachment(t *testing.T) {
+	got := ToText(`<action-text-attachment content-type="text/html" content="<p>Inside</p>"></action-text-attachment>`)
+	if got != "Inside" {
+		t.Errorf("ToText = %q, want %q", got, "Inside")
+	}
+}
+
 func TestToTextTrixFigure(t *testing.T) {
 	got := ToText(`<p>Before</p><figure data-trix-attachment='{"filename":"photo.png","url":"/img.png","contentType":"image/png"}'></figure><p>After</p>`)
 	if !strings.Contains(got, "[photo.png]") {
@@ -182,6 +196,13 @@ func TestToTextEmbeddedContentStopsRecursing(t *testing.T) {
 
 func TestExtractImageURLsInsideEmbeddedHTMLAttachment(t *testing.T) {
 	urls := ExtractImageURLs(`<figure data-trix-attachment='{"contentType":"text/html","content":"<p><img src=\"https://example.com/logo.png\"></p>"}'></figure>`)
+	if len(urls) != 1 || urls[0] != "https://example.com/logo.png" {
+		t.Errorf("ExtractImageURLs = %v, want the image inside the embedded body", urls)
+	}
+}
+
+func TestExtractImageURLsInsideEmbeddedActionTextAttachment(t *testing.T) {
+	urls := ExtractImageURLs(`<action-text-attachment content-type="text/html" content="<img src=&quot;https://example.com/logo.png&quot;>"></action-text-attachment>`)
 	if len(urls) != 1 || urls[0] != "https://example.com/logo.png" {
 		t.Errorf("ExtractImageURLs = %v, want the image inside the embedded body", urls)
 	}

--- a/internal/htmlutil/htmlutil_test.go
+++ b/internal/htmlutil/htmlutil_test.go
@@ -105,6 +105,13 @@ func TestMessageSourceTextIncludesEmbeddedEmailBody(t *testing.T) {
 	}
 }
 
+func TestMessageSourceTextIncludesEmbeddedActionTextAttachment(t *testing.T) {
+	html := `<action-text-attachment content-type="text/html" content="<p>External confirmation: BLUE-42</p>"></action-text-attachment>`
+	if got := strings.Join(strings.Fields(MessageSourceText(html)), " "); got != "External confirmation: BLUE-42" {
+		t.Errorf("MessageSourceText = %q", got)
+	}
+}
+
 func TestMessageSourceTextFailsClosedWhenHTMLExceedsParserDepth(t *testing.T) {
 	html := strings.Repeat("<div>", 1_000) + "not selectable" + strings.Repeat("</div>", 1_000)
 	if got := MessageSourceText(html); got != "" {
@@ -176,6 +183,13 @@ func TestToTextActionTextAttachment(t *testing.T) {
 	}
 }
 
+func TestToTextRendersEmbeddedActionTextAttachment(t *testing.T) {
+	got := ToText(`<action-text-attachment content-type="text/html" content="<p>Inside</p>"></action-text-attachment>`)
+	if got != "Inside" {
+		t.Errorf("ToText = %q, want %q", got, "Inside")
+	}
+}
+
 func TestToTextTrixFigure(t *testing.T) {
 	got := ToText(`<p>Before</p><figure data-trix-attachment='{"filename":"photo.png","url":"/img.png","contentType":"image/png"}'></figure><p>After</p>`)
 	if !strings.Contains(got, "[photo.png]") {
@@ -199,6 +213,13 @@ func TestToTextEmbeddedContentStopsRecursing(t *testing.T) {
 
 func TestExtractImageURLsInsideEmbeddedHTMLAttachment(t *testing.T) {
 	urls := ExtractImageURLs(`<figure data-trix-attachment='{"contentType":"text/html","content":"<p><img src=\"https://example.com/logo.png\"></p>"}'></figure>`)
+	if len(urls) != 1 || urls[0] != "https://example.com/logo.png" {
+		t.Errorf("ExtractImageURLs = %v, want the image inside the embedded body", urls)
+	}
+}
+
+func TestExtractImageURLsInsideEmbeddedActionTextAttachment(t *testing.T) {
+	urls := ExtractImageURLs(`<action-text-attachment content-type="text/html" content="<img src=&quot;https://example.com/logo.png&quot;>"></action-text-attachment>`)
 	if len(urls) != 1 || urls[0] != "https://example.com/logo.png" {
 		t.Errorf("ExtractImageURLs = %v, want the image inside the embedded body", urls)
 	}

--- a/internal/htmlutil/markdown.go
+++ b/internal/htmlutil/markdown.go
@@ -111,7 +111,7 @@ func (m *markdownizer) element(n *html.Node) {
 	case "figure":
 		m.figure(n)
 	case "action-text-attachment":
-		m.attachment(getAttr(n, "filename"), getAttr(n, "url"), getAttr(n, "content-type"))
+		m.renderActionTextAttachment(n)
 	default:
 		m.children(n)
 	}
@@ -488,6 +488,16 @@ func (m *markdownizer) image(n *html.Node) {
 	case alt != "":
 		m.write(escapeText(alt, m.line.String()))
 	}
+}
+
+// renderActionTextAttachment renders unnamed inline content as embedded HTML while
+// preserving named elements as file attachments.
+func (m *markdownizer) renderActionTextAttachment(n *html.Node) {
+	if content := embeddedActionTextContent(n); content != "" {
+		m.embedded(content)
+		return
+	}
+	m.attachment(getAttr(n, "filename"), getAttr(n, "url"), getAttr(n, "content-type"))
 }
 
 func (m *markdownizer) figure(n *html.Node) {

--- a/internal/htmlutil/markdown.go
+++ b/internal/htmlutil/markdown.go
@@ -709,8 +709,14 @@ func (m *markdownizer) embedded(content string) {
 // dimensions, decoration beside the text that already says who or what they show. A
 // caption names an image its missing filename does not — the alt text of the <img>
 // the node used to be.
+// actionTextAttachment renders an unnamed attachment's inline content as embedded HTML
+// and a named one as a file attachment.
 func (m *markdownizer) actionTextAttachment(n *html.Node) {
 	if isImageContentType(getAttr(n, "content-type")) && isDecorativeImage(getAttr(n, "width"), getAttr(n, "height")) {
+		return
+	}
+	if content := embeddedActionTextContent(n); content != "" {
+		m.embedded(content)
 		return
 	}
 	filename := getAttr(n, "filename")

--- a/internal/htmlutil/markdown_test.go
+++ b/internal/htmlutil/markdown_test.go
@@ -221,6 +221,24 @@ func TestToMarkdownEmbeddedHTMLAttachment(t *testing.T) {
 	}
 }
 
+// A nested action-text-attachment carries its HTML in a content attribute.
+func TestToMarkdownEmbeddedActionTextAttachment(t *testing.T) {
+	got := toMarkdown(`<figure data-trix-attachment='{"contentType":"text/html","content":"<action-text-attachment content-type=\"text/html\" content=\"<p>Dear customer,</p><p>Please <a href=&amp;quot;https://example.com/sign&amp;quot;>sign the document</a>.</p>\"></action-text-attachment>"}'></figure>`)
+
+	want := "Dear customer,\n\nPlease [sign the document](https://example.com/sign)."
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
+func TestToMarkdownNamedActionTextAttachmentIgnoresInlineContent(t *testing.T) {
+	got := toMarkdown(`<action-text-attachment filename="report.pdf" content-type="application/pdf" content="<p>not the body</p>"></action-text-attachment>`)
+	want := "📎 report.pdf"
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
 func TestToMarkdownEmbeddedContentStopsRecursing(t *testing.T) {
 	nested := `<figure data-trix-attachment='{"contentType":"text/html","content":"<p>innermost</p>"}'></figure>`
 	for range embeddedContentDepthLimit + 2 {

--- a/internal/htmlutil/markdown_test.go
+++ b/internal/htmlutil/markdown_test.go
@@ -449,6 +449,24 @@ func TestToMarkdownEmbeddedHTMLAttachment(t *testing.T) {
 	}
 }
 
+// A nested action-text-attachment carries its HTML in a content attribute.
+func TestToMarkdownEmbeddedActionTextAttachment(t *testing.T) {
+	got := toMarkdown(`<figure data-trix-attachment='{"contentType":"text/html","content":"<action-text-attachment content-type=\"text/html\" content=\"<p>Dear customer,</p><p>Please <a href=&amp;quot;https://example.com/sign&amp;quot;>sign the document</a>.</p>\"></action-text-attachment>"}'></figure>`)
+
+	want := "Dear customer,\n\nPlease [sign the document](https://example.com/sign)."
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
+func TestToMarkdownNamedActionTextAttachmentIgnoresInlineContent(t *testing.T) {
+	got := toMarkdown(`<action-text-attachment filename="report.pdf" content-type="application/pdf" content="<p>not the body</p>"></action-text-attachment>`)
+	want := "📎 report.pdf"
+	if got != want {
+		t.Errorf("ToMarkdown = %q, want %q", got, want)
+	}
+}
+
 func TestToMarkdownEmbeddedContentStopsRecursing(t *testing.T) {
 	nested := "<p>innermost</p>"
 	for range embeddedContentDepthLimit + 1 {


### PR DESCRIPTION
## What changed

Handle bare `<action-text-attachment>` elements whose HTML is stored in a `content` attribute.

HEY can nest this element inside a Trix HTML attachment. Previously, `ToMarkdown` treated it as a file attachment and rendered `📎 attachment`, dropping the embedded text and links.

Unnamed elements with non-empty `content` are now rendered through the existing bounded embedded-HTML path. Named elements remain file attachments.

Added regression coverage for both the nested HTML case and filename precedence.

## Testing

- `make check`
- `make build`