### PR TITLE
Name x, not v, as the peek key in the cover picker

### DIFF
--- a/internal/tui/cover_picker.go
+++ b/internal/tui/cover_picker.go
@@ -95,7 +95,7 @@ func (p *coverPicker) view(styles styles, width int) string {
 		b.WriteString(preview + "\n\n")
 	}
 	b.WriteString(strings.Join(wrapText(
-		"A cover hides the threads you have already read. Press v to look under it.",
+		"A cover hides the threads you have already read. Press x to look under it.",
 		contentWidth), "\n"))
 	return b.String()
 }


### PR DESCRIPTION
The cover picker's footer said "Press v to look under it", but `v` moves a thread. `x` is what lifts the cover, and the divider hint, the help bar and docs/tui.md already say so. One-word text fix.