### PR TITLE
Fix all-day calendar event edits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655
-	github.com/basecamp/hey-sdk/go v0.28.0
+	github.com/basecamp/hey-sdk/go v0.28.1
 	github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/fsnotify/fsnotify v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655 h1:zz0WUSEmjURj0T+soXuTtgX291nYouqa+UoyYY3Xxk8=
 github.com/basecamp/actioncable-go v0.0.0-20260824145920-822e6cf08655/go.mod h1:ezaV5z1GXQAsqyejqTs6wCFl2D8Wj+COLQkHc/kwoRs=
-github.com/basecamp/hey-sdk/go v0.28.0 h1:N3sNaELGngFuEW9cAWner+mwhWH734Fjru/PcTdLIUg=
-github.com/basecamp/hey-sdk/go v0.28.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
+github.com/basecamp/hey-sdk/go v0.28.1 h1:qv7fpN2gEJa9TO0VBXic/QEfmSJZSF3ui0VuRHlRQUw=
+github.com/basecamp/hey-sdk/go v0.28.1/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
 github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d h1:zEQVGq1x1nhKMZ2TudFAcSJ32CHT8richI1vQakIKz4=
 github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d/go.mod h1:Ee2c/q1/pg+5T5741PIuA3s6VJMQC7I0XBNXIHIujzA=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=

--- a/internal/cmd/events_test.go
+++ b/internal/cmd/events_test.go
@@ -217,6 +217,34 @@ func TestEventsEditKeepsWhatItWasNotAskedToChange(t *testing.T) {
 	}
 }
 
+// An all-day edit carries calendar dates without clock times.
+func TestEventsEditAllDayEventOmitsClockTimes(t *testing.T) {
+	_, err := runJSONCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/calendars/9/recordings.json":
+			_, _ = io.WriteString(w, `{"Calendar::Event":[{"id":4821,"title":"Sarah's birthday","all_day":true,"starts_at":"2026-09-02T00:00:00Z","ends_at":"2026-09-02T00:00:00Z"}]}`)
+		case r.Method == http.MethodPatch && r.URL.Path == "/calendar/events/4821.json":
+			form := eventForm(t, r)
+			for _, field := range []string{
+				"calendar_event[starts_at_time]",
+				"calendar_event[ends_at_time]",
+			} {
+				if form.Has(field) {
+					t.Errorf("%s was sent as %q, want it left out", field, form.Get(field))
+				}
+			}
+			_, _ = io.WriteString(w, `{"id":4821,"title":"Sarah's birthday (edited)","all_day":true}`)
+		default:
+			t.Errorf("unexpected request = %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}), "event", "edit", "4821", "2026-09-02", "--calendar", "9", "--title", "Sarah's birthday (edited)")
+	if err != nil {
+		t.Fatalf("execute all-day event edit: %v", err)
+	}
+}
+
 // Giving a date reads that day rather than a window around today — as the window
 // [day, day+1), since HEY's recordings window is a pair of instants and the degenerate
 // same-day window can never contain a timed event.

--- a/internal/mcpserver/model/PROVENANCE.json
+++ b/internal/mcpserver/model/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source": "github.com/basecamp/hey-sdk",
-  "commit": "cbc342f6419eb7d9cf703d25efc43c866bfc4ab6",
-  "ref": "go/v0.28.0",
+  "commit": "bf5835025544322da130864735352d801059a516",
+  "ref": "go/v0.28.1",
   "files": ["behavior-model.json", "openapi.json"],
   "synced_by": "scripts/sync-mcp-model.sh"
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-HNpAec6YTVfXMqDF5QaFmu7pA/yrnJrWdLqJXDNzcN8=";
+  vendorHash = "sha256-xUVghXU7kEc4Rdz6JvR5ULRvjgtuh2Zrf2miXTNhVEg=";
 
   subPackages = [ "cmd/hey" ];
 


### PR DESCRIPTION
## Summary

- bump `github.com/basecamp/hey-sdk/go` to v0.28.1
- verify all-day event edits omit both clock-time fields
- sync the vendored SDK model provenance with the pinned release

Fixes #362.

## Validation

- Confirmed the new regression test fails against SDK v0.28.0 with `starts_at_time=:00` and `ends_at_time=:00`
- Confirmed the test passes against SDK v0.28.1
- `GOWORK=off make check`
- Live HEY smoke test with this branch: create all-day event, edit its title, and delete it successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all-day calendar event edits by upgrading `@basecamp/hey-sdk/go` to v0.28.1, which stops the edit request from sending the `starts_at_time` and `ends_at_time` fields as `:00` for all-day events. Adds a regression test that verifies those fields are omitted.

- Bumps `github.com/basecamp/hey-sdk/go` from v0.28.0 to v0.28.1 and syncs the vendored SDK model provenance and Nix vendor hash.
- Adds a test confirming all-day event edits send calendar dates without clock times.

<sup>Written for commit 214f8e239cb9e6c29345c438b122f08023fa190c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

