### PR TITLE
Explain how to remove Reply Later with hey move

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ hey draft delete 12345             # trash it
 hey seen 12345                     # mark a thread as seen
 hey unseen 12345 67890             # mark threads as unseen
 hey move 12345 --to feed           # move a thread to another box
+hey move 12345 67890 --to imbox    # remove Reply Later from seen threads
 hey move 12345 67890 --to "paper trail"  # move multiple threads
 hey bubble up 12345 --now          # bubble a thread up to the top of the Imbox
 hey bubble up 12345 --on 2026-09-04  # bubble a thread up on a date
@@ -487,7 +488,7 @@ Snippets are named reusable email content, separate from clips saved out of rece
 
 `hey box view <name|id>`, `hey label view <id>` and `hey collection view <id>` list the same postings and answer the same formats: `--json`, `--styled`, `--markdown`, `--ids-only`, and `--count`. The data-only formats print the pagination notice and any `next_page` cursor on stderr, so the IDs on stdout stay pipeable. `--json` differs only in what wraps the postings: a box answers with HEY's box payload, a label and a collection with the source and its `total_count`.
 
-Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Bubble Up has its own commands: `hey bubble up` raises a thread right away with `--now`, on a date with `--on` (HEY resurfaces it at its morning hour of that day, or its evening hour when the date is today), or at the morning hour of tomorrow, Saturday, or next Monday with `--tomorrow`, `--weekend`, and `--next-week`; `hey bubble pop` cancels one. `hey bubble list` shows both buckets — the threads back in the Imbox after bubbling up and the ones still scheduled, each with when it resurfaces. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
+Move destinations are Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Reply Later is a box rather than a separate flag: moving a Reply Later thread to Imbox removes Reply Later, preserves its seen state, and leaves a seen thread in Previously Seen. It does not return the thread to the box it occupied before Reply Later. Bubble Up has its own commands: `hey bubble up` raises a thread right away with `--now`, on a date with `--on` (HEY resurfaces it at its morning hour of that day, or its evening hour when the date is today), or at the morning hour of tomorrow, Saturday, or next Monday with `--tomorrow`, `--weekend`, and `--next-week`; `hey bubble pop` cancels one. `hey bubble list` shows both buckets — the threads back in the Imbox after bubbling up and the ones still scheduled, each with when it resurfaces. Trashing a shared thread removes your access instead of deleting it for everyone. Ignored threads remain in their box and can be restored with `hey stop-ignoring`.
 
 ### Watching for changes
 

--- a/internal/cmd/move.go
+++ b/internal/cmd/move.go
@@ -25,12 +25,12 @@ func newMoveCommand() *moveCommand {
 	moveCommand.cmd = &cobra.Command{
 		Use:   "move <box-item-id>...",
 		Short: "Move email threads to another box",
-		Long:  "Move one or more email threads to Imbox, The Feed, Set Aside, Reply Later, or Paper Trail.",
+		Long:  "Move one or more email threads to Imbox, The Feed, Set Aside, Reply Later, or Paper Trail. Moving a Reply Later thread to Imbox removes Reply Later while preserving its seen state.",
 		Example: `  hey move 12345 --to feed
-  hey move 12345 67890 --to "paper trail"
+  hey move 12345 67890 --to imbox
   hey move 12345 --to 987`,
 		Annotations: map[string]string{
-			"agent_notes": "Accepts box item IDs from hey box view output. --to accepts a box name, kind, or ID. Use hey bubble up for Bubble Up.",
+			"agent_notes": "Accepts box item IDs from hey box view output. --to accepts a box name, kind, or ID. To remove Reply Later, move the threads to Imbox; seen threads then appear in Previously Seen. Use hey bubble up for Bubble Up.",
 		},
 		RunE: moveCommand.run,
 		Args: usageMinOneArg(),

--- a/internal/cmd/move_test.go
+++ b/internal/cmd/move_test.go
@@ -77,6 +77,20 @@ func runMove(t *testing.T, server *httptest.Server, args ...string) (output.Resp
 	return resp, err
 }
 
+func TestMoveHelpExplainsHowToRemoveReplyLater(t *testing.T) {
+	cmd := newMoveCommand().cmd
+
+	if !strings.Contains(cmd.Long, "Moving a Reply Later thread to Imbox removes Reply Later") {
+		t.Errorf("long help does not explain how to remove Reply Later: %q", cmd.Long)
+	}
+	if !strings.Contains(cmd.Example, "--to imbox") {
+		t.Errorf("examples do not show the Imbox destination: %q", cmd.Example)
+	}
+	if !strings.Contains(cmd.Annotations["agent_notes"], "To remove Reply Later, move the threads to Imbox") {
+		t.Errorf("agent notes do not explain how to remove Reply Later: %q", cmd.Annotations["agent_notes"])
+	}
+}
+
 func TestMovePostingsToNamedBox(t *testing.T) {
 	server, recorded := moveServer(t)
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -219,6 +219,7 @@ notice on stderr. Both need list data, so they work on `hey box list`, `hey box 
 | Mark as seen | `hey seen 12345` |
 | Mark as unseen | `hey unseen 12345` |
 | Move email threads | `hey move 12345 --to feed` |
+| Remove Reply Later | `hey move 12345 --to imbox` |
 | Bubble a thread up now | `hey bubble up 12345 --now` |
 | Bubble a thread up on a date | `hey bubble up 12345 --on 2026-09-04` |
 | Bubble a thread up this weekend | `hey bubble up 12345 --weekend` |
@@ -270,6 +271,7 @@ Want to read email?
 ├── Mark as seen? → hey seen <id>
 ├── Mark as unseen? → hey unseen <id>
 ├── Move to another box? → hey move <id> --to <box>
+├── Remove or unmark Reply Later? → hey move <id> --to imbox
 ├── Move to Trash? → hey trash <id>
 ├── Mark as spam? → hey spam <id>
 ├── Ignore future activity? → hey ignore <id>
@@ -518,11 +520,12 @@ Takes box item IDs (the `id` field from `hey box view` output).
 ### Email - Moving Threads
 
 ```bash
-hey move 12345 --to imbox                     # Move one thread
+hey move 12345 --to feed                      # Move one thread
 hey move 12345 67890 --to "paper trail"       # Move multiple threads
+hey move 12345 67890 --to imbox               # Remove Reply Later from threads
 ```
 
-Takes box item IDs (the `id` field from `hey box view --json`). `--to` accepts a box name, kind, or ID. Supported destinations are Imbox, The Feed, Set Aside, Reply Later, and Paper Trail. Bubble Up goes through `hey bubble` instead.
+Takes box item IDs (the `id` field from `hey box view --json`). `--to` accepts a box name, kind, or ID. Supported destinations are Imbox, The Feed, Set Aside, Reply Later, and Paper Trail. Reply Later is a box, not an independent flag: moving a Reply Later thread to Imbox removes Reply Later, preserves its seen state, and leaves a seen thread in Previously Seen. It does not return the thread to the box it occupied before Reply Later. Bubble Up goes through `hey bubble` instead.
 
 ### Email - Bubble Up
 


### PR DESCRIPTION
<!-- pr-review-readiness-head: 1d6c9ea49376d44c0a940fb38d509a408edadbc2 -->

Agents can remove Reply Later without searching for a dedicated toggle: moving the thread to Imbox is the supported operation. This change makes that relationship explicit in CLI help, command metadata, the bundled HEY skill, and the README while documenting that the seen state is preserved and the previous box is not restored.

## Change

- Explain `hey move <id> --to imbox` as the way to remove Reply Later.
- Tell agents that seen threads appear in Previously Seen afterward.
- Clarify that Reply Later is a box rather than an independent flag.
- Keep the existing SDK and server operation unchanged.
- Add focused coverage for the user and agent help surfaces.

## Validation

```text
GOWORK=off go test ./internal/cmd -run 'TestMove|TestEmailCommandHelpKeepsPostingAsAnInternalTerm|TestSurfaceSnapshot'
PASS

GOWORK=off make test
PASS

GOWORK=off make lint
0 issues

git diff --check
PASS
```

## End-to-end agent check

A fresh Claude Code session in Herdr loaded this branch's HEY skill and drove the local branch build against a Haystack development server:

```text
Seeded across 90 days:       300 threads
Initially in Reply Later:    150 threads
Command selected by Claude:  hey move <150 posting IDs> --to imbox
Afterward in Reply Later:    0 threads
Afterward in Imbox:          300 threads
Unrelated threads moved:     0
```

The final state was independently confirmed from the Haystack development database.

## Scope and risk

Low risk: this changes help and agent guidance only. The existing `MovePostings` SDK operation, CLI mutation path, and HEY box behavior remain unchanged. No deployment steps, migrations, configuration, or SDK release are required.

## Review path

1. [`internal/cmd/move.go`](https://github.com/basecamp/hey-cli/blob/1d6c9ea49376d44c0a940fb38d509a408edadbc2/internal/cmd/move.go) — CLI and agent-facing explanation.
2. [`skills/hey/SKILL.md`](https://github.com/basecamp/hey-cli/blob/1d6c9ea49376d44c0a940fb38d509a408edadbc2/skills/hey/SKILL.md) — agent discovery paths and semantics.
3. [`internal/cmd/move_test.go`](https://github.com/basecamp/hey-cli/blob/1d6c9ea49376d44c0a940fb38d509a408edadbc2/internal/cmd/move_test.go) — focused help regression coverage.
4. [`README.md`](https://github.com/basecamp/hey-cli/blob/1d6c9ea49376d44c0a940fb38d509a408edadbc2/README.md) — user-facing command documentation.

Origin: [Basecamp card — CLI: Unmark Reply Later](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10251184438)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents `hey move --to imbox` as the way to remove Reply Later across CLI help, the HEY skill, and the README, without changing any runtime behavior.

- Adds a regression test asserting the help text and agent notes explain the Imbox move.
- Clarifies that moving a Reply Later thread to Imbox preserves its seen state and leaves the thread in Previously Seen, not the box it was in before Reply Later.
- Makes the example in `move` help use `--to imbox` instead of `--to "paper trail"`.

<sup>Written for commit 1d6c9ea49376d44c0a940fb38d509a408edadbc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

