### PR TITLE
Leave Previously Seen out of the mail help bar

### DIFF
--- a/internal/tui/mail.go
+++ b/internal/tui/mail.go
@@ -1060,7 +1060,6 @@ func (v *mailView) HelpBindings() []helpBinding {
 		helpBinding{"t", "trash"},
 		helpBinding{"!", "spam"},
 		ignoreBinding,
-		helpBinding{"9", "previously seen"},
 		helpBinding{"ctrl+r", "reload"},
 	)
 	if v.postingList.cover != coverNone {

--- a/internal/tui/mail_test.go
+++ b/internal/tui/mail_test.go
@@ -4101,21 +4101,17 @@ func TestMailViewMovePickerOnTheSeenScreenLeavesTheImboxOut(t *testing.T) {
 	}
 }
 
-func TestMailViewHelpBindingsNamePreviouslySeen(t *testing.T) {
+// Previously Seen holds ordinary threads, so its screen offers the same actions the
+// box list does rather than being a place you can only read from.
+func TestMailViewSeenScreenHelpOffersTheThreadActions(t *testing.T) {
 	v := mailWithPostings()
-	if !hasHelpBinding(v.HelpBindings(), "9") {
-		t.Error("the list help should name 9")
-	}
-
 	v.seenActive = true
+
 	bindings := v.HelpBindings()
 	for _, key := range []string{"enter", "space", "ctrl+b", "a", "l", "u", "t", "v", "b", "n"} {
 		if !hasHelpBinding(bindings, key) {
 			t.Errorf("seen screen help misses %q: %+v", key, bindings)
 		}
-	}
-	if hasHelpBinding(bindings, "9") {
-		t.Error("the seen screen help should not name 9")
 	}
 }
 


### PR DESCRIPTION
Drops `9 previously seen` from the mail list's help bar.

The tab is already on screen with its number on it, so the help bar was spending a slot to repeat what the nav row says. The key still works and `docs/tui.md` still describes it — this is the shortcut bar only.

The test that pinned the binding existed to tell the list's help from the seen screen's, and with the binding gone there is no difference left to tell. What it checked that still matters — that the seen screen offers the same thread actions the box list does — stays, under a name that says so.

`make check` passes.
