### PR TITLE
Enable the SDK's ETag response cache

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -71,6 +71,8 @@ Use --token or --cookie for non-interactive login.`,
 				if err := authMgr.LoginWithToken(token); err != nil {
 					return apierr.ErrAuth(fmt.Sprintf("could not save token: %v", err))
 				}
+				// Replaced credentials orphan whatever the old ones cached.
+				clearHTTPCache(cmd.ErrOrStderr())
 				return writeMutation(cmd, "Logged in with token", map[string]string{"method": "token"})
 			}
 
@@ -78,6 +80,8 @@ Use --token or --cookie for non-interactive login.`,
 				if err := authMgr.LoginWithCookie(cookie); err != nil {
 					return apierr.ErrAuth(fmt.Sprintf("could not save cookie: %v", err))
 				}
+				// Replaced credentials orphan whatever the old ones cached.
+				clearHTTPCache(cmd.ErrOrStderr())
 				return writeMutation(cmd, "Logged in with session cookie", map[string]string{"method": "cookie"})
 			}
 
@@ -87,6 +91,8 @@ Use --token or --cookie for non-interactive login.`,
 			if err := authMgr.Login(ctx, auth.LoginOptions{NoBrowser: noBrowser}); err != nil {
 				return apierr.ErrAuth(fmt.Sprintf("login failed: %v", err))
 			}
+			// Replaced credentials orphan whatever the old ones cached.
+			clearHTTPCache(cmd.ErrOrStderr())
 
 			if writer.IsStyled() {
 				w := cmd.OutOrStdout()
@@ -128,7 +134,7 @@ func buildLogoutCommand(path string) *cobra.Command {
 				return apierr.ErrAuth(fmt.Sprintf("could not clear credentials: %v", err))
 			}
 			// Cached mail must not outlive the credentials that fetched it.
-			clearHTTPCache()
+			clearHTTPCache(cmd.ErrOrStderr())
 			return writeMutation(cmd, "Logged out", nil)
 		},
 	}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -127,6 +127,8 @@ func buildLogoutCommand(path string) *cobra.Command {
 			if err := authMgr.Logout(); err != nil {
 				return apierr.ErrAuth(fmt.Sprintf("could not clear credentials: %v", err))
 			}
+			// Cached mail must not outlive the credentials that fetched it.
+			clearHTTPCache()
 			return writeMutation(cmd, "Logged out", nil)
 		},
 	}

--- a/internal/cmd/sdk.go
+++ b/internal/cmd/sdk.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -76,8 +77,15 @@ var sdkStats *statsHooks
 // initSDK creates the SDK client, bridging the CLI's auth and config.
 func initSDK(authMgr *auth.Manager, baseURL string) {
 	sdkCfg := &hey.Config{
-		BaseURL:      baseURL,
-		CacheEnabled: false,
+		BaseURL: baseURL,
+	}
+
+	// The SDK cache is a revalidation cache: every read still asks the server,
+	// conditionally, and only a 304 is answered from disk — so it can never serve
+	// stale mail. Logout clears it so cached mail does not outlive its credentials.
+	if dir := httpCacheDir(); dir != "" {
+		sdkCfg.CacheDir = dir
+		sdkCfg.CacheEnabled = true
 	}
 
 	var opts []hey.ClientOption
@@ -95,6 +103,22 @@ func initSDK(authMgr *auth.Manager, baseURL string) {
 	sdkClientOpts = opts
 	rootSDK = hey.NewClient(sdkCfg, nil, opts...)
 	sdk = rootSDK
+}
+
+// httpCacheDir is where the SDK keeps its ETag response cache, or empty when no
+// cache location can be resolved, which leaves caching off.
+func httpCacheDir() string {
+	if dir := config.CacheDir(); dir != "" {
+		return filepath.Join(dir, "http")
+	}
+	return ""
+}
+
+// clearHTTPCache drops the SDK's response cache.
+func clearHTTPCache() {
+	if dir := httpCacheDir(); dir != "" {
+		_ = hey.NewCache(dir).Clear()
+	}
 }
 
 // newSDKClient builds another client sharing the CLI's configuration — auth,

--- a/internal/cmd/sdk.go
+++ b/internal/cmd/sdk.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -114,10 +115,17 @@ func httpCacheDir() string {
 	return ""
 }
 
-// clearHTTPCache drops the SDK's response cache.
-func clearHTTPCache() {
-	if dir := httpCacheDir(); dir != "" {
-		_ = hey.NewCache(dir).Clear()
+// clearHTTPCache drops the SDK's response cache. It runs after a credential
+// change has already happened, so a failure is reported rather than failing
+// the command that carried it: the warning names the directory left to
+// remove by hand.
+func clearHTTPCache(errOut io.Writer) {
+	dir := httpCacheDir()
+	if dir == "" {
+		return
+	}
+	if err := hey.NewCache(dir).Clear(); err != nil {
+		fmt.Fprintf(errOut, "warning: could not clear cached responses in %s: %v\n", dir, err)
 	}
 }
 

--- a/internal/cmd/sdk_cache_test.go
+++ b/internal/cmd/sdk_cache_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/basecamp/hey-cli/internal/auth"
+)
+
+func TestInitSDKEnablesTheRevalidationCache(t *testing.T) {
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+
+	initSDK(auth.NewManager("https://app.hey.com", nil, t.TempDir()), "https://app.hey.com")
+
+	if !sdkClientCfg.CacheEnabled {
+		t.Error("expected the SDK cache enabled")
+	}
+	if want := filepath.Join(cacheHome, "hey-cli", "http"); sdkClientCfg.CacheDir != want {
+		t.Errorf("cache dir = %q, want %q", sdkClientCfg.CacheDir, want)
+	}
+}
+
+func TestLogoutClearsTheHTTPCache(t *testing.T) {
+	configHome := t.TempDir()
+	responses := filepath.Join(configHome, "hey-cli", "http", "responses")
+	if err := os.MkdirAll(responses, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		filepath.Join(responses, "abc123.body"):                    `{"cached":"mail"}`,
+		filepath.Join(configHome, "hey-cli", "http", "etags.json"): `{"abc123":"\"v1\""}`,
+	} {
+		if err := os.WriteFile(name, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, _, err := runAuthCommand(t, configHome, "https://app.hey.com", "", true, "auth", "login", "--cookie", "session-cookie"); err != nil {
+		t.Fatalf("auth login: %v", err)
+	}
+	if _, logout, err := runAuthCommand(t, configHome, "https://app.hey.com", "", true, "auth", "logout"); err != nil || logout.Summary != "Logged out" {
+		t.Fatalf("auth logout: %v (%q)", err, logout.Summary)
+	}
+
+	if _, err := os.Stat(responses); !os.IsNotExist(err) {
+		t.Error("expected logout to drop the cached responses")
+	}
+	if _, err := os.Stat(filepath.Join(configHome, "hey-cli", "http", "etags.json")); !os.IsNotExist(err) {
+		t.Error("expected logout to drop the cached ETags")
+	}
+}

--- a/internal/cmd/sdk_cache_test.go
+++ b/internal/cmd/sdk_cache_test.go
@@ -22,6 +22,35 @@ func TestInitSDKEnablesTheRevalidationCache(t *testing.T) {
 	}
 }
 
+// A login over standing credentials replaces them, orphaning whatever the old
+// ones cached: the replacement clears the cache without waiting for a logout.
+func TestLoginReplacingCredentialsClearsTheHTTPCache(t *testing.T) {
+	configHome := t.TempDir()
+	responses := filepath.Join(configHome, "hey-cli", "http", "responses")
+	if err := os.MkdirAll(responses, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		filepath.Join(responses, "abc123.body"):                    `{"cached":"mail"}`,
+		filepath.Join(configHome, "hey-cli", "http", "etags.json"): `{"abc123":"\"v1\""}`,
+	} {
+		if err := os.WriteFile(name, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, _, err := runAuthCommand(t, configHome, "https://app.hey.com", "", true, "auth", "login", "--cookie", "replacement-cookie"); err != nil {
+		t.Fatalf("auth login: %v", err)
+	}
+
+	if _, err := os.Stat(responses); !os.IsNotExist(err) {
+		t.Error("expected login to drop the previous credentials' cached responses")
+	}
+	if _, err := os.Stat(filepath.Join(configHome, "hey-cli", "http", "etags.json")); !os.IsNotExist(err) {
+		t.Error("expected login to drop the previous credentials' cached ETags")
+	}
+}
+
 func TestLogoutClearsTheHTTPCache(t *testing.T) {
 	configHome := t.TempDir()
 	responses := filepath.Join(configHome, "hey-cli", "http", "responses")

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -296,6 +296,8 @@ var loginInteractively = func(out io.Writer) error {
 	if err := authMgr.Login(ctx, auth.LoginOptions{Logger: logger}); err != nil {
 		return apierr.ErrAuth(fmt.Sprintf("login failed: %v", err))
 	}
+	// Replaced credentials orphan whatever the old ones cached.
+	clearHTTPCache(out)
 	return selectConfiguredAccount(context.Background())
 }
 


### PR DESCRIPTION
The CLI has run with `CacheEnabled: false` since the SDK migration (#23), so no request ever revalidated with `If-None-Match` and every read refetched full bodies the server had already told us hadn't changed — while HEY serves ETags broadly and answers conditionals with 304s.

The SDK cache is a revalidation cache: every read still asks the server, conditionally, and only a 304 is answered from disk — so enabling it can never serve stale mail. Specifics:

- The cache lives under the CLI's cache directory at `hey-cli/http` (XDG-aware); when no cache location resolves, caching stays off.
- Logout drops the cache, so cached mail does not outlive the credentials that fetched it.
- Cookie-session auth never caches (the SDK keys entries by the Authorization header), so nothing changes there.

Safe to merge independently of the SDK: the cache is inert where ETags aren't wired. Generated operations start revalidating once the SDK dependency carries basecamp/hey-sdk#140; until then the cache covers the hand-written request paths.

Card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10240004704

`TMPDIR=/tmp/t make check` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the SDK's ETag response cache so reads revalidate with `If-None-Match` and serve 304s from disk instead of refetching unchanged bodies. Replacing credentials—logout or login over standing credentials—clears the cache, so cached mail never outlives the credentials that fetched it.

- The cache lives at `hey-cli/http` under the CLI's XDG-aware cache directory; when no cache location resolves, caching stays off.
- Cookie-session auth is unaffected because the SDK keys cache entries by the Authorization header.
- Generated operations start revalidating once the SDK dependency carries `basecamp/hey-sdk#140`; until then, the cache covers the hand-written request paths only.

<sup>Written for commit 1c79b05e2c777af0e52b8c037fdb23528f6eb7e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

