### PR TITLE
Avoid duplicate HEY skills in Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ docs/omarchy.md.
 Coding-agent integration lives in `internal/harness` (agent registry, Claude Code / Codex
 detection, plugin and skill health checks) and `internal/cmd/setup_agent*.go` (`hey setup
 claude|codex|agents`). Claude Code gets the `hey@37signals` plugin from `basecamp/claude-plugins`
-plus a skill link; Codex gets the skill only until a `.codex-plugin` ships. `HEY_SETUP_AGENT`
+plus a skill link; Codex discovers the shared `~/.agents` skill directly. `HEY_SETUP_AGENT`
 selects the target for `hey setup agents`; `hey setup agents --remove` uninstalls the
 Claude plugin and removes only hey-cli-managed skill files. `hey doctor` reports per-agent diagnostics, and a
 `PersistentPostRunE` hook (`skill_refresh.go`) re-syncs installed skill copies once per release

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,7 +14,7 @@ manage the integrations on their own:
 
 ```bash
 hey setup claude    # install the skill and the hey@37signals plugin for Claude Code
-hey setup codex     # install the skill for Codex
+hey setup codex     # install the shared skill for Codex
 hey skill install   # install the skill only (~/.agents/skills/hey, linked for detected agents)
 hey setup agents             # non-interactive: skill + a single detected agent (the installer uses this)
 hey setup agents --remove    # remove HEY's managed skills and Claude Code plugin
@@ -26,6 +26,12 @@ the skill only and lists the `hey setup <agent>` choices. `HEY_SETUP_AGENT=claud
 picks explicitly. `HEY_NONINTERACTIVE=1` disables interactive sign-in for harnesses that
 run hey under a pseudo-terminal. The installed skill is refreshed automatically the first
 time a new hey release runs.
+
+Codex discovers the shared `~/.agents/skills/hey` skill directly. hey-cli does
+not also copy it to `~/.codex/skills/hey`, which would make Codex list the same
+skill twice. Setup and version refresh remove that legacy path only when its
+ownership marker proves an older hey-cli created it; user-authored files are
+left untouched.
 
 hey only ever writes skill directories it owns: each one it creates carries a
 `.managed-by-hey-cli` marker, and install, replacement and automatic refresh all refuse a

--- a/internal/cmd/setup_agent.go
+++ b/internal/cmd/setup_agent.go
@@ -422,7 +422,10 @@ func installCodexSkill() (string, error) {
 		}
 	}
 	path := harness.AgentSkillPath()
-	if path == "" || !baselineSkillInstalled() {
+	if path == "" {
+		return "", fmt.Errorf("cannot determine shared Agent Skills directory")
+	}
+	if !baselineSkillInstalled() {
 		return "", fmt.Errorf("shared HEY skill is not installed")
 	}
 	if _, err := migrateLegacyCodexSkill(); err != nil {

--- a/internal/cmd/setup_agent.go
+++ b/internal/cmd/setup_agent.go
@@ -72,7 +72,7 @@ var agentSetupHandlers = map[string]agentSetupHandler{
 	},
 	"codex": {
 		Labels: []string{
-			"Copy the HEY skill into Codex's skills directory",
+			"Install the shared HEY skill for Codex",
 		},
 		Run:               runCodexSetup,
 		RunNonInteractive: runCodexSetupNonInteractive,
@@ -393,8 +393,7 @@ func agentCommandFailure(out []byte, err error) string {
 
 // --- Codex ---
 
-// runCodexSetup copies the skill for Codex in the interactive wizard.
-// hey has no Codex plugin yet, so the skill is the whole integration.
+// runCodexSetup connects Codex to the shared agent skill.
 func runCodexSetup(cmd *cobra.Command) error {
 	w := cmd.OutOrStdout()
 	path, err := installCodexSkill()
@@ -412,10 +411,9 @@ func runCodexSetupNonInteractive(*cobra.Command) error {
 	return err
 }
 
-// installCodexSkill is the Codex handler's one step. Like Claude, it never
-// fabricates the agent: creating ~/.codex on a machine without Codex would
-// make every later detection — and this command's own verdict — report it
-// installed.
+// installCodexSkill is the Codex handler's one step. The caller installs the
+// shared baseline first; this removes any older hey-cli-managed Codex copy so
+// Codex discovers only one skill. Like Claude, it never fabricates the agent.
 func installCodexSkill() (string, error) {
 	if !harness.DetectCodex() {
 		return "", &agentSetupError{
@@ -423,7 +421,14 @@ func installCodexSkill() (string, error) {
 			Manual:  []string{"hey setup codex"},
 		}
 	}
-	return installSkillToCodex()
+	if _, err := removeLegacyCodexSkill(); err != nil {
+		return "", err
+	}
+	path := harness.AgentSkillPath()
+	if path == "" || !baselineSkillInstalled() {
+		return "", fmt.Errorf("shared HEY skill is not installed")
+	}
+	return path, nil
 }
 
 // --- Shared helpers ---

--- a/internal/cmd/setup_agent.go
+++ b/internal/cmd/setup_agent.go
@@ -421,12 +421,12 @@ func installCodexSkill() (string, error) {
 			Manual:  []string{"hey setup codex"},
 		}
 	}
-	if _, err := removeLegacyCodexSkill(); err != nil {
-		return "", err
-	}
 	path := harness.AgentSkillPath()
 	if path == "" || !baselineSkillInstalled() {
 		return "", fmt.Errorf("shared HEY skill is not installed")
+	}
+	if _, err := migrateLegacyCodexSkill(); err != nil {
+		return "", err
 	}
 	return path, nil
 }

--- a/internal/cmd/setup_agents_remove.go
+++ b/internal/cmd/setup_agents_remove.go
@@ -47,7 +47,7 @@ func runRemoveAgentSetup(cmd *cobra.Command) error {
 		}
 	}
 
-	if codexSkill := harness.CodexSkillPath(); codexSkill != "" {
+	if codexSkill := harness.LegacyCodexSkillPath(); codexSkill != "" {
 		if didRemove, removeErr := removeOwnedSkillFiles(filepath.Dir(codexSkill)); removeErr != nil {
 			failures = append(failures, "Codex skill: "+removeErr.Error())
 		} else if didRemove {

--- a/internal/cmd/setup_agents_test.go
+++ b/internal/cmd/setup_agents_test.go
@@ -342,10 +342,9 @@ func TestSetupAgentsDoesNotMigrateLegacyCredentials(t *testing.T) {
 	}
 }
 
-// A targeted agent whose skill path is occupied by an unmanaged skill is a
-// conflict, not a connection: the presence check alone must not flip
-// plugin_installed back to true over the handler's refusal.
-func TestSetupAgentsConflictedInstallIsNotConnected(t *testing.T) {
+// An unmanaged legacy Codex skill is user state: setup leaves it untouched
+// while connecting Codex through the shared ~/.agents skill.
+func TestSetupAgentsPreservesUnmanagedLegacyCodexSkill(t *testing.T) {
 	isolateAgents(t)
 	t.Setenv(agentSetupEnv, "codex")
 	home := t.TempDir()
@@ -365,15 +364,14 @@ func TestSetupAgentsConflictedInstallIsNotConnected(t *testing.T) {
 		t.Fatalf("setup agents: %v", err)
 	}
 	data := response.Data.(map[string]any)
-	errs := stringList(t, data["errors"])
-	if len(errs) == 0 || !strings.Contains(errs[0], "not written by hey-cli") {
+	if errs := stringList(t, data["errors"]); len(errs) != 0 {
 		t.Fatalf("errors = %v", errs)
 	}
 	agents := data["agents"].([]any)
-	if agents[0].(map[string]any)["plugin_installed"] != false {
-		t.Error("a refused install must not report plugin_installed")
+	if agents[0].(map[string]any)["plugin_installed"] != true {
+		t.Error("the shared skill should connect Codex")
 	}
-	if response.Summary != "Installed baseline skill; attempted Codex" {
+	if response.Summary != "Installed baseline skill; connected Codex" {
 		t.Errorf("summary = %q", response.Summary)
 	}
 	if got, _ := os.ReadFile(filepath.Join(codexSkill, "SKILL.md")); string(got) != custom {
@@ -593,9 +591,8 @@ func TestSetupAgentsRemoveDeletesManagedSkillsAndPreservesUserFiles(t *testing.T
 	if _, err := linkSkillToClaude(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := installSkillToCodex(); err != nil {
-		t.Fatal(err)
-	}
+	legacy := filepath.Join(home, ".codex", "skills", "hey")
+	writeSkillFixture(t, legacy, "# legacy managed skill", true)
 	baseline := filepath.Join(home, ".agents", "skills", "hey")
 	if err := os.WriteFile(filepath.Join(baseline, "notes.txt"), []byte("keep me"), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/cmd/setup_test.go
+++ b/internal/cmd/setup_test.go
@@ -787,10 +787,9 @@ func TestSetupJSONStaleCredentialsReportIncomplete(t *testing.T) {
 	}
 }
 
-// The wizard records a handler refusal as an issue even when the health
-// snapshot alone would miss it, so the warning remains visible in the
-// finished setup flow.
-func TestSetupWizardRecordsHandlerFailures(t *testing.T) {
+// A user-authored skill at the old Codex-specific path does not prevent the
+// wizard from connecting Codex through the shared skill, and is preserved.
+func TestSetupWizardPreservesUnmanagedLegacyCodexSkill(t *testing.T) {
 	isolateAgents(t)
 	server := identityServer(t)
 	configHome := t.TempDir()
@@ -811,16 +810,12 @@ func TestSetupWizardRecordsHandlerFailures(t *testing.T) {
 		t.Fatalf("setup: %v", err)
 	}
 	data := wizardData(t, response)
-	if data["status"] != "incomplete" {
-		t.Errorf("status = %v, want incomplete over a refused install", data["status"])
+	if data["status"] != "complete" {
+		t.Errorf("status = %v, want complete with the shared skill", data["status"])
 	}
 	rawIssues := data["issues"].([]any)
-	checks := make([]string, 0, len(rawIssues))
-	for _, raw := range rawIssues {
-		checks = append(checks, raw.(map[string]any)["check"].(string))
-	}
-	if !contains(checks, "Codex setup failed") {
-		t.Errorf("handler failure not recorded: %v", checks)
+	if len(rawIssues) != 0 {
+		t.Errorf("issues = %v, want none", rawIssues)
 	}
 	if got, _ := os.ReadFile(filepath.Join(codexSkill, "SKILL.md")); string(got) != custom {
 		t.Errorf("user skill changed: %q", got)

--- a/internal/cmd/setup_test.go
+++ b/internal/cmd/setup_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/basecamp/hey-cli/internal/auth"
+	"github.com/basecamp/hey-cli/internal/harness"
 	"github.com/basecamp/hey-cli/internal/output"
 )
 
@@ -733,6 +734,35 @@ func TestSetupRepeatKeepsDetectedConnectedAgentsVisible(t *testing.T) {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("repeat setup missing %q:\n%s", want, stdout)
 		}
+	}
+}
+
+func TestSetupRepeatMigratesManagedLegacyCodexSkill(t *testing.T) {
+	isolateAgents(t)
+	stubInteractive(t, true)
+	server := identityServer(t)
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runAuthCommand(t, home, server.URL, "", true, "auth", "login", "--cookie", "session-cookie"); err != nil {
+		t.Fatalf("auth login: %v", err)
+	}
+	if _, _, err := runAuthCommand(t, home, server.URL, "", true, "setup"); err != nil {
+		t.Fatalf("initial setup: %v", err)
+	}
+
+	legacy := filepath.Join(home, ".codex", "skills", "hey")
+	writeSkillFixture(t, legacy, "# managed legacy duplicate", true)
+	if check := harness.CheckCodexSkill(); check.Status != "fail" {
+		t.Fatalf("preflight did not notice managed duplicate: %+v", check)
+	}
+
+	if _, _, err := runAuthCommand(t, home, server.URL, "", true, "setup"); err != nil {
+		t.Fatalf("repeat setup: %v", err)
+	}
+	if _, err := os.Lstat(legacy); !os.IsNotExist(err) {
+		t.Fatalf("repeat setup left managed legacy duplicate: %v", err)
 	}
 }
 

--- a/internal/cmd/skill_install.go
+++ b/internal/cmd/skill_install.go
@@ -114,6 +114,16 @@ func runSkillInstall(cmd *cobra.Command, args []string) error {
 	result := map[string]string{"skill_path": skillPath}
 	lines := []string{"Installed hey skill to ~/.agents/skills/hey/SKILL.md"}
 
+	// Once the shared replacement is installed, remove a managed legacy copy
+	// before optional agent-specific setup. A later Claude failure must not
+	// leave Codex discovering both copies.
+	if removed, cleanupErr := migrateLegacyCodexSkill(); cleanupErr != nil {
+		return apierr.ErrAPI(0, cleanupErr.Error())
+	} else if removed {
+		result["removed_legacy_codex_skill"] = "true"
+		lines = append(lines, "Removed the redundant managed Codex skill copy")
+	}
+
 	if harness.DetectClaude() {
 		notice, linkErr := linkSkillToClaude()
 		if linkErr != nil {
@@ -127,13 +137,6 @@ func runSkillInstall(cmd *cobra.Command, args []string) error {
 		} else {
 			lines = append(lines, "Symlinked ~/.claude/skills/hey → ../../.agents/skills/hey")
 		}
-	}
-
-	if removed, cleanupErr := migrateLegacyCodexSkill(); cleanupErr != nil {
-		return apierr.ErrAPI(0, cleanupErr.Error())
-	} else if removed {
-		result["removed_legacy_codex_skill"] = "true"
-		lines = append(lines, "Removed the redundant managed Codex skill copy")
 	}
 
 	if writer.IsStyled() {
@@ -303,6 +306,9 @@ func removeLegacyCodexSkill() (bool, error) {
 // only working Codex integration and must remain available.
 func migrateLegacyCodexSkill() (bool, error) {
 	if !baselineSkillInstalled() {
+		return false, nil
+	}
+	if harness.SameFile(harness.AgentSkillPath(), harness.LegacyCodexSkillPath()) {
 		return false, nil
 	}
 	return removeLegacyCodexSkill()

--- a/internal/cmd/skill_install.go
+++ b/internal/cmd/skill_install.go
@@ -100,7 +100,7 @@ func newSkillInstallCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "install",
 		Short: "Install the hey skill globally for your coding agents",
-		Long:  "Copies the embedded SKILL.md to ~/.agents/skills/hey/, links it into ~/.claude/skills/hey when Claude Code is installed, and copies it for Codex when Codex is installed.",
+		Long:  "Copies the embedded SKILL.md to ~/.agents/skills/hey/ and links it into ~/.claude/skills/hey when Claude Code is installed. Codex discovers the shared skill directly.",
 		RunE:  runSkillInstall,
 	}
 }
@@ -129,13 +129,11 @@ func runSkillInstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if harness.DetectCodex() {
-		codexPath, codexErr := installSkillToCodex()
-		if codexErr != nil {
-			return apierr.ErrAPI(0, codexErr.Error())
-		}
-		result["codex_skill_path"] = codexPath
-		lines = append(lines, "Copied skill to "+codexPath)
+	if removed, cleanupErr := removeLegacyCodexSkill(); cleanupErr != nil {
+		return apierr.ErrAPI(0, cleanupErr.Error())
+	} else if removed {
+		result["removed_legacy_codex_skill"] = "true"
+		lines = append(lines, "Removed the redundant managed Codex skill copy")
 	}
 
 	if writer.IsStyled() {
@@ -289,26 +287,15 @@ func isManagedSkillCopy(path string) bool {
 	return sawMarker
 }
 
-// installSkillToCodex copies the embedded SKILL.md into Codex's skills
-// directory ($CODEX_HOME or ~/.codex). Codex does not follow the shared
-// ~/.agents layout, so this is a copy rather than a link.
-func installSkillToCodex() (string, error) {
-	skillPath := harness.CodexSkillPath()
+// removeLegacyCodexSkill removes only the redundant Codex-specific copy
+// written by an older hey-cli. An unmarked directory is user-owned and stays
+// untouched; Codex will continue to discover it alongside the shared skill.
+func removeLegacyCodexSkill() (bool, error) {
+	skillPath := harness.LegacyCodexSkillPath()
 	if skillPath == "" {
-		return "", fmt.Errorf("cannot determine Codex home directory")
+		return false, nil
 	}
-
-	data, err := skills.FS.ReadFile("hey/SKILL.md")
-	if err != nil {
-		return "", fmt.Errorf("reading embedded skill: %w", err)
-	}
-	if err := claimSkillDir(filepath.Dir(skillPath)); err != nil {
-		return "", err
-	}
-	if err := writeSkillFile(skillPath, data); err != nil {
-		return "", fmt.Errorf("writing Codex skill file: %w", err)
-	}
-	return skillPath, nil
+	return removeOwnedSkillFiles(filepath.Dir(skillPath))
 }
 
 // baselineSkillInstalled reports whether ~/.agents/skills/hey/SKILL.md is a

--- a/internal/cmd/skill_install.go
+++ b/internal/cmd/skill_install.go
@@ -129,7 +129,7 @@ func runSkillInstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if removed, cleanupErr := removeLegacyCodexSkill(); cleanupErr != nil {
+	if removed, cleanupErr := migrateLegacyCodexSkill(); cleanupErr != nil {
 		return apierr.ErrAPI(0, cleanupErr.Error())
 	} else if removed {
 		result["removed_legacy_codex_skill"] = "true"
@@ -296,6 +296,16 @@ func removeLegacyCodexSkill() (bool, error) {
 		return false, nil
 	}
 	return removeOwnedSkillFiles(filepath.Dir(skillPath))
+}
+
+// migrateLegacyCodexSkill removes the old Codex-specific copy only after the
+// shared skill is known healthy. Until then the legacy copy may be the user's
+// only working Codex integration and must remain available.
+func migrateLegacyCodexSkill() (bool, error) {
+	if !baselineSkillInstalled() {
+		return false, nil
+	}
+	return removeLegacyCodexSkill()
 }
 
 // baselineSkillInstalled reports whether ~/.agents/skills/hey/SKILL.md is a

--- a/internal/cmd/skill_install_test.go
+++ b/internal/cmd/skill_install_test.go
@@ -199,6 +199,9 @@ func TestSkillInstallPreservesUnmanagedLegacyCodexSkill(t *testing.T) {
 	if got, err := os.ReadFile(filepath.Join(legacy, skillFilename)); err != nil || !bytes.Equal(got, custom) {
 		t.Fatalf("unmanaged legacy skill changed: %q, %v", got, err)
 	}
+	if ownedSkillDir(legacy) {
+		t.Error("unmanaged legacy Codex skill was claimed")
+	}
 }
 
 func TestCodexMigrationPreservesLegacySkillWithoutSharedBaseline(t *testing.T) {
@@ -211,6 +214,17 @@ func TestCodexMigrationPreservesLegacySkillWithoutSharedBaseline(t *testing.T) {
 	}
 	if got, err := os.ReadFile(filepath.Join(legacy, skillFilename)); err != nil || string(got) != "# only working skill" {
 		t.Fatalf("legacy-only skill changed: %q, %v", got, err)
+	}
+}
+
+func TestCodexInstallReportsMissingSharedAgentSkillsHome(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("CODEX_HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	if _, err := installCodexSkill(); err == nil || err.Error() != "cannot determine shared Agent Skills directory" {
+		t.Fatalf("installCodexSkill error = %v", err)
 	}
 }
 
@@ -238,6 +252,42 @@ func TestSkillInstallFailurePreservesManagedLegacyCodexSkill(t *testing.T) {
 	}
 	if got, err := os.ReadFile(filepath.Join(legacy, skillFilename)); err != nil || string(got) != "# only working skill" {
 		t.Fatalf("legacy skill changed after failed baseline install: %q, %v", got, err)
+	}
+}
+
+func TestSkillInstallDoesNotRemoveSharedSkillWhenCodexHomeAliasesAgents(t *testing.T) {
+	home := agentHome(t)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".agents"))
+	jsonWriter(t)
+
+	if err := runSkillInstall(newSkillInstallCommand(), nil); err != nil {
+		t.Fatal(err)
+	}
+	shared := filepath.Join(home, ".agents", "skills", "hey")
+	if !baselineSkillInstalled() {
+		t.Fatal("shared skill was removed as its own legacy copy")
+	}
+	if !ownedSkillDir(shared) {
+		t.Fatal("shared skill lost its ownership marker")
+	}
+}
+
+func TestSkillInstallMigratesLegacyCopyBeforeClaudeSetupFailure(t *testing.T) {
+	home := agentHome(t, ".codex", ".claude/skills/hey")
+	legacy := filepath.Join(home, ".codex", "skills", "hey")
+	writeSkillFixture(t, legacy, "# legacy", true)
+	// A populated user-owned Claude directory makes the optional Claude step
+	// fail after the shared baseline succeeds.
+	if err := os.WriteFile(filepath.Join(home, ".claude", "skills", "hey", "keep"), []byte("mine"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	jsonWriter(t)
+
+	if err := runSkillInstall(newSkillInstallCommand(), nil); err == nil {
+		t.Fatal("install unexpectedly succeeded through user-owned Claude skill")
+	}
+	if _, err := os.Lstat(legacy); !os.IsNotExist(err) {
+		t.Fatalf("managed legacy Codex copy remains after shared install: %v", err)
 	}
 }
 

--- a/internal/cmd/skill_install_test.go
+++ b/internal/cmd/skill_install_test.go
@@ -163,6 +163,43 @@ func agentHome(t *testing.T, dirs ...string) string {
 	return home
 }
 
+func TestSkillInstallUsesSharedPathAndRemovesManagedLegacyCodexCopy(t *testing.T) {
+	home := agentHome(t, ".codex")
+	legacy := filepath.Join(home, ".codex", "skills", "hey")
+	writeSkillFixture(t, legacy, "# legacy", true)
+	jsonWriter(t)
+
+	if err := runSkillInstall(newSkillInstallCommand(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".agents", "skills", "hey", skillFilename)); err != nil {
+		t.Fatalf("shared skill missing: %v", err)
+	}
+	if _, err := os.Lstat(legacy); !os.IsNotExist(err) {
+		t.Fatalf("managed legacy Codex copy remains: %v", err)
+	}
+}
+
+func TestSkillInstallPreservesUnmanagedLegacyCodexSkill(t *testing.T) {
+	home := agentHome(t, ".codex")
+	legacy := filepath.Join(home, ".codex", "skills", "hey")
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	custom := []byte("# user-owned Codex skill\n")
+	if err := os.WriteFile(filepath.Join(legacy, skillFilename), custom, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	jsonWriter(t)
+
+	if err := runSkillInstall(newSkillInstallCommand(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(legacy, skillFilename)); err != nil || !bytes.Equal(got, custom) {
+		t.Fatalf("unmanaged legacy skill changed: %q, %v", got, err)
+	}
+}
+
 // Only hey-cli's own canonical symlink may be replaced. A user's symlink to
 // their own skill, or a regular file, is refused and left exactly as found.
 func TestSkillInstallRefusesForeignLinkOrFile(t *testing.T) {
@@ -195,39 +232,30 @@ func TestSkillInstallRefusesForeignLinkOrFile(t *testing.T) {
 	}
 }
 
-// The canonical baseline and Codex paths are conventions agents share, so a
-// hand-authored skill can legitimately live there. Every install path — the
-// explicit command and the installer's automatic `setup agents` alike — must
-// refuse an unmarked one rather than overwrite it and then claim it.
-func TestSkillInstallRefusesUnmarkedBaselineAndCodexSkills(t *testing.T) {
+// The canonical baseline is a convention agents share, so a hand-authored
+// skill can legitimately live there. Every install path must refuse an
+// unmarked one rather than overwrite it and then claim it.
+func TestSkillInstallRefusesUnmarkedBaselineSkill(t *testing.T) {
 	home := agentHome(t, ".codex")
 	custom := "# my own hey skill\n"
 	baseline := filepath.Join(home, ".agents", "skills", "hey")
-	codex := filepath.Join(home, ".codex", "skills", "hey")
-	for _, dir := range []string{baseline, codex} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(custom), 0o600); err != nil {
-			t.Fatal(err)
-		}
+	if err := os.MkdirAll(baseline, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseline, "SKILL.md"), []byte(custom), 0o600); err != nil {
+		t.Fatal(err)
 	}
 
 	var unmanaged *unmanagedSkillDirError
 	if _, err := installSkillFiles(); !errors.As(err, &unmanaged) {
 		t.Fatalf("installSkillFiles error = %v, want unmanaged refusal", err)
 	}
-	if _, err := installSkillToCodex(); !errors.As(err, &unmanaged) {
-		t.Fatalf("installSkillToCodex error = %v, want unmanaged refusal", err)
+	data, err := os.ReadFile(filepath.Join(baseline, "SKILL.md"))
+	if err != nil || string(data) != custom {
+		t.Errorf("%s changed: %q, %v", baseline, data, err)
 	}
-	for _, dir := range []string{baseline, codex} {
-		data, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
-		if err != nil || string(data) != custom {
-			t.Errorf("%s changed: %q, %v", dir, data, err)
-		}
-		if ownedSkillDir(dir) {
-			t.Errorf("%s was claimed", dir)
-		}
+	if ownedSkillDir(baseline) {
+		t.Errorf("%s was claimed", baseline)
 	}
 }
 
@@ -259,10 +287,7 @@ func TestSkillInstallRefusesSymlinkedSkillFileInManagedDir(t *testing.T) {
 	if err := os.WriteFile(precious, []byte("# do not truncate"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	for _, dir := range []string{
-		filepath.Join(home, ".agents", "skills", "hey"),
-		filepath.Join(home, ".codex", "skills", "hey"),
-	} {
+	for _, dir := range []string{filepath.Join(home, ".agents", "skills", "hey")} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -274,9 +299,6 @@ func TestSkillInstallRefusesSymlinkedSkillFileInManagedDir(t *testing.T) {
 
 	if _, err := installSkillFiles(); err == nil {
 		t.Error("baseline install wrote through a symlinked SKILL.md")
-	}
-	if _, err := installSkillToCodex(); err == nil {
-		t.Error("Codex install wrote through a symlinked SKILL.md")
 	}
 	if data, _ := os.ReadFile(precious); string(data) != "# do not truncate" {
 		t.Errorf("symlink target was truncated: %q", data)

--- a/internal/cmd/skill_install_test.go
+++ b/internal/cmd/skill_install_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/basecamp/hey-cli/internal/output"
@@ -197,6 +198,46 @@ func TestSkillInstallPreservesUnmanagedLegacyCodexSkill(t *testing.T) {
 	}
 	if got, err := os.ReadFile(filepath.Join(legacy, skillFilename)); err != nil || !bytes.Equal(got, custom) {
 		t.Fatalf("unmanaged legacy skill changed: %q, %v", got, err)
+	}
+}
+
+func TestCodexMigrationPreservesLegacySkillWithoutSharedBaseline(t *testing.T) {
+	home := agentHome(t, ".codex")
+	legacy := filepath.Join(home, ".codex", "skills", "hey")
+	writeSkillFixture(t, legacy, "# only working skill", true)
+
+	if _, err := installCodexSkill(); err == nil || !strings.Contains(err.Error(), "shared HEY skill is not installed") {
+		t.Fatalf("installCodexSkill error = %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(legacy, skillFilename)); err != nil || string(got) != "# only working skill" {
+		t.Fatalf("legacy-only skill changed: %q, %v", got, err)
+	}
+}
+
+func TestSkillInstallFailurePreservesManagedLegacyCodexSkill(t *testing.T) {
+	home := agentHome(t, ".codex")
+	legacy := filepath.Join(home, ".codex", "skills", "hey")
+	writeSkillFixture(t, legacy, "# only working skill", true)
+
+	baseline := filepath.Join(home, ".agents", "skills", "hey")
+	if err := os.MkdirAll(baseline, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeOwnershipMarker(baseline)
+	precious := filepath.Join(home, "user-skill.md")
+	if err := os.WriteFile(precious, []byte("# user skill"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(precious, filepath.Join(baseline, skillFilename)); err != nil {
+		t.Fatal(err)
+	}
+	jsonWriter(t)
+
+	if err := runSkillInstall(newSkillInstallCommand(), nil); err == nil {
+		t.Fatal("install succeeded over a non-regular baseline skill")
+	}
+	if got, err := os.ReadFile(filepath.Join(legacy, skillFilename)); err != nil || string(got) != "# only working skill" {
+		t.Fatalf("legacy skill changed after failed baseline install: %q, %v", got, err)
 	}
 }
 

--- a/internal/cmd/skill_refresh.go
+++ b/internal/cmd/skill_refresh.go
@@ -48,10 +48,8 @@ func refreshSkillsIfVersionChanged() bool {
 	}
 	sentinelPath := filepath.Join(configDir, ".last-run-version")
 
-	// The sentinel records the active Codex home alongside the version:
-	// skill locations depend on CODEX_HOME, so switching homes mid-release
-	// triggers one rescan instead of leaving the other home's marked skill
-	// stale until the next release.
+	// Legacy cleanup still depends on the active Codex home, so switching
+	// CODEX_HOME gets one migration pass per release.
 	sentinelState := version.Version + "\n" + harness.CodexHome() + "\n"
 	data, err := os.ReadFile(sentinelPath) // #nosec G304 -- fixed path under the user config dir
 	if err == nil && string(data) == sentinelState {
@@ -91,9 +89,6 @@ func skillRefreshLocations() []string {
 			filepath.Join(home, ".claude", "skills", "hey", skillFilename),
 		)
 	}
-	if codexPath := harness.CodexSkillPath(); codexPath != "" {
-		locations = append(locations, codexPath)
-	}
 	return locations
 }
 
@@ -129,6 +124,15 @@ func refreshInstalledSkills() (updated, failed int) {
 		} else {
 			failed++
 		}
+	}
+
+	// Current Codex reads the shared ~/.agents skill. A copy from an older
+	// release would produce a duplicate entry, so migrate it away when its
+	// ownership marker proves hey-cli created it.
+	if removed, err := removeLegacyCodexSkill(); err != nil {
+		failed++
+	} else if removed {
+		updated++
 	}
 
 	// Stamp the installed version in the baseline directory only on full

--- a/internal/cmd/skill_refresh.go
+++ b/internal/cmd/skill_refresh.go
@@ -129,7 +129,7 @@ func refreshInstalledSkills() (updated, failed int) {
 	// Current Codex reads the shared ~/.agents skill. A copy from an older
 	// release would produce a duplicate entry, so migrate it away when its
 	// ownership marker proves hey-cli created it.
-	if removed, err := removeLegacyCodexSkill(); err != nil {
+	if removed, err := migrateLegacyCodexSkill(); err != nil {
 		failed++
 	} else if removed {
 		updated++

--- a/internal/cmd/skill_refresh.go
+++ b/internal/cmd/skill_refresh.go
@@ -92,6 +92,8 @@ func skillRefreshLocations() []string {
 	return locations
 }
 
+var refreshSkillFile = writeSkillFile
+
 func refreshInstalledSkills() (updated, failed int) {
 	embedded, err := skills.FS.ReadFile("hey/SKILL.md")
 	if err != nil {
@@ -119,7 +121,7 @@ func refreshInstalledSkills() (updated, failed int) {
 		if !ownedSkillDir(filepath.Dir(location)) {
 			continue
 		}
-		if writeErr := os.WriteFile(location, embedded, 0o644); writeErr == nil { // #nosec G306 -- installed skills are intentionally user-readable
+		if writeErr := refreshSkillFile(location, embedded); writeErr == nil {
 			updated++
 		} else {
 			failed++
@@ -129,10 +131,12 @@ func refreshInstalledSkills() (updated, failed int) {
 	// Current Codex reads the shared ~/.agents skill. A copy from an older
 	// release would produce a duplicate entry, so migrate it away when its
 	// ownership marker proves hey-cli created it.
-	if removed, err := migrateLegacyCodexSkill(); err != nil {
-		failed++
-	} else if removed {
-		updated++
+	if failed == 0 {
+		if removed, err := migrateLegacyCodexSkill(); err != nil {
+			failed++
+		} else if removed {
+			updated++
+		}
 	}
 
 	// Stamp the installed version in the baseline directory only on full

--- a/internal/cmd/skill_refresh_test.go
+++ b/internal/cmd/skill_refresh_test.go
@@ -106,6 +106,45 @@ func TestRefreshSkillsWithoutInstallNeverInstalls(t *testing.T) {
 	}
 }
 
+func TestRefreshPreservesLegacyCodexSkillWithoutSharedBaseline(t *testing.T) {
+	home := refreshFixture(t)
+	stubVersion(t, "1.2.3")
+	legacy := writeSkillFixture(t, filepath.Join(home, ".codex", "skills", "hey"), "# only working skill", true)
+
+	if refreshSkillsIfVersionChanged() {
+		t.Error("legacy-only installation should not be migrated without a healthy shared skill")
+	}
+	if got, err := os.ReadFile(legacy); err != nil || string(got) != "# only working skill" {
+		t.Fatalf("legacy-only skill changed: %q, %v", got, err)
+	}
+}
+
+func TestRefreshPreservesLegacyCodexSkillWhenSharedBaselineIsInvalid(t *testing.T) {
+	home := refreshFixture(t)
+	stubVersion(t, "1.2.3")
+	legacy := writeSkillFixture(t, filepath.Join(home, ".codex", "skills", "hey"), "# only working skill", true)
+
+	baseline := filepath.Join(home, ".agents", "skills", "hey")
+	if err := os.MkdirAll(baseline, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeOwnershipMarker(baseline)
+	target := filepath.Join(home, "user-skill.md")
+	if err := os.WriteFile(target, []byte("# user skill"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(baseline, skillFilename)); err != nil {
+		t.Fatal(err)
+	}
+
+	if refreshSkillsIfVersionChanged() {
+		t.Error("invalid shared baseline should not trigger a completed migration")
+	}
+	if got, err := os.ReadFile(legacy); err != nil || string(got) != "# only working skill" {
+		t.Fatalf("legacy skill changed while the shared baseline was invalid: %q, %v", got, err)
+	}
+}
+
 // Refresh never touches symlinks: a dangling ~/.claude/skills/hey — a user's
 // link to a volume that is merely unmounted right now — survives untouched,
 // even when a marked baseline exists next to it.

--- a/internal/cmd/skill_refresh_test.go
+++ b/internal/cmd/skill_refresh_test.go
@@ -56,7 +56,7 @@ func TestRefreshSkillsUpdatesInstalledCopiesOnce(t *testing.T) {
 	stubVersion(t, "1.2.3")
 	skillPath := installStaleSkill(t, home)
 
-	// A Codex copy must be refreshed too.
+	// A managed Codex copy from an older release must be removed.
 	codexSkill := writeSkillFixture(t, filepath.Join(home, ".codex", "skills", "hey"), "# stale skill", true)
 
 	if !refreshSkillsIfVersionChanged() {
@@ -67,14 +67,12 @@ func TestRefreshSkillsUpdatesInstalledCopiesOnce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, path := range []string{skillPath, codexSkill} {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if string(data) != string(embedded) {
-			t.Errorf("%s was not refreshed", path)
-		}
+	data, err := os.ReadFile(skillPath)
+	if err != nil || string(data) != string(embedded) {
+		t.Errorf("%s was not refreshed: %v", skillPath, err)
+	}
+	if _, err := os.Stat(codexSkill); !os.IsNotExist(err) {
+		t.Errorf("legacy Codex skill was not removed: %v", err)
 	}
 
 	stamp, err := os.ReadFile(filepath.Join(filepath.Dir(skillPath), installedVersionFile))
@@ -255,9 +253,9 @@ func TestRefreshSkillsSkipsWithoutConfigDir(t *testing.T) {
 	}
 }
 
-// The sentinel tracks the active Codex home: a marked, stale skill in a
-// Codex home that was inactive during the first post-upgrade run is
-// refreshed as soon as that home becomes active, not at the next release.
+// The sentinel tracks the active Codex home: a marked legacy copy in a home
+// that was inactive during the first post-upgrade run is removed as soon as
+// that home becomes active, not at the next release.
 func TestRefreshSkillsRescansWhenCodexHomeChanges(t *testing.T) {
 	home := refreshFixture(t)
 	stubVersion(t, "9.9.9")
@@ -273,14 +271,13 @@ func TestRefreshSkillsRescansWhenCodexHomeChanges(t *testing.T) {
 	}
 
 	homeB := t.TempDir()
-	staleB := writeSkillFixture(t, filepath.Join(homeB, "skills", "hey"), "# stale skill", true)
+	legacyB := writeSkillFixture(t, filepath.Join(homeB, "skills", "hey"), "# stale skill", true)
 	t.Setenv("CODEX_HOME", homeB)
 	if !refreshSkillsIfVersionChanged() {
 		t.Fatal("switching Codex homes should rescan")
 	}
-	data, err := os.ReadFile(staleB)
-	if err != nil || string(data) == "# stale skill" {
-		t.Errorf("skill in the newly active Codex home was not refreshed: %v", err)
+	if _, err := os.Stat(legacyB); !os.IsNotExist(err) {
+		t.Errorf("legacy skill in the newly active Codex home was not removed: %v", err)
 	}
 	if refreshSkillsIfVersionChanged() {
 		t.Error("stable again: refresh must be a no-op")

--- a/internal/cmd/skill_refresh_test.go
+++ b/internal/cmd/skill_refresh_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -142,6 +143,38 @@ func TestRefreshPreservesLegacyCodexSkillWhenSharedBaselineIsInvalid(t *testing.
 	}
 	if got, err := os.ReadFile(legacy); err != nil || string(got) != "# only working skill" {
 		t.Fatalf("legacy skill changed while the shared baseline was invalid: %q, %v", got, err)
+	}
+}
+
+func TestRefreshFailurePreservesManagedLegacyCodexSkill(t *testing.T) {
+	home := refreshFixture(t)
+	installStaleSkill(t, home)
+	legacy := writeSkillFixture(t, filepath.Join(home, ".codex", "skills", "hey"), "# working legacy skill", true)
+
+	originalWrite := refreshSkillFile
+	refreshSkillFile = func(string, []byte) error { return errors.New("disk full") }
+	t.Cleanup(func() { refreshSkillFile = originalWrite })
+
+	updated, failed := refreshInstalledSkills()
+	if updated != 0 || failed == 0 {
+		t.Fatalf("refresh = %d updated, %d failed", updated, failed)
+	}
+	if got, err := os.ReadFile(legacy); err != nil || string(got) != "# working legacy skill" {
+		t.Fatalf("legacy skill changed after failed refresh: %q, %v", got, err)
+	}
+}
+
+func TestRefreshDoesNotRemoveSharedSkillWhenCodexHomeAliasesAgents(t *testing.T) {
+	home := refreshFixture(t)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".agents"))
+	skill := installStaleSkill(t, home)
+
+	updated, failed := refreshInstalledSkills()
+	if updated == 0 || failed != 0 {
+		t.Fatalf("refresh = %d updated, %d failed", updated, failed)
+	}
+	if _, err := os.Stat(skill); err != nil {
+		t.Fatalf("shared skill removed as its own legacy copy: %v", err)
 	}
 }
 

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -79,7 +79,7 @@ func CheckCodexSkill() *StatusCheck {
 		return &StatusCheck{
 			Name:    "Codex Skill",
 			Status:  "warn",
-			Message: "Cannot determine Codex home directory",
+			Message: "Cannot determine shared Agent Skills directory",
 		}
 	}
 	if _, err := os.Stat(skillPath); err != nil {
@@ -116,6 +116,15 @@ func CheckCodexSkill() *StatusCheck {
 			Status:  "fail",
 			Message: "A skill not written by hey-cli occupies " + skillDir,
 			Hint:    "Move it aside, then run: hey setup codex",
+		}
+	}
+	legacyPath := LegacyCodexSkillPath()
+	if !SameFile(skillPath, legacyPath) && RegularSkillFile(legacyPath) && SkillDirOwned(filepath.Dir(legacyPath)) {
+		return &StatusCheck{
+			Name:    "Codex Skill",
+			Status:  "fail",
+			Message: "Redundant managed skill installed at " + filepath.Dir(legacyPath),
+			Hint:    "Run: hey setup codex",
 		}
 	}
 	return &StatusCheck{

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -13,9 +13,9 @@ func init() {
 		Name:   "Codex",
 		ID:     "codex",
 		Detect: DetectCodex,
-		// hey has no Codex plugin yet (no .codex-plugin manifest ships in
-		// this repo), so Codex health is skill-presence only. When a native
-		// plugin lands, this grows the plugin/version checks basecamp-cli has.
+		// Codex discovers the shared ~/.agents skill directly, so health is
+		// skill-presence only. When a native plugin lands, this grows the
+		// plugin/version checks basecamp-cli has.
 		Checks: func() []*StatusCheck {
 			return []*StatusCheck{CheckCodexSkill()}
 		},
@@ -61,8 +61,10 @@ func CodexHome() string {
 	return filepath.Join(filepath.Clean(home), ".codex")
 }
 
-// CodexSkillPath returns where Codex reads the hey skill from.
-func CodexSkillPath() string {
+// LegacyCodexSkillPath returns the old Codex-specific skill path. Current Codex
+// discovers AgentSkillPath directly; this remains only so hey-cli can safely
+// migrate and remove copies written by older releases.
+func LegacyCodexSkillPath() string {
 	codexHome := CodexHome()
 	if codexHome == "" {
 		return ""
@@ -70,9 +72,9 @@ func CodexSkillPath() string {
 	return filepath.Join(codexHome, "skills", "hey", "SKILL.md")
 }
 
-// CheckCodexSkill checks whether the hey skill is installed for Codex.
+// CheckCodexSkill checks whether the shared hey skill is installed for Codex.
 func CheckCodexSkill() *StatusCheck {
-	skillPath := CodexSkillPath()
+	skillPath := AgentSkillPath()
 	if skillPath == "" {
 		return &StatusCheck{
 			Name:    "Codex Skill",

--- a/internal/harness/codex_test.go
+++ b/internal/harness/codex_test.go
@@ -68,4 +68,36 @@ func TestCheckCodexSkill(t *testing.T) {
 	if check := CheckCodexSkill(); check.Status != "pass" {
 		t.Errorf("managed skill: %+v", check)
 	}
+
+	legacyDir := filepath.Join(home, ".codex", "skills", "hey")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"SKILL.md":           "# legacy hey",
+		SkillOwnershipMarker: "hey-cli",
+	} {
+		if err := os.WriteFile(filepath.Join(legacyDir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if check := CheckCodexSkill(); check.Status != "fail" || check.Hint != "Run: hey setup codex" {
+		t.Errorf("managed duplicate skill: %+v", check)
+	}
+
+	// A CODEX_HOME that aliases ~/.agents makes the old and current paths
+	// identical. That is one skill, not a duplicate.
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".agents"))
+	if check := CheckCodexSkill(); check.Status != "pass" {
+		t.Errorf("aliased current skill: %+v", check)
+	}
+}
+
+func TestCheckCodexSkillReportsMissingAgentSkillsHome(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	check := CheckCodexSkill()
+	if check.Status != "warn" || check.Message != "Cannot determine shared Agent Skills directory" {
+		t.Errorf("check = %+v", check)
+	}
 }

--- a/internal/harness/codex_test.go
+++ b/internal/harness/codex_test.go
@@ -35,8 +35,8 @@ func TestCodexHomeHonorsEnvOverride(t *testing.T) {
 	if got := CodexHome(); got != override {
 		t.Errorf("CodexHome() = %q, want %q", got, override)
 	}
-	if got, want := CodexSkillPath(), filepath.Join(override, "skills", "hey", "SKILL.md"); got != want {
-		t.Errorf("CodexSkillPath() = %q, want %q", got, want)
+	if got, want := LegacyCodexSkillPath(), filepath.Join(override, "skills", "hey", "SKILL.md"); got != want {
+		t.Errorf("LegacyCodexSkillPath() = %q, want %q", got, want)
 	}
 }
 
@@ -49,7 +49,7 @@ func TestCheckCodexSkill(t *testing.T) {
 		t.Errorf("missing skill: %+v", check)
 	}
 
-	skillDir := filepath.Join(home, ".codex", "skills", "hey")
+	skillDir := filepath.Join(home, ".agents", "skills", "hey")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -11,6 +11,16 @@ import (
 // skill: present, but not a working hey integration.
 const SkillOwnershipMarker = ".managed-by-hey-cli"
 
+// AgentSkillPath returns the shared location used by agents that implement
+// the Agent Skills convention.
+func AgentSkillPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Clean(home), ".agents", "skills", "hey", "SKILL.md")
+}
+
 // SkillDirOwned reports whether hey-cli wrote the skill directory at dir.
 // The marker itself must be a regular file — the same shape rule as every
 // other skill file, so a planted symlink or directory in the marker's name

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -43,6 +43,23 @@ func RegularSkillFile(path string) bool {
 	return err == nil && info.Mode().IsRegular()
 }
 
+// SameFile reports whether two paths resolve to the same existing file. The
+// clean-path fallback also handles the useful missing-file case without
+// following or inventing any filesystem state.
+func SameFile(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA == nil && errB == nil && filepath.Clean(absA) == filepath.Clean(absB) {
+		return true
+	}
+	infoA, errA := os.Stat(a)
+	infoB, errB := os.Stat(b)
+	return errA == nil && errB == nil && os.SameFile(infoA, infoB)
+}
+
 // StatusCheck represents a single agent integration health check result.
 type StatusCheck struct {
 	Name    string `json:"name"`


### PR DESCRIPTION
Closes #287.

## Problem

Current Codex discovers personal skills from `~/.agents/skills`, so copying the same HEY skill into `~/.codex/skills` creates two indistinguishable entries.

## Change

- Make the shared Agent Skills location the single source used by Codex.
- Stop creating a second Codex-specific skill copy.
- Update Codex setup, health checks, refresh behavior, and documentation to use the shared path.
- During explicit setup and once-per-version refresh, remove an older Codex-specific copy only when hey-cli's ownership marker proves it is managed.
- Preserve unmarked user-authored copies.
- Preserve a managed legacy copy until the shared replacement has been installed and verified healthy.

The existing `hey setup agents --remove` path remains the supported uninstall flow. This PR does not change skill invocation policy; HEY remains available for normal implicit selection.

## Verification

- `TMPDIR=/tmp go test ./internal/...`
- `TMPDIR=/tmp go test ./internal/cmd ./internal/harness ./skills`
- `go vet ./...`
- formatting and tidy checks
- command-surface check
- golangci-lint: 0 issues

The short `TMPDIR` avoids unrelated Unix-domain socket path-length failures in macOS TUI tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Codex from seeing duplicate HEY skills by making the shared `~/.agents/skills` location the single source. Setup, `hey skill install`, health checks, and version refresh no longer copy the skill into `~/.codex/skills`; Codex discovers the shared skill directly.

**Migration**
- Removes an existing legacy `~/.codex/skills/hey` copy only during explicit setup or once-per-version refresh, and only when the ownership marker proves hey-cli created it and the shared replacement is healthy.
- Leaves unmarked user-authored copies untouched, and keeps the legacy copy if installing or refreshing the shared skill fails.
- Skips removal when `CODEX_HOME` aliases `~/.agents`, so the shared skill is never deleted as its own legacy copy.
- A managed legacy duplicate makes the Codex health check fail with a hint to run `hey setup codex`.
- `hey setup agents --remove` remains the supported uninstall flow.

<sup>Written for commit 56c73fa1700a28a7e181e5e68460f459dab76ac8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

