### PR TITLE
Prepare v1.4.3 release metadata

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hey",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "HEY integration for Claude Code. Read email, manage todos, track time.",
   "author": {
     "name": "37signals",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
   pname = "hey";
   # Bumped by `make update-nix-hash VERSION=vX.Y.Z` before each stable
   # release; scripts/release.sh refuses to tag until it matches.
-  version = "1.4.2";
+  version = "1.4.3";
 
   src = lib.cleanSource ./..;
 


### PR DESCRIPTION
## Summary

- stamp the Nix package version to 1.4.3
- stamp the Claude plugin version to 1.4.3

## Validation

- `GOWORK=off HEY_SMOKE_STRICT=1 make test-smoke`
- `GOWORK=off make release VERSION=v1.4.3 DRY_RUN=1`
- full release preflight completed again before the protected-branch push was rejected

This release metadata PR is required because `main` accepts changes through pull requests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `hey` version to 1.4.3 in the Claude plugin metadata and Nix package definition so release artifacts match the v1.4.3 tag.

<sup>Written for commit 7173c817e36225397cbee007fb51229b77c9d8fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

