### PR TITLE
Add OAuth device authorization login

### DIFF
--- a/.surface
+++ b/.surface
@@ -25,6 +25,7 @@ hey attachment save --output
 hey auth
 hey auth login
 hey auth login --cookie
+hey auth login --device
 hey auth login --no-browser
 hey auth login --token
 hey auth logout
@@ -268,6 +269,7 @@ hey label view --limit
 hey label view --page
 hey login
 hey login --cookie
+hey login --device
 hey login --no-browser
 hey login --token
 hey logout

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,6 +43,9 @@ scripts and agents can handle it.
 # Browser-based OAuth against HEY's own OAuth server (primary method)
 hey auth login
 
+# Or sign in from a headless machine using a code on another device
+hey auth login --device
+
 # Or use a pre-generated token
 hey auth login --token TOKEN
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -31,6 +31,7 @@ type Manager struct {
 	httpClient   *http.Client
 	callbackWait callbackWaiter
 	listen       listenerFactory
+	wait         func(context.Context, time.Duration) error
 	mu           sync.Mutex
 }
 
@@ -42,6 +43,18 @@ func NewManager(baseURL string, httpClient *http.Client, configDir string) *Mana
 		store:      NewStore(configDir),
 		httpClient: httpClient,
 		listen:     listenConfig.Listen,
+		wait:       waitForDuration,
+	}
+}
+
+func waitForDuration(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 
@@ -150,6 +163,19 @@ type LoginOptions struct {
 	Logger func(msg string)
 }
 
+// DeviceLoginOptions configures OAuth device authorization login.
+type DeviceLoginOptions struct {
+	Logger func(msg string)
+}
+
+func (o DeviceLoginOptions) log(msg string) {
+	if o.Logger != nil {
+		o.Logger(msg)
+		return
+	}
+	fmt.Fprint(os.Stderr, msg)
+}
+
 // log routes a progress message to the configured Logger, or to os.Stderr
 // verbatim when none is set so `hey auth login` output stays as it was.
 func (o LoginOptions) log(msg string) {
@@ -226,6 +252,67 @@ func (m *Manager) Login(ctx context.Context, opts LoginOptions) error {
 	}
 
 	return m.store.Save(m.baseURL, creds)
+}
+
+// LoginDevice authenticates using the OAuth 2.0 Device Authorization Grant (RFC 8628).
+func (m *Manager) LoginDevice(ctx context.Context, opts DeviceLoginOptions) error {
+	deviceEndpoint := m.baseURL + "/oauth/device_authorizations"
+	tokenEndpoint := m.baseURL + "/oauth/tokens"
+	installID, err := m.store.InstallID()
+	if err != nil {
+		return fmt.Errorf("install id: %w", err)
+	}
+
+	authorization, err := requestDeviceAuthorization(ctx, m.httpClient, deviceEndpoint, oauthClientID, installID)
+	if err != nil {
+		return err
+	}
+	opts.log(fmt.Sprintf("Open %s and enter code: %s\n", authorization.VerificationURI, authorization.UserCode))
+	if authorization.VerificationURIComplete != "" {
+		opts.log(fmt.Sprintf("Direct link: %s\n", authorization.VerificationURIComplete))
+	}
+	opts.log("Waiting for authorization...\n")
+
+	interval := time.Duration(authorization.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	expiresAt := time.Now().Add(time.Duration(authorization.ExpiresIn) * time.Second)
+	firstPoll := true
+
+	for {
+		if time.Now().After(expiresAt) {
+			return errors.New("device authorization expired")
+		}
+		if !firstPoll {
+			if err := m.wait(ctx, interval); err != nil {
+				return err
+			}
+		}
+		firstPoll = false
+
+		token, oauthErr, err := exchangeDeviceCode(ctx, m.httpClient, tokenEndpoint, authorization.DeviceCode, oauthClientID, installID)
+		if err != nil {
+			return err
+		}
+		switch oauthErr {
+		case "":
+			creds := &Credentials{AccessToken: token.AccessToken, RefreshToken: token.RefreshToken, OAuthType: "oauth", TokenEndpoint: tokenEndpoint}
+			if !token.ExpiresAt.IsZero() {
+				creds.ExpiresAt = token.ExpiresAt.Unix()
+			}
+			return m.store.Save(m.baseURL, creds)
+		case "authorization_pending":
+		case "slow_down":
+			interval += 5 * time.Second
+		case "access_denied":
+			return errors.New("device authorization was denied")
+		case "expired_token":
+			return errors.New("device authorization expired")
+		default:
+			return fmt.Errorf("device authorization failed: %s", oauthErr)
+		}
+	}
 }
 
 // LoginWithToken stores a pre-provided bearer token.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -165,22 +165,20 @@ type LoginOptions struct {
 
 // DeviceLoginOptions configures OAuth device authorization login.
 type DeviceLoginOptions struct {
+	// Logger receives login progress messages (the verification URL and user
+	// code, the waiting notice). Nil keeps the default os.Stderr output.
 	Logger func(msg string)
 }
 
-func (o DeviceLoginOptions) log(msg string) {
-	if o.Logger != nil {
-		o.Logger(msg)
-		return
-	}
-	fmt.Fprint(os.Stderr, msg)
-}
+func (o DeviceLoginOptions) log(msg string) { logProgress(o.Logger, msg) }
 
 // log routes a progress message to the configured Logger, or to os.Stderr
 // verbatim when none is set so `hey auth login` output stays as it was.
-func (o LoginOptions) log(msg string) {
-	if o.Logger != nil {
-		o.Logger(msg)
+func (o LoginOptions) log(msg string) { logProgress(o.Logger, msg) }
+
+func logProgress(logger func(msg string), msg string) {
+	if logger != nil {
+		logger(msg)
 		return
 	}
 	fmt.Fprint(os.Stderr, msg)
@@ -278,19 +276,8 @@ func (m *Manager) LoginDevice(ctx context.Context, opts DeviceLoginOptions) erro
 		interval = 5 * time.Second
 	}
 	expiresAt := time.Now().Add(time.Duration(authorization.ExpiresIn) * time.Second)
-	firstPoll := true
 
 	for {
-		if time.Now().After(expiresAt) {
-			return errors.New("device authorization expired")
-		}
-		if !firstPoll {
-			if err := m.wait(ctx, interval); err != nil {
-				return err
-			}
-		}
-		firstPoll = false
-
 		token, oauthErr, err := exchangeDeviceCode(ctx, m.httpClient, tokenEndpoint, authorization.DeviceCode, oauthClientID, installID)
 		if err != nil {
 			return err
@@ -311,6 +298,16 @@ func (m *Manager) LoginDevice(ctx context.Context, opts DeviceLoginOptions) erro
 			return errors.New("device authorization expired")
 		default:
 			return fmt.Errorf("device authorization failed: %s", oauthErr)
+		}
+
+		// The wait never outlives the code, and an expired code is not polled again.
+		if remaining := time.Until(expiresAt); remaining > 0 {
+			if err := m.wait(ctx, min(interval, remaining)); err != nil {
+				return err
+			}
+		}
+		if !time.Now().Before(expiresAt) {
+			return errors.New("device authorization expired")
 		}
 	}
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -30,6 +30,7 @@ func TestHEYTokenPrecedence(t *testing.T) {
 
 	t.Setenv("HEY_TOKEN", "env-token-123")
 	mgr := testManager(t, server)
+	mgr.wait = func(context.Context, time.Duration) error { return nil }
 
 	token, err := mgr.AccessToken(context.Background())
 	if err != nil {
@@ -226,6 +227,44 @@ func TestLoginDoesNotSaveCredentialsOnFailure(t *testing.T) {
 				t.Fatal("credentials were saved after failed login")
 			}
 		})
+	}
+}
+
+func TestLoginDevice(t *testing.T) {
+	var polls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/device_authorizations":
+			_, _ = io.WriteString(w, `{"device_code":"secret","user_code":"ABCD-EFGH","verification_uri":"https://example.test/device","expires_in":60,"interval":0}`)
+		case "/oauth/tokens":
+			polls++
+			if polls == 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"error":"authorization_pending"}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"access_token":"device-access","refresh_token":"device-refresh","expires_in":3600}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	mgr := testManager(t, server)
+	mgr.wait = func(context.Context, time.Duration) error { return nil }
+	var messages strings.Builder
+	if err := mgr.LoginDevice(t.Context(), DeviceLoginOptions{Logger: func(msg string) { messages.WriteString(msg) }}); err != nil {
+		t.Fatalf("LoginDevice: %v", err)
+	}
+	if !strings.Contains(messages.String(), "ABCD-EFGH") || strings.Contains(messages.String(), "secret") {
+		t.Errorf("login messages = %q", messages.String())
+	}
+	creds, err := mgr.GetStore().Load(mgr.CredentialKey())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if creds.AccessToken != "device-access" || creds.RefreshToken != "device-refresh" {
+		t.Errorf("credentials = %#v", creds)
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -268,6 +268,43 @@ func TestLoginDevice(t *testing.T) {
 	}
 }
 
+// The server's expires_in bounds the polling: a wait never runs past it, and a
+// device code that expired while waiting is not exchanged again.
+func TestLoginDeviceStopsPollingAtExpiry(t *testing.T) {
+	var polls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/device_authorizations":
+			_, _ = io.WriteString(w, `{"device_code":"secret","user_code":"ABCD-EFGH","verification_uri":"https://example.test/device","expires_in":1,"interval":30}`)
+		case "/oauth/tokens":
+			polls++
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `{"error":"authorization_pending"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	mgr := testManager(t, server)
+	var waits []time.Duration
+	mgr.wait = func(_ context.Context, d time.Duration) error {
+		waits = append(waits, d)
+		time.Sleep(d + 50*time.Millisecond) // a timer fires at or after d, never before
+		return nil
+	}
+	err := mgr.LoginDevice(t.Context(), DeviceLoginOptions{Logger: func(string) {}})
+	if err == nil || !strings.Contains(err.Error(), "expired") {
+		t.Fatalf("LoginDevice error = %v, want expiry", err)
+	}
+	if len(waits) != 1 || waits[0] > time.Second {
+		t.Errorf("waits = %v, want one wait capped at the remaining second", waits)
+	}
+	if polls != 1 {
+		t.Errorf("polls = %d, want one before expiry", polls)
+	}
+}
+
 func TestWaitForCallback(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,6 +24,96 @@ type OAuthToken struct {
 	TokenType    string    `json:"token_type"`
 	ExpiresIn    int64     `json:"expires_in"`
 	ExpiresAt    time.Time `json:"-"`
+}
+
+// DeviceAuthorization represents an RFC 8628 device authorization response.
+type DeviceAuthorization struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int64  `json:"expires_in"`
+	Interval                int64  `json:"interval"`
+}
+
+type deviceTokenError struct {
+	Code string `json:"error"`
+}
+
+func requestDeviceAuthorization(ctx context.Context, httpClient *http.Client, endpoint, clientID, installID string) (*DeviceAuthorization, error) {
+	data := url.Values{"client_id": {clientID}, "install_id": {installID}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating device authorization request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", version.UserAgent())
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("device authorization request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return nil, fmt.Errorf("reading device authorization response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("device authorization failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var authorization DeviceAuthorization
+	if err := json.Unmarshal(body, &authorization); err != nil {
+		return nil, fmt.Errorf("parsing device authorization response: %w", err)
+	}
+	if authorization.DeviceCode == "" || authorization.UserCode == "" || authorization.VerificationURI == "" || authorization.ExpiresIn <= 0 {
+		return nil, errors.New("device authorization response is missing required fields")
+	}
+	return &authorization, nil
+}
+
+func exchangeDeviceCode(ctx context.Context, httpClient *http.Client, tokenEndpoint, deviceCode, clientID, installID string) (*OAuthToken, string, error) {
+	data := url.Values{
+		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+		"device_code": {deviceCode},
+		"client_id":   {clientID},
+		"install_id":  {installID},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, "", fmt.Errorf("creating device token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", version.UserAgent())
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("device token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return nil, "", fmt.Errorf("reading device token response: %w", err)
+	}
+	if resp.StatusCode == http.StatusOK {
+		var token OAuthToken
+		if err := json.Unmarshal(body, &token); err != nil {
+			return nil, "", fmt.Errorf("parsing device token response: %w", err)
+		}
+		if token.AccessToken == "" {
+			return nil, "", errors.New("device token response is missing access_token")
+		}
+		if token.ExpiresIn > 0 {
+			token.ExpiresAt = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
+		}
+		return &token, "", nil
+	}
+
+	var oauthErr deviceTokenError
+	if err := json.Unmarshal(body, &oauthErr); err == nil && oauthErr.Code != "" && (resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusForbidden) {
+		return nil, oauthErr.Code, nil
+	}
+	return nil, "", fmt.Errorf("device token exchange failed (status %d): %s", resp.StatusCode, string(body))
 }
 
 // exchangeCode exchanges an authorization code for tokens using PKCE.

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -91,6 +91,51 @@ func TestRefreshOAuthTokenRequest(t *testing.T) {
 	}
 }
 
+func TestDeviceAuthorizationAndTokenRequests(t *testing.T) {
+	var polls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		switch r.URL.Path {
+		case "/device":
+			if r.Form.Get("client_id") != "client" || r.Form.Get("install_id") != "install" {
+				t.Errorf("device form = %v", r.Form)
+			}
+			_, _ = io.WriteString(w, `{"device_code":"device-secret","user_code":"ABCD-EFGH","verification_uri":"https://example.test/device","verification_uri_complete":"https://example.test/device?code=ABCD-EFGH","expires_in":600,"interval":5}`)
+		case "/token":
+			polls++
+			if r.Form.Get("grant_type") != "urn:ietf:params:oauth:grant-type:device_code" || r.Form.Get("device_code") != "device-secret" {
+				t.Errorf("token form = %v", r.Form)
+			}
+			if polls == 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"error":"authorization_pending"}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"access_token":"access","refresh_token":"refresh","expires_in":3600}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	authorization, err := requestDeviceAuthorization(t.Context(), server.Client(), server.URL+"/device", "client", "install")
+	if err != nil {
+		t.Fatalf("requestDeviceAuthorization: %v", err)
+	}
+	if authorization.UserCode != "ABCD-EFGH" || authorization.Interval != 5 {
+		t.Errorf("authorization = %#v", authorization)
+	}
+	if _, pending, err := exchangeDeviceCode(t.Context(), server.Client(), server.URL+"/token", authorization.DeviceCode, "client", "install"); err != nil || pending != "authorization_pending" {
+		t.Fatalf("pending exchange = %q, %v", pending, err)
+	}
+	token, pending, err := exchangeDeviceCode(t.Context(), server.Client(), server.URL+"/token", authorization.DeviceCode, "client", "install")
+	if err != nil || pending != "" || token.AccessToken != "access" {
+		t.Fatalf("token exchange = %#v, %q, %v", token, pending, err)
+	}
+}
+
 func TestOAuthTokenResponseFailures(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -97,11 +97,14 @@ func TestDeviceAuthorizationAndTokenRequests(t *testing.T) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("ParseForm: %v", err)
 		}
+		if r.Method != http.MethodPost || r.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+			t.Errorf("%s request = %s %s", r.URL.Path, r.Method, r.Header.Get("Content-Type"))
+		}
+		if r.Form.Get("client_id") != "client" || r.Form.Get("install_id") != "install" {
+			t.Errorf("%s form = %v", r.URL.Path, r.Form)
+		}
 		switch r.URL.Path {
 		case "/device":
-			if r.Form.Get("client_id") != "client" || r.Form.Get("install_id") != "install" {
-				t.Errorf("device form = %v", r.Form)
-			}
 			_, _ = io.WriteString(w, `{"device_code":"device-secret","user_code":"ABCD-EFGH","verification_uri":"https://example.test/device","verification_uri_complete":"https://example.test/device?code=ABCD-EFGH","expires_in":600,"interval":5}`)
 		case "/token":
 			polls++

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -51,6 +51,7 @@ func buildLoginCommand(path string) *cobra.Command {
 		token     string
 		cookie    string
 		noBrowser bool
+		device    bool
 	)
 
 	cmd := &cobra.Command{
@@ -59,14 +60,24 @@ func buildLoginCommand(path string) *cobra.Command {
 		Long: `Authenticate with the HEY server.
 
 Opens a browser for OAuth authentication against HEY's own OAuth server, using PKCE.
-Use --token or --cookie for non-interactive login.`,
+Use --device on a headless machine, or --token/--cookie with an existing credential.`,
 		Example: strings.Join([]string{
 			"  " + path,
 			"  " + path + " --token YOUR_BEARER_TOKEN",
 			"  " + path + " --cookie SESSION_COOKIE_VALUE",
 			"  " + path + " --no-browser",
+			"  " + path + " --device",
 		}, "\n"),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			selected := 0
+			for _, active := range []bool{token != "", cookie != "", noBrowser, device} {
+				if active {
+					selected++
+				}
+			}
+			if selected > 1 {
+				return apierr.ErrUsage("choose only one of --device, --no-browser, --token, or --cookie")
+			}
 			if token != "" {
 				if err := authMgr.LoginWithToken(token); err != nil {
 					return apierr.ErrAuth(fmt.Sprintf("could not save token: %v", err))
@@ -83,6 +94,16 @@ Use --token or --cookie for non-interactive login.`,
 				// Replaced credentials orphan whatever the old ones cached.
 				clearHTTPCache(cmd.ErrOrStderr())
 				return writeMutation(cmd, "Logged in with session cookie", map[string]string{"method": "cookie"})
+			}
+
+			if device {
+				ctx, cancel := context.WithTimeout(cmd.Context(), 16*time.Minute)
+				defer cancel()
+				if err := authMgr.LoginDevice(ctx, auth.DeviceLoginOptions{}); err != nil {
+					return apierr.ErrAuth(fmt.Sprintf("login failed: %v", err))
+				}
+				clearHTTPCache(cmd.ErrOrStderr())
+				return writeMutation(cmd, "Logged in successfully", map[string]string{"method": "device"})
 			}
 
 			ctx, cancel := context.WithTimeout(cmd.Context(), 6*time.Minute)
@@ -112,6 +133,7 @@ Use --token or --cookie for non-interactive login.`,
 	cmd.Flags().StringVar(&token, "token", "", "Pre-generated Bearer token")
 	cmd.Flags().StringVar(&cookie, "cookie", "", "Session cookie value from browser (session_token)")
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Don't open browser, print URL instead")
+	cmd.Flags().BoolVar(&device, "device", false, "Use device authorization for headless sign-in")
 
 	return cmd
 }

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -70,13 +70,16 @@ Use --device on a headless machine, or --token/--cookie with an existing credent
 		}, "\n"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			selected := 0
-			for _, active := range []bool{token != "", cookie != "", noBrowser, device} {
+			for _, active := range []bool{token != "", cookie != "", device} {
 				if active {
 					selected++
 				}
 			}
 			if selected > 1 {
-				return apierr.ErrUsage("choose only one of --device, --no-browser, --token, or --cookie")
+				return apierr.ErrUsage("choose only one of --device, --token, or --cookie")
+			}
+			if device && noBrowser {
+				return apierr.ErrUsage("--no-browser cannot be combined with --device")
 			}
 			if token != "" {
 				if err := authMgr.LoginWithToken(token); err != nil {
@@ -97,9 +100,8 @@ Use --device on a headless machine, or --token/--cookie with an existing credent
 			}
 
 			if device {
-				ctx, cancel := context.WithTimeout(cmd.Context(), 16*time.Minute)
-				defer cancel()
-				if err := authMgr.LoginDevice(ctx, auth.DeviceLoginOptions{}); err != nil {
+				// The server's expires_in bounds the wait; Ctrl-C ends it early.
+				if err := authMgr.LoginDevice(cmd.Context(), auth.DeviceLoginOptions{}); err != nil {
 					return apierr.ErrAuth(fmt.Sprintf("login failed: %v", err))
 				}
 				clearHTTPCache(cmd.ErrOrStderr())

--- a/internal/cmd/auth_commands_test.go
+++ b/internal/cmd/auth_commands_test.go
@@ -119,6 +119,15 @@ func TestAuthTokenLoginAndStoredTokenOutput(t *testing.T) {
 	}
 }
 
+func TestAuthLoginRejectsConflictingMethods(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	_, _, err := runAuthCommand(t, t.TempDir(), server.URL, "", true, "auth", "login", "--device", "--no-browser")
+	if err == nil || !strings.Contains(err.Error(), "choose only one") {
+		t.Fatalf("error = %v, want conflicting method error", err)
+	}
+}
+
 // A session cookie is sent as a Cookie header, so printing it as a bearer token gave
 // the caller something that 401s with nothing to explain it -- and put the cookie in
 // their shell history.

--- a/internal/cmd/auth_commands_test.go
+++ b/internal/cmd/auth_commands_test.go
@@ -122,9 +122,33 @@ func TestAuthTokenLoginAndStoredTokenOutput(t *testing.T) {
 func TestAuthLoginRejectsConflictingMethods(t *testing.T) {
 	server := httptest.NewServer(http.NotFoundHandler())
 	defer server.Close()
-	_, _, err := runAuthCommand(t, t.TempDir(), server.URL, "", true, "auth", "login", "--device", "--no-browser")
-	if err == nil || !strings.Contains(err.Error(), "choose only one") {
-		t.Fatalf("error = %v, want conflicting method error", err)
+	for _, test := range []struct {
+		args []string
+		want string
+	}{
+		{args: []string{"--device", "--no-browser"}, want: "--no-browser cannot be combined with --device"},
+		{args: []string{"--device", "--token", "abc"}, want: "choose only one"},
+		{args: []string{"--token", "abc", "--cookie", "xyz"}, want: "choose only one"},
+	} {
+		args := append([]string{"auth", "login"}, test.args...)
+		_, _, err := runAuthCommand(t, t.TempDir(), server.URL, "", true, args...)
+		if err == nil || !strings.Contains(err.Error(), test.want) {
+			t.Errorf("hey %s error = %v, want %q", strings.Join(args, " "), err, test.want)
+		}
+	}
+}
+
+// --no-browser only shapes the browser flow; alongside --token or --cookie it is
+// ignored, as it was before --device arrived.
+func TestAuthLoginTokenIgnoresNoBrowser(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	stdout, _, err := runAuthCommand(t, t.TempDir(), server.URL, "", true, "auth", "login", "--token", "abc", "--no-browser")
+	if err != nil {
+		t.Fatalf("hey auth login --token --no-browser: %v", err)
+	}
+	if !strings.Contains(stdout, "Logged in with token") {
+		t.Errorf("stdout = %q, want token login", stdout)
 	}
 }
 

--- a/skills/hey/SKILL.md
+++ b/skills/hey/SKILL.md
@@ -151,6 +151,7 @@ notice on stderr. Both need list data, so they work on `hey box list`, `hey box 
 | Task | Command |
 |------|---------|
 | List linked mail accounts | `hey account list --json` |
+| Sign in on a headless machine | `hey auth login --device` |
 | Set default mail account | `hey account use <id\|all>` |
 | Run once for one account | `hey --account <id> box list --json` |
 | Review trusted local settings | `hey config trusted-locals --json` |


### PR DESCRIPTION
## Summary

- add `hey auth login --device` and the matching `hey login --device` shortcut
- request and display an RFC 8628 user code without exposing the secret device code
- poll the token endpoint with the server interval, `slow_down` backoff, expiry, cancellation, denial, and refresh-token persistence
- document the headless sign-in command and update the committed CLI surface
- cover request shapes, pending/success behavior, credential storage, and conflicting login flags with unit tests

Closes #381.

## Server dependency

This PR implements and tests only the CLI side. It expects HEY to provide:

- `POST /oauth/device_authorizations`
- a HEY-hosted `verification_uri` page for user code entry/approval
- device-code grant support at `POST /oauth/tokens`

Until those server/web pieces exist, `--device` will return the device-authorization endpoint error. Endpoint names and response details can be adjusted to match the HEY implementation during review.

## Verification

- `make check`
- `go test ./internal/auth ./internal/cmd`
- `make fmt-check`
- `make lint`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `hey auth login --device` (and the `hey login --device` shortcut) for signing in on headless machines using the OAuth device authorization grant (RFC 8628). Users see a short user code to enter at a verification URL; the secret device code is never displayed.

- Polls the token endpoint using the server's interval and `expires_in` lifetime, handling `slow_down`, `expired_token`, and `access_denied`; success saves access and refresh tokens.
- `--device` cannot be combined with `--token`, `--cookie`, or `--no-browser`; `--no-browser` with `--token`/`--cookie` still works as before.
- Requires HEY to provide `POST /oauth/device_authorizations` and device-code grant support at `POST /oauth/tokens`; until those exist, `--device` returns the endpoint error. Closes #381.

<sup>Written for commit 15a4d5919919e0124bd83c8035f1cc3bfe5baccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

