### PR TITLE
Bind the OAuth callback listener to an ephemeral loopback port (RFC 8252 §7.3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ All API interactions go through the HEY SDK (`hey-sdk/go`), with typed service m
 
 Authentication supports four methods, all managed through `internal/auth/`:
 
-1. **Browser-based OAuth with PKCE** (primary) — `hey auth login` opens a browser for OAuth authentication against HEY's own OAuth server (`/oauth/authorizations/new`), using PKCE (S256) for security. A local callback server on `127.0.0.1:8976` receives the authorization code, which is exchanged for access and refresh tokens at `/oauth/tokens`.
+1. **Browser-based OAuth with PKCE** (primary) — `hey auth login` opens a browser for OAuth authentication against HEY's own OAuth server (`/oauth/authorizations/new`), using PKCE (S256) for security. A local callback server on an ephemeral `127.0.0.1` port (RFC 8252 §7.3) receives the authorization code, which is exchanged for access and refresh tokens at `/oauth/tokens`.
 2. **Pre-generated bearer token** — `hey auth login --token TOKEN` stores a token directly.
 3. **Browser session cookie** — `hey auth login --cookie COOKIE` uses an existing HEY.com session.
 4. **Environment variable** — Set `HEY_TOKEN` to use a token without storing it.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -20,8 +20,12 @@ const (
 	installID     = "hey-cli"
 )
 
-type callbackWaiter func(context.Context, string, string, string, LoginOptions) (string, error)
+type callbackWaiter func(context.Context, string, string, net.Listener, LoginOptions) (string, error)
 type listenerFactory func(context.Context, string, string) (net.Listener, error)
+
+// The callback listener binds an ephemeral loopback port (RFC 8252 §7.3):
+// a fixed port lets any local process squat it and block sign-in.
+const callbackListenAddr = "127.0.0.1:0"
 
 // Manager handles OAuth authentication.
 type Manager struct {
@@ -163,8 +167,15 @@ func (o LoginOptions) log(msg string) {
 func (m *Manager) Login(ctx context.Context, opts LoginOptions) error {
 	authEndpoint := m.baseURL + "/oauth/authorizations/new"
 	tokenEndpoint := m.baseURL + "/oauth/tokens"
-	callbackAddr := "127.0.0.1:8976"
-	redirectURI := "http://" + callbackAddr + "/callback"
+
+	// Listen before building the authorization URL: the redirect_uri has to
+	// carry whichever port the kernel handed out.
+	listener, err := m.listen(ctx, "tcp", callbackListenAddr)
+	if err != nil {
+		return fmt.Errorf("failed to start callback server: %w", err)
+	}
+	defer func() { _ = listener.Close() }()
+	redirectURI := "http://" + listener.Addr().String() + "/callback"
 
 	state := generateState()
 	codeVerifier := generateCodeVerifier()
@@ -186,12 +197,12 @@ func (m *Manager) Login(ctx context.Context, opts LoginOptions) error {
 	u.RawQuery = q.Encode()
 	authURL := u.String()
 
-	// Start local callback server
+	// Serve the callback on the listener we already hold
 	waitForCallback := m.callbackWait
 	if waitForCallback == nil {
 		waitForCallback = m.waitForCallback
 	}
-	code, err := waitForCallback(ctx, state, authURL, callbackAddr, opts)
+	code, err := waitForCallback(ctx, state, authURL, listener, opts)
 	if err != nil {
 		return err
 	}
@@ -317,13 +328,7 @@ func (m *Manager) CredentialKey() string {
 	return m.baseURL
 }
 
-func (m *Manager) waitForCallback(ctx context.Context, expectedState, authURL, callbackAddr string, opts LoginOptions) (string, error) {
-	listener, err := m.listen(ctx, "tcp", callbackAddr)
-	if err != nil {
-		return "", fmt.Errorf("failed to start callback server: %w", err)
-	}
-	defer func() { _ = listener.Close() }()
-
+func (m *Manager) waitForCallback(ctx context.Context, expectedState, authURL string, listener net.Listener, opts LoginOptions) (string, error) {
 	codeCh := make(chan string, 1)
 	errCh := make(chan error, 1)
 	var shutdownOnce sync.Once
@@ -340,7 +345,7 @@ func (m *Manager) waitForCallback(ctx context.Context, expectedState, authURL, c
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:gosec // G118: cancel deferred in goroutine; async shutdown required to avoid handler self-deadlock
 			go func() {
 				defer cancel()
-				// The listener is closed on the way out of waitForCallback, and
+				// The caller closes the listener on the way out of Login, and
 				// Shutdown closes it too; whichever gets there second sees
 				// net.ErrClosed, which is the server being down, not a failure.
 				if shutdownErr := server.Shutdown(shutdownCtx); shutdownErr != nil &&

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -92,6 +92,7 @@ func TestNormalizeBaseURL(t *testing.T) {
 }
 
 func TestLoginOAuthFlow(t *testing.T) {
+	redirectURIs := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/oauth/tokens" {
 			t.Errorf("path = %q, want /oauth/tokens", r.URL.Path)
@@ -102,8 +103,8 @@ func TestLoginOAuthFlow(t *testing.T) {
 		if got := r.Form.Get("code"); got != "callback-code" {
 			t.Errorf("code = %q, want callback-code", got)
 		}
-		if got := r.Form.Get("redirect_uri"); got != "http://127.0.0.1:8976/callback" {
-			t.Errorf("redirect_uri = %q", got)
+		if got, want := r.Form.Get("redirect_uri"), <-redirectURIs; got != want {
+			t.Errorf("redirect_uri = %q, want the callback listener's %q", got, want)
 		}
 		if got := r.Form.Get("code_verifier"); got == "" {
 			t.Error("code_verifier is empty")
@@ -115,16 +116,26 @@ func TestLoginOAuthFlow(t *testing.T) {
 
 	t.Setenv("HEY_TOKEN", "")
 	mgr := testManager(t, server)
-	mgr.callbackWait = func(_ context.Context, state, authURL, callbackAddr string, opts LoginOptions) (string, error) {
+	listen := mgr.listen
+	mgr.listen = func(ctx context.Context, network, address string) (net.Listener, error) {
+		if network != "tcp" || address != "127.0.0.1:0" {
+			t.Errorf("listen arguments = %q, %q, want an ephemeral loopback port", network, address)
+		}
+		return listen(ctx, network, address)
+	}
+	mgr.callbackWait = func(_ context.Context, state, authURL string, listener net.Listener, opts LoginOptions) (string, error) {
 		if state == "" {
 			t.Error("state is empty")
-		}
-		if callbackAddr != "127.0.0.1:8976" {
-			t.Errorf("callback address = %q", callbackAddr)
 		}
 		if !opts.NoBrowser {
 			t.Error("NoBrowser = false, want true")
 		}
+		addr, ok := listener.Addr().(*net.TCPAddr)
+		if !ok || !addr.IP.Equal(net.IPv4(127, 0, 0, 1)) || addr.Port == 0 {
+			t.Fatalf("listener address = %v, want a bound 127.0.0.1 port", listener.Addr())
+		}
+		redirectURI := "http://" + addr.String() + "/callback"
+		redirectURIs <- redirectURI
 		u, err := url.Parse(authURL)
 		if err != nil {
 			t.Fatalf("Parse auth URL: %v", err)
@@ -136,7 +147,7 @@ func TestLoginOAuthFlow(t *testing.T) {
 		want := map[string]string{
 			"client_id":             oauthClientID,
 			"grant_type":            "authorization_code",
-			"redirect_uri":          "http://127.0.0.1:8976/callback",
+			"redirect_uri":          redirectURI,
 			"state":                 state,
 			"code_challenge_method": "S256",
 			"install_id":            installID,
@@ -193,7 +204,7 @@ func TestLoginDoesNotSaveCredentialsOnFailure(t *testing.T) {
 
 			t.Setenv("HEY_TOKEN", "")
 			mgr := testManager(t, server)
-			mgr.callbackWait = func(context.Context, string, string, string, LoginOptions) (string, error) {
+			mgr.callbackWait = func(context.Context, string, string, net.Listener, LoginOptions) (string, error) {
 				return "callback-code", tt.waitErr
 			}
 			err := mgr.Login(t.Context(), LoginOptions{})
@@ -231,20 +242,15 @@ func TestWaitForCallback(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Listen: %v", err)
 			}
+			t.Cleanup(func() { _ = listener.Close() })
 			mgr := NewManager("http://example.test", http.DefaultClient, t.TempDir())
-			mgr.listen = func(_ context.Context, network, address string) (net.Listener, error) {
-				if network != "tcp" || address != "requested-address" {
-					t.Errorf("listen arguments = %q, %q", network, address)
-				}
-				return listener, nil
-			}
 			type result struct {
 				code string
 				err  error
 			}
 			resultCh := make(chan result, 1)
 			go func() {
-				code, waitErr := mgr.waitForCallback(t.Context(), "expected", "http://example.test/authorize", "requested-address", LoginOptions{NoBrowser: true})
+				code, waitErr := mgr.waitForCallback(t.Context(), "expected", "http://example.test/authorize", listener, LoginOptions{NoBrowser: true})
 				resultCh <- result{code: code, err: waitErr}
 			}()
 
@@ -280,35 +286,36 @@ func TestWaitForCallback(t *testing.T) {
 	}
 }
 
-func TestWaitForCallbackFailures(t *testing.T) {
-	t.Run("listen", func(t *testing.T) {
-		mgr := NewManager("http://example.test", http.DefaultClient, t.TempDir())
-		mgr.listen = func(context.Context, string, string) (net.Listener, error) {
-			return nil, errors.New("address unavailable")
-		}
-		_, err := mgr.waitForCallback(t.Context(), "state", "auth-url", "address", LoginOptions{NoBrowser: true})
-		if err == nil || !strings.Contains(err.Error(), "failed to start callback server") {
-			t.Fatalf("error = %v", err)
-		}
-	})
+func TestLoginListenFailure(t *testing.T) {
+	t.Setenv("HEY_TOKEN", "")
+	mgr := NewManager("http://example.test", http.DefaultClient, t.TempDir())
+	mgr.listen = func(context.Context, string, string) (net.Listener, error) {
+		return nil, errors.New("address unavailable")
+	}
+	mgr.callbackWait = func(context.Context, string, string, net.Listener, LoginOptions) (string, error) {
+		t.Fatal("callback wait ran without a listener")
+		return "", nil
+	}
+	err := mgr.Login(t.Context(), LoginOptions{NoBrowser: true})
+	if err == nil || !strings.Contains(err.Error(), "failed to start callback server") {
+		t.Fatalf("error = %v", err)
+	}
+}
 
-	t.Run("context cancellation", func(t *testing.T) {
-		listenConfig := &net.ListenConfig{}
-		listener, err := listenConfig.Listen(t.Context(), "tcp", "127.0.0.1:0")
-		if err != nil {
-			t.Fatalf("Listen: %v", err)
-		}
-		mgr := NewManager("http://example.test", http.DefaultClient, t.TempDir())
-		mgr.listen = func(context.Context, string, string) (net.Listener, error) {
-			return listener, nil
-		}
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		_, err = mgr.waitForCallback(ctx, "state", "auth-url", "address", LoginOptions{NoBrowser: true})
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("error = %v, want context.Canceled", err)
-		}
-	})
+func TestWaitForCallbackContextCancellation(t *testing.T) {
+	listenConfig := &net.ListenConfig{}
+	listener, err := listenConfig.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	mgr := NewManager("http://example.test", http.DefaultClient, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = mgr.waitForCallback(ctx, "state", "auth-url", listener, LoginOptions{NoBrowser: true})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
 }
 
 func TestLoginWithCookieAuthenticateAndLogout(t *testing.T) {
@@ -763,10 +770,8 @@ func TestLoginOptionsLoggerReceivesProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
+	t.Cleanup(func() { _ = listener.Close() })
 	mgr := NewManager("http://example.test", http.DefaultClient, t.TempDir())
-	mgr.listen = func(context.Context, string, string) (net.Listener, error) {
-		return listener, nil
-	}
 
 	// Capture stderr: a configured Logger must own all progress output.
 	origStderr := os.Stderr
@@ -783,7 +788,7 @@ func TestLoginOptionsLoggerReceivesProgress(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_, _ = mgr.waitForCallback(t.Context(), "expected", "http://example.test/authorize", "addr", opts)
+		_, _ = mgr.waitForCallback(t.Context(), "expected", "http://example.test/authorize", listener, opts)
 	}()
 
 	client := &http.Client{Timeout: 2 * time.Second}


### PR DESCRIPTION
## What

`hey auth login` binds its OAuth callback listener to `127.0.0.1:0` instead of the fixed `127.0.0.1:8976`, and the `redirect_uri` sent in both the authorization request and the token exchange carries whichever port the kernel handed out. The listener is bound before the authorization URL is built so the URL can name the real port; `Login` owns the listener and `waitForCallback` serves on it.

## Why

RFC 8252 §7.3. A fixed port lets any local process squat `127.0.0.1:8976` and block the CLI from ever signing in. **Hygiene / DoS-resistance only** — a local process picks its own port either way, so this is not what stops loopback impersonation; PKCE is. Tracked on Security Hardening card 10248717570 (item 6 of the H1 #3945131 plan).

## Depends on

basecamp/haystack#8704 — the server must accept any port for the CLI's loopback client. **Deploy the server first**; it stays compatible with the fixed port, so this can merge and ship in the next CLI release once that's live. A CLI built from this branch against a server without it gets `redirect_uri mismatch`.

## Tests

- `TestLoginOAuthFlow`: asserts `Login` listens on `tcp` `127.0.0.1:0`, that the listener is bound to a real `127.0.0.1` port, and that the same `http://127.0.0.1:<port>/callback` appears in the authorization URL and in the token exchange.
- `TestLoginListenFailure`: a failed bind surfaces as `failed to start callback server` before any callback wait runs.
- `TestWaitForCallback*` and the logger test now hand the listener in directly.
- `go test -race ./...` green for `internal/auth`; `golangci-lint` clean. (`internal/tui`'s `open_remote_unix_test` fails on this macOS sandbox on `main` too — unix socket path length — unrelated.)

AGENTS.md updated to stop naming the fixed port.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds the OAuth callback listener for `hey auth login` to an ephemeral loopback port (`127.0.0.1:0`) instead of the fixed `127.0.0.1:8976`, so a local process can no longer squat the port and block sign-in. The `redirect_uri` now carries whichever port the kernel assigned, in both the authorization request and the token exchange.

**Rollout**

- Requires the HEY server to accept any loopback port for the CLI's `redirect_uri`; deploy the server first — it stays compatible with the fixed port until this ships.
- A CLI built from this branch against an older server fails with `redirect_uri mismatch`.
- This is DoS-resistance only; it doesn't stop loopback impersonation, which PKCE already handles.

<sup>Written for commit f3deedc44fb937ecc0096ea35b29ec436395ddf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

