### PR TITLE
Update release metadata for v1.3.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hey",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "HEY integration for Claude Code. Read email, manage todos, track time.",
   "author": {
     "name": "37signals",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
   pname = "hey";
   # Bumped by `make update-nix-hash VERSION=vX.Y.Z` before each stable
   # release; scripts/release.sh refuses to tag until it matches.
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = lib.cleanSource ./..;
 


### PR DESCRIPTION
## Summary

- stamp the Nix package version to 1.3.1
- stamp the Claude plugin version to 1.3.1

## Validation

- `GOWORK=off make release VERSION=1.3.1 DRY_RUN=1`
- the full non-dry-run release preflight also passed before branch protection rejected the direct `main` push; the release script rolled back without pushing the tag

After this merges, rerunning the release script will tag the stamped commit and trigger the release workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stamps the release version to 1.3.1 in the Nix package and Claude plugin metadata so the release script can tag this commit.

- Updates `nix/package.nix` and `.claude-plugin/plugin.json` from 1.3.0 to 1.3.1.
- After merge, rerun the release script to tag the stamped commit and trigger the release workflow.

<sup>Written for commit 9a2ee470bc884d367b1cf649055747918247cb85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

