### PR TITLE
Bump hey-sdk to v0.30.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/actioncable-go v1.0.0
-	github.com/basecamp/hey-sdk/go v0.29.0
+	github.com/basecamp/hey-sdk/go v0.30.0
 	github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/fsnotify/fsnotify v1.10.1
@@ -90,7 +90,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.4.1 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/oapi-codegen/runtime v1.6.0 // indirect
+	github.com/oapi-codegen/runtime v1.7.0 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/actioncable-go v1.0.0 h1:m8UGFYfBfa/YivQNayc2VoS+oVKLG+ixKzhIzdACWDM=
 github.com/basecamp/actioncable-go v1.0.0/go.mod h1:ezaV5z1GXQAsqyejqTs6wCFl2D8Wj+COLQkHc/kwoRs=
-github.com/basecamp/hey-sdk/go v0.29.0 h1:/u9iD5x2Rm2IqVpF55XDfGMNwVyvtC+rJjpYC9BrFeo=
-github.com/basecamp/hey-sdk/go v0.29.0/go.mod h1:k6sO2XhMkU3UY8lD2ozp0735Ic3q8xoMQt7YUT3TlYk=
+github.com/basecamp/hey-sdk/go v0.30.0 h1:PKAxAL8ZXUNuLPR+YE6Vd8BSuGj+kWm3bkCmwSwxP8s=
+github.com/basecamp/hey-sdk/go v0.30.0/go.mod h1:CRBUw9E72QFvCtjZmPgu8wrKEXcBMWc9RMxvl0+XQVc=
 github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d h1:zEQVGq1x1nhKMZ2TudFAcSJ32CHT8richI1vQakIKz4=
 github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d/go.mod h1:Ee2c/q1/pg+5T5741PIuA3s6VJMQC7I0XBNXIHIujzA=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
@@ -301,8 +301,8 @@ github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0
 github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
 github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
-github.com/oapi-codegen/runtime v1.6.0 h1:7Xx+GlueD6nRuyKoCPzL434Jfi3BetbiJOrzCHp/VPU=
-github.com/oapi-codegen/runtime v1.6.0/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
+github.com/oapi-codegen/runtime v1.7.0 h1:t7358VYPvNbWJ9gdAkIK/smVeHpBf6yp8VTsaZsb/7k=
+github.com/oapi-codegen/runtime v1.7.0/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/internal/mcpserver/model/PROVENANCE.json
+++ b/internal/mcpserver/model/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source": "github.com/basecamp/hey-sdk",
-  "commit": "764f371a979d367213f29aedef2e6ce611e9f402",
-  "ref": "go/v0.29.0",
+  "commit": "9b16fc7a7fd76ef500a77fce7f0223fc4166b43c",
+  "ref": "go/v0.30.0",
   "files": ["behavior-model.json", "openapi.json"],
   "synced_by": "scripts/sync-mcp-model.sh"
 }

--- a/internal/mcpserver/model/behavior-model.json
+++ b/internal/mcpserver/model/behavior-model.json
@@ -470,6 +470,10 @@
     },
     "GetBox": {
       "idempotent": false,
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count"
+      },
       "readonly": true,
       "retry": {
         "backoff": "exponential",
@@ -956,6 +960,19 @@
       }
     },
     "GetWorkflow": {
+      "idempotent": false,
+      "readonly": true,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetWorkflowStage": {
       "idempotent": false,
       "readonly": true,
       "retry": {

--- a/internal/mcpserver/model/openapi.json
+++ b/internal/mcpserver/model/openapi.json
@@ -482,6 +482,10 @@
         "tags": [
           "Boxes"
         ],
+        "x-hey-pagination": {
+          "style": "link",
+          "totalCountHeader": "X-Total-Count"
+        },
         "x-hey-retry": {
           "maxAttempts": 3,
           "baseDelayMs": 1000,
@@ -1858,7 +1862,7 @@
         }
       },
       "patch": {
-        "description": "Update the journal entry for a day: writes (or creates) it and answers the entry as a\nrecording, or 204 when empty content removes it.",
+        "description": "Update the journal entry for a day: writes it, creating it if the day has none, and\nanswers the entry as a recording. Empty content removes the entry instead, and HEY then\nanswers 204 with no body — which is not this shape, so send that through the SDK's own\njournal wrapper rather than here.",
         "operationId": "UpdateJournalEntry",
         "requestBody": {
           "content": {
@@ -10471,6 +10475,87 @@
           ]
         }
       }
+    },
+    "/workflows/{workflowId}/stages/{stageId}": {
+      "get": {
+        "description": "A workflow stage and its cards, served as HTML by HEY.",
+        "operationId": "GetWorkflowStage",
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "stageId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GetWorkflowStage 200 response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetWorkflowStageOutputPayload"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Workflows"
+        ]
+      }
     }
   },
   "components": {
@@ -12459,6 +12544,10 @@
       "GetWorkflowResponseContent": {
         "$ref": "#/components/schemas/Workflow"
       },
+      "GetWorkflowStageOutputPayload": {
+        "type": "string",
+        "contentEncoding": "byte"
+      },
       "HabitPayload": {
         "type": "object",
         "properties": {
@@ -12797,6 +12886,12 @@
           },
           "show_addressed_selector": {
             "type": "boolean"
+          },
+          "posting": {
+            "$ref": "#/components/schemas/MessagePostingContext"
+          },
+          "addressed_sender": {
+            "$ref": "#/components/schemas/AddressedSender"
           }
         }
       },
@@ -13284,7 +13379,7 @@
       },
       "Recording": {
         "type": "object",
-        "description": "Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)",
+        "description": "Recording — polymorphic by `type` (Calendar::Event, Calendar::Todo, etc.)",
         "properties": {
           "id": {
             "type": "integer",
@@ -13345,7 +13440,7 @@
           },
           "type": {
             "type": "string",
-            "description": "Discriminator: CalendarEvent, CalendarTodo, etc."
+            "description": "Discriminator — the recordable's Ruby class name: Calendar::Event, Calendar::Todo,\nCalendar::JournalEntry, Calendar::Habit, Calendar::TimeTrack, Calendar::Countdown,\nCalendar::DayBackground, Calendar::DayTitle or Calendar::Habit::Completion."
           },
           "parent": {
             "$ref": "#/components/schemas/Recording"
@@ -13486,7 +13581,7 @@
         "x-hey-polymorphic": {
           "discriminator": "type",
           "variants": {
-            "CalendarEvent": [
+            "Calendar::Event": [
               "edit_url",
               "summary",
               "url",
@@ -13500,27 +13595,27 @@
               "join_link",
               "attached_entry"
             ],
-            "CalendarTodo": [
+            "Calendar::Todo": [
               "position"
             ],
-            "CalendarJournalEntry": [
+            "Calendar::JournalEntry": [
               "content"
             ],
-            "CalendarHabit": [
+            "Calendar::Habit": [
               "color",
               "icon",
               "days",
               "icon_url",
               "stopped_at"
             ],
-            "CalendarTimeTrack": [
+            "Calendar::TimeTrack": [
               "notes",
               "category"
             ],
-            "CalendarCountdown": [
+            "Calendar::Countdown": [
               "label"
             ],
-            "CalendarDayBackground": [
+            "Calendar::DayBackground": [
               "image_url"
             ]
           }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule.override { inherit go; } (finalAttrs: {
 
   # To update: run `make update-nix-hash` (Docker). It rewrites this quoted
   # value in place, so keep it a string literal rather than lib.fakeHash.
-  vendorHash = "sha256-Lm+yjYS2EFgsbzc3E0HSSKyk4+zM/JBAULVrgI69yHk=";
+  vendorHash = "sha256-S1A3439veo9zh50NgYYbNYb6bK9oVW+B1wF54HZp2O8=";
 
   subPackages = [ "cmd/hey" ];
 


### PR DESCRIPTION
## Summary

Pins [hey-sdk v0.30.0](https://github.com/basecamp/hey-sdk/releases/tag/v0.30.0) (`go/v0.30.0`, 9b16fc7).

What it brings the CLI:

- Draft sends and edits that HEY rejects with a 422 now surface the validation message instead of a bare "validation error", and a draft edit that fails no longer reads as applied (basecamp/hey-sdk#133). Closes #350.
- Also in the release, not yet called here: the workflow stage reader (basecamp/hey-sdk#141), generated operation retry policies (basecamp/hey-sdk#94), Retry-After rounding (basecamp/hey-sdk#151), and the Rust SDK (basecamp/hey-sdk#145).

Alongside the pin:

- `internal/mcpserver/model/` resynced from `go/v0.30.0` via `make update-mcp-model`: PROVENANCE moves to 9b16fc7, and the model gains `GetWorkflowStage` under the Workflows tag, which the catalog already pins as unmapped, so `TestCatalogUnmappedTagsArePinned` is unchanged.
- `github.com/oapi-codegen/runtime` v1.6.0 → v1.7.0 (indirect, pulled by the SDK).
- `nix/package.nix` vendorHash recomputed with `make update-nix-hash` and verified by a full Nix build.

## Test plan

- [x] `make check` (fmt, vet, lint, unit tests, tidy, surface, release lockstep)
- [x] `make update-nix-hash` built the flake against the new go.sum
- [x] `go.mod` carries a single `github.com/basecamp/hey-sdk/go v0.30.0` requirement and no `replace`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `hey-sdk` from v0.29.0 to v0.30.0, so draft sends and edits HEY rejects with a 422 now surface the validation message instead of a bare "validation error", and a failed draft edit no longer reads as applied.

**Changes**
- The MCP model resyncs to `go/v0.30.0`, adding `GetWorkflowStage` under the Workflows tag, which the catalog already pins as unmapped.
- `github.com/oapi-codegen/runtime` bumps to v1.7.0 as an indirect dependency.
- `nix/package.nix` vendorHash is recomputed via `make update-nix-hash` and verified with a full Nix build.
- Other SDK additions like the workflow stage reader and retry policy fixes are not called by the CLI yet.

<sup>Written for commit 5e34a4f3e411e8ea8bb5bb0bebfa0f9c32df5015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

