### PR TITLE
Identify each CLI install to HEY with its own install_id

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -14,11 +14,8 @@ import (
 	"time"
 )
 
-// Built-in OAuth client credentials for the CLI app.
-const (
-	oauthClientID = "khMWSVDVSq78oyKA3KtxmYRv"
-	installID     = "hey-cli"
-)
+// Built-in OAuth client ID for the CLI app.
+const oauthClientID = "khMWSVDVSq78oyKA3KtxmYRv"
 
 type callbackWaiter func(context.Context, string, string, net.Listener, LoginOptions) (string, error)
 type listenerFactory func(context.Context, string, string) (net.Listener, error)
@@ -177,6 +174,11 @@ func (m *Manager) Login(ctx context.Context, opts LoginOptions) error {
 	defer func() { _ = listener.Close() }()
 	redirectURI := "http://" + listener.Addr().String() + "/callback"
 
+	installID, err := m.store.InstallID()
+	if err != nil {
+		return fmt.Errorf("install id: %w", err)
+	}
+
 	state := generateState()
 	codeVerifier := generateCodeVerifier()
 	codeChallenge := generateCodeChallenge(codeVerifier)
@@ -293,6 +295,11 @@ func (m *Manager) refreshLocked(ctx context.Context, creds *Credentials) error {
 	tokenEndpoint := creds.TokenEndpoint
 	if tokenEndpoint == "" {
 		tokenEndpoint = m.baseURL + "/oauth/tokens"
+	}
+
+	installID, err := m.store.installID()
+	if err != nil {
+		return fmt.Errorf("install id: %w", err)
 	}
 
 	token, err := refreshOAuthToken(ctx, m.httpClient, tokenEndpoint, creds.RefreshToken, oauthClientID, installID)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -93,12 +93,16 @@ func TestNormalizeBaseURL(t *testing.T) {
 
 func TestLoginOAuthFlow(t *testing.T) {
 	redirectURIs := make(chan string, 1)
+	var installID string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/oauth/tokens" {
 			t.Errorf("path = %q, want /oauth/tokens", r.URL.Path)
 		}
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("install_id"); got != installID {
+			t.Errorf("install_id = %q, want this install's %q", got, installID)
 		}
 		if got := r.Form.Get("code"); got != "callback-code" {
 			t.Errorf("code = %q, want callback-code", got)
@@ -122,6 +126,10 @@ func TestLoginOAuthFlow(t *testing.T) {
 			t.Errorf("listen arguments = %q, %q, want an ephemeral loopback port", network, address)
 		}
 		return listen(ctx, network, address)
+	}
+	var err error
+	if installID, err = mgr.GetStore().InstallID(); err != nil {
+		t.Fatalf("InstallID: %v", err)
 	}
 	mgr.callbackWait = func(_ context.Context, state, authURL string, listener net.Listener, opts LoginOptions) (string, error) {
 		if state == "" {
@@ -709,6 +717,9 @@ func TestConcurrentManagersRefreshOnce(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("install_id"); got == "" || got == "hey-cli" {
+			t.Errorf("install_id = %q, want a per-install identifier", got)
 		}
 		// Rotation: the refresh token is spent by the first refresh that presents it.
 		if r.Form.Get("refresh_token") != "first-refresh" {

--- a/internal/auth/install_id.go
+++ b/internal/auth/install_id.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// InstallID identifies this install to HEY as a device, minting the identifier on first
+// use. It lives beside the credentials rather than in them: a device outlasts a logout,
+// and HEY alerts on a sign-in from a device it hasn't seen.
+func (s *Store) InstallID() (string, error) {
+	unlock, err := s.lock()
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
+
+	return s.installID()
+}
+
+// installID is the unlocked variant, for a caller already holding the store lock.
+func (s *Store) installID() (string, error) {
+	path := s.installIDPath()
+
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path built from the store's own config directory
+	if err == nil {
+		if id := strings.TrimSpace(string(data)); id != "" {
+			return id, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	id := newInstallID()
+	if err := os.MkdirAll(s.fallbackDir, 0700); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, []byte(id+"\n"), 0600); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func (s *Store) installIDPath() string {
+	return filepath.Join(s.fallbackDir, "install_id")
+}
+
+// newInstallID is a random version-4 UUID, the shape the mobile apps send.
+func newInstallID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}

--- a/internal/auth/install_id.go
+++ b/internal/auth/install_id.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -27,7 +28,11 @@ func (s *Store) installID() (string, error) {
 
 	data, err := os.ReadFile(path) //nolint:gosec // G304: path built from the store's own config directory
 	if err == nil {
-		if id := strings.TrimSpace(string(data)); id != "" {
+		// Only a well-formed identifier is a usable identity. A truncated or
+		// garbage file — an earlier write interrupted by a crash or a full
+		// disk, say — must not be adopted and sent to HEY on every login and
+		// refresh, so fall through and mint a fresh one over it.
+		if id := strings.TrimSpace(string(data)); isInstallID(id) {
 			return id, nil
 		}
 	} else if !os.IsNotExist(err) {
@@ -38,10 +43,56 @@ func (s *Store) installID() (string, error) {
 	if err := os.MkdirAll(s.fallbackDir, 0700); err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(path, []byte(id+"\n"), 0600); err != nil {
+	if err := writeFileAtomic(path, []byte(id+"\n"), 0600); err != nil {
 		return "", err
 	}
 	return id, nil
+}
+
+// installIDPattern is the canonical version-4 UUID shape newInstallID mints and
+// the mobile apps send.
+var installIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func isInstallID(id string) bool {
+	return installIDPattern.MatchString(id)
+}
+
+// writeFileAtomic writes data to a temporary mode-perm file in the destination
+// directory and renames it into place. A crash or full disk mid-write then
+// leaves the previous file (or none) rather than a truncated one that the next
+// run would mistake for a valid identifier.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".install_id-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if tmpName != "" {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	tmpName = "" // renamed into place; nothing to clean up
+	return nil
 }
 
 func (s *Store) installIDPath() string {

--- a/internal/auth/install_id_test.go
+++ b/internal/auth/install_id_test.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+var uuidV4 = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestInstallIDIsMintedOnceAndPersists(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "1")
+	configDir := t.TempDir()
+	store := NewStore(configDir)
+
+	first, err := store.InstallID()
+	if err != nil {
+		t.Fatalf("InstallID: %v", err)
+	}
+	if !uuidV4.MatchString(first) {
+		t.Fatalf("install id = %q, want a v4 UUID", first)
+	}
+
+	second, err := store.InstallID()
+	if err != nil {
+		t.Fatalf("InstallID: %v", err)
+	}
+	if second != first {
+		t.Errorf("install id changed between calls: %q then %q", first, second)
+	}
+
+	if other, _ := NewStore(configDir).InstallID(); other != first {
+		t.Errorf("install id = %q from a second store on the same directory, want %q", other, first)
+	}
+
+	info, err := os.Stat(filepath.Join(configDir, "install_id"))
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("install_id mode = %o, want 0600", perm)
+	}
+}
+
+func TestInstallIDSurvivesLogout(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "1")
+	configDir := t.TempDir()
+	mgr := NewManager("https://app.hey.com", nil, configDir)
+
+	id, err := mgr.GetStore().InstallID()
+	if err != nil {
+		t.Fatalf("InstallID: %v", err)
+	}
+	if err := mgr.LoginWithToken("token"); err != nil {
+		t.Fatalf("LoginWithToken: %v", err)
+	}
+	if err := mgr.Logout(); err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+
+	if after, _ := mgr.GetStore().InstallID(); after != id {
+		t.Errorf("install id = %q after logout, want %q", after, id)
+	}
+}
+
+func TestInstallIDsDifferPerInstall(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "1")
+	a, _ := NewStore(t.TempDir()).InstallID()
+	b, _ := NewStore(t.TempDir()).InstallID()
+	if a == b {
+		t.Errorf("two installs share install id %q", a)
+	}
+}

--- a/internal/auth/install_id_test.go
+++ b/internal/auth/install_id_test.go
@@ -72,3 +72,30 @@ func TestInstallIDsDifferPerInstall(t *testing.T) {
 		t.Errorf("two installs share install id %q", a)
 	}
 }
+
+func TestInstallIDReplacesAMalformedFile(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "1")
+	configDir := t.TempDir()
+	path := filepath.Join(configDir, "install_id")
+
+	// A truncated or garbage file — e.g. a write interrupted by a crash or a
+	// full disk, or the old constant "hey-cli" identifier — is not a usable
+	// identity and must be reminted, never sent to HEY as-is.
+	if err := os.WriteFile(path, []byte("hey-cli"), 0600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	id, err := NewStore(configDir).InstallID()
+	if err != nil {
+		t.Fatalf("InstallID: %v", err)
+	}
+	if !uuidV4.MatchString(id) {
+		t.Fatalf("install id = %q, want a v4 UUID", id)
+	}
+
+	// The mint is durable: the replacement is written back, so a second store
+	// reads the same value rather than reminting again.
+	if again, _ := NewStore(configDir).InstallID(); again != id {
+		t.Errorf("install id = %q on reload, want the reminted %q", again, id)
+	}
+}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -146,6 +146,16 @@ func newAuthStatusCommand() *cobra.Command {
 				"authenticated":  false,
 			}
 
+			// The install identifier is install-scoped: it survives logout and
+			// is sent on every OAuth login and refresh. Surface it in every
+			// status path — env token and logged-out included, both of which
+			// return before the signed-in path — so the JSON and styled output
+			// stay consistent and can diagnose HEY's new-device alerts.
+			installID, _ := authMgr.GetStore().InstallID()
+			if installID != "" {
+				status["install_id"] = installID
+			}
+
 			if os.Getenv("HEY_TOKEN") != "" {
 				status["authenticated"] = true
 				status["method"] = "env_var"
@@ -154,6 +164,9 @@ func newAuthStatusCommand() *cobra.Command {
 					w := cmd.OutOrStdout()
 					fmt.Fprintf(w, "Base URL:  %s\n", cfg.BaseURL)
 					fmt.Fprintf(w, "Mail:      %s (%s)\n", cfg.AccountID, cfg.SourceOf("account_id"))
+					if installID != "" {
+						fmt.Fprintf(w, "Install:   %s\n", installID)
+					}
 					fmt.Fprintln(w, "Status:    Logged in (via HEY_TOKEN env var)")
 					return nil
 				}
@@ -167,6 +180,9 @@ func newAuthStatusCommand() *cobra.Command {
 					w := cmd.OutOrStdout()
 					fmt.Fprintf(w, "Base URL:  %s\n", cfg.BaseURL)
 					fmt.Fprintf(w, "Mail:      %s (%s)\n", cfg.AccountID, cfg.SourceOf("account_id"))
+					if installID != "" {
+						fmt.Fprintf(w, "Install:   %s\n", installID)
+					}
 					fmt.Fprintln(w, "Status:    Not logged in")
 					return nil
 				}
@@ -196,10 +212,6 @@ func newAuthStatusCommand() *cobra.Command {
 			if creds.RefreshToken != "" {
 				status["refresh_available"] = true
 			}
-			if installID, err := store.InstallID(); err == nil {
-				status["install_id"] = installID
-			}
-
 			if writer.IsStyled() {
 				w := cmd.OutOrStdout()
 				fmt.Fprintf(w, "Base URL:  %s\n", cfg.BaseURL)
@@ -219,7 +231,7 @@ func newAuthStatusCommand() *cobra.Command {
 						fmt.Fprintf(w, "Cookie:    %s...%s\n", cookie[:8], cookie[len(cookie)-4:])
 					}
 				}
-				if installID, ok := status["install_id"].(string); ok {
+				if installID != "" {
 					fmt.Fprintf(w, "Install:   %s\n", installID)
 				}
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -196,6 +196,9 @@ func newAuthStatusCommand() *cobra.Command {
 			if creds.RefreshToken != "" {
 				status["refresh_available"] = true
 			}
+			if installID, err := store.InstallID(); err == nil {
+				status["install_id"] = installID
+			}
 
 			if writer.IsStyled() {
 				w := cmd.OutOrStdout()
@@ -215,6 +218,9 @@ func newAuthStatusCommand() *cobra.Command {
 					if len(cookie) > 12 {
 						fmt.Fprintf(w, "Cookie:    %s...%s\n", cookie[:8], cookie[len(cookie)-4:])
 					}
+				}
+				if installID, ok := status["install_id"].(string); ok {
+					fmt.Fprintf(w, "Install:   %s\n", installID)
 				}
 
 				if creds.ExpiresAt > 0 {

--- a/internal/cmd/auth_commands_test.go
+++ b/internal/cmd/auth_commands_test.go
@@ -328,3 +328,57 @@ func TestLoginLogoutShortcutsMirrorAuthCommands(t *testing.T) {
 		t.Errorf("hey login example = %q", login2.Example)
 	}
 }
+
+func TestAuthStatusReportsInstallID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected HTTP request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+	configHome := t.TempDir()
+
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", true, "auth", "login", "--cookie", "session-cookie"); err != nil {
+		t.Fatalf("auth login: %v", err)
+	}
+
+	// JSON output carries install_id...
+	installID := statusInstallID(t, configHome, server.URL, "")
+	if installID == "" || strings.Count(installID, "-") != 4 {
+		t.Fatalf("status install_id = %q, want a UUID", installID)
+	}
+
+	// ...and the styled output prints the matching Install: line.
+	styled, _, err := runAuthCommand(t, configHome, server.URL, "", false, "auth", "status", "--styled")
+	if err != nil {
+		t.Fatalf("auth status (styled): %v", err)
+	}
+	if !strings.Contains(styled, "Install:   "+installID) {
+		t.Errorf("styled status = %q, want an Install: line with %q", styled, installID)
+	}
+
+	// The identifier is install-scoped: it survives logout and shows when
+	// authenticating through HEY_TOKEN, paths that both return before the
+	// signed-in status output.
+	if _, _, err := runAuthCommand(t, configHome, server.URL, "", true, "auth", "logout"); err != nil {
+		t.Fatalf("auth logout: %v", err)
+	}
+	if after := statusInstallID(t, configHome, server.URL, ""); after != installID {
+		t.Errorf("install_id after logout = %q, want %q", after, installID)
+	}
+	if env := statusInstallID(t, configHome, server.URL, "environment-token"); env != installID {
+		t.Errorf("install_id with HEY_TOKEN = %q, want %q", env, installID)
+	}
+}
+
+func statusInstallID(t *testing.T, configHome, baseURL, envToken string) string {
+	t.Helper()
+	_, status, err := runAuthCommand(t, configHome, baseURL, envToken, true, "auth", "status")
+	if err != nil {
+		t.Fatalf("auth status: %v", err)
+	}
+	data, ok := status.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("status data = %T", status.Data)
+	}
+	id, _ := data["install_id"].(string)
+	return id
+}


### PR DESCRIPTION
## Why
Every hey-cli install sent the constant `install_id=hey-cli` on login and refresh, so HEY treated every CLI sign-in, on any machine, as one already-known device and never sent a new-device alert for it. This is the CLI half of the HEY OAuth blast-radius work (Security Hardening card 10248716553, H1 #3945131); the server half binds each refresh-token lineage to the install that presents it and stops accepting the placeholder for new sign-ins.

## What
- Mint a random v4 UUID per install on first use and keep it at `<config dir>/install_id` (0600). It lives beside the credentials, not inside them: a device outlives a logout, and re-logging in from the same machine should not look like a new device.
- Send it as `install_id` on the authorization request, the code exchange, and every refresh. The refresh path reads it under the store lock it already holds, so `hey tui` and `hey watch` present the same id.
- The id is minted before the request goes out, never after success, so a lost response can't leave two ids racing for the same lineage.
- `hey auth status` shows it (`Install:` / `install_id`) for support.

## Rollout
No migration step. Existing installs mint an id on their next run; their next refresh presents it and the server rebinds the existing grant to it (quietly — the server treats the placeholder-to-real transition as the same device). An old binary left running (`hey watch`) keeps sending the placeholder, which the server accepts as a no-op.

## Tests
- Id is a v4 UUID, minted once, shared by every store on the same directory, file mode 0600.
- Survives `Logout`.
- Differs between installs.
- Login sends the same id on the auth URL and the token exchange; the two-process refresh test asserts a per-install id, not the placeholder.
- `go test ./internal/...`, `go vet`, `golangci-lint` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends a unique per-install identifier to HEY on login and refresh so HEY can treat each CLI install as a distinct device and send new-device alerts. Previously every install sent the constant `hey-cli`.

- Mints a random v4 UUID per install and stores it in `<config dir>/install_id` with mode 0600.
- Sends the ID on login, token exchange, and refresh; refresh reads it under the existing store lock.
- Writes the ID atomically and validates it on read, reminting a truncated or garbage file rather than sending it.
- The ID survives logout, so re-login from the same machine uses the same ID.
- `hey auth status` surfaces the ID in every status path, in JSON and styled output.
- No migration needed: existing installs mint an ID on next run, and the server binds the grant to it.

<sup>Written for commit 146ff7765a57a71125c21cf5d239d1a87691547b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

