### PR TITLE
Bump the github-actions group with the lockstep and audit follow-ups

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+# actionlint's rules for this repository. See https://github.com/rhysd/actionlint/blob/main/docs/config.md
+paths:
+  .github/workflows/**/*.yml:
+    ignore:
+      # GitHub's self-repository `uses: $/...` syntax (July 2026) is what zizmor's
+      # self-repository audit asks for in place of `./...`, and what our reusable-workflow
+      # calls use. actionlint 1.7.12 predates it and has no release that knows it
+      # (rhysd/actionlint#711); drop this once one does. The ignore names the exact calls,
+      # so a new `$/` call is a deliberate edit here rather than a silent pass.
+      - 'reusable workflow call "\$/\.github/workflows/(security)\.yml" at "uses" is not following the format'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -57,14 +57,14 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"
           upload: never
           output: sarif-results
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         if: always()
         continue-on-error: true # Requires GitHub Advanced Security
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   security:
     name: Security scan
-    uses: ./.github/workflows/security.yml
+    uses: ./.github/workflows/security.yml # zizmor: ignore[self-repository] -- actionlint v1.7.12 rejects the $/ form; a job-level call has no earlier step that could swap the checkout
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
 
       # Fail fast: goreleaser's notarize block turns itself off when any of
       # these secrets is empty, so without this check a misconfigured canonical

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   security:
     name: Security scan
-    uses: ./.github/workflows/security.yml # zizmor: ignore[self-repository] -- actionlint v1.7.12 rejects the $/ form; a job-level call has no earlier step that could swap the checkout
+    uses: $/.github/workflows/security.yml
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         continue-on-error: true
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
           scan-type: fs
           format: sarif
           output: trivy-results.sarif
-      - uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: trivy-results.sarif
           category: trivy
@@ -68,12 +68,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: securego/gosec@9e75c0576c9878035d4221392108d458abe10fc3 # v2.28.0
+      - uses: securego/gosec@deb54465fea23d19a77f037e11e6589021f8501d # v2.29.0
         env:
           GOTOOLCHAIN: auto
         with:
           args: -fmt sarif -out gosec-results.sarif ./...
-      - uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         if: ${{ always() && hashFiles('gosec-results.sarif') != '' }}
         with:
           sarif_file: gosec-results.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
         with:
           advanced-security: false
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 	check-release-lockstep update-nix-hash tools clean install help
 
 BINARY := $(CURDIR)/bin/hey
-GOSEC_VERSION := v2.28.0
+GOSEC_VERSION := v2.29.0
 COVERAGE_FLOOR ?= 70.8
 COVERAGE_PROFILE ?= coverage.out
 COVERAGE_FUNCTIONS ?= coverage.func.txt


### PR DESCRIPTION
Carries dependabot's github-actions group bump from #415 (codeql-action v4.37.9, sbom-action v0.24.2, gosec v2.29.0, zizmor-action v0.6.3) and the two follow-ups that PR cannot make on its own:

- **Lint / Bats e2e**: `check-release-lockstep` compares the Makefile's `GOSEC_VERSION` against the `securego/gosec` pin in security.yml. The bump moved the action to v2.29.0, so the Makefile follows. `make gosec` at v2.29.0 runs clean locally (0 issues).
- **GitHub Actions audit**: zizmor 0.6.3 introduces the `self-repository` audit, which flags release.yml calling the reusable security workflow as `./.github/workflows/security.yml` and wants GitHub's newer `$/` form. actionlint v1.7.12 (the newest release) rejects `$/` outright, so the two linters in that job cannot both be satisfied by the syntax change. The audit's concern is a `./` reference resolving to a checkout mutated by an earlier step; a job-level reusable-workflow call has no earlier step, so the finding is suppressed on that line with the reason, matching the repo's other `zizmor: ignore` markers. Worth switching to `$/` once actionlint parses it.

Local gate: `make check` (fmt, vet, lint, unit tests, tidy, surface, release lockstep) and `make gosec` pass; `make test-e2e` passes every lockstep and nix test, with the only failures being the five `install_ssh_key.bats` cases that use GNU `stat -c` in their assert helper and fail on macOS regardless of branch.

Supersedes #415.
