### PR TITLE
Keep the TUI socket tests under macOS's socket path cap

### DIFF
--- a/internal/tui/open_remote_unix_test.go
+++ b/internal/tui/open_remote_unix_test.go
@@ -162,9 +162,18 @@ func TestRunReportsTopicListenerConfigurationErrors(t *testing.T) {
 	}
 }
 
+// setPrivateRuntimeDir points the TUI at a private runtime directory the test owns.
+// The directory is made under the system temp root with a short name rather than
+// with t.TempDir(): a unix socket path is capped at 104 bytes on macOS, and
+// t.TempDir() embeds the test name inside an already long per-user temp path,
+// which put the socket over the cap and failed bind with "invalid argument".
 func setPrivateRuntimeDir(t *testing.T) {
 	t.Helper()
-	runtimeDir := t.TempDir()
+	runtimeDir, err := os.MkdirTemp("", "hey")
+	if err != nil {
+		t.Fatalf("create runtime directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(runtimeDir) })
 	if err := os.Chmod(runtimeDir, 0o700); err != nil {
 		t.Fatalf("protect runtime directory: %v", err)
 	}


### PR DESCRIPTION
The three open-remote tests in `internal/tui` bind a unix socket under `t.TempDir()`. On macOS that path embeds the test name inside the long per-user temp dir and lands around 115 bytes, over the 104-byte `sun_path` cap, so they fail with `bind: invalid argument` on every Mac while passing on Linux CI. That also fails the local release preflight, since `make release` runs the unit tests before tagging.

The helper now makes a short directory straight under the temp root with `os.MkdirTemp("", "hey")` and cleans it up itself, the way Go's own `net` tests place their sockets. Only this helper feeds a bind; the file's other two `t.TempDir()` uses compute or reject paths and are unchanged.