### PR TITLE
Refresh the Nix vendorHash on Dependabot Go bumps

### DIFF
--- a/.github/workflows/dependabot-sync-nix-vendor-hash.yml
+++ b/.github/workflows/dependabot-sync-nix-vendor-hash.yml
@@ -14,10 +14,12 @@ name: Refresh Nix vendorHash on Dependabot PRs
 # main's own, and none of them references a secret a Go bump can reach — keep
 # it that way. The full actor analysis is in the reusable workflow's header.
 #
-# Needs the cli-release-bot App installed here and RELEASE_APP_PRIVATE_KEY
-# stored as a Dependabot secret (Dependabot-triggered runs do not see Actions
-# secrets); the dispatch path reads the Actions secret release.yml already
-# uses.
+# Needs the cli-release-bot App installed here with contents: write, and its
+# private key stored as a repository *Dependabot* secret named
+# RELEASE_APP_PRIVATE_KEY (Dependabot-triggered runs see only Dependabot
+# secrets) and, for the workflow_dispatch path, as a repository Actions secret
+# of the same name. release.yml's copies live in the `release` environment
+# and are not reachable from here, by design.
 
 on:
   pull_request:
@@ -39,7 +41,10 @@ jobs:
     uses: basecamp/.github/.github/workflows/dependabot-sync-nix-vendor-hash.yml@8f44c1e73b288ef09d2a3e48a5771d34fba22b39
     with:
       pr: ${{ inputs.pr }}
-      app-client-id: ${{ vars.RELEASE_CLIENT_ID }}
+      # cli-release-bot's client id — the `release` environment's
+      # RELEASE_CLIENT_ID, which is a public identifier (every release run
+      # prints it) and, being environment-scoped, is not readable here.
+      app-client-id: Iv23liAbERu6z8d7t5A8
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/dependabot-sync-nix-vendor-hash.yml
+++ b/.github/workflows/dependabot-sync-nix-vendor-hash.yml
@@ -1,0 +1,48 @@
+name: Refresh Nix vendorHash on Dependabot PRs
+
+# A Dependabot Go bump changes go.sum and leaves nix/package.nix's vendorHash
+# stale, so "Nix flake builds" — required on main — fails with a fixed-output
+# hash mismatch and the PR wedges until someone runs `make update-nix-hash`
+# with Docker (#427). This refreshes the hash on the PR itself.
+#
+# The SHA-pinned reusable workflow builds the flake at the PR's merge commit,
+# takes the corrected hash from Nix's go-modules fixed-output mismatch, and
+# commits exactly that one line of nix/package.nix back to the PR with a
+# one-hour cli-release-bot token scoped to this repository, so the PR's own
+# "Nix flake builds" check re-runs on the new head and verifies it. Go bumps
+# only: the pull_request jobs that then re-run under the App bot's actor are
+# main's own, and none of them references a secret a Go bump can reach — keep
+# it that way. The full actor analysis is in the reusable workflow's header.
+#
+# Needs the cli-release-bot App installed here and RELEASE_APP_PRIVATE_KEY
+# stored as a Dependabot secret (Dependabot-triggered runs do not see Actions
+# secrets); the dispatch path reads the Actions secret release.yml already
+# uses.
+
+on:
+  pull_request:
+    paths:
+      - go.mod
+      - go.sum
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Dependabot pull request number to refresh
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  refresh:
+    if: github.event_name == 'workflow_dispatch' || (github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]') # zizmor: ignore[bot-conditions] -- dual check: actor validates the current trigger (and stops the App bot's own push from looping back), user.login validates PR origin; on:pull_request, not pull_request_target, so GitHub sets the actor from who pushed
+    uses: basecamp/.github/.github/workflows/dependabot-sync-nix-vendor-hash.yml@8f44c1e73b288ef09d2a3e48a5771d34fba22b39
+    with:
+      pr: ${{ inputs.pr }}
+      app-client-id: ${{ vars.RELEASE_CLIENT_ID }}
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+    secrets:
+      app-private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependabot-sync-nix-vendor-hash.yml
+++ b/.github/workflows/dependabot-sync-nix-vendor-hash.yml
@@ -38,7 +38,7 @@ permissions: {}
 jobs:
   refresh:
     if: github.event_name == 'workflow_dispatch' || (github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]') # zizmor: ignore[bot-conditions] -- dual check: actor validates the current trigger (and stops the App bot's own push from looping back), user.login validates PR origin; on:pull_request, not pull_request_target, so GitHub sets the actor from who pushed
-    uses: basecamp/.github/.github/workflows/dependabot-sync-nix-vendor-hash.yml@8f44c1e73b288ef09d2a3e48a5771d34fba22b39
+    uses: basecamp/.github/.github/workflows/dependabot-sync-nix-vendor-hash.yml@12f8950fc925285f3dd5bce2e5cc9ea8b7f72da6
     with:
       pr: ${{ inputs.pr }}
       # cli-release-bot's client id — the `release` environment's

--- a/.github/workflows/dependabot-sync-nix-vendor-hash.yml
+++ b/.github/workflows/dependabot-sync-nix-vendor-hash.yml
@@ -9,10 +9,15 @@ name: Refresh Nix vendorHash on Dependabot PRs
 # takes the corrected hash from Nix's go-modules fixed-output mismatch, and
 # commits exactly that one line of nix/package.nix back to the PR with a
 # one-hour cli-release-bot token scoped to this repository, so the PR's own
-# "Nix flake builds" check re-runs on the new head and verifies it. Go bumps
-# only: the pull_request jobs that then re-run under the App bot's actor are
-# main's own, and none of them references a secret a Go bump can reach — keep
-# it that way. The full actor analysis is in the reusable workflow's header.
+# "Nix flake builds" check re-runs on the new head and verifies it. That
+# check being required is what keeps the stale head from merging while the
+# refresh runs: auto-merge waits for required checks only, so the requirement
+# is part of this workflow's contract, not a nicety. Go bumps only, enforced
+# by the reusable workflow on the PR's actual diff (go.mod, go.sum and
+# nix/package.nix, nothing else; the paths filter below only spares a runner):
+# the pull_request jobs that then re-run under the App bot's actor are main's
+# own, and none of them references a secret a Go bump can reach — keep it that
+# way. The full actor analysis is in the reusable workflow's header.
 #
 # Needs the cli-release-bot App installed here with contents: write, and its
 # private key stored as a repository *Dependabot* secret named
@@ -38,7 +43,7 @@ permissions: {}
 jobs:
   refresh:
     if: github.event_name == 'workflow_dispatch' || (github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]') # zizmor: ignore[bot-conditions] -- dual check: actor validates the current trigger (and stops the App bot's own push from looping back), user.login validates PR origin; on:pull_request, not pull_request_target, so GitHub sets the actor from who pushed
-    uses: basecamp/.github/.github/workflows/dependabot-sync-nix-vendor-hash.yml@12f8950fc925285f3dd5bce2e5cc9ea8b7f72da6
+    uses: basecamp/.github/.github/workflows/dependabot-sync-nix-vendor-hash.yml@49eaa2156461cee5ac15c5236d3ff3f5fe900d3f
     with:
       pr: ${{ inputs.pr }}
       # cli-release-bot's client id — the `release` environment's


### PR DESCRIPTION
Stacked on basecamp/.github#19 and pinned to its branch SHA; re-pin to the merged SHA once that lands.

Every Dependabot Go bump here arrives red on "Nix flake builds": `go.sum` moves, the `vendorHash` in `nix/package.nix` does not, and because that check is required the PR wedges until someone runs `make update-nix-hash` with Docker — #427 is sitting there now. This thin caller runs the reusable workflow on Dependabot PRs that touch `go.mod`/`go.sum`: it builds the flake at the PR's merge commit, takes the corrected hash from Nix's go-modules fixed-output mismatch, and commits exactly that one line of `nix/package.nix` back to the PR with a one-hour `cli-release-bot` token scoped to this repository. That push re-triggers the PR's own CI, whose Nix check verifies the new hash; the re-triggered run is actored by the App bot, so the Dependabot actor guard ends the loop. Auto-merge, already armed by `dependabot-auto-merge.yml`, then proceeds unattended.

Why pushing into a Dependabot PR is sound here when it was abandoned for actions bumps (basecamp/.github#11): the workflow code that re-runs after the push is main's, and I audited every `pull_request` job in this repo — none references a secret outside the actor-gated auto-merge job, so the actor flip exposes nothing to the bumped dependency code that `go test` does not already run under Dependabot's sandbox. The reusable workflow's header carries the full reasoning; this file's header states the invariant to keep.

## What has to be in place, and verification

Live verification is not possible from this branch: `workflow_dispatch` resolves workflows registered from the default branch only (a dispatch from here was refused with a 404), and no path other than dispatch or a Dependabot push can reach the job. A probe run on this branch did settle the credential question: `vars.RELEASE_CLIENT_ID` is empty outside `release.yml`, because both it and `RELEASE_APP_PRIVATE_KEY` live in the `release` environment and are unreachable from any other job — so the client id is passed as a literal here (it is a public identifier, printed in every release run), and the private key needs a copy outside that environment.

Before the Dependabot-triggered path works here:

1. Install the `cli-release-bot` App on this repository with `contents: write` (I cannot see its installation list; the release jobs only ever mint for `homebrew-tap` and `skills`).
2. Add its private key as a **repository Dependabot secret** `RELEASE_APP_PRIVATE_KEY` — Dependabot-triggered runs see only Dependabot secrets. basecamp-cli already has this one; hey-cli has none.
3. Optionally, the same key as a repository Actions secret of the same name, which is what the `workflow_dispatch` path reads.

Then, with basecamp/.github#19 and this merged: comment `@dependabot rebase` on #427 (or dispatch this workflow with `pr=427`). The run computes the hash at #427's merge commit (its failing job reported `sha256-ru1Q0ytS0Gq2f9JHovoPZYU9OejoVqtwsyNs1HnQ6TA=` against the pre-Go-1.27 main this morning; the value may differ now that main builds with Go 1.27, which is exactly why it is computed at the merge and verified by the PR's own check rather than copied), pushes the one-line commit, and #427's "Nix flake builds" re-runs green; auto-merge, already armed on #427, then lands it.

actionlint 1.7.12 and zizmor 1.30.0 are clean; the `bot-conditions` ignore carries the same dual-check reasoning as `dependabot-auto-merge.yml`. No required check changes.
