### PR TITLE
Follow a symlinked temporary directory to the TUI socket

### DIFF
--- a/internal/tui/open_remote_unix.go
+++ b/internal/tui/open_remote_unix.go
@@ -76,12 +76,15 @@ func tuiRuntimeDir() (string, error) {
 		return ensurePrivateDirectory(filepath.Join(runtimeDir, tuiRuntimeDirname))
 	}
 
-	tempDir := os.TempDir()
+	tempDir, err := filepath.EvalSymlinks(os.TempDir())
+	if err != nil {
+		return "", fmt.Errorf("inspect temporary directory: %w", err)
+	}
 	info, err := os.Lstat(tempDir)
 	if err != nil {
 		return "", fmt.Errorf("inspect temporary directory: %w", err)
 	}
-	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+	if !info.IsDir() {
 		return "", fmt.Errorf("temporary directory is not a directory")
 	}
 	if info.Mode().Perm()&0o022 != 0 && info.Mode()&os.ModeSticky == 0 {

--- a/internal/tui/open_remote_unix_test.go
+++ b/internal/tui/open_remote_unix_test.go
@@ -80,6 +80,28 @@ func TestTopicRemoteFallbackUsesPrivatePerUserDirectory(t *testing.T) {
 	}
 }
 
+// macOS's /tmp is a symlink to /private/tmp, and it is what os.TempDir answers whenever
+// TMPDIR is unset — an ssh session, a launchd job, a shell started without the login
+// environment — so the fallback has to follow the link rather than refuse it.
+func TestTopicRemoteFallbackFollowsSymlinkedTemporaryDirectory(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "tmp")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink temporary directory: %v", err)
+	}
+	t.Setenv("TMPDIR", link)
+
+	path := mustTUISocketPath(t, "omarchy")
+	resolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatalf("resolve temporary directory: %v", err)
+	}
+	if got := filepath.Dir(filepath.Dir(path)); got != resolved {
+		t.Fatalf("socket %s is not under the resolved temporary directory %s", path, resolved)
+	}
+}
+
 func TestTopicRemoteRejectsInsecureRuntimeDirectory(t *testing.T) {
 	runtimeDir := t.TempDir()
 	if err := os.Chmod(runtimeDir, 0o755); err != nil {


### PR DESCRIPTION
Fixes #394

## Repro

`hey tui` places its open-request socket under a per-user directory in the temp root when `XDG_RUNTIME_DIR` is unset, and `tuiRuntimeDir` refused a temp root that is a symlink. On macOS `/tmp` is a symlink to `/private/tmp`, and `/tmp` is exactly what `os.TempDir()` answers whenever `TMPDIR` is unset — an ssh session, a launchd job, a shell started outside the login environment, or a fresh machine where the terminal was not launched from a session that exports it. Every other command works because only the TUI touches the socket path; `hey tui` fails with `Error: temporary directory is not a directory`.

Reproduced on this Mac on `main` with `TMPDIR` cleared: `tuiSocketPath("")` returns that error. `TestTopicRemoteFallbackFollowsSymlinkedTemporaryDirectory` pins the same shape portably (a `TMPDIR` that is a symlink to a real directory) and fails on `main`.

## Fix

Resolve the temp root with `filepath.EvalSymlinks` and inspect the directory it names. The sticky-bit/world-writable check now runs against the real directory (`/private/tmp` is `1777`, so it passes), and the per-user `hey-cli-<uid>` directory is created and validated under the resolved path exactly as before — the symlink rejection on that directory is unchanged, since it is the one an attacker in a shared temp root could swap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `hey tui` failing on macOS when the temporary directory is a symlink (as `/tmp` is to `/private/tmp`). The runtime-dir fallback now resolves symlinks before validating the directory, so the socket path works when `TMPDIR` is unset. The per-user directory is still created and validated as before, and a test covers this case.

<sup>Written for commit d85e6003e8068057cb49c1d32ca0401ccfeed791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

