### PR TITLE
Prepare v1.3.0 release metadata

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hey",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "HEY integration for Claude Code. Read email, manage todos, track time.",
   "author": {
     "name": "37signals",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
   pname = "hey";
   # Bumped by `make update-nix-hash VERSION=vX.Y.Z` before each stable
   # release; scripts/release.sh refuses to tag until it matches.
-  version = "1.2.1";
+  version = "1.3.0";
 
   src = lib.cleanSource ./..;
 


### PR DESCRIPTION
## What

Stamp the stable release metadata for v1.3.0:

- Claude plugin version: `1.3.0`
- Nix package version: `1.3.0`

The release preflight passed locally with:

```bash
GOWORK=off make release VERSION=v1.3.0 DRY_RUN=1
```

After this lands, `make release VERSION=v1.3.0` can create and push the release tag without writing directly to protected `main`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Claude plugin and Nix package versions from `1.2.1` to `1.3.0` to prepare the stable v1.3.0 release.

- Updates version metadata in `.claude-plugin/plugin.json` and `nix/package.nix`.
- Unblocks `make release VERSION=v1.3.0` to create and push the release tag without writing to protected `main`.

<sup>Written for commit cb06b34be5d039b6287d16615cc29cc314643d64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

