### PR TITLE
Step the date with the arrows alone

### DIFF
--- a/internal/tui/datetime.go
+++ b/internal/tui/datetime.go
@@ -255,19 +255,15 @@ func (p *dateTimePicker) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 }
 
-// dateStep is the day-at-a-time keys. The arrows are unbound in a single-line text input,
-// and a + cannot appear in YYYY-MM-DD, so typing one is only ever a step. A - is the date's
-// own separator, so it is typed into the field like any other character (hey-cli#368).
+// dateStep is the day-at-a-time keys: the arrows, which are unbound in a single-line text
+// input. Nothing printable steps, because a date is typed as YYYY-MM-DD and every key that
+// can appear in one has to reach the input — a - that stepped instead could never be typed.
 func dateStep(msg tea.KeyPressMsg) (days int, stepped bool) {
 	switch msg.Key().Code {
 	case tea.KeyUp:
 		return 1, true
 	case tea.KeyDown:
 		return -1, true
-	}
-	switch msg.String() {
-	case "+", "=":
-		return 1, true
 	}
 	return 0, false
 }

--- a/internal/tui/datetime_test.go
+++ b/internal/tui/datetime_test.go
@@ -74,9 +74,9 @@ func TestDateTimePickerStepsTheDateByADay(t *testing.T) {
 		t.Errorf("after two downs, date() = %q, want 2026-08-21", got)
 	}
 
-	typeInto(t, picker, "+")
+	picker.handleKey(tea.KeyPressMsg{Code: tea.KeyUp})
 	if got := picker.date(); got != "2026-08-22" {
-		t.Errorf("after +, date() = %q, want 2026-08-22", got)
+		t.Errorf("after up, date() = %q, want 2026-08-22", got)
 	}
 
 	picker.dateInput.SetValue("next tuesday")
@@ -94,6 +94,20 @@ func TestDateTimePickerTypesTheDateSeparator(t *testing.T) {
 	typeInto(t, picker, "-22")
 	if got := picker.date(); got != "2026-08-22" {
 		t.Errorf("after typing -22, date() = %q, want 2026-08-22", got)
+	}
+}
+
+func TestDateTimePickerTypesADateWithItsHyphens(t *testing.T) {
+	picker := testPicker()
+	picker.focusFirst()
+	picker.dateInput.SetValue("")
+
+	typeInto(t, picker, "2026-09-14")
+	if got := picker.date(); got != "2026-09-14" {
+		t.Errorf("after typing 2026-09-14, date() = %q", got)
+	}
+	if got := picker.problem(); got != "" {
+		t.Errorf("problem() = %q, want none for a typed date", got)
 	}
 }
 


### PR DESCRIPTION
Follows up #365, which fixed #368 by letting the hyphen through to the date input.

## What is left

#365 kept `+`/`=` as a step-forward key. That pair was an undocumented extra — the help line only ever offered `↑↓ day` — and with `-` typed through rather than stepping back, the binding is one-sided: a step forward on keys nobody was told about, with no step back to match.

`dateStep` answers only the arrows now; every printable key reaches the text input. The existing step test steps back with ↑ where it used `+`, and `TestDateTimePickerTypesADateWithItsHyphens` keys a whole `YYYY-MM-DD` into an emptied field and checks it parses clean — the reporter's repro end to end, alongside #365's separator test.
