### PR TITLE
Keep the silent sign-in test out of the developer's keyring

### DIFF
--- a/internal/cmd/setup_test.go
+++ b/internal/cmd/setup_test.go
@@ -172,6 +172,9 @@ func TestSetupSilentSuccessShowsSpinnerAndCompletion(t *testing.T) {
 func TestSetupSilentSuccessKeepsSignInInstructions(t *testing.T) {
 	stubStdinTerminal(t)
 	t.Setenv("HEY_NONINTERACTIVE", "")
+	// Without this the manager consults the developer's real keyring, sees them
+	// signed in, and skips the stubbed login this test exists to observe.
+	t.Setenv("HEY_NO_KEYRING", "1")
 	previousAuthMgr := authMgr
 	authMgr = auth.NewManager("http://app.hey.localhost:3003", http.DefaultClient, t.TempDir())
 	t.Cleanup(func() { authMgr = previousAuthMgr })


### PR DESCRIPTION
`TestSetupSilentSuccessKeepsSignInInstructions` stubs `loginInteractively` and asserts the sign-in instructions surface during a silent setup — but it builds its `auth.Manager` without `HEY_NO_KEYRING=1`, so the manager consults the real system keyring first. On a developer machine that's signed in to HEY, the wizard concludes there's nothing to do, never calls the stub, and the test fails; in CI, with no keyring, it passes. This made `make release` fail its preflight on any signed-in machine.

One line (plus the why): `HEY_NO_KEYRING=1`, confining the test to its temp dir like every other auth-touching test in the package.