### PR TITLE
File the open thread to Set Aside and Reply Later with a and l

### DIFF
--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -254,7 +254,7 @@ type mailView struct {
 	topicViewport    viewport.Model
 	topicContent     string
 	topicID          int64
-	threadPostingID  int64 // the posting the open thread was opened from, zero when it has none
+	threadPosting    mail.Posting // snapshot of the posting the open thread was opened from, zero when it has none
 	topicName        string
 	entries          []mail.Entry
 	attachments      []messageAttachment
@@ -516,7 +516,14 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		}
 		v.inThread = true
 		v.topicID = msg.topicID
-		v.threadPostingID = msg.postingID
+		// The posting the thread was opened from, snapshotted rather than looked up
+		// again later: the automatic mark-seen and the live refresh can resort the
+		// row, slide it under the cover, or drop it off the head page while the
+		// thread stays on screen.
+		v.threadPosting = mail.Posting{ID: msg.postingID, TopicID: msg.topicID}
+		if opened := v.openedPosting(msg.postingID); opened != nil {
+			v.threadPosting = *opened
+		}
 		v.topicName = msg.title
 		v.entries = msg.entries
 		v.attachments = msg.attachments
@@ -1414,7 +1421,7 @@ func (v *mailView) ExitThread() {
 	if v.inThread {
 		v.inThread = false
 		v.threadNotice = ""
-		v.threadPostingID = 0
+		v.threadPosting = mail.Posting{}
 		v.modal = nil
 		v.requests.cancel()
 		return
@@ -1595,7 +1602,7 @@ func (v *mailView) switchBox(index int) tea.Cmd {
 	}
 	v.inThread = false
 	v.threadNotice = ""
-	v.threadPostingID = 0
+	v.threadPosting = mail.Posting{}
 	v.clearSearch()
 	v.clearBundle()
 	v.clearSeen()
@@ -1617,7 +1624,7 @@ func (v *mailView) openPreviouslySeen() tea.Cmd {
 	}
 	v.inThread = false
 	v.threadNotice = ""
-	v.threadPostingID = 0
+	v.threadPosting = mail.Posting{}
 	v.clearSearch()
 	v.clearBundle()
 	v.notice = ""
@@ -2290,15 +2297,15 @@ func (v *mailView) fileOpenThread(key string) tea.Cmd {
 	return nil
 }
 
-// fileablePosting is the row the open thread files on: the posting the thread was
-// opened from, found by id rather than under the cursor because the mark-seen that
-// opening triggers can resort the list, slide the row under the cover, and clamp
-// the cursor onto some other row while the thread is on screen.
+// fileablePosting is the posting the open thread files on: the snapshot taken when
+// the thread opened, standing in for a row the list may no longer hold — the
+// automatic mark-seen resorts it under the cover and clamps the cursor away, and a
+// live refresh can drop it off the head page — while the thread stays on screen.
 func (v *mailView) fileablePosting() *mail.Posting {
-	if v.searchActive || v.bundleActive || v.threadPostingID == 0 {
+	if v.searchActive || v.bundleActive || v.threadPosting.ID == 0 {
 		return nil
 	}
-	return v.openedPosting(v.threadPostingID)
+	return &v.threadPosting
 }
 
 func (v *mailView) handlePostingAction(key string) tea.Cmd {

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -929,6 +929,9 @@ func (v *mailView) HelpBindings() []helpBinding {
 	}
 	if v.inThread {
 		bindings := []helpBinding{{"r", "reply"}, {"f", "forward"}}
+		if v.canFileOpenThread() {
+			bindings = append(bindings, helpBinding{"l", "reply later"}, helpBinding{"a", "set aside"})
+		}
 		if len(v.entries) > 1 {
 			bindings = append(bindings, helpBinding{"j/k", "next/previous message"})
 		}
@@ -1230,6 +1233,8 @@ func (v *mailView) HandleContentKey(msg tea.KeyPressMsg) tea.Cmd {
 			if v.topicID != 0 {
 				return v.loadForwardContext(v.topicID, v.topicName)
 			}
+		case "a", "A", "l":
+			return v.fileOpenThread(msg.String())
 		case "[":
 			v.moveAttachmentCursor(-1)
 			return nil
@@ -2265,6 +2270,27 @@ func (v *mailView) imboxSource() *mail.Source {
 		}
 	}
 	return nil
+}
+
+// fileOpenThread files the thread on screen the way the same key files it on the
+// list, matching the web app's topic toolbar keeping its hotkeys live while a
+// thread is open. Only a thread opened from a filing list — a box or Previously
+// Seen — has a posting row to act on: over search results, bundles, and topics
+// opened directly the key answers with a notice instead of silence.
+func (v *mailView) fileOpenThread(key string) tea.Cmd {
+	if v.canFileOpenThread() {
+		return v.handlePostingAction(key)
+	}
+	v.notice = "Can't file this thread from here"
+	return nil
+}
+
+func (v *mailView) canFileOpenThread() bool {
+	if v.searchActive || v.bundleActive {
+		return false
+	}
+	selected := v.actionList().selectedPosting()
+	return selected != nil && selected.TopicID == v.topicID
 }
 
 func (v *mailView) handlePostingAction(key string) tea.Cmd {

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -254,6 +254,7 @@ type mailView struct {
 	topicViewport    viewport.Model
 	topicContent     string
 	topicID          int64
+	threadPostingID  int64 // the posting the open thread was opened from, zero when it has none
 	topicName        string
 	entries          []mail.Entry
 	attachments      []messageAttachment
@@ -515,6 +516,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		}
 		v.inThread = true
 		v.topicID = msg.topicID
+		v.threadPostingID = msg.postingID
 		v.topicName = msg.title
 		v.entries = msg.entries
 		v.attachments = msg.attachments
@@ -929,7 +931,7 @@ func (v *mailView) HelpBindings() []helpBinding {
 	}
 	if v.inThread {
 		bindings := []helpBinding{{"r", "reply"}, {"f", "forward"}}
-		if v.canFileOpenThread() {
+		if v.fileablePosting() != nil {
 			bindings = append(bindings, helpBinding{"l", "reply later"}, helpBinding{"a", "set aside"})
 		}
 		if len(v.entries) > 1 {
@@ -1412,6 +1414,7 @@ func (v *mailView) ExitThread() {
 	if v.inThread {
 		v.inThread = false
 		v.threadNotice = ""
+		v.threadPostingID = 0
 		v.modal = nil
 		v.requests.cancel()
 		return
@@ -1592,6 +1595,7 @@ func (v *mailView) switchBox(index int) tea.Cmd {
 	}
 	v.inThread = false
 	v.threadNotice = ""
+	v.threadPostingID = 0
 	v.clearSearch()
 	v.clearBundle()
 	v.clearSeen()
@@ -1613,6 +1617,7 @@ func (v *mailView) openPreviouslySeen() tea.Cmd {
 	}
 	v.inThread = false
 	v.threadNotice = ""
+	v.threadPostingID = 0
 	v.clearSearch()
 	v.clearBundle()
 	v.notice = ""
@@ -2278,19 +2283,22 @@ func (v *mailView) imboxSource() *mail.Source {
 // Seen — has a posting row to act on: over search results, bundles, and topics
 // opened directly the key answers with a notice instead of silence.
 func (v *mailView) fileOpenThread(key string) tea.Cmd {
-	if v.canFileOpenThread() {
-		return v.handlePostingAction(key)
+	if posting := v.fileablePosting(); posting != nil {
+		return v.postingAction(key, *posting)
 	}
 	v.notice = "Can't file this thread from here"
 	return nil
 }
 
-func (v *mailView) canFileOpenThread() bool {
-	if v.searchActive || v.bundleActive {
-		return false
+// fileablePosting is the row the open thread files on: the posting the thread was
+// opened from, found by id rather than under the cursor because the mark-seen that
+// opening triggers can resort the list, slide the row under the cover, and clamp
+// the cursor onto some other row while the thread is on screen.
+func (v *mailView) fileablePosting() *mail.Posting {
+	if v.searchActive || v.bundleActive || v.threadPostingID == 0 {
+		return nil
 	}
-	selected := v.actionList().selectedPosting()
-	return selected != nil && selected.TopicID == v.topicID
+	return v.openedPosting(v.threadPostingID)
 }
 
 func (v *mailView) handlePostingAction(key string) tea.Cmd {
@@ -2298,7 +2306,10 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 	if selected == nil {
 		return nil
 	}
-	p := *selected
+	return v.postingAction(key, *selected)
+}
+
+func (v *mailView) postingAction(key string, p mail.Posting) tea.Cmd {
 	boxID := v.currentBoxID()
 
 	switch key {

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -734,6 +734,12 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 				v.postingList.postings[idx].Muted = false
 			}
 		}
+		// The open thread can file back into the box on screen — out and back while
+		// it stays open — and its row was removed when it first filed away, so the
+		// list re-reads its head to hold what the server now does.
+		if msg.destinationKind != "" && msg.destinationKind == v.actionBoxKind() && v.postingIndex(msg.postingID) < 0 {
+			return tea.Batch(done, v.refreshBox(msg.boxID)), true
+		}
 		if v.requests.kind == mailRequestPostings {
 			if source := v.currentSource(); source != nil {
 				return tea.Batch(done, v.requestPostings(*source)), true

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -200,6 +200,7 @@ type postingActionDoneMsg struct {
 	postingID       int64
 	effect          postingActionEffect
 	destinationKind string // the box kind a move filed into, empty for every other action
+	filingSeq       uint64 // which open-thread filing dispatched the move, zero for a list row's
 	seen            bool   // the action was taken on the Previously Seen screen
 	err             error
 }
@@ -257,6 +258,7 @@ type mailView struct {
 	topicID          int64
 	threadPosting    mail.Posting // snapshot of the posting the open thread was opened from, zero when it has none
 	threadBoxKind    string       // the box kind the open thread files out of, following it as filings move it
+	threadFilingSeq  uint64       // dispatch order of open-thread filings, so only the latest records where the thread landed
 	topicName        string
 	entries          []mail.Entry
 	attachments      []messageAttachment
@@ -700,8 +702,10 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 	case postingActionDoneMsg:
 		v.finishMutation()
 		// A move of the open thread leaves it on screen in its new box, so later
-		// filing keys measure against where it landed, not where it was opened.
-		if msg.err == nil && v.inThread && msg.postingID == v.threadPosting.ID && msg.destinationKind != "" {
+		// filing keys measure against where it landed, not where it was opened —
+		// and only the latest dispatched filing gets to say where that is.
+		if msg.err == nil && v.inThread && msg.postingID == v.threadPosting.ID &&
+			msg.destinationKind != "" && msg.filingSeq == v.threadFilingSeq {
 			v.threadBoxKind = msg.destinationKind
 		}
 		if msg.seen {
@@ -2301,11 +2305,28 @@ func (v *mailView) imboxSource() *mail.Source {
 // Seen — has a posting row to act on: over search results, bundles, and topics
 // opened directly the key answers with a notice instead of silence.
 func (v *mailView) fileOpenThread(key string) tea.Cmd {
-	if posting := v.fileablePosting(); posting != nil {
-		return v.postingAction(key, *posting, v.threadBoxKind)
+	posting := v.fileablePosting()
+	if posting == nil {
+		v.notice = "Can't file this thread from here"
+		return nil
 	}
-	v.notice = "Can't file this thread from here"
-	return nil
+	move := v.postingAction(key, *posting, v.threadBoxKind)
+	if move == nil {
+		return nil
+	}
+	// Filing keys pressed faster than their requests answer can complete out of
+	// order, so each dispatch takes a sequence number and only the latest one
+	// records where the thread landed.
+	v.threadFilingSeq++
+	seq := v.threadFilingSeq
+	return func() tea.Msg {
+		msg := move()
+		if done, ok := msg.(postingActionDoneMsg); ok {
+			done.filingSeq = seq
+			return done
+		}
+		return msg
+	}
 }
 
 // fileablePosting is the posting the open thread files on: the snapshot taken when

--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -194,13 +194,14 @@ const (
 )
 
 type postingActionDoneMsg struct {
-	action     string
-	boxID      int64
-	sourceKind mail.Kind
-	postingID  int64
-	effect     postingActionEffect
-	seen       bool // the action was taken on the Previously Seen screen
-	err        error
+	action          string
+	boxID           int64
+	sourceKind      mail.Kind
+	postingID       int64
+	effect          postingActionEffect
+	destinationKind string // the box kind a move filed into, empty for every other action
+	seen            bool   // the action was taken on the Previously Seen screen
+	err             error
 }
 
 // postingSeenMsg reports the mark-seen that opening a thread triggers on its
@@ -255,6 +256,7 @@ type mailView struct {
 	topicContent     string
 	topicID          int64
 	threadPosting    mail.Posting // snapshot of the posting the open thread was opened from, zero when it has none
+	threadBoxKind    string       // the box kind the open thread files out of, following it as filings move it
 	topicName        string
 	entries          []mail.Entry
 	attachments      []messageAttachment
@@ -524,6 +526,7 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 		if opened := v.openedPosting(msg.postingID); opened != nil {
 			v.threadPosting = *opened
 		}
+		v.threadBoxKind = v.actionBoxKind()
 		v.topicName = msg.title
 		v.entries = msg.entries
 		v.attachments = msg.attachments
@@ -696,6 +699,11 @@ func (v *mailView) Update(msg tea.Msg) (tea.Cmd, bool) {
 
 	case postingActionDoneMsg:
 		v.finishMutation()
+		// A move of the open thread leaves it on screen in its new box, so later
+		// filing keys measure against where it landed, not where it was opened.
+		if msg.err == nil && v.inThread && msg.postingID == v.threadPosting.ID && msg.destinationKind != "" {
+			v.threadBoxKind = msg.destinationKind
+		}
 		if msg.seen {
 			return v.applySeenPostingAction(msg), true
 		}
@@ -1422,6 +1430,7 @@ func (v *mailView) ExitThread() {
 		v.inThread = false
 		v.threadNotice = ""
 		v.threadPosting = mail.Posting{}
+		v.threadBoxKind = ""
 		v.modal = nil
 		v.requests.cancel()
 		return
@@ -1603,6 +1612,7 @@ func (v *mailView) switchBox(index int) tea.Cmd {
 	v.inThread = false
 	v.threadNotice = ""
 	v.threadPosting = mail.Posting{}
+	v.threadBoxKind = ""
 	v.clearSearch()
 	v.clearBundle()
 	v.clearSeen()
@@ -1625,6 +1635,7 @@ func (v *mailView) openPreviouslySeen() tea.Cmd {
 	v.inThread = false
 	v.threadNotice = ""
 	v.threadPosting = mail.Posting{}
+	v.threadBoxKind = ""
 	v.clearSearch()
 	v.clearBundle()
 	v.notice = ""
@@ -2291,7 +2302,7 @@ func (v *mailView) imboxSource() *mail.Source {
 // opened directly the key answers with a notice instead of silence.
 func (v *mailView) fileOpenThread(key string) tea.Cmd {
 	if posting := v.fileablePosting(); posting != nil {
-		return v.postingAction(key, *posting)
+		return v.postingAction(key, *posting, v.threadBoxKind)
 	}
 	v.notice = "Can't file this thread from here"
 	return nil
@@ -2313,21 +2324,34 @@ func (v *mailView) handlePostingAction(key string) tea.Cmd {
 	if selected == nil {
 		return nil
 	}
-	return v.postingAction(key, *selected)
+	return v.postingAction(key, *selected, v.actionBoxKind())
 }
 
-func (v *mailView) postingAction(key string, p mail.Posting) tea.Cmd {
+// actionBoxKind is the box kind a list row files out of, empty over a source that
+// is not one of HEY's own boxes.
+func (v *mailView) actionBoxKind() string {
+	if source := v.actionSource(); source != nil {
+		return source.BoxKind
+	}
+	return ""
+}
+
+// postingAction runs key's action on p. fromBoxKind is the box kind the posting
+// files out of — the list's own box for a row, the box the open thread lives in
+// for a filing key pressed there — so a move to the box it is already in answers
+// with a notice instead of a request.
+func (v *mailView) postingAction(key string, p mail.Posting, fromBoxKind string) tea.Cmd {
 	boxID := v.currentBoxID()
 
 	switch key {
 	// Only lowercase moves to Reply Later: Shift+L navigates to Labels, the
 	// way Shift+K reaches Collections.
 	case "l":
-		return v.moveSelectedToKnownBox("Reply Later", hey.BoxKindLater, boxID, p.ID, func() error {
+		return v.moveSelectedToKnownBox("Reply Later", hey.BoxKindLater, fromBoxKind, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToReplyLater(v.vc.ctx, p.ID)
 		})
 	case "a", "A":
-		return v.moveSelectedToKnownBox("Set Aside", hey.BoxKindSetAside, boxID, p.ID, func() error {
+		return v.moveSelectedToKnownBox("Set Aside", hey.BoxKindSetAside, fromBoxKind, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToSetAside(v.vc.ctx, p.ID)
 		})
 	case "e", "E":
@@ -2347,13 +2371,13 @@ func (v *mailView) postingAction(key string, p mail.Posting) tea.Cmd {
 			return v.vc.sdk.Postings().MarkUnseen(v.vc.ctx, []int64{p.ID})
 		})
 	case "i", "I":
-		return v.moveSelectedToImbox(boxID, p.ID)
+		return v.moveSelectedToImbox(fromBoxKind, boxID, p.ID)
 	case "d", "D":
-		return v.moveSelectedToKnownBox("The Feed", hey.BoxKindFeed, boxID, p.ID, func() error {
+		return v.moveSelectedToKnownBox("The Feed", hey.BoxKindFeed, fromBoxKind, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToFeed(v.vc.ctx, p.ID)
 		})
 	case "p", "P":
-		return v.moveSelectedToKnownBox("Paper Trail", hey.BoxKindTrail, boxID, p.ID, func() error {
+		return v.moveSelectedToKnownBox("Paper Trail", hey.BoxKindTrail, fromBoxKind, boxID, p.ID, func() error {
 			return v.vc.sdk.Postings().MoveToPaperTrail(v.vc.ctx, p.ID)
 		})
 	case "t", "T":
@@ -2394,10 +2418,10 @@ func (v *mailView) postingAction(key string, p mail.Posting) tea.Cmd {
 	return nil
 }
 
-func (v *mailView) moveSelectedToImbox(boxID, postingID int64) tea.Cmd {
+func (v *mailView) moveSelectedToImbox(fromBoxKind string, boxID, postingID int64) tea.Cmd {
 	if source := v.imboxSource(); source != nil {
 		imboxID := source.ID
-		return v.moveSelectedToKnownBox("Imbox", hey.BoxKindImbox, boxID, postingID, func() error {
+		return v.moveSelectedToKnownBox("Imbox", hey.BoxKindImbox, fromBoxKind, boxID, postingID, func() error {
 			return v.vc.sdk.Postings().Move(v.vc.ctx, imboxID, postingID)
 		})
 	}
@@ -2405,12 +2429,23 @@ func (v *mailView) moveSelectedToImbox(boxID, postingID int64) tea.Cmd {
 	return nil
 }
 
-func (v *mailView) moveSelectedToKnownBox(name, kind string, boxID, postingID int64, fn func() error) tea.Cmd {
-	if !v.movesOutOfCurrentBox(kind) {
+func (v *mailView) moveSelectedToKnownBox(name, kind, fromBoxKind string, boxID, postingID int64, fn func() error) tea.Cmd {
+	// The destination is one of HEY's own box kinds, so the posting's kind answers
+	// whether the move would do anything — a label or a collection carries none and
+	// is never the destination.
+	if fromBoxKind == kind {
 		v.notice = "Already in " + name
 		return nil
 	}
-	return v.doPostingAction("Thread moved to "+name, v.boxMoveEffect(), boxID, postingID, fn)
+	move := v.doPostingAction("Thread moved to "+name, v.boxMoveEffect(), boxID, postingID, fn)
+	return func() tea.Msg {
+		done, ok := move().(postingActionDoneMsg)
+		if !ok {
+			return nil
+		}
+		done.destinationKind = kind
+		return done
+	}
 }
 
 func (v *mailView) boxMoveEffect() postingActionEffect {
@@ -2421,17 +2456,6 @@ func (v *mailView) boxMoveEffect() postingActionEffect {
 		return postingActionNone
 	}
 	return postingActionRemove
-}
-
-// movesOutOfCurrentBox reports whether a key that files a thread somewhere would move it
-// at all. The destination is one of HEY's own box kinds, so it is the box's kind that
-// answers — a label or a collection carries none and is never the destination.
-func (v *mailView) movesOutOfCurrentBox(destinationBoxKind string) bool {
-	source := v.actionSource()
-	if source == nil {
-		return true
-	}
-	return source.BoxKind != destinationBoxKind
 }
 
 func (v *mailView) doPostingAction(label string, effect postingActionEffect, boxID, postingID int64, fn func() error) tea.Cmd {

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -715,6 +715,48 @@ func TestMailViewFilesOpenThreadAfterLiveRefreshDropsItsRow(t *testing.T) {
 	}
 }
 
+func TestMailViewFilesOpenThreadWhereItLandedLastTime(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.boxes = append(v.boxes, mail.Source{Kind: mail.KindBox, ID: 3, Name: "Set Aside", BoxKind: hey.BoxKindSetAside})
+	v.boxIndex = len(v.boxes) - 1
+	v.Update(currentPostingsLoaded(v, testPostings()))
+	v.Update(runCmd(v.HandleContentKey(keyPress("enter"))))
+	if !v.inThread {
+		t.Fatal("enter should open the selected thread")
+	}
+
+	// The thread was opened from Set Aside, so a answers without a request.
+	if cmd := v.HandleContentKey(keyPress("a")); cmd != nil {
+		t.Errorf("filing to the box the thread is in should not move: %#v", runCmd(cmd))
+	}
+	if v.notice != "Already in Set Aside" {
+		t.Errorf("notice = %q, want %q", v.notice, "Already in Set Aside")
+	}
+
+	// Filing to Reply Later moves the thread there, and later keys measure
+	// against where it landed: l answers in place, a moves it back.
+	done, ok := runCmd(v.HandleContentKey(keyPress("l"))).(postingActionDoneMsg)
+	if !ok || done.err != nil {
+		t.Fatalf("filing command returned %#v", done)
+	}
+	v.Update(done)
+
+	if cmd := v.HandleContentKey(keyPress("l")); cmd != nil {
+		t.Errorf("filing to the box the thread landed in should not move: %#v", runCmd(cmd))
+	}
+	if v.notice != "Already in Reply Later" {
+		t.Errorf("notice = %q, want %q", v.notice, "Already in Reply Later")
+	}
+
+	done, ok = runCmd(v.HandleContentKey(keyPress("a"))).(postingActionDoneMsg)
+	if !ok || done.err != nil {
+		t.Fatalf("filing command returned %#v", done)
+	}
+	if recorded.body.BoxID == nil || *recorded.body.BoxID != 3 {
+		t.Errorf("box_id = %v, want 3", recorded.body.BoxID)
+	}
+}
+
 func TestMailViewFilesOpenThreadOnlyFromFilingLists(t *testing.T) {
 	t.Run("search result", func(t *testing.T) {
 		v := mailWithPostings()

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -755,6 +755,22 @@ func TestMailViewFilesOpenThreadWhereItLandedLastTime(t *testing.T) {
 	if recorded.body.BoxID == nil || *recorded.body.BoxID != 3 {
 		t.Errorf("box_id = %v, want 3", recorded.body.BoxID)
 	}
+
+	// Landing back in the box on screen, whose row was removed when the thread
+	// first filed away, re-reads the head so the list holds what the server does.
+	restore, _ := v.Update(done)
+	if restore == nil {
+		t.Fatal("filing back into the box on screen should re-read its head")
+	}
+	v.Update(postingsRefreshedMsg{
+		requestID:  v.liveRequestID,
+		boxID:      v.currentBoxID(),
+		sourceKind: v.currentSourceKind(),
+		postings:   testPostings(),
+	})
+	if v.postingIndex(100) == -1 {
+		t.Error("the re-read head should put the returned thread back on the list")
+	}
 }
 
 func TestMailViewFilesOpenThreadRecordsOnlyTheLatestFiling(t *testing.T) {

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -681,6 +681,40 @@ func TestMailViewFilesOpenThreadAfterMarkSeenCoversItsRow(t *testing.T) {
 	}
 }
 
+func TestMailViewFilesOpenThreadAfterLiveRefreshDropsItsRow(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.Update(runCmd(v.HandleContentKey(keyPress("enter"))))
+	if !v.inThread {
+		t.Fatal("enter should open the selected thread")
+	}
+
+	// A live refresh whose head no longer returns the opened row takes it out of
+	// the list entirely, so filing cannot go looking for it there.
+	v.Update(postingsRefreshedMsg{
+		requestID:  v.liveRequestID,
+		boxID:      v.currentBoxID(),
+		sourceKind: v.currentSourceKind(),
+		postings:   testPostings()[1:],
+	})
+	if v.postingIndex(100) != -1 {
+		t.Fatal("test needs the refresh to drop the opened row from the list")
+	}
+	if bindings := fmt.Sprint(v.HelpBindings()); !strings.Contains(bindings, "set aside") {
+		t.Errorf("thread help = %s, should keep advertising filing", bindings)
+	}
+
+	done, ok := runCmd(v.HandleContentKey(keyPress("l"))).(postingActionDoneMsg)
+	if !ok || done.err != nil {
+		t.Fatalf("filing command returned %#v", done)
+	}
+	if recorded.method != http.MethodPost || recorded.path != "/postings/moves.json" {
+		t.Errorf("request = %s %s, want POST /postings/moves.json", recorded.method, recorded.path)
+	}
+	if len(recorded.body.PostingIDs) != 1 || recorded.body.PostingIDs[0] != 100 {
+		t.Errorf("posting_ids = %v, want [100]", recorded.body.PostingIDs)
+	}
+}
+
 func TestMailViewFilesOpenThreadOnlyFromFilingLists(t *testing.T) {
 	t.Run("search result", func(t *testing.T) {
 		v := mailWithPostings()
@@ -688,7 +722,7 @@ func TestMailViewFilesOpenThreadOnlyFromFilingLists(t *testing.T) {
 		v.searchList.setPostings([]mail.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
 		v.inThread = true
 		v.topicID = 100
-		v.threadPostingID = 10
+		v.threadPosting = mail.Posting{ID: 10, TopicID: 100}
 
 		if cmd := v.HandleContentKey(keyPress("a")); cmd != nil {
 			t.Errorf("a search-opened thread should not file: %#v", runCmd(cmd))
@@ -716,7 +750,7 @@ func TestMailViewThreadHelpAdvertisesFilingKeys(t *testing.T) {
 	v := mailWithPostings()
 	v.inThread = true
 	v.topicID = 100
-	v.threadPostingID = 100
+	v.threadPosting = mail.Posting{ID: 100, TopicID: 100}
 
 	bindings := fmt.Sprint(v.HelpBindings())
 	for _, want := range []string{"reply later", "set aside"} {
@@ -725,7 +759,7 @@ func TestMailViewThreadHelpAdvertisesFilingKeys(t *testing.T) {
 		}
 	}
 
-	v.threadPostingID = 0 // opened by URL, with no posting row behind it
+	v.threadPosting = mail.Posting{} // opened by URL, with no posting row behind it
 	bindings = fmt.Sprint(v.HelpBindings())
 	for _, missing := range []string{"reply later", "set aside"} {
 		if strings.Contains(bindings, missing) {

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -757,6 +757,37 @@ func TestMailViewFilesOpenThreadWhereItLandedLastTime(t *testing.T) {
 	}
 }
 
+func TestMailViewFilesOpenThreadRecordsOnlyTheLatestFiling(t *testing.T) {
+	v, _ := mailWithTestServer(t, http.StatusNoContent)
+	v.Update(runCmd(v.HandleContentKey(keyPress("enter"))))
+	if !v.inThread {
+		t.Fatal("enter should open the selected thread")
+	}
+
+	// Two filing keys faster than their requests answer, with the responses
+	// crossing: the first-dispatched move answers last. Only the latest
+	// dispatch records where the thread landed.
+	aside := v.HandleContentKey(keyPress("a"))
+	later := v.HandleContentKey(keyPress("l"))
+	laterDone, ok := runCmd(later).(postingActionDoneMsg)
+	if !ok || laterDone.err != nil {
+		t.Fatalf("filing command returned %#v", laterDone)
+	}
+	asideDone, ok := runCmd(aside).(postingActionDoneMsg)
+	if !ok || asideDone.err != nil {
+		t.Fatalf("filing command returned %#v", asideDone)
+	}
+	v.Update(laterDone)
+	v.Update(asideDone)
+
+	if cmd := v.HandleContentKey(keyPress("l")); cmd != nil {
+		t.Errorf("the thread landed in Reply Later, so l should answer in place: %#v", runCmd(cmd))
+	}
+	if v.notice != "Already in Reply Later" {
+		t.Errorf("notice = %q, want %q", v.notice, "Already in Reply Later")
+	}
+}
+
 func TestMailViewFilesOpenThreadOnlyFromFilingLists(t *testing.T) {
 	t.Run("search result", func(t *testing.T) {
 		v := mailWithPostings()

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -606,6 +606,105 @@ func TestMailViewPostingKeysCallExpectedEndpoints(t *testing.T) {
 	}
 }
 
+func TestMailViewFilesOpenThread(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		boxID  int64
+		notice string
+	}{
+		{"reply later", "l", 4, "Thread moved to Reply Later"},
+		{"set aside", "a", 3, "Thread moved to Set Aside"},
+		{"set aside uppercase", "A", 3, "Thread moved to Set Aside"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, recorded := mailWithTestServer(t, http.StatusNoContent)
+			v.Update(runCmd(v.HandleContentKey(keyPress("enter"))))
+			if !v.inThread {
+				t.Fatal("enter should open the selected thread")
+			}
+
+			done, ok := runCmd(v.HandleContentKey(keyPress(tt.key))).(postingActionDoneMsg)
+			if !ok || done.err != nil {
+				t.Fatalf("filing command returned %#v", done)
+			}
+			if recorded.method != http.MethodPost || recorded.path != "/postings/moves.json" {
+				t.Errorf("request = %s %s, want POST /postings/moves.json", recorded.method, recorded.path)
+			}
+			if len(recorded.body.PostingIDs) != 1 || recorded.body.PostingIDs[0] != 100 {
+				t.Errorf("posting_ids = %v, want [100]", recorded.body.PostingIDs)
+			}
+			if recorded.body.BoxID == nil || *recorded.body.BoxID != tt.boxID {
+				t.Errorf("box_id = %v, want %d", recorded.body.BoxID, tt.boxID)
+			}
+
+			answer, _ := v.Update(done)
+			if toast := deliverToView(v, answer); toast != tt.notice {
+				t.Errorf("toast = %q, want %q", toast, tt.notice)
+			}
+			if !v.inThread {
+				t.Error("filing should keep the thread open, the way the web app stays on the topic")
+			}
+			if v.postingIndex(100) != -1 {
+				t.Error("the filed thread should leave the box list behind the reader")
+			}
+		})
+	}
+}
+
+func TestMailViewFilesOpenThreadOnlyFromFilingLists(t *testing.T) {
+	t.Run("search result", func(t *testing.T) {
+		v := mailWithPostings()
+		v.searchActive = true
+		v.searchList.setPostings([]mail.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
+		v.inThread = true
+		v.topicID = 100
+
+		if cmd := v.HandleContentKey(keyPress("a")); cmd != nil {
+			t.Errorf("a search-opened thread should not file: %#v", runCmd(cmd))
+		}
+		if v.notice != "Can't file this thread from here" {
+			t.Errorf("notice = %q, want the filing explanation", v.notice)
+		}
+	})
+
+	t.Run("directly opened topic", func(t *testing.T) {
+		v := mailWithPostings()
+		v.inThread = true
+		v.topicID = 555 // opened by URL, not from the selected row
+
+		if cmd := v.HandleContentKey(keyPress("l")); cmd != nil {
+			t.Errorf("a directly opened thread should not file the selected row: %#v", runCmd(cmd))
+		}
+		if v.notice != "Can't file this thread from here" {
+			t.Errorf("notice = %q, want the filing explanation", v.notice)
+		}
+	})
+}
+
+func TestMailViewThreadHelpAdvertisesFilingKeys(t *testing.T) {
+	v := mailWithPostings()
+	v.inThread = true
+	v.topicID = 100
+
+	bindings := fmt.Sprint(v.HelpBindings())
+	for _, want := range []string{"reply later", "set aside"} {
+		if !strings.Contains(bindings, want) {
+			t.Errorf("thread help = %s, want %q", bindings, want)
+		}
+	}
+
+	v.topicID = 555
+	bindings = fmt.Sprint(v.HelpBindings())
+	for _, missing := range []string{"reply later", "set aside"} {
+		if strings.Contains(bindings, missing) {
+			t.Errorf("unfilable thread help = %s, should drop %q", bindings, missing)
+		}
+	}
+}
+
 func TestMailViewUnseenKeysRestoreSeenAndBubbledUpThreads(t *testing.T) {
 	for _, testCase := range []struct {
 		name      string

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -654,6 +654,33 @@ func TestMailViewFilesOpenThread(t *testing.T) {
 	}
 }
 
+func TestMailViewFilesOpenThreadAfterMarkSeenCoversItsRow(t *testing.T) {
+	v, recorded := mailWithTestServer(t, http.StatusNoContent)
+	v.postingList.setCover(coverTopo)
+
+	opened, _ := v.Update(runCmd(v.HandleContentKey(keyPress("enter"))))
+	if !v.inThread {
+		t.Fatal("enter should open the selected thread")
+	}
+	// The mark-seen that opening triggers slides the row under the cover and
+	// clamps the cursor off it, so filing cannot go through the selection.
+	deliverToView(v, opened)
+	if p := v.actionList().selectedPosting(); p != nil && p.ID == 100 {
+		t.Fatal("mark-seen under a cover should move the cursor off the opened row")
+	}
+
+	done, ok := runCmd(v.HandleContentKey(keyPress("a"))).(postingActionDoneMsg)
+	if !ok || done.err != nil {
+		t.Fatalf("filing command returned %#v", done)
+	}
+	if recorded.method != http.MethodPost || recorded.path != "/postings/moves.json" {
+		t.Errorf("request = %s %s, want POST /postings/moves.json", recorded.method, recorded.path)
+	}
+	if len(recorded.body.PostingIDs) != 1 || recorded.body.PostingIDs[0] != 100 {
+		t.Errorf("posting_ids = %v, want [100]", recorded.body.PostingIDs)
+	}
+}
+
 func TestMailViewFilesOpenThreadOnlyFromFilingLists(t *testing.T) {
 	t.Run("search result", func(t *testing.T) {
 		v := mailWithPostings()
@@ -661,6 +688,7 @@ func TestMailViewFilesOpenThreadOnlyFromFilingLists(t *testing.T) {
 		v.searchList.setPostings([]mail.Posting{{ID: 10, TopicID: 100, Name: "Hello world"}})
 		v.inThread = true
 		v.topicID = 100
+		v.threadPostingID = 10
 
 		if cmd := v.HandleContentKey(keyPress("a")); cmd != nil {
 			t.Errorf("a search-opened thread should not file: %#v", runCmd(cmd))
@@ -673,7 +701,7 @@ func TestMailViewFilesOpenThreadOnlyFromFilingLists(t *testing.T) {
 	t.Run("directly opened topic", func(t *testing.T) {
 		v := mailWithPostings()
 		v.inThread = true
-		v.topicID = 555 // opened by URL, not from the selected row
+		v.topicID = 555 // opened by URL, with no posting row behind it
 
 		if cmd := v.HandleContentKey(keyPress("l")); cmd != nil {
 			t.Errorf("a directly opened thread should not file the selected row: %#v", runCmd(cmd))
@@ -688,6 +716,7 @@ func TestMailViewThreadHelpAdvertisesFilingKeys(t *testing.T) {
 	v := mailWithPostings()
 	v.inThread = true
 	v.topicID = 100
+	v.threadPostingID = 100
 
 	bindings := fmt.Sprint(v.HelpBindings())
 	for _, want := range []string{"reply later", "set aside"} {
@@ -696,7 +725,7 @@ func TestMailViewThreadHelpAdvertisesFilingKeys(t *testing.T) {
 		}
 	}
 
-	v.topicID = 555
+	v.threadPostingID = 0 // opened by URL, with no posting row behind it
 	bindings = fmt.Sprint(v.HelpBindings())
 	for _, missing := range []string{"reply later", "set aside"} {
 		if strings.Contains(bindings, missing) {


### PR DESCRIPTION
Customer report on [CLIs card 10240722474](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10240722474): Set Aside (`a`) and Reply Later (`l`) "not doing anything" in the TUI.

The list keys work (confirmed on the card for postings and bundles), but the web app's topic toolbar keeps its filing hotkeys live while a thread is on screen (`app/views/topics/toolbars/_action_bar.html.erb` binds `l,L` and `a,A` document-wide), so a web reader's habit is to press `a`/`l` with the email **open** — and in the TUI thread view those keys fell through to the viewport and silently scrolled.

Now `a`/`A`/`l` from an open thread route through the same posting action the list uses, when the thread was opened from a list that files (a box or Previously Seen):

- The action fires on the thread's own posting row; the reader stays on the thread, the way the web app stays on the topic, with the usual "Thread moved to …" toast and the list updated behind.
- Search results, bundles, and directly opened topics have no posting row to act on (the guard checks the selected row's topic against the open thread), so the key answers with a notice — "Can't file this thread from here" — instead of silence, which was the complaint.
- The thread help advertises `l reply later` / `a set aside` only where they work.

Scope stays on the card's two keys: the rest of the list's action set (`e`, `u`, `d`, `t`, …) is left alone because `u`/`d` are the viewport's half-page scroll keys in the open thread, so extending filing there is a keymap decision, not a bug fix.

`TMPDIR=/tmp/t make check` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `a` (Set Aside) and `l` (Reply Later) in the TUI thread view, which previously fell through to the viewport and silently scrolled. The keys now file the open thread the same way they do on the list, keeping the reader on the thread with the usual toast.

**Details**
- Filing routes through the posting the thread was opened from, snapshotted at open so the mark-seen resort or a live refresh dropping the row can't lose it; search results, bundles, and directly opened topics show a notice instead of silence.
- Filing measures against the box the open thread now lives in, so moving a thread and filing again lands it back rather than answering "Already in ...".
- Filing the thread back into the box on screen re-reads that box's head so the row returns to the list.
- Only the latest filing records where the thread landed when keys are pressed faster than their requests answer, so out-of-order responses can't file past where the server put it.
- The thread help only advertises the keys where they work.
- The rest of the list action set is untouched because `u`/`d` are the viewport's half-page scroll keys in the open thread.

<sup>Written for commit 0224bdee84d2fc587bdb08a9c008ce56d2d0596d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

