### PR TITLE
Reference in-repo workflows with GitHub's self-repository syntax

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# actionlint's rules for this repository. See https://github.com/rhysd/actionlint/blob/main/docs/config.md
+paths:
+  .github/workflows/**/*.yml:
+    ignore:
+      # GitHub's self-repository `uses: $/...` syntax (July 2026) is what zizmor's
+      # self-repository audit asks for in place of `./...`, and what our reusable-workflow
+      # calls use. actionlint 1.7.12 predates it and has no release that knows it
+      # (rhysd/actionlint#711); drop this once one does.
+      - 'reusable workflow call "\$/.+" at "uses" is not following the format'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   security:
     name: Security scan
-    uses: ./.github/workflows/security.yml
+    uses: $/.github/workflows/security.yml
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
zizmor 1.30.0, which zizmor-action 0.6.3 runs by default, adds a self-repository audit that flags workspace-relative `uses: ./...` references to in-repo actions and reusable workflows. GitHub's `uses: $/...` form resolves against the running commit rather than the checked-out filesystem, so it can't pick up an action cloned by an earlier step, and GitHub counts it as pinned. This repo pins zizmor-action 0.6.2 and would fail the audit on the next Dependabot bump, so `release.yml`'s call to the `security.yml` reusable workflow moves to the new form.

actionlint 1.7.12 rejects the new form and no release knows it yet (rhysd/actionlint#711), so `.github/actionlint.yaml` ignores that one message for workflow files, with a note to drop it once a release does.

CI's audit job on this PR (actionlint, then zizmor) is the proof.

Same change as basecamp/hey-sdk#171 and #174.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the release workflow's in-repo reusable workflow call to GitHub's self-repository syntax (`uses: $/...`). This complies with zizmor 1.30.0's self-repository audit, which flags workspace-relative `./` references, and GitHub counts `$/...` as pinned. The new form resolves against the running commit rather than the checked-out filesystem. Also adds `.github/actionlint.yaml` to ignore actionlint's current rejection of the new syntax until it's supported.

<sup>Written for commit a00fe32ffcd7afd53fcf130e68ca76274bdc0f79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-cli/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

