### PR TITLE
Suppress G304 on the install id read in the form gosec honors

### DIFF
--- a/internal/auth/install_id.go
+++ b/internal/auth/install_id.go
@@ -26,7 +26,7 @@ func (s *Store) InstallID() (string, error) {
 func (s *Store) installID() (string, error) {
 	path := s.installIDPath()
 
-	data, err := os.ReadFile(path) //nolint:gosec // G304: path built from the store's own config directory
+	data, err := os.ReadFile(path) // #nosec G304 -- path built from the store's own config directory
 	if err == nil {
 		// Only a well-formed identifier is a usable identity. A truncated or
 		// garbage file — an earlier write interrupted by a crash or a full


### PR DESCRIPTION
The "Go security analysis" job in the security workflow has failed on every push to main since the install id landed in #355 (six runs), and the release workflow requires it, so no release can ship until it is green.

The finding is G304 on `os.ReadFile(path)` in `internal/auth/install_id.go`. The line already carries `//nolint:gosec // G304: …`, the form used on forty other lines in this repo, and gosec v2.28.0 honors it everywhere except here. I do not have an explanation for the difference. Switching this one line to gosec's own `// #nosec G304 -- reason` clears it: gosec exits 0 on the package and golangci-lint still reports 0 issues.

Unblocks the v1.4.0 release.