### PR TITLE
Type the hyphen into the TUI date picker instead of stepping the date

### DIFF
--- a/internal/tui/datetime.go
+++ b/internal/tui/datetime.go
@@ -237,6 +237,11 @@ func (p *dateTimePicker) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 			p.shiftDate(days)
 			return nil
 		}
+		// "-" cannot appear in a YYYY-MM-DD date, so swallow it here
+		// instead of letting it through to the text input (hey-cli#368)
+		if msg.String() == "-" {
+			return nil
+		}
 		var cmd tea.Cmd
 		p.dateInput, cmd = p.dateInput.Update(msg)
 		return cmd
@@ -263,13 +268,10 @@ func dateStep(msg tea.KeyPressMsg) (days int, stepped bool) {
 	case tea.KeyUp:
 		return 1, true
 	case tea.KeyDown:
-		return -1, true
 	}
 	switch msg.String() {
 	case "+", "=":
 		return 1, true
-	case "-":
-		return -1, true
 	}
 	return 0, false
 }

--- a/internal/tui/datetime.go
+++ b/internal/tui/datetime.go
@@ -237,11 +237,6 @@ func (p *dateTimePicker) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 			p.shiftDate(days)
 			return nil
 		}
-		// "-" cannot appear in a YYYY-MM-DD date, so swallow it here
-		// instead of letting it through to the text input (hey-cli#368)
-		if msg.String() == "-" {
-			return nil
-		}
 		var cmd tea.Cmd
 		p.dateInput, cmd = p.dateInput.Update(msg)
 		return cmd
@@ -260,14 +255,15 @@ func (p *dateTimePicker) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 }
 
-// dateStep is the day-at-a-time keys. Both pairs are here because neither means anything
-// else on a date field: the arrows are unbound in a single-line text input, and a + or a -
-// cannot appear in YYYY-MM-DD, so typing one is only ever a step.
+// dateStep is the day-at-a-time keys. The arrows are unbound in a single-line text input,
+// and a + cannot appear in YYYY-MM-DD, so typing one is only ever a step. A - is the date's
+// own separator, so it is typed into the field like any other character (hey-cli#368).
 func dateStep(msg tea.KeyPressMsg) (days int, stepped bool) {
 	switch msg.Key().Code {
 	case tea.KeyUp:
 		return 1, true
 	case tea.KeyDown:
+		return -1, true
 	}
 	switch msg.String() {
 	case "+", "=":

--- a/internal/tui/datetime_test.go
+++ b/internal/tui/datetime_test.go
@@ -68,15 +68,15 @@ func TestDateTimePickerStepsTheDateByADay(t *testing.T) {
 		t.Errorf("after up, date() = %q, want 2026-08-23", got)
 	}
 
-	picker.handleKey(tea.KeyPressMsg{Code: tea.KeyDown})
-	picker.handleKey(tea.KeyPressMsg{Code: tea.KeyDown})
-	if got := picker.date(); got != "2026-08-21" {
-		t.Errorf("after two downs, date() = %q, want 2026-08-21", got)
+	// "-" no longer steps date (hey-cli#368)
+	typeInto(t, picker, "-")
+	if got := picker.date(); got != "2026-08-23" {
+		t.Errorf("after -, date() = %q, want unchanged", got)
 	}
 
 	typeInto(t, picker, "+")
-	if got := picker.date(); got != "2026-08-22" {
-		t.Errorf("after +, date() = %q, want 2026-08-22", got)
+	if got := picker.date(); got != "2026-08-24" {
+		t.Errorf("after +, date() = %q, want 2026-08-24", got)
 	}
 
 	picker.dateInput.SetValue("next tuesday")

--- a/internal/tui/datetime_test.go
+++ b/internal/tui/datetime_test.go
@@ -68,21 +68,32 @@ func TestDateTimePickerStepsTheDateByADay(t *testing.T) {
 		t.Errorf("after up, date() = %q, want 2026-08-23", got)
 	}
 
-	// "-" no longer steps date (hey-cli#368)
-	typeInto(t, picker, "-")
-	if got := picker.date(); got != "2026-08-23" {
-		t.Errorf("after -, date() = %q, want unchanged", got)
+	picker.handleKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	picker.handleKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	if got := picker.date(); got != "2026-08-21" {
+		t.Errorf("after two downs, date() = %q, want 2026-08-21", got)
 	}
 
 	typeInto(t, picker, "+")
-	if got := picker.date(); got != "2026-08-24" {
-		t.Errorf("after +, date() = %q, want 2026-08-24", got)
+	if got := picker.date(); got != "2026-08-22" {
+		t.Errorf("after +, date() = %q, want 2026-08-22", got)
 	}
 
 	picker.dateInput.SetValue("next tuesday")
 	picker.handleKey(tea.KeyPressMsg{Code: tea.KeyUp})
 	if got := picker.date(); got != "next tuesday" {
 		t.Errorf("stepping an unreadable date changed it to %q", got)
+	}
+}
+
+func TestDateTimePickerTypesTheDateSeparator(t *testing.T) {
+	picker := testPicker()
+	picker.focusFirst()
+	picker.dateInput.SetValue("2026-08")
+
+	typeInto(t, picker, "-22")
+	if got := picker.date(); got != "2026-08-22" {
+		t.Errorf("after typing -22, date() = %q, want 2026-08-22", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #368.

`-` was bound as the date field's step-back key, so typing the separator of a YYYY-MM-DD date moved the date a day instead of landing in the field. `-` now goes through to the input like any other character; the arrows keep stepping the day both ways, and `+`/`=` still step forward since neither can appear in a date.

This branch originally carried a go.mod pin for the draft 422 fix. That half lives in hey-sdk#133 — the wrappers there are what surface HEY's reasons — and the CLI needs no code change for it beyond the routine hey-sdk bump once that ships.
